### PR TITLE
Remove send log buttons

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@
  - [dkanada](https://github.com/dkanada)
  - [thornbill](https://github.com/thornbill)
  - [grafixeyehero](https://github.com/grafixeyehero)
+ - [BnMcG](https://github.com/bnmcg)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/HomeFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/HomeFragment.java
@@ -137,13 +137,11 @@ public class HomeFragment extends StdBrowseFragment {
     public void onResume() {
         super.onResume();
 
-        addLogsButton();
         //make sure rows have had a chance to be created
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
                 addNowPlaying();
-                addLogsButton();
                 //check for resume row and add if not there
                 if (!hasResumeRow()) addContinueWatching();
             }
@@ -365,18 +363,7 @@ public class HomeFragment extends StdBrowseFragment {
         toolsRow = new ArrayObjectAdapter(mGridPresenter);
         toolsRow.add(new GridButton(SETTINGS, mApplication.getString(R.string.lbl_app_settings), R.drawable.gears));
         toolsRow.add(new GridButton(LOGOUT, mApplication.getString(R.string.lbl_logout) + TvApp.getApplication().getCurrentUser().getName(), R.drawable.logout));
-
-        sendLogsButton = new GridButton(REPORT, mApplication.getString(R.string.lbl_send_logs), R.drawable.upload);
         rowAdapter.add(new ListRow(gridHeader, toolsRow));
-    }
-
-    private void addLogsButton() {
-        if (toolsRow != null) {
-            if (TvApp.getApplication().getPrefs().getBoolean("pref_enable_debug",false)) {
-                if (toolsRow.indexOf(sendLogsButton) < 0) toolsRow.add(sendLogsButton);
-            } else if (toolsRow.indexOf(sendLogsButton) > -1) toolsRow.remove(sendLogsButton);
-        }
-
     }
 
     @Override
@@ -409,9 +396,6 @@ public class HomeFragment extends StdBrowseFragment {
                     case SETTINGS:
                         Intent settings = new Intent(getActivity(), SettingsActivity.class);
                         getActivity().startActivity(settings);
-                        break;
-                    case REPORT:
-                        Utils.reportError(getActivity(), "Send Log to Dev");
                         break;
                     default:
                         Toast.makeText(getActivity(), item.toString(), Toast.LENGTH_SHORT)

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/HomeFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/HomeFragment.java
@@ -58,11 +58,6 @@ import mediabrowser.model.querying.NextUpQuery;
 public class HomeFragment extends StdBrowseFragment {
     private static final int LOGOUT = 0;
     private static final int SETTINGS = 1;
-    private static final int REPORT = 2;
-
-    private ArrayObjectAdapter toolsRow;
-    private GridButton sendLogsButton;
-
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
@@ -360,7 +355,7 @@ public class HomeFragment extends StdBrowseFragment {
         HeaderItem gridHeader = new HeaderItem(rowAdapter.size(), mApplication.getString(R.string.lbl_settings));
 
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
-        toolsRow = new ArrayObjectAdapter(mGridPresenter);
+        ArrayObjectAdapter toolsRow = new ArrayObjectAdapter(mGridPresenter);
         toolsRow.add(new GridButton(SETTINGS, mApplication.getString(R.string.lbl_app_settings), R.drawable.gears));
         toolsRow.add(new GridButton(LOGOUT, mApplication.getString(R.string.lbl_logout) + TvApp.getApplication().getCurrentUser().getName(), R.drawable.logout));
         rowAdapter.add(new ListRow(gridHeader, toolsRow));

--- a/app/src/main/java/org/jellyfin/androidtv/startup/SelectUserFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/SelectUserFragment.java
@@ -39,7 +39,6 @@ public class SelectUserFragment extends CustomBrowseFragment {
     private static final int GRID_ITEM_WIDTH = 200;
     private static final int GRID_ITEM_HEIGHT = 200;
     private static final int ENTER_MANUALLY = 0;
-    private static final int REPORT = 2;
     private static final int SWITCH_SERVER = 3;
     private ServerInfo mServer;
 

--- a/app/src/main/java/org/jellyfin/androidtv/startup/SelectUserFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/SelectUserFragment.java
@@ -68,7 +68,6 @@ public class SelectUserFragment extends CustomBrowseFragment {
         ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
         gridRowAdapter.add(new GridButton(ENTER_MANUALLY, mApplication.getString(R.string.lbl_enter_manually), R.drawable.edit));
         gridRowAdapter.add(new GridButton(SWITCH_SERVER, mApplication.getString(R.string.lbl_switch_server), R.drawable.server));
-        gridRowAdapter.add(new GridButton(REPORT, mApplication.getString(R.string.lbl_send_logs), R.drawable.upload));
         rowAdapter.add(new ListRow(gridHeader, gridRowAdapter));
     }
 
@@ -105,9 +104,6 @@ public class SelectUserFragment extends CustomBrowseFragment {
                     case ENTER_MANUALLY:
                         // Manual login
                         AuthenticationHelper.enterManualUser(getActivity());
-                        break;
-                    case REPORT:
-                        Utils.reportError(getActivity(), "Send Log to Dev");
                         break;
                     default:
                         Toast.makeText(getActivity(), item.toString(), Toast.LENGTH_SHORT)


### PR DESCRIPTION
Resolves #45 

Remove "send log" buttons that no longer work. Tested on Fire TV Gen 2. Removes buttons from both the login and the home screens.