### PR TITLE
Fix NPE when getChildCount returns null Integer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowsePersonsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowsePersonsFragment.java
@@ -3,12 +3,10 @@ package org.jellyfin.androidtv.browsing;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 
+import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.PersonsQuery;
 
-/**
- * Created by Eric on 12/4/2014.
- */
 public class BrowsePersonsFragment extends CustomViewFragment {
 
     private static String letters = TvApp.getApplication().getResources().getString(R.string.byletter_letters);
@@ -16,7 +14,7 @@ public class BrowsePersonsFragment extends CustomViewFragment {
     @Override
     protected void setupQueries(IRowLoader rowLoader) {
 
-        if (mFolder.getChildCount() > 0) {
+        if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //First add a '#' item
             PersonsQuery numbers = new PersonsQuery();
             numbers.setParentId(mFolder.getId());

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/ByGenreFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/ByGenreFragment.java
@@ -6,15 +6,13 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.querying.StdItemQuery;
 import org.jellyfin.androidtv.util.DelayedMessage;
 
+import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.ItemsByNameQuery;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 
-/**
- * Created by Eric on 12/4/2014.
- */
 public class ByGenreFragment extends CustomViewFragment {
 
     @Override
@@ -25,7 +23,7 @@ public class ByGenreFragment extends CustomViewFragment {
     @Override
     protected void setupQueries(final IRowLoader rowLoader) {
 
-        if (mFolder.getChildCount() > 0) {
+        if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             final DelayedMessage message = new DelayedMessage(getActivity());
 
             //Get all genres for this folder

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/ByLetterFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/ByLetterFragment.java
@@ -4,11 +4,9 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.querying.StdItemQuery;
 
+import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 
-/**
- * Created by Eric on 12/4/2014.
- */
 public class ByLetterFragment extends CustomViewFragment {
 
     private static String letters = TvApp.getApplication().getResources().getString(R.string.byletter_letters);
@@ -16,7 +14,7 @@ public class ByLetterFragment extends CustomViewFragment {
     @Override
     protected void setupQueries(IRowLoader rowLoader) {
 
-        if (mFolder.getChildCount() > 0) {
+        if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //First add a '#' item
             StdItemQuery numbers = new StdItemQuery();
             numbers.setParentId(mFolder.getId());

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/CollectionFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/CollectionFragment.java
@@ -4,10 +4,8 @@ import android.os.Bundle;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.querying.StdItemQuery;
+import org.jellyfin.androidtv.util.Utils;
 
-/**
- * Created by Eric on 12/4/2014.
- */
 public class CollectionFragment extends EnhancedBrowseFragment {
 
     @Override
@@ -18,8 +16,7 @@ public class CollectionFragment extends EnhancedBrowseFragment {
 
     @Override
     protected void setupQueries(IRowLoader rowLoader) {
-
-        if (mFolder.getChildCount() > 0) {
+        if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             StdItemQuery movies = new StdItemQuery();
             movies.setParentId(mFolder.getId());
             movies.setIncludeItemTypes(new String[]{"Movie"});

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
@@ -8,15 +8,13 @@ import org.jellyfin.androidtv.querying.StdItemQuery;
 
 import java.util.Arrays;
 
+import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 
-/**
- * Created by Eric on 12/4/2014.
- */
 public class GenericFolderFragment extends EnhancedBrowseFragment {
 
     @Override
@@ -39,7 +37,11 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
             rowLoader.loadRows(mRows);
         } else {
 
-            if (mFolder.getChildCount() > 0 || mFolder.getType().equals("Channel") || mFolder.getType().equals("ChannelFolderItem") || mFolder.getType().equals("UserView") || mFolder.getType().equals("CollectionFolder")) {
+            if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0 ||
+                    mFolder.getType().equals("Channel") ||
+                    mFolder.getType().equals("ChannelFolderItem") ||
+                    mFolder.getType().equals("UserView") ||
+                    mFolder.getType().equals("CollectionFolder")) {
                 boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getType()) && !"channels".equals(mFolder.getCollectionType());
 
                 if (showSpecialViews) {

--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -388,8 +388,17 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
                     BaseItemPerson director = BaseItemUtils.getFirstPerson(item, PersonType.Director);
 
-                    mDetailsOverviewRow.setInfoItem1("Series".equals(item.getType()) ? new InfoItem(getString(R.string.lbl_seasons), item.getChildCount().toString()) :
-                            new InfoItem(getString(R.string.lbl_directed_by), director != null ? director.getName() : getString(R.string.lbl_bracket_unknown)));
+                    InfoItem firstRow;
+                    if ("Series".equals(item.getType())) {
+                        firstRow = new InfoItem(
+                                getString(R.string.lbl_seasons),
+                                Utils.getSafeValue(item.getChildCount(), 0).toString());
+                    } else {
+                        firstRow = new InfoItem(
+                                getString(R.string.lbl_directed_by),
+                                director != null ? director.getName() : getString(R.string.lbl_bracket_unknown));
+                    }
+                    mDetailsOverviewRow.setInfoItem1(firstRow);
 
                     if ((item.getRunTimeTicks() != null && item.getRunTimeTicks() > 0) || item.getOriginalRunTimeTicks() != null) {
                         mDetailsOverviewRow.setInfoItem2(new InfoItem(getString(R.string.lbl_runs), getRunTime()));


### PR DESCRIPTION
This should fix an issue reported on [reddit](https://www.reddit.com/r/jellyfin/comments/bdznxn/beta5_androidtv_gray_screen/) where the app would crash if `getChildCount` returned `null` in cases where it is unboxed to an `int`.