### PR TITLE
Use ${applicationId} in authorities so the ".debug" prefix is applied while developing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,7 +82,7 @@
         </receiver>
 
         <provider
-            android:authorities="org.jellyfin.androidtv.recommendations"
+            android:authorities="${applicationId}.recommendations"
             android:name=".integration.RecommendationContentProvider"
             android:exported="true"
             android:grantUriPermissions="true"


### PR DESCRIPTION
When I tried running my locally clones version of the Jellyfin Android TV app I wan't able to because I have the stable version installed from the Play Store and this caused a conflict with the recommendation provider. By using the `${applicationId}` variable the key is automatically applied for the current build type (release / debug) of the app.