### PR TITLE
Fix missing generic type

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/model/FilterOptions.java
+++ b/app/src/main/java/org/jellyfin/androidtv/model/FilterOptions.java
@@ -5,25 +5,33 @@ import java.util.List;
 
 import mediabrowser.model.querying.ItemFilter;
 
-/**
- * Created by Eric on 8/18/2015.
- */
 public class FilterOptions {
     private boolean favoriteOnly;
     private boolean unwatchedOnly;
 
-    public void setFavoriteOnly(boolean value) {favoriteOnly = value;}
-    public void setUnwatchedOnly(boolean value) {unwatchedOnly = value;}
-    public boolean isUnwatchedOnly() {return unwatchedOnly;}
-    public boolean isFavoriteOnly() {return favoriteOnly;}
+    public void setFavoriteOnly(boolean value) {
+        favoriteOnly = value;
+    }
+
+    public void setUnwatchedOnly(boolean value) {
+        unwatchedOnly = value;
+    }
+
+    public boolean isUnwatchedOnly() {
+        return unwatchedOnly;
+    }
+
+    public boolean isFavoriteOnly() {
+        return favoriteOnly;
+    }
 
     public ItemFilter[] getFilters() {
         if (!unwatchedOnly && !favoriteOnly) return null;
 
-        List<ItemFilter> filters = new ArrayList();
+        List<ItemFilter> filters = new ArrayList<>();
         if (favoriteOnly) filters.add(ItemFilter.IsFavorite);
         if (unwatchedOnly) filters.add(ItemFilter.IsUnplayed);
 
-        return filters.toArray(new ItemFilter[filters.size()]);
+        return filters.toArray(new ItemFilter[0]);
     }
 }


### PR DESCRIPTION
Fixes the following build time warning due to a missing generic type definition.

```
Note: /home/bill/Projects/jellyfin-androidtv/app/src/main/java/org/jellyfin/androidtv/model/FilterOptions.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```