### PR TITLE
Fix search with denied permissions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/search/SearchActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/search/SearchActivity.java
@@ -8,11 +8,11 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.base.BaseActivity;
 
 public class SearchActivity extends BaseActivity {
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (SpeechRecognizer.isRecognitionAvailable(TvApp.getApplication())) {
+        if (TvApp.getApplication().isVoiceSearchAllowed() &&
+                SpeechRecognizer.isRecognitionAvailable(TvApp.getApplication())) {
             setContentView(R.layout.activity_search);
         } else {
             setContentView(R.layout.activity_search_no_speech);


### PR DESCRIPTION
Fixes an issue where the `onRequestPermissionsResult` callback is never called and the search activity was never displayed if the `RECORD_AUDIO` permission was denied.

cc @joshuaboniface 