### PR TITLE
Fix NPE on startup when local address is null

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/BaseRowItem.java
@@ -361,7 +361,7 @@ public class BaseRowItem {
                 Long pos = chapterInfo.getStartPositionTicks() / 10000;
                 return TimeUtils.formatMillis(pos.intValue());
             case Server:
-                return serverInfo.getLocalAddress().substring(7);
+                return serverInfo.getLocalAddress() != null ? serverInfo.getLocalAddress().substring(7) : "";
             case LiveTvChannel:
                 return channelInfo.getNumber();
             case LiveTvProgram:


### PR DESCRIPTION
Should fix the crash on startup as reported [on Reddit](https://old.reddit.com/r/jellyfin/comments/c4femc/androidtv_client_does_not_load_after_leaving/).