### PR TITLE
Fix video codec in transcode profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -48,7 +48,7 @@ public class ProfileHelper {
 //
 //        } else {
             transProfile.setContainer(ContainerTypes.MKV);
-            transProfile.setVideoCodec(ContainerTypes.MP4);
+            transProfile.setVideoCodec(CodecTypes.H264);
             transProfile.setAudioCodec(Utils.join(",", CodecTypes.AAC, CodecTypes.MP3));
             transProfile.setType(DlnaProfileType.Video);
             transProfile.setContext(EncodingContext.Streaming);


### PR DESCRIPTION
Fixes a regression in the transcode profile causing the app to request an invalid video codec.
See https://github.com/jellyfin/jellyfin-androidtv/commit/5565cbc475412bae4607b3b2c8fd763dddb99f4a#diff-4143bb1939f6bb0e2bc74743e0eae2f5R51

Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/180