### PR TITLE
Fix crash due to null context in RecommendationBuilder

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/RecommendationBuilder.java
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/RecommendationBuilder.java
@@ -100,7 +100,7 @@ public class RecommendationBuilder {
                         .setPriority(mPriority)
                         .setLocalOnly(true)
                         .setOngoing(true)
-                        .setColor(Utils.getBrandColor())
+                        .setColor(Utils.getBrandColor(mContext))
                         .setCategory(Notification.CATEGORY_RECOMMENDATION)
                         .setLargeIcon(mBitmap)
                         .setSmallIcon(mSmallIcon)

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -212,9 +212,11 @@ public class Utils {
     }
 
     public static int getThemeColor(int resourceId) {
-        TypedArray styledAttributes = TvApp.getApplication()
-                .getCurrentActivity()
-                .getTheme()
+        return getThemeColor(TvApp.getApplication().getCurrentActivity(), resourceId);
+    }
+
+    public static int getThemeColor(Context context, int resourceId) {
+        TypedArray styledAttributes = context.getTheme()
                 .obtainStyledAttributes(new int[] { resourceId });
         int themeColor = styledAttributes.getColor(0, 0);
         styledAttributes.recycle();
@@ -224,6 +226,10 @@ public class Utils {
 
     public static int getBrandColor() {
         return getThemeColor(android.R.attr.colorPrimary);
+    }
+
+    public static int getBrandColor(Context context) {
+        return getThemeColor(context, android.R.attr.colorPrimary);
     }
 
     public static void processPasswordEntry(Activity activity, UserDto user) {


### PR DESCRIPTION
Fixes a crash in `RecommendationBuilder` when Jellyfin is in the background. Seems like this may be the cause of #122.