### PR TITLE
Set errexit in gradlew

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -6,6 +6,8 @@
 ##
 ##############################################################################
 
+set -o errexit
+
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
 PRG="$0"


### PR DESCRIPTION
Will cause failing builds to abort properly.