### PR TITLE
Fix credentials path for autologin

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/browsing/HomeFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/HomeFragment.java
@@ -68,7 +68,7 @@ public class HomeFragment extends StdBrowseFragment {
 
         //Save last login so we can get back proper context on entry
         try {
-            AuthenticationHelper.saveLoginCredentials(new LogonCredentials(TvApp.getApplication().getApiClient().getServerInfo(), TvApp.getApplication().getCurrentUser()), "credentials.json");
+            AuthenticationHelper.saveLoginCredentials(new LogonCredentials(TvApp.getApplication().getApiClient().getServerInfo(), TvApp.getApplication().getCurrentUser()), TvApp.CREDENTIALS_PATH);
         } catch (IOException e) {
             TvApp.getApplication().getLogger().ErrorException("Unable to save login creds", e);
         }


### PR DESCRIPTION
The credentials path was updated and moved to a constant but one location was missed. (This is exactly why you should use variables instead of hard coding strings everywhere :man_facepalming:)

Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/95