### PR TITLE
Fix error when libvlc is not properly released

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
@@ -477,10 +477,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         mVlcPlayer.stop();
         mVlcPlayer.getVLCVout().detachViews();
         mVlcPlayer.release();
+        mLibVLC.release();
         mLibVLC = null;
         mVlcPlayer = null;
         mSurfaceView.setKeepScreenOn(false);
-
     }
 
     int normalWidth;


### PR DESCRIPTION
Addresses the following error with libvlc objects not being released. I have not noticed if this actually causes any errors in the client though.
```
org.jellyfin.androidtv.debug E/System: java.lang.AssertionError: VLCObject (org.videolan.libvlc.LibVLC) finalized but not natively released (1 refs)
        at org.videolan.libvlc.VLCObject.finalize(VLCObject.java:97)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:250)
        at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:237)
        at java.lang.Daemons$Daemon.run(Daemons.java:103)
        at java.lang.Thread.run(Thread.java:764)
```