### PR TITLE
Add Azure Pipelines config

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,0 +1,15 @@
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: Gradle@2
+  inputs:
+    gradleWrapperFile: 'gradlew'
+    tasks: 'build'
+    publishJUnitResults: true
+    testResultsFiles: '**/TEST-*.xml'
+    javaHomeOption: 'JDKVersion'
+    sonarQubeRunAnalysis: false


### PR DESCRIPTION
* Adds an Azure Pipelines config for building the app and running unit tests

See: https://github.com/thornbill/jellyfin-androidtv/pull/1/checks

@jellyfin/core someone with access will need to set this up on the Azure side.