### PR TITLE
Fix using DelayedMessage on not the main ui thread

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/DelayedMessage.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DelayedMessage.java
@@ -4,28 +4,31 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.Handler;
 
+import androidx.annotation.NonNull;
+
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 
-/**
- * Created by Eric on 12/28/2014.
- */
 public class DelayedMessage {
-    private String title = TvApp.getApplication().getString(R.string.lbl_please_wait);
-    private String message = TvApp.getApplication().getString(R.string.msg_little_longer);
-    private Runnable runnable;
+    private final String title;
+    private final String message;
+    private final Handler handler;
+    private final Runnable runnable;
     private ProgressDialog dialog;
-    private Handler handler;
 
-    public DelayedMessage(final Context activity) {
+    public DelayedMessage(@NonNull final Context activity) {
         this(activity, 750);
     }
-    public DelayedMessage(final Context activity, int delay) {
-        handler = new Handler();
+
+    public DelayedMessage(@NonNull final Context activity, int delay) {
+        title = TvApp.getApplication().getString(R.string.lbl_please_wait);
+        message = TvApp.getApplication().getString(R.string.msg_little_longer);
+
+        handler = new Handler(activity.getMainLooper());
         runnable = new Runnable() {
             @Override
             public void run() {
-                if (activity != null) dialog = ProgressDialog.show(activity, title, message);
+                dialog = ProgressDialog.show(activity, title, message);
             }
         };
         handler.postDelayed(runnable, delay);
@@ -33,6 +36,8 @@ public class DelayedMessage {
 
     public void Cancel() {
         handler.removeCallbacks(runnable);
-        if (dialog != null) dialog.dismiss();
+        if (dialog != null) {
+            dialog.dismiss();
+        }
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
@@ -90,12 +90,12 @@ public class AuthenticationHelper {
 
     private static Response<ConnectionResult> getSignInResponse(final Activity activity, final String address) {
         // This is taking longer than expected message
-//        final DelayedMessage message = new DelayedMessage(activity);
+        final DelayedMessage message = new DelayedMessage(activity);
 
         return new Response<ConnectionResult>() {
             @Override
             public void onResponse(ConnectionResult serverResult) {
-//                message.Cancel();
+                message.Cancel();
 
                 // Check the server version
                 if (!isSupportedServerVersion(serverResult.getServers().get(0))) {
@@ -124,7 +124,7 @@ public class AuthenticationHelper {
 
             @Override
             public void onError(Exception exception) {
-//                message.Cancel();
+                message.Cancel();
                 TvApp.getApplication().getLogger().ErrorException("Error trying to sign in to specific server " + address, exception);
                 Utils.showToast(activity, activity.getString(R.string.msg_error_connecting_server));
             }


### PR DESCRIPTION
Follow up on #182 with a proper fix.

Passing `activity.getMainLooper()` to the `Handler` constructor ensures that it has the proper reference to the main UI thread.