### PR TITLE
Fix version check when no servers in response

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
@@ -181,7 +181,8 @@ public class StartupActivity extends Activity {
                     }
 
                     // Check the server version
-                    if (!AuthenticationHelper.isSupportedServerVersion(response.getServers().get(0))) {
+                    if (!response.getServers().isEmpty() &&
+                            !AuthenticationHelper.isSupportedServerVersion(response.getServers().get(0))) {
                         Utils.showToast(activity, activity.getString(R.string.msg_error_server_version, TvApp.MINIMUM_SERVER_VERSION));
                         AuthenticationHelper.automaticSignIn(connectionManager, activity);
                         return;

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
@@ -98,7 +98,8 @@ public class AuthenticationHelper {
 //                message.Cancel();
 
                 // Check the server version
-                if (!isSupportedServerVersion(serverResult.getServers().get(0))) {
+                if (!serverResult.getServers().isEmpty() &&
+                        !isSupportedServerVersion(serverResult.getServers().get(0))) {
                     Utils.showToast(activity, activity.getString(R.string.msg_error_server_version, TvApp.MINIMUM_SERVER_VERSION));
                     return;
                 }


### PR DESCRIPTION
Fixes a crash when the response does not include a server for some reason (invalid url, server offline, etc.).

Refs: #177 