### PR TITLE
Fix exception due to adding elements to fixed length arrays

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -180,7 +180,7 @@ public class ProfileHelper {
             ContainerTypes.WTV
         );
         videoDirectPlayProfile.setContainer(Utils.join(",", videoContainers));
-        List<String> audioCodecs = Arrays.asList(
+        List<String> audioCodecs = new ArrayList<>(Arrays.asList(
             CodecTypes.AAC,
             CodecTypes.MP3,
             CodecTypes.MP2,
@@ -195,7 +195,7 @@ public class ProfileHelper {
             CodecTypes.OPUS,
             CodecTypes.FLAC,
             CodecTypes.TRUEHD
-        );
+        ));
         if (!Utils.downMixAudio() && isLiveTv) {
             audioCodecs.add(CodecTypes.AAC_LATM);
         }
@@ -316,14 +316,14 @@ public class ProfileHelper {
                 TvApp.getApplication().getLogger().Info("*** Excluding DTS and AC3 audio from direct play due to compatible audio setting");
                 videoDirectPlayProfile.setAudioCodec(Utils.join(",", CodecTypes.AAC, CodecTypes.MP3, CodecTypes.MP2));
             } else {
-                List<String> audioCodecs = Arrays.asList(
+                List<String> audioCodecs = new ArrayList<>(Arrays.asList(
                     CodecTypes.AAC,
                     CodecTypes.AC3,
                     CodecTypes.EAC3,
                     CodecTypes.AAC_LATM,
                     CodecTypes.MP3,
                     CodecTypes.MP2
-                );
+                ));
                 if (allowDTS) {
                     audioCodecs.add(CodecTypes.DCA);
                     audioCodecs.add(CodecTypes.DTS);


### PR DESCRIPTION
This wraps `Arrays.toList()` calls in an `ArrayList` if elements are later added to the `List`. This was causing an exception due to `Arrays.toList()` creating a fixed length `List`.