### PR TITLE
Revert to 0.9.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.application'
-def version = "0.9.1"
+def version = "0.10.1"
 
 android {
     compileSdkVersion 28
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 901
+        versionCode 903
         versionName version
     }
 


### PR DESCRIPTION
Updating build.gradle to have a higher version number than the currently published 0.10.0. This is needed in order to roll it back for Google Play.