### PR TITLE
Fix Live TV playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -411,7 +411,7 @@ public class TvApp extends Application implements ActivityCompat.OnRequestPermis
 
     public void setDirectStreamLiveTv(boolean value) { getPrefs().edit().putBoolean("pref_live_direct", value).commit(); }
 
-    public boolean useVlcForLiveTv() { return getPrefs().getBoolean("pref_enable_vlc_livetv", true); }
+    public boolean useVlcForLiveTv() { return getPrefs().getBoolean("pref_enable_vlc_livetv", false); }
 
     public int getResumePreroll() {
         try {

--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -829,7 +829,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             mDetailsOverviewRow.addAction(mResumeButton);
             mResumeButton.setVisibility(("Series".equals(mBaseItem.getType()) && ! mBaseItem.getUserData().getPlayed()) || (mBaseItem.getCanResume() ) ? View.VISIBLE : View.GONE);
 
-            TextUnderButton play = new TextUnderButton(this, R.drawable.play, buttonSize, 2, getString(BaseItemUtils.isLiveTv(mBaseItem) ? R.string.lbl_tune_to_channel : mBaseItem.getIsFolder() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
+            TextUnderButton play = new TextUnderButton(this, R.drawable.play, buttonSize, 2, getString(BaseItemUtils.isLiveTv(mBaseItem) ? R.string.lbl_tune_to_channel : mBaseItem.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     play(mBaseItem, 0, false);
@@ -837,7 +837,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             });
             mDetailsOverviewRow.addAction(play);
 
-            if (!mBaseItem.getIsFolder() && !BaseItemUtils.isLiveTv(mBaseItem)) {
+            if (!mBaseItem.getIsFolderItem() && !BaseItemUtils.isLiveTv(mBaseItem)) {
                 queueButton = new TextUnderButton(this, R.drawable.addtoqueue, buttonSize, 2, getString(R.string.lbl_add_to_queue), new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -847,7 +847,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 mDetailsOverviewRow.addAction(queueButton);
             }
 
-            if (mBaseItem.getIsFolder()) {
+            if (mBaseItem.getIsFolderItem()) {
                 TextUnderButton shuffle = new TextUnderButton(this, R.drawable.shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -1329,7 +1329,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         @Override
         public void onClick(final View v) {
             final UserItemDataDto data = mBaseItem.getUserData();
-            if (mBaseItem.getIsFolder()) {
+            if (mBaseItem.getIsFolderItem()) {
                 new AlertDialog.Builder(mActivity)
                         .setTitle(getString(data.getPlayed() ? R.string.lbl_mark_unplayed : R.string.lbl_mark_played))
                         .setMessage(getString(data.getPlayed() ? R.string.lbl_confirm_mark_unwatched : R.string.lbl_confirm_mark_watched))

--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -560,7 +560,7 @@ public class ItemListActivity extends BaseActivity {
 
     private void addButtons(int buttonSize) {
         if (BaseItemUtils.canPlay(mBaseItem)) {
-            TextUnderButton play = new TextUnderButton(this, R.drawable.play, buttonSize, 2, getString(mBaseItem.getIsFolder() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
+            TextUnderButton play = new TextUnderButton(this, R.drawable.play, buttonSize, 2, getString(mBaseItem.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (mItems.size() > 0) {
@@ -573,7 +573,7 @@ public class ItemListActivity extends BaseActivity {
             play.setGotFocusListener(mainAreaFocusListener);
             mButtonRow.addView(play);
             play.requestFocus();
-            if (mBaseItem.getIsFolder()) {
+            if (mBaseItem.getIsFolderItem()) {
                 TextUnderButton shuffle = new TextUnderButton(this, R.drawable.shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/BaseRowItem.java
@@ -26,9 +26,6 @@ import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
 import org.jellyfin.apiclient.model.search.SearchHint;
 
-/**
- * Created by Eric on 12/15/2014.
- */
 public class BaseRowItem {
     private int index;
     private BaseItemDto baseItem;
@@ -137,7 +134,9 @@ public class BaseRowItem {
     public boolean isBaseItem() { return type == ItemType.BaseItem; }
     public boolean getPreferParentThumb() { return preferParentThumb; }
     public ItemType getItemType() { return type; }
-    public boolean isFolder() { return type == ItemType.BaseItem && baseItem != null && baseItem.getIsFolder(); }
+    public boolean isFolder() {
+        return type == ItemType.BaseItem && baseItem != null && baseItem.getIsFolderItem();
+    }
     public boolean showCardInfoOverlay() {return type == ItemType.BaseItem && baseItem != null
             && ("Folder".equals(baseItem.getType()) || "PhotoAlbum".equals(baseItem.getType()) || "RecordingGroup".equals(baseItem.getType())
             || "UserView".equals(baseItem.getType()) || "CollectionFolder".equals(baseItem.getType()) || "Photo".equals(baseItem.getType())

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
@@ -42,9 +42,6 @@ import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.search.SearchHint;
 
-/**
- * Created by Eric on 12/21/2014.
- */
 public class ItemLauncher {
     public static void launch(BaseRowItem rowItem, ItemRowAdapter adapter, int pos, final Activity activity) {
         launch(rowItem, adapter, pos, activity, false);
@@ -170,7 +167,7 @@ public class ItemLauncher {
                 }
 
                 // or generic handling
-                if (baseItem.getIsFolder()) {
+                if (baseItem.getIsFolderItem()) {
                     // open generic folder browsing - but need display prefs
                     TvApp.getApplication().getDisplayPrefsAsync(baseItem.getDisplayPreferencesId(), new Response<DisplayPreferences>() {
                         @Override
@@ -259,7 +256,7 @@ public class ItemLauncher {
                 application.getApiClient().GetItemAsync(hint.getItemId(), application.getCurrentUser().getId(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
-                        if ((response.getIsFolder() && !"Series".equals(response.getType())) || "MusicArtist".equals(response.getType())) {
+                        if ((response.getIsFolderItem() && !"Series".equals(response.getType())) || "MusicArtist".equals(response.getType())) {
                             // open generic folder browsing
                             Intent intent = new Intent(activity, GenericGridActivity.class);
                             intent.putExtra("Folder", TvApp.getApplication().getSerializer().SerializeToString(response));

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -32,9 +32,6 @@ import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 
-/**
- * Created by Eric on 4/17/2015.
- */
 public class KeyProcessor {
 
     public static final int MENU_MARK_FAVORITE = 0;
@@ -258,38 +255,61 @@ public class KeyProcessor {
         int order = 0;
 
         if (rowItem instanceof AudioQueueItem) {
-            if (!(activity instanceof AudioNowPlayingActivity)) menu.getMenu().add(0, MENU_GOTO_NOW_PLAYING, order++, R.string.lbl_goto_now_playing);
-            if (rowItem.getBaseItem() != MediaManager.getCurrentAudioItem()) menu.getMenu().add(0, MENU_ADVANCE_QUEUE, order++, R.string.lbl_play_from_here);
+            if (!(activity instanceof AudioNowPlayingActivity)) {
+                menu.getMenu().add(0, MENU_GOTO_NOW_PLAYING, order++, R.string.lbl_goto_now_playing);
+            }
+            if (rowItem.getBaseItem() != MediaManager.getCurrentAudioItem()) {
+                menu.getMenu().add(0, MENU_ADVANCE_QUEUE, order++, R.string.lbl_play_from_here);
+            }
             // don't allow removal of last item - framework will crash trying to animate an empty row
-            if (MediaManager.getCurrentAudioQueue().size() > 1) menu.getMenu().add(0, MENU_REMOVE_FROM_QUEUE, order++, R.string.lbl_remove_from_queue);
+            if (MediaManager.getCurrentAudioQueue().size() > 1) {
+                menu.getMenu().add(0, MENU_REMOVE_FROM_QUEUE, order++, R.string.lbl_remove_from_queue);
+            }
         } else {
             if (BaseItemUtils.canPlay(item)) {
-                if (item.getIsFolder() && !"MusicAlbum".equals(item.getType()) && !"Playlist".equals(item.getType()) && !"MusicArtist".equals(item.getType()) && userData!= null && userData.getUnplayedItemCount() !=null && userData.getUnplayedItemCount() > 0) menu.getMenu().add(0, MENU_PLAY_FIRST_UNWATCHED, order++, R.string.lbl_play_first_unwatched);
-                menu.getMenu().add(0, MENU_PLAY, order++, item.getIsFolder() ? R.string.lbl_play_all : R.string.lbl_play);
-                if (item.getIsFolder()) menu.getMenu().add(0, MENU_PLAY_SHUFFLE, order++, R.string.lbl_shuffle_all);
-
+                if (item.getIsFolderItem()
+                        && !"MusicAlbum".equals(item.getType())
+                        && !"Playlist".equals(item.getType())
+                        && !"MusicArtist".equals(item.getType())
+                        && userData!= null
+                        && userData.getUnplayedItemCount() !=null
+                        && userData.getUnplayedItemCount() > 0) {
+                    menu.getMenu().add(0, MENU_PLAY_FIRST_UNWATCHED, order++, R.string.lbl_play_first_unwatched);
+                }
+                menu.getMenu().add(0, MENU_PLAY, order++, item.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play);
+                if (item.getIsFolderItem()) {
+                    menu.getMenu().add(0, MENU_PLAY_SHUFFLE, order++, R.string.lbl_shuffle_all);
+                }
             }
-            isMusic = "MusicAlbum".equals(item.getType()) || "MusicArtist".equals(item.getType()) || "Audio".equals(item.getType()) || ("Playlist".equals(item.getType()) && "Audio".equals(item.getMediaType()));
 
-            if (isMusic || !item.getIsFolder()) menu.getMenu().add(0, MENU_ADD_QUEUE, order++, R.string.lbl_add_to_queue);
+            isMusic = "MusicAlbum".equals(item.getType())
+                    || "MusicArtist".equals(item.getType())
+                    || "Audio".equals(item.getType())
+                    || ("Playlist".equals(item.getType()) && "Audio".equals(item.getMediaType()));
+
+            if (isMusic || !item.getIsFolderItem()) {
+                menu.getMenu().add(0, MENU_ADD_QUEUE, order++, R.string.lbl_add_to_queue);
+            }
 
             if (isMusic) {
-                if (!"Playlist".equals(item.getType())) menu.getMenu().add(0, MENU_INSTANT_MIX, order++, R.string.lbl_instant_mix);
+                if (!"Playlist".equals(item.getType())) {
+                    menu.getMenu().add(0, MENU_INSTANT_MIX, order++, R.string.lbl_instant_mix);
+                }
             } else {
-                if (userData != null && userData.getPlayed())
+                if (userData != null && userData.getPlayed()) {
                     menu.getMenu().add(0, MENU_UNMARK_PLAYED, order++, activity.getString(R.string.lbl_mark_unplayed));
-                else
+                } else {
                     menu.getMenu().add(0, MENU_MARK_PLAYED, order++, activity.getString(R.string.lbl_mark_played));
+                }
             }
-
-
         }
 
         if (userData != null) {
-            if (userData.getIsFavorite())
+            if (userData.getIsFavorite()) {
                 menu.getMenu().add(0, MENU_UNMARK_FAVORITE, order++, activity.getString(R.string.lbl_remove_favorite));
-            else
+            } else {
                 menu.getMenu().add(0, MENU_MARK_FAVORITE, order++, activity.getString(R.string.lbl_add_favorite));
+            }
 
             if (userData.getLikes() == null) {
                 menu.getMenu().add(0, MENU_LIKE, order++, activity.getString(R.string.lbl_like));
@@ -309,17 +329,18 @@ public class KeyProcessor {
         mCurrentRowItemNdx = rowItem.getIndex();
         mCurrentItemId = item.getId();
         mCurrentActivity = activity;
-        currentItemIsFolder = item.getIsFolder();
+        currentItemIsFolder = item.getIsFolderItem();
 
         menu.setOnMenuItemClickListener(menuItemClickListener);
         menu.show();
-
     }
 
     private static void createPlayMenu(BaseItemDto item, boolean isFolder, boolean isMusic, BaseActivity activity) {
         PopupMenu menu = Utils.createPopupMenu(activity, activity.getCurrentFocus(), Gravity.RIGHT);
         int order = 0;
-        if (!isMusic && !"Playlist".equals(item.getType())) menu.getMenu().add(0, MENU_PLAY_FIRST_UNWATCHED, order++, R.string.lbl_play_first_unwatched);
+        if (!isMusic && !"Playlist".equals(item.getType())) {
+            menu.getMenu().add(0, MENU_PLAY_FIRST_UNWATCHED, order++, R.string.lbl_play_first_unwatched);
+        }
         menu.getMenu().add(0, MENU_PLAY, order++, R.string.lbl_play_all);
         menu.getMenu().add(0, MENU_PLAY_SHUFFLE, order++, R.string.lbl_shuffle_all);
         if (isMusic) {
@@ -335,7 +356,6 @@ public class KeyProcessor {
 
         menu.setOnMenuItemClickListener(menuItemClickListener);
         menu.show();
-
     }
 
     private static PopupMenu.OnMenuItemClickListener menuItemClickListener = new PopupMenu.OnMenuItemClickListener() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
@@ -33,7 +33,7 @@ public class BaseItemUtils {
                 && (!item.getType().equals("Episode") || !item.getLocationType().equals(LocationType.Virtual)))
                 && (!item.getType().equals("Person"))
                 && (!item.getType().equals("SeriesTimer"))
-                && (!item.getIsFolder() || item.getChildCount() == null || item.getChildCount() > 0);
+                && (!item.getIsFolderItem() || item.getChildCount() == null || item.getChildCount() > 0);
     }
 
     public static String getFullName(BaseItemDto item) {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -125,11 +125,11 @@
             <!--/>-->
         <CheckBoxPreference android:key="pref_live_direct"
             android:title="@string/lbl_direct_stream_live"
-            android:defaultValue="false"
+            android:defaultValue="true"
             />
         <CheckBoxPreference android:key="pref_enable_vlc_livetv"
             android:title="@string/lbl_use_vlc_livetv"
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:summary="@string/desc_use_vlc_livetv"
             />
         <CheckBoxPreference android:key="pref_live_tv_use_external"


### PR DESCRIPTION
* Fixes NPE caused by `getIsFolder()` returning null value. `getIsFolderItem` coerces null to a boolean value.
* Changes default settings for Live TV to direct play by default

:warning:  This does not fix issues with playing a transcoded live tv stream.