### PR TITLE
Remove space from application name

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
@@ -165,7 +165,7 @@ public class StartupActivity extends Activity {
                 jsonSerializer,
                 logger,
                 volleyHttpClient,
-                "Android TV",
+                "AndroidTV",
                 BuildConfig.VERSION_NAME,
                 new AndroidDevice(application),
                 capabilities,


### PR DESCRIPTION
For some reason, having a space in the application name is causing issues with displaying seasons in the app. I'm removing it temporarily until a proper solution can be found.