### PR TITLE
Replace string usages for BaseItemDto.Type with the EBaseItemType

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,13 +43,13 @@ dependencies {
     googleImplementation 'com.devbrackets.android:exomedia:2.5.6'
     googleImplementation 'com.google.android.exoplayer:exoplayer:r1.5.6'
 
-    // This is split like this: because this is a modular gradle project on jitpack
+    // This is split like this because this is a modular gradle project on jitpack
     // see https://github.com/jitpack/gradle-modular
     // The split allows dependency substitution to work in the settings.gradle file,
     // at least for the 'library' part. 'android' part is still broken somehow, but this
     // is better than nothing.
-    implementation 'com.github.jellyfin.jellyfin-apiclient-java:android:v0.4.0'
-    implementation 'com.github.jellyfin.jellyfin-apiclient-java:library:v0.4.0'
+    implementation 'com.github.jellyfin.jellyfin-apiclient-java:android:v0.5.0'
+    implementation 'com.github.jellyfin.jellyfin-apiclient-java:library:v0.5.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.leanback:leanback:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     // The split allows dependency substitution to work in the settings.gradle file,
     // at least for the 'library' part. 'android' part is still broken somehow, but this
     // is better than nothing.
-    implementation 'com.github.jellyfin.jellyfin-apiclient-java:android:v0.5.0'
-    implementation 'com.github.jellyfin.jellyfin-apiclient-java:library:v0.5.0'
+    implementation 'com.github.jellyfin.jellyfin-apiclient-java:android:master-SNAPSHOT'
+    implementation 'com.github.jellyfin.jellyfin-apiclient-java:library:master-SNAPSHOT'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.leanback:leanback:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -45,6 +45,7 @@ import org.jellyfin.apiclient.interaction.VolleyHttpClient;
 import org.jellyfin.apiclient.logging.AndroidLogger;
 import org.jellyfin.apiclient.model.configuration.ServerConfiguration;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 import org.jellyfin.apiclient.model.logging.ILogger;
@@ -294,23 +295,23 @@ public class TvApp extends Application {
         return getPrefs().getString("pref_login_behavior", "0").equals("1") && getConfiguredAutoCredentials().getServerInfo().getId() != null;
     }
 
-    public boolean useExternalPlayer(String itemType) {
+    public boolean useExternalPlayer(EBaseItemType itemType) {
         switch (itemType) {
-            case "Movie":
-            case "Episode":
-            case "Video":
-            case "Series":
-            case "Recording":
+            case Movie:
+            case Episode:
+            case Video:
+            case Series:
+            case Recording:
                 return getPrefs().getBoolean("pref_video_use_external", false);
-            case "TvChannel":
-            case "Program":
+            case TvChannel:
+            case Program:
                 return getPrefs().getBoolean("pref_live_tv_use_external", false);
             default:
                 return false;
         }
     }
 
-    public Class getPlaybackActivityClass(String itemType) {
+    public Class getPlaybackActivityClass(EBaseItemType itemType) {
         return useExternalPlayer(itemType) ? ExternalPlayerActivity.class : PlaybackOverlayActivity.class;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -45,7 +45,7 @@ import org.jellyfin.apiclient.interaction.VolleyHttpClient;
 import org.jellyfin.apiclient.logging.AndroidLogger;
 import org.jellyfin.apiclient.model.configuration.ServerConfiguration;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 import org.jellyfin.apiclient.model.logging.ILogger;
@@ -295,7 +295,7 @@ public class TvApp extends Application {
         return getPrefs().getString("pref_login_behavior", "0").equals("1") && getConfiguredAutoCredentials().getServerInfo().getId() != null;
     }
 
-    public boolean useExternalPlayer(EBaseItemType itemType) {
+    public boolean useExternalPlayer(BaseItemType itemType) {
         switch (itemType) {
             case Movie:
             case Episode:
@@ -311,7 +311,7 @@ public class TvApp extends Application {
         }
     }
 
-    public Class getPlaybackActivityClass(EBaseItemType itemType) {
+    public Class getPlaybackActivityClass(BaseItemType itemType) {
         return useExternalPlayer(itemType) ? ExternalPlayerActivity.class : PlaybackOverlayActivity.class;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseGridFragment.java
@@ -6,6 +6,7 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.model.ChangeTriggerType;
 import org.jellyfin.androidtv.querying.StdItemQuery;
 
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 
@@ -30,7 +31,7 @@ public class BrowseGridFragment extends StdGridFragment {
     protected void setupQueries(IGridLoader gridLoader) {
         StdItemQuery query = new StdItemQuery(new ItemFields[] {ItemFields.PrimaryImageAspectRatio});
         query.setParentId(mParentId);
-        if (mFolder.getType().equals("UserView") || mFolder.getType().equals("CollectionFolder")) {
+        if (mFolder.getEBaseItemType() == EBaseItemType.UserView || mFolder.getEBaseItemType() == EBaseItemType.CollectionFolder) {
             String type = mFolder.getCollectionType() != null ? mFolder.getCollectionType().toLowerCase() : "";
             switch (type) {
                 case "movies":

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseGridFragment.java
@@ -6,7 +6,7 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.model.ChangeTriggerType;
 import org.jellyfin.androidtv.querying.StdItemQuery;
 
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 
@@ -31,7 +31,7 @@ public class BrowseGridFragment extends StdGridFragment {
     protected void setupQueries(IGridLoader gridLoader) {
         StdItemQuery query = new StdItemQuery(new ItemFields[] {ItemFields.PrimaryImageAspectRatio});
         query.setParentId(mParentId);
-        if (mFolder.getEBaseItemType() == EBaseItemType.UserView || mFolder.getEBaseItemType() == EBaseItemType.CollectionFolder) {
+        if (mFolder.getBaseItemType() == BaseItemType.UserView || mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {
             String type = mFolder.getCollectionType() != null ? mFolder.getCollectionType().toLowerCase() : "";
             switch (type) {
                 case "movies":

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseRecordingsFragment.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.livetv.RecordingGroupQuery;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
@@ -120,7 +120,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                             programInfo.setChannelName(timer.getChannelName());
                             programInfo.setName(Utils.getSafeValue(timer.getName(), "Unknown"));
                             TvApp.getApplication().getLogger().Warn("No program info for timer %s.  Creating one...", programInfo.getName());
-                            programInfo.setEBaseItemType(EBaseItemType.Program);
+                            programInfo.setBaseItemType(BaseItemType.Program);
                             programInfo.setTimerId(timer.getId());
                             programInfo.setSeriesTimerId(timer.getSeriesTimerId());
                             programInfo.setStartDate(timer.getStartDate());

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseRecordingsFragment.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.livetv.RecordingGroupQuery;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
@@ -119,7 +120,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                             programInfo.setChannelName(timer.getChannelName());
                             programInfo.setName(Utils.getSafeValue(timer.getName(), "Unknown"));
                             TvApp.getApplication().getLogger().Warn("No program info for timer %s.  Creating one...", programInfo.getName());
-                            programInfo.setType("Program");
+                            programInfo.setEBaseItemType(EBaseItemType.Program);
                             programInfo.setTimerId(timer.getId());
                             programInfo.setSeriesTimerId(timer.getSeriesTimerId());
                             programInfo.setStartDate(timer.getStartDate());

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
@@ -258,7 +259,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                                             programInfo.setChannelName(timer.getChannelName());
                                             programInfo.setName(Utils.getSafeValue(timer.getName(), "Unknown"));
                                             TvApp.getApplication().getLogger().Warn("No program info for timer %s.  Creating one...", programInfo.getName());
-                                            programInfo.setType("Program");
+                                            programInfo.setEBaseItemType(EBaseItemType.Program);
                                             programInfo.setTimerId(timer.getId());
                                             programInfo.setSeriesTimerId(timer.getSeriesTimerId());
                                             programInfo.setStartDate(timer.getStartDate());

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
@@ -259,7 +259,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                                             programInfo.setChannelName(timer.getChannelName());
                                             programInfo.setName(Utils.getSafeValue(timer.getName(), "Unknown"));
                                             TvApp.getApplication().getLogger().Warn("No program info for timer %s.  Creating one...", programInfo.getName());
-                                            programInfo.setEBaseItemType(EBaseItemType.Program);
+                                            programInfo.setBaseItemType(BaseItemType.Program);
                                             programInfo.setTimerId(timer.getId());
                                             programInfo.setSeriesTimerId(timer.getSeriesTimerId());
                                             programInfo.setStartDate(timer.getStartDate());

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/EnhancedBrowseFragment.java
@@ -60,7 +60,7 @@ import java.util.TimerTask;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 
 public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
@@ -113,7 +113,7 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
         super.onCreate(savedInstanceState);
         BaseItemDto item = new BaseItemDto();
         item.setId(ItemListActivity.FAV_SONGS);
-        item.setEBaseItemType(EBaseItemType.Playlist);
+        item.setBaseItemType(BaseItemType.Playlist);
         item.setIsFolder(true);
 
         favSongsRowItem = new BaseRowItem(0, item);
@@ -389,8 +389,8 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
     }
 
     private void refreshCurrentItem() {
-        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != EBaseItemType.Photo && mCurrentItem.getBaseItemType() != EBaseItemType.MusicArtist
-                && mCurrentItem.getBaseItemType() != EBaseItemType.MusicAlbum && mCurrentItem.getBaseItemType() != EBaseItemType.Playlist) {
+        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != BaseItemType.Photo && mCurrentItem.getBaseItemType() != BaseItemType.MusicArtist
+                && mCurrentItem.getBaseItemType() != BaseItemType.MusicAlbum && mCurrentItem.getBaseItemType() != BaseItemType.Playlist) {
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override
                 public void onResponse() {

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/EnhancedBrowseFragment.java
@@ -60,6 +60,7 @@ import java.util.TimerTask;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 
 public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
@@ -112,7 +113,7 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
         super.onCreate(savedInstanceState);
         BaseItemDto item = new BaseItemDto();
         item.setId(ItemListActivity.FAV_SONGS);
-        item.setType("Playlist");
+        item.setEBaseItemType(EBaseItemType.Playlist);
         item.setIsFolder(true);
 
         favSongsRowItem = new BaseRowItem(0, item);
@@ -388,8 +389,8 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
     }
 
     private void refreshCurrentItem() {
-        if (mCurrentItem != null && !"Photo".equals(mCurrentItem.getType()) && !"MusicArtist".equals(mCurrentItem.getType())
-                && !"MusicAlbum".equals(mCurrentItem.getType()) && !"Playlist".equals(mCurrentItem.getType())) {
+        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != EBaseItemType.Photo && mCurrentItem.getBaseItemType() != EBaseItemType.MusicArtist
+                && mCurrentItem.getBaseItemType() != EBaseItemType.MusicAlbum && mCurrentItem.getBaseItemType() != EBaseItemType.Playlist) {
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override
                 public void onResponse() {

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
@@ -9,7 +9,7 @@ import org.jellyfin.androidtv.querying.StdItemQuery;
 import java.util.Arrays;
 
 import org.jellyfin.androidtv.util.Utils;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
@@ -24,12 +24,12 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
 
     }
 
-    private static EBaseItemType[] showSpecialViewTypes = new EBaseItemType[] {EBaseItemType.CollectionFolder, EBaseItemType.Folder, EBaseItemType.UserView, EBaseItemType.ChannelFolderItem };
+    private static BaseItemType[] showSpecialViewTypes = new BaseItemType[] {BaseItemType.CollectionFolder, BaseItemType.Folder, BaseItemType.UserView, BaseItemType.ChannelFolderItem };
 
     @Override
     protected void setupQueries(IRowLoader rowLoader) {
 
-        if (mFolder.getEBaseItemType() == EBaseItemType.RecordingGroup){
+        if (mFolder.getBaseItemType() == BaseItemType.RecordingGroup){
             RecordingQuery query = new RecordingQuery();
             query.setUserId(TvApp.getApplication().getCurrentUser().getId());
             query.setGroupId(mFolder.getId());
@@ -39,14 +39,14 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
         } else {
 
             if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0 ||
-                    mFolder.getEBaseItemType() == EBaseItemType.Channel ||
-                    mFolder.getEBaseItemType() == EBaseItemType.ChannelFolderItem ||
-                    mFolder.getEBaseItemType() == EBaseItemType.UserView ||
-                    mFolder.getEBaseItemType() == EBaseItemType.CollectionFolder) {
-                boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getEBaseItemType()) && !"channels".equals(mFolder.getCollectionType());
+                    mFolder.getBaseItemType() == BaseItemType.Channel ||
+                    mFolder.getBaseItemType() == BaseItemType.ChannelFolderItem ||
+                    mFolder.getBaseItemType() == BaseItemType.UserView ||
+                    mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {
+                boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getBaseItemType()) && !"channels".equals(mFolder.getCollectionType());
 
                 if (showSpecialViews) {
-                    if (mFolder.getEBaseItemType() != EBaseItemType.ChannelFolderItem) {
+                    if (mFolder.getBaseItemType() != BaseItemType.ChannelFolderItem) {
                         StdItemQuery resume = new StdItemQuery();
                         resume.setParentId(mFolder.getId());
                         resume.setLimit(50);

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.querying.StdItemQuery;
 import java.util.Arrays;
 
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
@@ -23,12 +24,12 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
 
     }
 
-    private static String[] showSpecialViewTypes = new String[] {"CollectionFolder", "Folder", "UserView", "ChannelFolderItem"};
+    private static EBaseItemType[] showSpecialViewTypes = new EBaseItemType[] {EBaseItemType.CollectionFolder, EBaseItemType.Folder, EBaseItemType.UserView, EBaseItemType.ChannelFolderItem };
 
     @Override
     protected void setupQueries(IRowLoader rowLoader) {
 
-        if (mFolder.getType().equals("RecordingGroup")){
+        if (mFolder.getEBaseItemType() == EBaseItemType.RecordingGroup){
             RecordingQuery query = new RecordingQuery();
             query.setUserId(TvApp.getApplication().getCurrentUser().getId());
             query.setGroupId(mFolder.getId());
@@ -38,14 +39,14 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
         } else {
 
             if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0 ||
-                    mFolder.getType().equals("Channel") ||
-                    mFolder.getType().equals("ChannelFolderItem") ||
-                    mFolder.getType().equals("UserView") ||
-                    mFolder.getType().equals("CollectionFolder")) {
-                boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getType()) && !"channels".equals(mFolder.getCollectionType());
+                    mFolder.getEBaseItemType() == EBaseItemType.Channel ||
+                    mFolder.getEBaseItemType() == EBaseItemType.ChannelFolderItem ||
+                    mFolder.getEBaseItemType() == EBaseItemType.UserView ||
+                    mFolder.getEBaseItemType() == EBaseItemType.CollectionFolder) {
+                boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getEBaseItemType()) && !"channels".equals(mFolder.getCollectionType());
 
                 if (showSpecialViews) {
-                    if (!mFolder.getType().equals("ChannelFolderItem")) {
+                    if (mFolder.getEBaseItemType() != EBaseItemType.ChannelFolderItem) {
                         StdItemQuery resume = new StdItemQuery();
                         resume.setParentId(mFolder.getId());
                         resume.setLimit(50);

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/StdBrowseFragment.java
@@ -67,6 +67,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import org.jellyfin.apiclient.interaction.EmptyResponse;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 
 public class StdBrowseFragment extends BrowseFragment implements IRowLoader {
     private static final String TAG = "StdBrowseFragment";
@@ -400,7 +401,7 @@ public class StdBrowseFragment extends BrowseFragment implements IRowLoader {
     }
 
     private void refreshCurrentItem() {
-        if (mCurrentItem != null && !mCurrentItem.getType().equals("UserView") && !mCurrentItem.getType().equals("CollectionFolder")) {
+        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != EBaseItemType.UserView && mCurrentItem.getBaseItemType() != EBaseItemType.CollectionFolder) {
             TvApp.getApplication().getLogger().Debug("Refresh item "+mCurrentItem.getFullName());
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/StdBrowseFragment.java
@@ -67,7 +67,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import org.jellyfin.apiclient.interaction.EmptyResponse;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 
 public class StdBrowseFragment extends BrowseFragment implements IRowLoader {
     private static final String TAG = "StdBrowseFragment";
@@ -401,7 +401,7 @@ public class StdBrowseFragment extends BrowseFragment implements IRowLoader {
     }
 
     private void refreshCurrentItem() {
-        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != EBaseItemType.UserView && mCurrentItem.getBaseItemType() != EBaseItemType.CollectionFolder) {
+        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != BaseItemType.UserView && mCurrentItem.getBaseItemType() != BaseItemType.CollectionFolder) {
             TvApp.getApplication().getLogger().Debug("Refresh item "+mCurrentItem.getFullName());
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/StdGridFragment.java
@@ -73,7 +73,7 @@ import java.util.TimerTask;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 
 public class StdGridFragment extends HorizontalGridFragment implements IGridLoader {
@@ -451,7 +451,7 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
         toolBar.addView(new ImageButton(getActivity(), R.drawable.ic_search, size, new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                TvApp.getApplication().showSearch(getActivity(), "music".equals(mFolder.getCollectionType()) || mFolder.getEBaseItemType() == EBaseItemType.MusicAlbum || mFolder.getEBaseItemType() == EBaseItemType.MusicArtist);
+                TvApp.getApplication().showSearch(getActivity(), "music".equals(mFolder.getCollectionType()) || mFolder.getBaseItemType() == BaseItemType.MusicAlbum || mFolder.getBaseItemType() == BaseItemType.MusicArtist);
             }
         }));
 
@@ -589,8 +589,8 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
             getGridPresenter().setPosition(MediaManager.getCurrentMediaPosition());
             MediaManager.setCurrentMediaPosition(-1); // re-set so it doesn't mess with parent views
         }
-        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != EBaseItemType.Photo && mCurrentItem.getBaseItemType() != EBaseItemType.PhotoAlbum
-                && mCurrentItem.getBaseItemType() != EBaseItemType.MusicArtist && mCurrentItem.getBaseItemType() != EBaseItemType.MusicAlbum) {
+        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != BaseItemType.Photo && mCurrentItem.getBaseItemType() != BaseItemType.PhotoAlbum
+                && mCurrentItem.getBaseItemType() != BaseItemType.MusicArtist && mCurrentItem.getBaseItemType() != BaseItemType.MusicAlbum) {
             TvApp.getApplication().getLogger().Debug("Refresh item "+mCurrentItem.getFullName());
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/StdGridFragment.java
@@ -73,6 +73,7 @@ import java.util.TimerTask;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 
 public class StdGridFragment extends HorizontalGridFragment implements IGridLoader {
@@ -450,7 +451,7 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
         toolBar.addView(new ImageButton(getActivity(), R.drawable.ic_search, size, new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                TvApp.getApplication().showSearch(getActivity(), "music".equals(mFolder.getCollectionType()) || "MusicAlbum".equals(mFolder.getType()) || "MusicArtist".equals(mFolder.getType()));
+                TvApp.getApplication().showSearch(getActivity(), "music".equals(mFolder.getCollectionType()) || mFolder.getEBaseItemType() == EBaseItemType.MusicAlbum || mFolder.getEBaseItemType() == EBaseItemType.MusicArtist);
             }
         }));
 
@@ -588,8 +589,8 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
             getGridPresenter().setPosition(MediaManager.getCurrentMediaPosition());
             MediaManager.setCurrentMediaPosition(-1); // re-set so it doesn't mess with parent views
         }
-        if (mCurrentItem != null && !"Photo".equals(mCurrentItem.getType()) && !"PhotoAlbum".equals(mCurrentItem.getType())
-                && !"MusicArtist".equals(mCurrentItem.getType()) && !"MusicAlbum".equals(mCurrentItem.getType())) {
+        if (mCurrentItem != null && mCurrentItem.getBaseItemType() != EBaseItemType.Photo && mCurrentItem.getBaseItemType() != EBaseItemType.PhotoAlbum
+                && mCurrentItem.getBaseItemType() != EBaseItemType.MusicArtist && mCurrentItem.getBaseItemType() != EBaseItemType.MusicAlbum) {
             TvApp.getApplication().getLogger().Debug("Refresh item "+mCurrentItem.getFullName());
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override

--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -77,7 +77,7 @@ import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
@@ -170,7 +170,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         registerMessageListener(new IMessageListener() {
             @Override
             public void onMessageReceived(CustomMessage message) {
-                if (message == CustomMessage.ActionComplete && mSeriesTimerInfo != null && mBaseItem.getEBaseItemType() == EBaseItemType.SeriesTimer) {
+                if (message == CustomMessage.ActionComplete && mSeriesTimerInfo != null && mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) {
                     //update info
                     mApplication.getApiClient().GetLiveTvSeriesTimerAsync(mSeriesTimerInfo.getId(), new Response<SeriesTimerInfoDto>() {
                         @Override
@@ -207,11 +207,11 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         rotateBackdrops();
 
         //Update information that may have changed - delay slightly to allow changes to take on the server
-        if (mApplication.getLastPlayback().after(mLastUpdated) && mBaseItem.getEBaseItemType() != EBaseItemType.MusicArtist) {
+        if (mApplication.getLastPlayback().after(mLastUpdated) && mBaseItem.getBaseItemType() != BaseItemType.MusicArtist) {
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    if (mBaseItem.getEBaseItemType() == EBaseItemType.Episode && mApplication.getLastPlayback().after(mLastUpdated) && mApplication.getLastPlayedItem() != null && !mBaseItem.getId().equals(mApplication.getLastPlayedItem().getId()) && mApplication.getLastPlayedItem().getEBaseItemType() == EBaseItemType.Episode) {
+                    if (mBaseItem.getBaseItemType() == BaseItemType.Episode && mApplication.getLastPlayback().after(mLastUpdated) && mApplication.getLastPlayedItem() != null && !mBaseItem.getId().equals(mApplication.getLastPlayedItem().getId()) && mApplication.getLastPlayedItem().getBaseItemType() == BaseItemType.Episode) {
                         mApplication.getLogger().Info("Re-loading after new episode playback");
                         loadItem(mApplication.getLastPlayedItem().getId());
                         mApplication.setLastPlayedItem(null); //blank this out so a detail screen we back up to doesn't also do this
@@ -223,7 +223,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                                 if (!isFinishing()) {
                                     mBaseItem = response;
                                     if (mResumeButton != null) {
-                                        mResumeButton.setVisibility((mBaseItem.getEBaseItemType() == EBaseItemType.Series && ! mBaseItem.getUserData().getPlayed()) || response.getCanResume() ? View.VISIBLE : View.GONE);
+                                        mResumeButton.setVisibility((mBaseItem.getBaseItemType() == BaseItemType.Series && ! mBaseItem.getUserData().getPlayed()) || response.getCanResume() ? View.VISIBLE : View.GONE);
                                         if (response.getCanResume()){
                                             mResumeButton.setText(String.format(getString(R.string.lbl_resume_from), TimeUtils.formatMillis((response.getUserData().getPlaybackPositionTicks()/10000) - mApplication.getResumePreroll())));
                                         }
@@ -294,25 +294,25 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         }
     }
 
-    private static EBaseItemType[] buttonTypes = new EBaseItemType[] {
-        EBaseItemType.Episode,
-        EBaseItemType.Movie,
-        EBaseItemType.Series,
-        EBaseItemType.Season,
-        EBaseItemType.Folder,
-        EBaseItemType.Video,
-        EBaseItemType.Recording,
-        EBaseItemType.Program,
-        EBaseItemType.ChannelVideoItem,
-        EBaseItemType.Trailer,
-        EBaseItemType.MusicArtist,
-        EBaseItemType.Person,
-        EBaseItemType.MusicVideo,
-        EBaseItemType.SeriesTimer
+    private static BaseItemType[] buttonTypes = new BaseItemType[] {
+        BaseItemType.Episode,
+        BaseItemType.Movie,
+        BaseItemType.Series,
+        BaseItemType.Season,
+        BaseItemType.Folder,
+        BaseItemType.Video,
+        BaseItemType.Recording,
+        BaseItemType.Program,
+        BaseItemType.ChannelVideoItem,
+        BaseItemType.Trailer,
+        BaseItemType.MusicArtist,
+        BaseItemType.Person,
+        BaseItemType.MusicVideo,
+        BaseItemType.SeriesTimer
     };
 
 
-    private static List<EBaseItemType> buttonTypeList = Arrays.asList(buttonTypes);
+    private static List<BaseItemType> buttonTypeList = Arrays.asList(buttonTypes);
     private static String[] directPlayableTypes = new String[] {"Episode","Movie","Video","Recording","Program"};
     private static List<String> directPlayableTypeList = Arrays.asList(directPlayableTypes);
 
@@ -350,7 +350,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             BaseItemDto item = new BaseItemDto();
             item.setId(mSeriesTimerInfo.getId());
             item.setSeriesTimerId(mSeriesTimerInfo.getId());
-            item.setEBaseItemType(EBaseItemType.SeriesTimer);
+            item.setBaseItemType(BaseItemType.SeriesTimer);
             item.setName(mSeriesTimerInfo.getName());
             item.setOverview(BaseItemUtils.getSeriesOverview(mSeriesTimerInfo));
 
@@ -387,7 +387,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
             // Figure image size
             Double aspect = ImageUtils.getImageAspectRatio(item, false);
-            posterHeight = aspect > 1 ? Utils.convertDpToPixel(mActivity, 160) : Utils.convertDpToPixel(mActivity, item.getEBaseItemType() == EBaseItemType.Person || item.getEBaseItemType() == EBaseItemType.MusicArtist ? 300 : 200);
+            posterHeight = aspect > 1 ? Utils.convertDpToPixel(mActivity, 160) : Utils.convertDpToPixel(mActivity, item.getBaseItemType() == BaseItemType.Person || item.getBaseItemType() == BaseItemType.MusicArtist ? 300 : 200);
             posterWidth = (int)((aspect) * posterHeight);
             if (posterHeight < 10) posterWidth = Utils.convertDpToPixel(mActivity, 150);  //Guard against zero size images causing picasso to barf
 
@@ -396,7 +396,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             mDetailsOverviewRow = new MyDetailsOverviewRow(item);
 
             mDetailsOverviewRow.setSummary(item.getOverview());
-            switch (item.getEBaseItemType()) {
+            switch (item.getBaseItemType()) {
                 case Person:
                 case MusicArtist:
                     mDetailsOverviewRow.setSummarySubTitle("");
@@ -406,7 +406,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                     BaseItemPerson director = BaseItemUtils.getFirstPerson(item, PersonType.Director);
 
                     InfoItem firstRow;
-                    if (item.getEBaseItemType() == EBaseItemType.Series) {
+                    if (item.getBaseItemType() == BaseItemType.Series) {
                         firstRow = new InfoItem(
                                 getString(R.string.lbl_seasons),
                                 Utils.getSafeValue(item.getChildCount(), 0).toString());
@@ -506,8 +506,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     protected void addAdditionalRows(ArrayObjectAdapter adapter) {
-        TvApp.getApplication().getLogger().Debug("Item type: " + mBaseItem.getEBaseItemType());
-        switch (mBaseItem.getEBaseItemType()) {
+        TvApp.getApplication().getLogger().Debug("Item type: " + mBaseItem.getBaseItemType());
+        switch (mBaseItem.getBaseItemType()) {
             case Movie:
 
                 //Cast/Crew
@@ -695,7 +695,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     private void updateInfo(BaseItemDto item) {
-        if (buttonTypeList.contains(item.getEBaseItemType())) addButtons(BUTTON_SIZE);
+        if (buttonTypeList.contains(item.getBaseItemType())) addButtons(BUTTON_SIZE);
 //        updatePlayedDate();
 //
         updateBackground(ImageUtils.getBackdropImageUrl(item, TvApp.getApplication().getApiClient(), true));
@@ -724,10 +724,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     private String getEndTime() {
-        if (mBaseItem != null && mBaseItem.getEBaseItemType() != EBaseItemType.MusicArtist && mBaseItem.getEBaseItemType() != EBaseItemType.Person) {
+        if (mBaseItem != null && mBaseItem.getBaseItemType() != BaseItemType.MusicArtist && mBaseItem.getBaseItemType() != BaseItemType.Person) {
             Long runtime = Utils.getSafeValue(mBaseItem.getRunTimeTicks(), mBaseItem.getOriginalRunTimeTicks());
             if (runtime != null && runtime > 0) {
-                long endTimeTicks = mBaseItem.getEBaseItemType() == EBaseItemType.Program && mBaseItem.getEndDate() != null ? TimeUtils.convertToLocalDate(mBaseItem.getEndDate()).getTime() : System.currentTimeMillis() + runtime / 10000;
+                long endTimeTicks = mBaseItem.getBaseItemType() == BaseItemType.Program && mBaseItem.getEndDate() != null ? TimeUtils.convertToLocalDate(mBaseItem.getEndDate()).getTime() : System.currentTimeMillis() + runtime / 10000;
                 if (mBaseItem.getCanResume()) {
                     endTimeTicks = System.currentTimeMillis() + ((runtime - mBaseItem.getUserData().getPlaybackPositionTicks()) / 10000);
                     return android.text.format.DateFormat.getTimeFormat(this).format(new Date(endTimeTicks));
@@ -741,7 +741,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     private void addItemToQueue() {
-        if (mBaseItem.getEBaseItemType() == EBaseItemType.Audio) {
+        if (mBaseItem.getBaseItemType() == BaseItemType.Audio) {
             MediaManager.addToAudioQueue(Arrays.asList(mBaseItem));
 
         } else {
@@ -810,7 +810,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     private void addButtons(int buttonSize) {
         String buttonLabel;
-        if (mBaseItem.getEBaseItemType() == EBaseItemType.Series || mBaseItem.getEBaseItemType() == EBaseItemType.SeriesTimer) {
+        if (mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) {
             buttonLabel = getString(R.string.lbl_play_next_up);
         } else {
             long startPos = 0;
@@ -822,7 +822,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         mResumeButton = new TextUnderButton(this, R.drawable.ic_resume, buttonSize, 2, buttonLabel, new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (mBaseItem.getEBaseItemType() == EBaseItemType.Series) {
+                if (mBaseItem.getBaseItemType() == BaseItemType.Series) {
                     //play next up
                     NextUpQuery nextUpQuery = new NextUpQuery();
                     nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
@@ -854,7 +854,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
         if (BaseItemUtils.canPlay(mBaseItem)) {
             mDetailsOverviewRow.addAction(mResumeButton);
-            mResumeButton.setVisibility((mBaseItem.getEBaseItemType() == EBaseItemType.Series && ! mBaseItem.getUserData().getPlayed()) || (mBaseItem.getCanResume() ) ? View.VISIBLE : View.GONE);
+            mResumeButton.setVisibility((mBaseItem.getBaseItemType() == BaseItemType.Series && ! mBaseItem.getUserData().getPlayed()) || (mBaseItem.getCanResume() ) ? View.VISIBLE : View.GONE);
 
             TextUnderButton play = new TextUnderButton(this, R.drawable.ic_play, buttonSize, 2, getString(BaseItemUtils.isLiveTv(mBaseItem) ? R.string.lbl_tune_to_channel : mBaseItem.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
                 @Override
@@ -884,7 +884,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 mDetailsOverviewRow.addAction(shuffle);
             }
 
-            if (mBaseItem.getEBaseItemType() == EBaseItemType.MusicArtist) {
+            if (mBaseItem.getBaseItemType() == BaseItemType.MusicArtist) {
                 TextUnderButton imix = new TextUnderButton(this, R.drawable.ic_mix, buttonSize, getString(R.string.lbl_instant_mix), new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -1068,7 +1068,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
         UserItemDataDto userData = mBaseItem.getUserData();
         if (userData != null && mProgramInfo == null) {
-            if (mBaseItem.getEBaseItemType() != EBaseItemType.MusicArtist && mBaseItem.getEBaseItemType() != EBaseItemType.Person) {
+            if (mBaseItem.getBaseItemType() != BaseItemType.MusicArtist && mBaseItem.getBaseItemType() != BaseItemType.Person) {
                 mWatchedToggleButton = new TextUnderButton(this, userData.getPlayed() ? R.drawable.ic_watch_red : R.drawable.ic_watch, buttonSize, getString(R.string.lbl_watched), markWatchedListener);
                 mDetailsOverviewRow.addAction(mWatchedToggleButton);
             }
@@ -1083,7 +1083,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             mDetailsOverviewRow.addAction(favButton);
         }
 
-        if (mBaseItem.getEBaseItemType() == EBaseItemType.Episode && mBaseItem.getSeriesId() != null) {
+        if (mBaseItem.getBaseItemType() == BaseItemType.Episode && mBaseItem.getSeriesId() != null) {
             //add the prev button first so it will be there in proper position - we'll show it later if needed
             mPrevButton = new TextUnderButton(this, R.drawable.ic_previous_episode, buttonSize, 3, getString(R.string.lbl_previous_episode), new View.OnClickListener() {
                 @Override
@@ -1128,8 +1128,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             mDetailsOverviewRow.addAction(goToSeriesButton);
         }
 
-        if ((mBaseItem.getEBaseItemType() == EBaseItemType.Recording && TvApp.getApplication().getCurrentUser().getPolicy().getEnableLiveTvManagement() && mBaseItem.getCanDelete()) ||
-                ((mBaseItem.getEBaseItemType() == EBaseItemType.Movie || mBaseItem.getEBaseItemType() == EBaseItemType.Episode || mBaseItem.getEBaseItemType() == EBaseItemType.Video) && TvApp.getApplication().getCurrentUser().getPolicy().getEnableContentDeletion())) {
+        if ((mBaseItem.getBaseItemType() == BaseItemType.Recording && TvApp.getApplication().getCurrentUser().getPolicy().getEnableLiveTvManagement() && mBaseItem.getCanDelete()) ||
+                ((mBaseItem.getBaseItemType() == BaseItemType.Movie || mBaseItem.getBaseItemType() == BaseItemType.Episode || mBaseItem.getBaseItemType() == BaseItemType.Video) && TvApp.getApplication().getCurrentUser().getPolicy().getEnableContentDeletion())) {
             deleteButton = new TextUnderButton(this, R.drawable.ic_trash, buttonSize, getString(R.string.lbl_delete), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -1139,7 +1139,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             mDetailsOverviewRow.addAction(deleteButton);
         }
 
-        if (mSeriesTimerInfo != null && mBaseItem.getEBaseItemType() == EBaseItemType.SeriesTimer) {
+        if (mSeriesTimerInfo != null && mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) {
             //Settings
             mDetailsOverviewRow.addAction(new TextUnderButton(this, R.drawable.ic_settings, buttonSize, getString(R.string.lbl_series_settings), new View.OnClickListener() {
                 @Override
@@ -1225,7 +1225,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
         moreButton.setVisibility(View.GONE);
         mDetailsOverviewRow.addAction(moreButton);
-        if (mBaseItem.getEBaseItemType() != EBaseItemType.Episode) showMoreButtonIfNeeded();  //Episodes check for previous and then call this above
+        if (mBaseItem.getBaseItemType() != BaseItemType.Episode) showMoreButtonIfNeeded();  //Episodes check for previous and then call this above
 
     }
 
@@ -1419,13 +1419,13 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     protected void play(final BaseItemDto item, final int pos, final boolean shuffle) {
         final Activity activity = this;
-        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getEBaseItemType() == EBaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
+        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
-                if (item.getEBaseItemType() == EBaseItemType.MusicArtist) {
+                if (item.getBaseItemType() == BaseItemType.MusicArtist) {
                     MediaManager.playNow(response);
                 } else {
-                    Intent intent = new Intent(activity, mApplication.getPlaybackActivityClass(item.getEBaseItemType()));
+                    Intent intent = new Intent(activity, mApplication.getPlaybackActivityClass(item.getBaseItemType()));
                     MediaManager.setCurrentVideoQueue(response);
                     intent.putExtra("Position", pos);
                     startActivity(intent);
@@ -1437,7 +1437,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     protected void play(final BaseItemDto[] items, final int pos, final boolean shuffle) {
         List<BaseItemDto> itemsToPlay = Arrays.asList(items);
-        Intent intent = new Intent(this, mApplication.getPlaybackActivityClass(items[0].getEBaseItemType()));
+        Intent intent = new Intent(this, mApplication.getPlaybackActivityClass(items[0].getBaseItemType()));
         if (shuffle) Collections.shuffle(itemsToPlay);
         MediaManager.setCurrentVideoQueue(itemsToPlay);
         intent.putExtra("Position", pos);

--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -57,7 +57,7 @@ import java.util.List;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.playlists.PlaylistItemQuery;
@@ -154,7 +154,7 @@ public class ItemListActivity extends BaseActivity {
         mItemList.setRowClickedListener(new ItemRowView.RowClickedListener() {
             @Override
             public void onRowClicked(ItemRowView row) {
-                showMenu(row, row.getItem().getEBaseItemType() != EBaseItemType.Audio);
+                showMenu(row, row.getItem().getBaseItemType() != BaseItemType.Audio);
             }
         });
 
@@ -332,7 +332,7 @@ public class ItemListActivity extends BaseActivity {
                 return true;
             }
         });
-        if (row.getItem().getEBaseItemType() == EBaseItemType.Audio) {
+        if (row.getItem().getBaseItemType() == BaseItemType.Audio) {
             MenuItem mix = menu.getMenu().add(0, 1, order++, R.string.lbl_instant_mix);
             mix.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override
@@ -358,7 +358,7 @@ public class ItemListActivity extends BaseActivity {
                 item.setOverview(getString(R.string.desc_automatic_fav_songs));
                 item.setPlayAccess(PlayAccess.Full);
                 item.setMediaType("Audio");
-                item.setEBaseItemType(EBaseItemType.Playlist);
+                item.setBaseItemType(BaseItemType.Playlist);
                 item.setIsFolder(true);
                 setBaseItem(item);
                 break;
@@ -369,7 +369,7 @@ public class ItemListActivity extends BaseActivity {
                 queue.setOverview(getString(R.string.desc_current_video_queue));
                 queue.setPlayAccess(PlayAccess.Full);
                 queue.setMediaType("Video");
-                queue.setEBaseItemType(EBaseItemType.Playlist);
+                queue.setBaseItemType(BaseItemType.Playlist);
                 queue.setIsFolder(true);
                 if (MediaManager.getCurrentVideoQueue() != null) {
                     long runtime = 0;
@@ -407,7 +407,7 @@ public class ItemListActivity extends BaseActivity {
         updatePoster(mBaseItem);
 
         //get items
-        if (mBaseItem.getEBaseItemType() == EBaseItemType.Playlist) {
+        if (mBaseItem.getBaseItemType() == BaseItemType.Playlist) {
             // Have to use different query here
             switch (mItemId) {
                 case FAV_SONGS:
@@ -517,7 +517,7 @@ public class ItemListActivity extends BaseActivity {
             for (String genre : mBaseItem.getGenres()) {
                 if (!first) InfoLayoutHelper.addSpacer(this, layout, "  /  ", 14);
                 first = false;
-                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getEBaseItemType()));
+                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getBaseItemType()));
             }
         }
     }
@@ -542,7 +542,7 @@ public class ItemListActivity extends BaseActivity {
 
     private void play(List<BaseItemDto> items) {
         if ("Video".equals(mBaseItem.getMediaType())) {
-            Intent intent = new Intent(mActivity, mApplication.getPlaybackActivityClass(mBaseItem.getEBaseItemType()));
+            Intent intent = new Intent(mActivity, mApplication.getPlaybackActivityClass(mBaseItem.getBaseItemType()));
             //Resume first item if needed
             BaseItemDto first = items.size() > 0 ? items.get(0) : null;
             if (first != null && first.getUserData() != null) {
@@ -598,7 +598,7 @@ public class ItemListActivity extends BaseActivity {
             }
         }
 
-        if (mBaseItem.getEBaseItemType() == EBaseItemType.MusicAlbum) {
+        if (mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum) {
             TextUnderButton mix = new TextUnderButton(this, R.drawable.ic_mix, buttonSize, 2, getString(R.string.lbl_instant_mix), new View.OnClickListener() {
                 @Override
                 public void onClick(final View v) {
@@ -632,7 +632,7 @@ public class ItemListActivity extends BaseActivity {
 
             }
 
-            if (mBaseItem.getEBaseItemType() == EBaseItemType.Playlist) {
+            if (mBaseItem.getBaseItemType() == BaseItemType.Playlist) {
                 if (VIDEO_QUEUE.equals(mBaseItem.getId())) {
                     mButtonRow.addView(new TextUnderButton(this, R.drawable.ic_save, buttonSize, 2, getString(R.string.lbl_save_as_playlist), new View.OnClickListener() {
                         @Override

--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -57,6 +57,7 @@ import java.util.List;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.playlists.PlaylistItemQuery;
@@ -153,7 +154,7 @@ public class ItemListActivity extends BaseActivity {
         mItemList.setRowClickedListener(new ItemRowView.RowClickedListener() {
             @Override
             public void onRowClicked(ItemRowView row) {
-                showMenu(row, !"Audio".equals(row.getItem().getType()));
+                showMenu(row, row.getItem().getEBaseItemType() != EBaseItemType.Audio);
             }
         });
 
@@ -331,7 +332,7 @@ public class ItemListActivity extends BaseActivity {
                 return true;
             }
         });
-        if ("Audio".equals(row.getItem().getType())) {
+        if (row.getItem().getEBaseItemType() == EBaseItemType.Audio) {
             MenuItem mix = menu.getMenu().add(0, 1, order++, R.string.lbl_instant_mix);
             mix.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override
@@ -357,7 +358,7 @@ public class ItemListActivity extends BaseActivity {
                 item.setOverview(getString(R.string.desc_automatic_fav_songs));
                 item.setPlayAccess(PlayAccess.Full);
                 item.setMediaType("Audio");
-                item.setType("Playlist");
+                item.setEBaseItemType(EBaseItemType.Playlist);
                 item.setIsFolder(true);
                 setBaseItem(item);
                 break;
@@ -368,7 +369,7 @@ public class ItemListActivity extends BaseActivity {
                 queue.setOverview(getString(R.string.desc_current_video_queue));
                 queue.setPlayAccess(PlayAccess.Full);
                 queue.setMediaType("Video");
-                queue.setType("Playlist");
+                queue.setEBaseItemType(EBaseItemType.Playlist);
                 queue.setIsFolder(true);
                 if (MediaManager.getCurrentVideoQueue() != null) {
                     long runtime = 0;
@@ -406,7 +407,7 @@ public class ItemListActivity extends BaseActivity {
         updatePoster(mBaseItem);
 
         //get items
-        if ("Playlist".equals(mBaseItem.getType())) {
+        if (mBaseItem.getEBaseItemType() == EBaseItemType.Playlist) {
             // Have to use different query here
             switch (mItemId) {
                 case FAV_SONGS:
@@ -516,7 +517,7 @@ public class ItemListActivity extends BaseActivity {
             for (String genre : mBaseItem.getGenres()) {
                 if (!first) InfoLayoutHelper.addSpacer(this, layout, "  /  ", 14);
                 first = false;
-                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getType()));
+                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getEBaseItemType()));
             }
         }
     }
@@ -541,7 +542,7 @@ public class ItemListActivity extends BaseActivity {
 
     private void play(List<BaseItemDto> items) {
         if ("Video".equals(mBaseItem.getMediaType())) {
-            Intent intent = new Intent(mActivity, mApplication.getPlaybackActivityClass(mBaseItem.getType()));
+            Intent intent = new Intent(mActivity, mApplication.getPlaybackActivityClass(mBaseItem.getEBaseItemType()));
             //Resume first item if needed
             BaseItemDto first = items.size() > 0 ? items.get(0) : null;
             if (first != null && first.getUserData() != null) {
@@ -597,7 +598,7 @@ public class ItemListActivity extends BaseActivity {
             }
         }
 
-        if ("MusicAlbum".equals(mBaseItem.getType())) {
+        if (mBaseItem.getEBaseItemType() == EBaseItemType.MusicAlbum) {
             TextUnderButton mix = new TextUnderButton(this, R.drawable.ic_mix, buttonSize, 2, getString(R.string.lbl_instant_mix), new View.OnClickListener() {
                 @Override
                 public void onClick(final View v) {
@@ -631,7 +632,7 @@ public class ItemListActivity extends BaseActivity {
 
             }
 
-            if ("Playlist".equals(mBaseItem.getType())) {
+            if (mBaseItem.getEBaseItemType() == EBaseItemType.Playlist) {
                 if (VIDEO_QUEUE.equals(mBaseItem.getId())) {
                     mButtonRow.addView(new TextUnderButton(this, R.drawable.ic_save, buttonSize, 2, getString(R.string.lbl_save_as_playlist), new View.OnClickListener() {
                         @Override

--- a/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
@@ -154,7 +154,7 @@ public class TvApiEventListener extends ApiEventListener {
                         switch (response.getItems()[0].getMediaType()) {
                             case "Video":
                                 MediaManager.setCurrentVideoQueue(Arrays.asList(response.getItems()));
-                                Intent intent = new Intent(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getPlaybackActivityClass(response.getItems()[0].getEBaseItemType()));
+                                Intent intent = new Intent(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getPlaybackActivityClass(response.getItems()[0].getBaseItemType()));
                                 TvApp.getApplication().getCurrentActivity().startActivity(intent);
                                 break;
                             case "Audio":

--- a/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
@@ -154,7 +154,7 @@ public class TvApiEventListener extends ApiEventListener {
                         switch (response.getItems()[0].getMediaType()) {
                             case "Video":
                                 MediaManager.setCurrentVideoQueue(Arrays.asList(response.getItems()));
-                                Intent intent = new Intent(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getPlaybackActivityClass(response.getItems()[0].getType()));
+                                Intent intent = new Intent(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getPlaybackActivityClass(response.getItems()[0].getEBaseItemType()));
                                 TvApp.getApplication().getCurrentActivity().startActivity(intent);
                                 break;
                             case "Audio":

--- a/app/src/main/java/org/jellyfin/androidtv/integration/RecommendationManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/RecommendationManager.java
@@ -206,7 +206,7 @@ public class RecommendationManager {
                     if (response.getCanResume()) {
                         addRecommendation(response, RecommendationType.Movie);
                     } else {
-                        switch (response.getEBaseItemType()) {
+                        switch (response.getBaseItemType()) {
                             case Movie:
                                 //First remove us if we were a recommendation
                                 mRecommendations.remove(RecommendationType.Movie, response.getId());

--- a/app/src/main/java/org/jellyfin/androidtv/integration/RecommendationManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/RecommendationManager.java
@@ -206,8 +206,8 @@ public class RecommendationManager {
                     if (response.getCanResume()) {
                         addRecommendation(response, RecommendationType.Movie);
                     } else {
-                        switch (response.getType()) {
-                            case "Movie":
+                        switch (response.getEBaseItemType()) {
+                            case Movie:
                                 //First remove us if we were a recommendation
                                 mRecommendations.remove(RecommendationType.Movie, response.getId());
 
@@ -230,7 +230,7 @@ public class RecommendationManager {
                                     }
                                 });
                                 break;
-                            case "Episode":
+                            case Episode:
                                 //First remove us if we were a recommendation
                                 mRecommendations.remove(RecommendationType.Tv, response.getId());
 

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/BaseRowItem.java
@@ -21,7 +21,7 @@ import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.apiclient.ServerInfo;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
@@ -56,7 +56,7 @@ public class BaseRowItem {
     public BaseRowItem(int index, BaseItemDto item, boolean preferParentThumb, boolean staticHeight, SelectAction selectAction) {
         this.index = index;
         this.baseItem = item;
-        this.type = item.getEBaseItemType() == EBaseItemType.Program ? ItemType.LiveTvProgram : item.getEBaseItemType() == EBaseItemType.Recording ? ItemType.LiveTvRecording : ItemType.BaseItem;
+        this.type = item.getBaseItemType() == BaseItemType.Program ? ItemType.LiveTvProgram : item.getBaseItemType() == BaseItemType.Recording ? ItemType.LiveTvRecording : ItemType.BaseItem;
         this.preferParentThumb = preferParentThumb;
         this.staticHeight = staticHeight;
         this.selectAction = selectAction;
@@ -192,10 +192,10 @@ public class BaseRowItem {
 
     public boolean showCardInfoOverlay() {
         return type == ItemType.BaseItem && baseItem != null
-                && Arrays.asList(EBaseItemType.Folder, EBaseItemType.PhotoAlbum, EBaseItemType.RecordingGroup,
-                EBaseItemType.UserView, EBaseItemType.CollectionFolder, EBaseItemType.Photo,
-                EBaseItemType.Video, EBaseItemType.Person, EBaseItemType.Playlist,
-                EBaseItemType.MusicArtist).contains(baseItem.getEBaseItemType());
+                && Arrays.asList(BaseItemType.Folder, BaseItemType.PhotoAlbum, BaseItemType.RecordingGroup,
+                BaseItemType.UserView, BaseItemType.CollectionFolder, BaseItemType.Photo,
+                BaseItemType.Video, BaseItemType.Person, BaseItemType.Playlist,
+                BaseItemType.MusicArtist).contains(baseItem.getBaseItemType());
     }
 
     public boolean isValid() {
@@ -303,7 +303,7 @@ public class BaseRowItem {
     public String getCardName() {
         switch (type) {
             case BaseItem:
-                if (baseItem.getEBaseItemType() == EBaseItemType.Audio) {
+                if (baseItem.getBaseItemType() == BaseItemType.Audio) {
                     return baseItem.getAlbumArtist() != null ? baseItem.getAlbumArtist() : baseItem.getAlbum() != null ? baseItem.getAlbum() : "<Unknown>";
                 }
             default:
@@ -343,7 +343,7 @@ public class BaseRowItem {
             case BaseItem:
             case LiveTvRecording:
             case LiveTvProgram:
-                return baseItem.getEBaseItemType() == EBaseItemType.Audio ? getFullName() : baseItem.getName();
+                return baseItem.getBaseItemType() == BaseItemType.Audio ? getFullName() : baseItem.getName();
             case Person:
                 return person.getName();
             case Server:
@@ -424,9 +424,9 @@ public class BaseRowItem {
         return "";
     }
 
-    public EBaseItemType getBaseItemType() {
+    public BaseItemType getBaseItemType() {
         if (baseItem != null)
-            return baseItem.getEBaseItemType();
+            return baseItem.getBaseItemType();
         else
             return null;
     }
@@ -475,7 +475,7 @@ public class BaseRowItem {
     public int getChildCount() {
         switch (type) {
             case BaseItem:
-                return isFolder() && baseItem.getEBaseItemType() != EBaseItemType.MusicArtist && baseItem.getChildCount() != null ? baseItem.getChildCount() : -1;
+                return isFolder() && baseItem.getBaseItemType() != BaseItemType.MusicArtist && baseItem.getChildCount() != null ? baseItem.getChildCount() : -1;
             case Person:
             case Server:
             case User:
@@ -492,7 +492,7 @@ public class BaseRowItem {
     }
 
     public String getChildCountStr() {
-        if (baseItem != null && baseItem.getEBaseItemType() == EBaseItemType.Playlist && baseItem.getCumulativeRunTimeTicks() != null) {
+        if (baseItem != null && baseItem.getBaseItemType() == BaseItemType.Playlist && baseItem.getCumulativeRunTimeTicks() != null) {
             return TimeUtils.formatMillis(baseItem.getCumulativeRunTimeTicks() / 10000);
         } else {
             Integer count = getChildCount();
@@ -512,9 +512,9 @@ public class BaseRowItem {
     public Drawable getBadgeImage() {
         switch (type) {
             case BaseItem:
-                if (baseItem.getEBaseItemType() == EBaseItemType.Movie && baseItem.getCriticRating() != null) {
+                if (baseItem.getBaseItemType() == BaseItemType.Movie && baseItem.getCriticRating() != null) {
                     return baseItem.getCriticRating() > 59 ? TvApp.getApplication().getDrawableCompat(R.drawable.fresh) : TvApp.getApplication().getDrawableCompat(R.drawable.rotten);
-                } else if (baseItem.getEBaseItemType() == EBaseItemType.Program && baseItem.getTimerId() != null) {
+                } else if (baseItem.getBaseItemType() == BaseItemType.Program && baseItem.getTimerId() != null) {
                     return baseItem.getSeriesTimerId() != null ? TvApp.getApplication().getDrawableCompat(R.drawable.ic_record_series_red) : TvApp.getApplication().getDrawableCompat(R.drawable.ic_record_red);
                 }
                 break;

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 import org.jellyfin.apiclient.model.library.PlayAccess;
@@ -51,13 +51,13 @@ public class ItemLauncher {
             case BaseItem:
                 final BaseItemDto baseItem = rowItem.getBaseItem();
                 try {
-                    TvApp.getApplication().getLogger().Debug("Item selected: " + rowItem.getIndex() + " - " + baseItem.getName() + " (" + baseItem.getEBaseItemType() + ")");
+                    TvApp.getApplication().getLogger().Debug("Item selected: " + rowItem.getIndex() + " - " + baseItem.getName() + " (" + baseItem.getBaseItemType() + ")");
                 } catch (Exception e) {
                     //swallow it
                 }
 
                 //specialized type handling
-                switch (baseItem.getEBaseItemType()) {
+                switch (baseItem.getBaseItemType()) {
                     case UserView:
                     case CollectionFolder:
                         //We need to get display prefs...
@@ -201,10 +201,10 @@ public class ItemLauncher {
                         case Play:
                             if (baseItem.getPlayAccess() == PlayAccess.Full) {
                                 //Just play it directly
-                                PlaybackHelper.getItemsToPlay(baseItem, baseItem.getEBaseItemType() == EBaseItemType.Movie, false, new Response<List<BaseItemDto>>() {
+                                PlaybackHelper.getItemsToPlay(baseItem, baseItem.getBaseItemType() == BaseItemType.Movie, false, new Response<List<BaseItemDto>>() {
                                     @Override
                                     public void onResponse(List<BaseItemDto> response) {
-                                        Intent intent = new Intent(activity, application.getPlaybackActivityClass(baseItem.getEBaseItemType()));
+                                        Intent intent = new Intent(activity, application.getPlaybackActivityClass(baseItem.getBaseItemType()));
                                         MediaManager.setCurrentVideoQueue(response);
                                         intent.putExtra("Position", 0);
                                         activity.startActivity(intent);
@@ -237,7 +237,7 @@ public class ItemLauncher {
                         List<BaseItemDto> items = new ArrayList<>();
                         items.add(response);
                         MediaManager.setCurrentVideoQueue(items);
-                        Intent intent = new Intent(activity, application.getPlaybackActivityClass(response.getEBaseItemType()));
+                        Intent intent = new Intent(activity, application.getPlaybackActivityClass(response.getBaseItemType()));
                         Long start = chapter.getStartPositionTicks() / 10000;
                         intent.putExtra("Position", start.intValue());
                         activity.startActivity(intent);
@@ -266,14 +266,14 @@ public class ItemLauncher {
                 application.getApiClient().GetItemAsync(hint.getItemId(), application.getCurrentUser().getId(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
-                        if ((response.getIsFolderItem() && response.getEBaseItemType() != EBaseItemType.Series) || response.getEBaseItemType() == EBaseItemType.MusicArtist) {
+                        if ((response.getIsFolderItem() && response.getBaseItemType() != BaseItemType.Series) || response.getBaseItemType() == BaseItemType.MusicArtist) {
                             // open generic folder browsing
                             Intent intent = new Intent(activity, GenericGridActivity.class);
                             intent.putExtra("Folder", TvApp.getApplication().getSerializer().SerializeToString(response));
 
                             activity.startActivity(intent);
 
-                        } else if (response.getEBaseItemType() == EBaseItemType.Audio) {
+                        } else if (response.getBaseItemType() == BaseItemType.Audio) {
                             PlaybackHelper.retrieveAndPlay(response.getId(), false, activity);
                             //produce item menu
 //                            KeyProcessor.HandleKey(KeyEvent.KEYCODE_MENU, rowItem, (BaseActivity) activity);
@@ -282,9 +282,9 @@ public class ItemLauncher {
                         } else {
                             Intent intent = new Intent(activity, FullDetailsActivity.class);
                             intent.putExtra("ItemId", response.getId());
-                            if (response.getEBaseItemType() == EBaseItemType.Program) {
+                            if (response.getBaseItemType() == BaseItemType.Program) {
                                 // TODO: Seems like this is never used...
-                                intent.putExtra("ItemType", response.getEBaseItemType().name());
+                                intent.putExtra("ItemType", response.getBaseItemType().name());
 
                                 intent.putExtra("ChannelId", response.getChannelId());
                                 intent.putExtra("ProgramInfo", TvApp.getApplication().getSerializer().SerializeToString(response));
@@ -310,7 +310,7 @@ public class ItemLauncher {
                         programIntent.putExtra("ItemId", program.getId());
 
                         // TODO Seems unused
-                        programIntent.putExtra("ItemType", program.getEBaseItemType().name());
+                        programIntent.putExtra("ItemType", program.getBaseItemType().name());
 
                         programIntent.putExtra("ChannelId", program.getChannelId());
                         programIntent.putExtra("ProgramInfo", TvApp.getApplication().getSerializer().SerializeToString(program));
@@ -325,7 +325,7 @@ public class ItemLauncher {
                                 public void onResponse(BaseItemDto response) {
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
-                                    Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(response.getEBaseItemType()));
+                                    Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(response.getBaseItemType()));
                                     MediaManager.setCurrentVideoQueue(items);
                                     intent.putExtra("Position", 0);
                                     activity.startActivity(intent);
@@ -347,8 +347,8 @@ public class ItemLauncher {
                         PlaybackHelper.getItemsToPlay(response, false, false, new Response<List<BaseItemDto>>() {
                             @Override
                             public void onResponse(List<BaseItemDto> response) {
-                                // TODO Check whether this usage of EBaseItemType.valueOf is okay.
-                                Intent intent = new Intent(activity, application.getPlaybackActivityClass(EBaseItemType.valueOf(channel.getType())));
+                                // TODO Check whether this usage of BaseItemType.valueOf is okay.
+                                Intent intent = new Intent(activity, application.getPlaybackActivityClass(BaseItemType.valueOf(channel.getType())));
                                 MediaManager.setCurrentVideoQueue(response);
                                 intent.putExtra("Position", 0);
                                 activity.startActivity(intent);

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemRowAdapter.java
@@ -38,6 +38,7 @@ import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.apiclient.ServerInfo;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
@@ -812,7 +813,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     for (BaseItemDto item : response.getItems()) {
                         //re-map the display prefs id to our actual id
                         item.setDisplayPreferencesId(item.getId());
-                        if (!ignoreTypeList.contains(item.getCollectionType()) && !ignoreTypeList.contains(item.getType())) {
+                        if (!ignoreTypeList.contains(item.getCollectionType())) {
                             adapter.add(new BaseRowItem(i++, item, preferParentThumb, staticHeight));
                         }
                     }
@@ -1314,7 +1315,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     int i = 0;
                     int prevItems = adapter.size() > 0 ? adapter.size() : 0;
                     for (BaseItemDto item : response.getItems()) {
-                        item.setType("RecordingGroup"); // the API does not fill this in
+                        item.setEBaseItemType(EBaseItemType.RecordingGroup); // the API does not fill this in
                         item.setIsFolder(true); // nor this
                         adapter.add(new BaseRowItem(item));
                         i++;

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemRowAdapter.java
@@ -38,7 +38,7 @@ import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.apiclient.ServerInfo;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
@@ -1315,7 +1315,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     int i = 0;
                     int prevItems = adapter.size() > 0 ? adapter.size() : 0;
                     for (BaseItemDto item : response.getItems()) {
-                        item.setEBaseItemType(EBaseItemType.RecordingGroup); // the API does not fill this in
+                        item.setBaseItemType(BaseItemType.RecordingGroup); // the API does not fill this in
                         item.setIsFolder(true); // nor this
                         adapter.add(new BaseRowItem(item));
                         i++;

--- a/app/src/main/java/org/jellyfin/androidtv/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/livetv/TvManager.java
@@ -32,6 +32,7 @@ import java.util.TimeZone;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
@@ -405,7 +406,7 @@ public class TvManager {
                         programInfo.setChannelName(timer.getChannelName());
                         programInfo.setName(Utils.getSafeValue(timer.getName(), "Unknown"));
                         TvApp.getApplication().getLogger().Warn("No program info for timer %s.  Creating one...", programInfo.getName());
-                        programInfo.setType("Program");
+                        programInfo.setEBaseItemType(EBaseItemType.Program);
                         programInfo.setTimerId(timer.getId());
                         programInfo.setSeriesTimerId(timer.getSeriesTimerId());
                         programInfo.setStartDate(timer.getStartDate());

--- a/app/src/main/java/org/jellyfin/androidtv/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/livetv/TvManager.java
@@ -32,7 +32,7 @@ import java.util.TimeZone;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
@@ -406,7 +406,7 @@ public class TvManager {
                         programInfo.setChannelName(timer.getChannelName());
                         programInfo.setName(Utils.getSafeValue(timer.getName(), "Unknown"));
                         TvApp.getApplication().getLogger().Warn("No program info for timer %s.  Creating one...", programInfo.getName());
-                        programInfo.setEBaseItemType(EBaseItemType.Program);
+                        programInfo.setBaseItemType(BaseItemType.Program);
                         programInfo.setTimerId(timer.getId());
                         programInfo.setSeriesTimerId(timer.getSeriesTimerId());
                         programInfo.setStartDate(timer.getStartDate());

--- a/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
@@ -490,7 +490,7 @@ public class AudioNowPlayingActivity extends BaseActivity  {
             for (String genre : mBaseItem.getGenres()) {
                 if (!first) InfoLayoutHelper.addSpacer(this, layout, "  /  ", 14);
                 first = false;
-                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getType()));
+                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getEBaseItemType()));
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
@@ -490,7 +490,7 @@ public class AudioNowPlayingActivity extends BaseActivity  {
             for (String genre : mBaseItem.getGenres()) {
                 if (!first) InfoLayoutHelper.addSpacer(this, layout, "  /  ", 14);
                 first = false;
-                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getEBaseItemType()));
+                layout.addView(new GenreButton(this, roboto, 16, genre, mBaseItem.getBaseItemType()));
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.session.PlayMethod;
 
@@ -206,7 +206,7 @@ public class ExternalPlayerActivity extends Activity {
             //Get playback info for current item
             mCurrentNdx = ndx;
             final BaseItemDto item = mItemsToPlay.get(mCurrentNdx);
-            isLiveTv = item.getEBaseItemType() == EBaseItemType.TvChannel;
+            isLiveTv = item.getBaseItemType() == BaseItemType.TvChannel;
 
             if (!isLiveTv && mApplication.getPrefs().getBoolean("pref_send_path_external", false)) {
                 // Just pass the path directly

--- a/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.session.PlayMethod;
 
@@ -205,7 +206,7 @@ public class ExternalPlayerActivity extends Activity {
             //Get playback info for current item
             mCurrentNdx = ndx;
             final BaseItemDto item = mItemsToPlay.get(mCurrentNdx);
-            isLiveTv = item.getType().equals("TvChannel");
+            isLiveTv = item.getEBaseItemType() == EBaseItemType.TvChannel;
 
             if (!isLiveTv && mApplication.getPrefs().getBoolean("pref_send_path_external", false)) {
                 // Just pass the path directly

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -33,7 +33,7 @@ import org.jellyfin.apiclient.model.dlna.DeviceProfile;
 import org.jellyfin.apiclient.model.dlna.DirectPlayProfile;
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
@@ -332,7 +332,7 @@ public class PlaybackController {
                     return;
                 }
 
-                isLiveTv = item.getEBaseItemType() == EBaseItemType.TvChannel;
+                isLiveTv = item.getBaseItemType() == BaseItemType.TvChannel;
                 startSpinner();
 
                 //Build options for each player
@@ -921,7 +921,7 @@ public class PlaybackController {
     public void updateTvProgramInfo() {
         // Get the current program info when playing a live TV channel
         final BaseItemDto channel = getCurrentlyPlayingItem();
-        if (channel.getEBaseItemType() == EBaseItemType.TvChannel) {
+        if (channel.getBaseItemType() == BaseItemType.TvChannel) {
             TvApp.getApplication().getApiClient().GetLiveTvChannelAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<ChannelInfoDto>() {
                 @Override
                 public void onResponse(ChannelInfoDto response) {

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -33,6 +33,7 @@ import org.jellyfin.apiclient.model.dlna.DeviceProfile;
 import org.jellyfin.apiclient.model.dlna.DirectPlayProfile;
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
@@ -331,7 +332,7 @@ public class PlaybackController {
                     return;
                 }
 
-                isLiveTv = item.getType().equals("TvChannel");
+                isLiveTv = item.getEBaseItemType() == EBaseItemType.TvChannel;
                 startSpinner();
 
                 //Build options for each player
@@ -920,7 +921,7 @@ public class PlaybackController {
     public void updateTvProgramInfo() {
         // Get the current program info when playing a live TV channel
         final BaseItemDto channel = getCurrentlyPlayingItem();
-        if (channel.getType().equals("TvChannel")) {
+        if (channel.getEBaseItemType() == EBaseItemType.TvChannel) {
             TvApp.getApplication().getApiClient().GetLiveTvChannelAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<ChannelInfoDto>() {
                 @Override
                 public void onResponse(ChannelInfoDto response) {

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/CardPresenter.java
@@ -102,33 +102,33 @@ public class CardPresenter extends Presenter {
                     } else {
                         aspect = Utils.getSafeValue(ImageUtils.getImageAspectRatio(itemDto, m.getPreferParentThumb()), ImageUtils.ASPECT_RATIO_7_9);
                     }
-                    switch (itemDto.getType()) {
-                        case "Audio":
-                        case "MusicAlbum":
+                    switch (itemDto.getEBaseItemType()) {
+                        case Audio:
+                        case MusicAlbum:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_audio);
                             if (aspect < 0.8) {
                                 aspect = 1.0;
                             }
                             showWatched = false;
                             break;
-                        case "Person":
+                        case Person:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_person);
                             break;
-                        case "MusicArtist":
+                        case MusicArtist:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_person);
                             if (aspect < .8) {
                                 aspect = 1.0;
                             }
                             showWatched = false;
                             break;
-                        case "RecordingGroup":
+                        case RecordingGroup:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_record);
                             break;
-                        case "Season":
-                        case "Series":
+                        case Season:
+                        case Series:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_tv);
                             break;
-                        case "Episode":
+                        case Episode:
                             //TvApp.getApplication().getLogger().Debug("**** Image width: "+ cardWidth + " Aspect: " + Utils.getImageAspectRatio(itemDto, m.getPreferParentThumb()) + " Item: "+itemDto.getName());
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_land_tv);
                             switch (itemDto.getLocationType()) {
@@ -147,31 +147,31 @@ public class CardPresenter extends Presenter {
                             //Always show info for episodes
                             mCardView.setCardType(BaseCardView.CARD_TYPE_INFO_UNDER);
                             break;
-                        case "CollectionFolder":
+                        case CollectionFolder:
                             // Force the aspect ratio to 16x9 because the server is returning the wrong value of 1
                             aspect = ImageUtils.ASPECT_RATIO_16_9;
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_folder);
                             break;
-                        case "Folder":
-                        case "MovieGenreFolder":
-                        case "MusicGenreFolder":
-                        case "MovieGenre":
-                        case "Genre":
-                        case "MusicGenre":
-                        case "UserView":
+                        case Folder:
+                        case MovieGenreFolder:
+                        case MusicGenreFolder:
+                        case MovieGenre:
+                        case Genre:
+                        case MusicGenre:
+                        case UserView:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_folder);
                             break;
-                        case "Photo":
+                        case Photo:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_land_photo);
                             showWatched = false;
                             break;
-                        case "PhotoAlbum":
-                        case "Playlist":
+                        case PhotoAlbum:
+                        case Playlist:
                             showWatched = false;
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_folder);
                             break;
-                        case "Movie":
-                        case "Video":
+                        case Movie:
+                        case Video:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_port_video);
                             showProgress = true;
                             break;

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/CardPresenter.java
@@ -102,7 +102,7 @@ public class CardPresenter extends Presenter {
                     } else {
                         aspect = Utils.getSafeValue(ImageUtils.getImageAspectRatio(itemDto, m.getPreferParentThumb()), ImageUtils.ASPECT_RATIO_7_9);
                     }
-                    switch (itemDto.getEBaseItemType()) {
+                    switch (itemDto.getBaseItemType()) {
                         case Audio:
                         case MusicAlbum:
                             mDefaultCardImage = TvApp.getApplication().getDrawableCompat(R.drawable.tile_audio);

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/MyDetailsOverviewRowPresenter.java
@@ -131,7 +131,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
             vh.mSummary.setText(summarySpanned);
         }
 
-        switch (row.getItem().getEBaseItemType()) {
+        switch (row.getItem().getBaseItemType()) {
             case Person:
                 RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) vh.mSummary.getLayoutParams();
                 params.topMargin = 10;
@@ -160,7 +160,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
             for (String genre : item.getGenres()) {
                 if (!first) InfoLayoutHelper.addSpacer(TvApp.getApplication().getCurrentActivity(), layout, "  /  ", 12);
                 first = false;
-                layout.addView(new GenreButton(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getDefaultFont(), 14, genre, item.getEBaseItemType()));
+                layout.addView(new GenreButton(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getDefaultFont(), 14, genre, item.getBaseItemType()));
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/MyDetailsOverviewRowPresenter.java
@@ -131,8 +131,8 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
             vh.mSummary.setText(summarySpanned);
         }
 
-        switch (row.getItem().getType()) {
-            case "Person":
+        switch (row.getItem().getEBaseItemType()) {
+            case Person:
                 RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) vh.mSummary.getLayoutParams();
                 params.topMargin = 10;
                 params.height = Utils.convertDpToPixel(TvApp.getApplication(), 185);
@@ -160,7 +160,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
             for (String genre : item.getGenres()) {
                 if (!first) InfoLayoutHelper.addSpacer(TvApp.getApplication().getCurrentActivity(), layout, "  /  ", 12);
                 first = false;
-                layout.addView(new GenreButton(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getDefaultFont(), 14, genre, item.getType()));
+                layout.addView(new GenreButton(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getDefaultFont(), 14, genre, item.getEBaseItemType()));
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/MyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/MyImageCardView.java
@@ -237,22 +237,22 @@ public class MyImageCardView extends BaseCardView {
         if (mOverlayName == null) return;
 
         if (getCardType() == BaseCardView.CARD_TYPE_MAIN_ONLY && item.showCardInfoOverlay()) {
-            switch (item.getType()) {
-                case "Photo":
+            switch (item.getBaseItemType()) {
+                case Photo:
                     mOverlayName.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(item.getBaseItem().getPremiereDate())) : item.getFullName());
                     mOverlayIcon.setImageResource(R.drawable.ic_camera);
                     break;
-                case "PhotoAlbum":
+                case PhotoAlbum:
                     mOverlayName.setText(item.getFullName());
                     mOverlayIcon.setImageResource(R.drawable.ic_photos);
                     break;
-                case "Video":
+                case Video:
                     mOverlayName.setText(item.getFullName());
                     mOverlayIcon.setImageResource(R.drawable.ic_movie);
                     break;
-                case "Playlist":
-                case "MusicArtist":
-                case "Person":
+                case Playlist:
+                case MusicArtist:
+                case Person:
                     mOverlayName.setText(item.getFullName());
                     hideIcon();
                     break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GenreButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GenreButton.java
@@ -4,11 +4,13 @@ import android.content.Context;
 import android.graphics.Typeface;
 import androidx.appcompat.widget.AppCompatTextView;
 
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
+
 /**
  * Created by Eric on 2/21/2015.
  */
 public class GenreButton extends AppCompatTextView {
-    public GenreButton(Context context, Typeface font, int size, String text, String itemType) {
+    public GenreButton(Context context, Typeface font, int size, String text, EBaseItemType itemType) {
         super(context);
         setTypeface(font);
         setTextSize(size);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GenreButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GenreButton.java
@@ -4,13 +4,13 @@ import android.content.Context;
 import android.graphics.Typeface;
 import androidx.appcompat.widget.AppCompatTextView;
 
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 
 /**
  * Created by Eric on 2/21/2015.
  */
 public class GenreButton extends AppCompatTextView {
-    public GenreButton(Context context, Typeface font, int size, String text, EBaseItemType itemType) {
+    public GenreButton(Context context, Typeface font, int size, String text, BaseItemType itemType) {
         super(context);
         setTypeface(font);
         setTextSize(size);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemPanel.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemPanel.java
@@ -13,7 +13,7 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 
 /**
  * Created by Eric on 7/27/2015.
@@ -50,7 +50,7 @@ public class ItemPanel extends RelativeLayout {
 
     public void setItem(BaseRowItem item) {
         if (item != null) {
-            title.setText(item.getFullName() + (item.getItemType() == BaseRowItem.ItemType.BaseItem && item.getBaseItemType() == EBaseItemType.Episode ? " - " + item.getName() : ""));
+            title.setText(item.getFullName() + (item.getItemType() == BaseRowItem.ItemType.BaseItem && item.getBaseItemType() == BaseItemType.Episode ? " - " + item.getName() : ""));
             if (TvApp.getApplication().getCurrentActivity() != null) InfoLayoutHelper.addInfoRow(TvApp.getApplication().getCurrentActivity(), item, infoRow, true, true);
             summary.setText(item.getSummary());
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemPanel.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemPanel.java
@@ -13,6 +13,7 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 
 /**
  * Created by Eric on 7/27/2015.
@@ -49,7 +50,7 @@ public class ItemPanel extends RelativeLayout {
 
     public void setItem(BaseRowItem item) {
         if (item != null) {
-            title.setText(item.getFullName() + (item.getItemType() == BaseRowItem.ItemType.BaseItem && "Episode".equals(item.getBaseItem().getType()) ? " - " + item.getName() : ""));
+            title.setText(item.getFullName() + (item.getItemType() == BaseRowItem.ItemType.BaseItem && item.getBaseItemType() == EBaseItemType.Episode ? " - " + item.getName() : ""));
             if (TvApp.getApplication().getCurrentActivity() != null) InfoLayoutHelper.addInfoRow(TvApp.getApplication().getCurrentActivity(), item, infoRow, true, true);
             summary.setText(item.getSummary());
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemRowView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemRowView.java
@@ -95,7 +95,7 @@ public class ItemRowView extends FrameLayout {
         mBaseItem = item;
         ourIndex = ndx + 1;
         mIndexNo.setText(Integer.toString(ourIndex));
-        switch (item.getEBaseItemType()) {
+        switch (item.getBaseItemType()) {
             case Audio:
                 mItemName.setText(item.getName());
                 String artist = item.getArtists() != null && item.getArtists().size() > 0 ? item.getArtists().get(0) : !TextUtils.isEmpty(item.getAlbumArtist()) ? item.getAlbumArtist() : null;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemRowView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemRowView.java
@@ -95,8 +95,8 @@ public class ItemRowView extends FrameLayout {
         mBaseItem = item;
         ourIndex = ndx + 1;
         mIndexNo.setText(Integer.toString(ourIndex));
-        switch (item.getType()) {
-            case "Audio":
+        switch (item.getEBaseItemType()) {
+            case Audio:
                 mItemName.setText(item.getName());
                 String artist = item.getArtists() != null && item.getArtists().size() > 0 ? item.getArtists().get(0) : !TextUtils.isEmpty(item.getAlbumArtist()) ? item.getAlbumArtist() : null;
                 if (!TextUtils.isEmpty(artist)) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
 import org.jellyfin.apiclient.model.dto.StudioDto;
 import org.jellyfin.apiclient.model.dto.UserDto;
@@ -27,8 +27,8 @@ public class ImageUtils {
 
     private static final int MAX_PRIMARY_IMAGE_HEIGHT = 370;
 
-    private static final List<EBaseItemType> THUMB_FALLBACK_TYPES = Collections.singletonList(EBaseItemType.Episode);
-    private static final List<EBaseItemType> PROGRESS_INDICATOR_TYPES = Arrays.asList(EBaseItemType.Episode, EBaseItemType.Movie, EBaseItemType.MusicVideo, EBaseItemType.Video);
+    private static final List<BaseItemType> THUMB_FALLBACK_TYPES = Collections.singletonList(BaseItemType.Episode);
+    private static final List<BaseItemType> PROGRESS_INDICATOR_TYPES = Arrays.asList(BaseItemType.Episode, BaseItemType.Movie, BaseItemType.MusicVideo, BaseItemType.Video);
 
     public static Double getImageAspectRatio(BaseItemDto item, boolean preferParentThumb) {
         if (preferParentThumb &&
@@ -36,7 +36,7 @@ public class ImageUtils {
             return ASPECT_RATIO_16_9;
         }
 
-        if (THUMB_FALLBACK_TYPES.contains(item.getEBaseItemType())) {
+        if (THUMB_FALLBACK_TYPES.contains(item.getBaseItemType())) {
             if (item.getPrimaryImageAspectRatio() != null) {
                 return item.getPrimaryImageAspectRatio();
             }
@@ -135,8 +135,8 @@ public class ImageUtils {
         options.setImageType(ImageType.Banner);
 
         UserItemDataDto userData = item.getUserData();
-        if (userData != null && item.getEBaseItemType() != EBaseItemType.MusicArtist && item.getEBaseItemType() != EBaseItemType.MusicAlbum) {
-            if (PROGRESS_INDICATOR_TYPES.contains(item.getEBaseItemType()) &&
+        if (userData != null && item.getBaseItemType() != BaseItemType.MusicArtist && item.getBaseItemType() != BaseItemType.MusicAlbum) {
+            if (PROGRESS_INDICATOR_TYPES.contains(item.getBaseItemType()) &&
                     userData.getPlayedPercentage() != null &&
                     userData.getPlayedPercentage() > 0 &&
                     userData.getPlayedPercentage() < 99) {
@@ -164,7 +164,7 @@ public class ImageUtils {
     }
 
     public static String getPrimaryImageUrl(BaseItemDto item, ApiClient apiClient, boolean showProgress, boolean preferParentThumb, boolean preferSeriesPoster, int maxHeight) {
-        if (item.getEBaseItemType() == EBaseItemType.SeriesTimer) {
+        if (item.getBaseItemType() == BaseItemType.SeriesTimer) {
             return getResourceUrl(R.drawable.tile_land_series_timer);
         }
 
@@ -173,7 +173,7 @@ public class ImageUtils {
         String imageTag = item.getImageTags() != null ? item.getImageTags().get(ImageType.Primary) : null;
         ImageType imageType = ImageType.Primary;
 
-        if (preferSeriesPoster && item.getEBaseItemType() == EBaseItemType.Episode) {
+        if (preferSeriesPoster && item.getBaseItemType() == BaseItemType.Episode) {
             if (item.getSeasonId() != null) {
                 imageTag = null;
                 itemId = item.getSeasonId();
@@ -181,7 +181,7 @@ public class ImageUtils {
                 imageTag = item.getSeriesPrimaryImageTag();
                 itemId = item.getSeriesId();
             }
-        } else if (preferParentThumb || (item.getEBaseItemType() == EBaseItemType.Episode && imageTag == null)) {
+        } else if (preferParentThumb || (item.getBaseItemType() == BaseItemType.Episode && imageTag == null)) {
             //try for thumb of season or series
             if (item.getParentThumbImageTag() != null) {
                 imageTag = item.getParentThumbImageTag();
@@ -193,16 +193,16 @@ public class ImageUtils {
                 imageType = ImageType.Thumb;
             }
         } else {
-            if (item.getEBaseItemType() == EBaseItemType.Season && imageTag == null) {
+            if (item.getBaseItemType() == BaseItemType.Season && imageTag == null) {
                 imageTag = item.getSeriesPrimaryImageTag();
                 itemId = item.getSeriesId();
-            } else if (item.getEBaseItemType() == EBaseItemType.Program && item.getHasThumb()) {
+            } else if (item.getBaseItemType() == BaseItemType.Program && item.getHasThumb()) {
                 imageTag = item.getImageTags().get(ImageType.Thumb);
                 imageType = ImageType.Thumb;
             }
         }
 
-        if (item.getEBaseItemType() == EBaseItemType.Audio && !item.getHasPrimaryImage()) {
+        if (item.getBaseItemType() == BaseItemType.Audio && !item.getHasPrimaryImage()) {
             //Try the album or artist
             if (item.getAlbumId() != null && item.getAlbumPrimaryImageTag() != null) {
                 imageTag = item.getAlbumPrimaryImageTag();
@@ -219,7 +219,7 @@ public class ImageUtils {
 
         UserItemDataDto userData = item.getUserData();
         if (userData != null) {
-            if (showProgress && PROGRESS_INDICATOR_TYPES.contains(item.getEBaseItemType()) &&
+            if (showProgress && PROGRESS_INDICATOR_TYPES.contains(item.getBaseItemType()) &&
                     userData.getPlayedPercentage() != null &&
                     userData.getPlayedPercentage() > 0 &&
                     userData.getPlayedPercentage() < 99) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
 import org.jellyfin.apiclient.model.dto.StudioDto;
 import org.jellyfin.apiclient.model.dto.UserDto;
@@ -26,8 +27,8 @@ public class ImageUtils {
 
     private static final int MAX_PRIMARY_IMAGE_HEIGHT = 370;
 
-    private static final List<String> THUMB_FALLBACK_TYPES = Collections.singletonList("Episode");
-    private static final List<String> PROGRESS_INDICATOR_TYPES = Arrays.asList("Episode", "Movie", "MusicVideo", "Video");
+    private static final List<EBaseItemType> THUMB_FALLBACK_TYPES = Collections.singletonList(EBaseItemType.Episode);
+    private static final List<EBaseItemType> PROGRESS_INDICATOR_TYPES = Arrays.asList(EBaseItemType.Episode, EBaseItemType.Movie, EBaseItemType.MusicVideo, EBaseItemType.Video);
 
     public static Double getImageAspectRatio(BaseItemDto item, boolean preferParentThumb) {
         if (preferParentThumb &&
@@ -35,7 +36,7 @@ public class ImageUtils {
             return ASPECT_RATIO_16_9;
         }
 
-        if (THUMB_FALLBACK_TYPES.contains(item.getType())) {
+        if (THUMB_FALLBACK_TYPES.contains(item.getEBaseItemType())) {
             if (item.getPrimaryImageAspectRatio() != null) {
                 return item.getPrimaryImageAspectRatio();
             }
@@ -134,8 +135,8 @@ public class ImageUtils {
         options.setImageType(ImageType.Banner);
 
         UserItemDataDto userData = item.getUserData();
-        if (userData != null && !"MusicArtist".equals(item.getType()) && !"MusicAlbum".equals(item.getType())) {
-            if (PROGRESS_INDICATOR_TYPES.contains(item.getType()) &&
+        if (userData != null && item.getEBaseItemType() != EBaseItemType.MusicArtist && item.getEBaseItemType() != EBaseItemType.MusicAlbum) {
+            if (PROGRESS_INDICATOR_TYPES.contains(item.getEBaseItemType()) &&
                     userData.getPlayedPercentage() != null &&
                     userData.getPlayedPercentage() > 0 &&
                     userData.getPlayedPercentage() < 99) {
@@ -163,7 +164,7 @@ public class ImageUtils {
     }
 
     public static String getPrimaryImageUrl(BaseItemDto item, ApiClient apiClient, boolean showProgress, boolean preferParentThumb, boolean preferSeriesPoster, int maxHeight) {
-        if (item.getType().equals("SeriesTimer")) {
+        if (item.getEBaseItemType() == EBaseItemType.SeriesTimer) {
             return getResourceUrl(R.drawable.tile_land_series_timer);
         }
 
@@ -172,7 +173,7 @@ public class ImageUtils {
         String imageTag = item.getImageTags() != null ? item.getImageTags().get(ImageType.Primary) : null;
         ImageType imageType = ImageType.Primary;
 
-        if (preferSeriesPoster && item.getType().equals("Episode")) {
+        if (preferSeriesPoster && item.getEBaseItemType() == EBaseItemType.Episode) {
             if (item.getSeasonId() != null) {
                 imageTag = null;
                 itemId = item.getSeasonId();
@@ -180,7 +181,7 @@ public class ImageUtils {
                 imageTag = item.getSeriesPrimaryImageTag();
                 itemId = item.getSeriesId();
             }
-        } else if (preferParentThumb || (item.getType().equals("Episode") && imageTag == null)) {
+        } else if (preferParentThumb || (item.getEBaseItemType() == EBaseItemType.Episode && imageTag == null)) {
             //try for thumb of season or series
             if (item.getParentThumbImageTag() != null) {
                 imageTag = item.getParentThumbImageTag();
@@ -192,16 +193,16 @@ public class ImageUtils {
                 imageType = ImageType.Thumb;
             }
         } else {
-            if (item.getType().equals("Season") && imageTag == null) {
+            if (item.getEBaseItemType() == EBaseItemType.Season && imageTag == null) {
                 imageTag = item.getSeriesPrimaryImageTag();
                 itemId = item.getSeriesId();
-            } else if (item.getType().equals("Program") && item.getHasThumb()) {
+            } else if (item.getEBaseItemType() == EBaseItemType.Program && item.getHasThumb()) {
                 imageTag = item.getImageTags().get(ImageType.Thumb);
                 imageType = ImageType.Thumb;
             }
         }
 
-        if ("Audio".equals(item.getType()) && !item.getHasPrimaryImage()) {
+        if (item.getEBaseItemType() == EBaseItemType.Audio && !item.getHasPrimaryImage()) {
             //Try the album or artist
             if (item.getAlbumId() != null && item.getAlbumPrimaryImageTag() != null) {
                 imageTag = item.getAlbumPrimaryImageTag();
@@ -218,7 +219,7 @@ public class ImageUtils {
 
         UserItemDataDto userData = item.getUserData();
         if (userData != null) {
-            if (showProgress && PROGRESS_INDICATOR_TYPES.contains(item.getType()) &&
+            if (showProgress && PROGRESS_INDICATOR_TYPES.contains(item.getEBaseItemType()) &&
                     userData.getPlayedPercentage() != null &&
                     userData.getPlayedPercentage() > 0 &&
                     userData.getPlayedPercentage() < 99) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -18,6 +18,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
 import org.jellyfin.apiclient.model.entities.SeriesStatus;
 
@@ -47,31 +48,31 @@ public class InfoLayoutHelper {
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
         layout.removeAllViews();
         addCriticInfo(activity, item, layout);
-        switch (item.getType()) {
-            case "Episode":
+        switch (item.getEBaseItemType()) {
+            case Episode:
                 addSeasonEpisode(activity, item, layout);
                 addDate(activity, item, layout);
                 break;
-            case "BoxSet":
+            case BoxSet:
                 addBoxSetCounts(activity, item, layout);
                 break;
-            case "Series":
+            case Series:
                 //addSeasonCount(activity, item, layout);
                 addSeriesAirs(activity, item, layout);
                 addDate(activity, item, layout);
                 includeEndTime = false;
                 break;
-            case "Program":
+            case Program:
                 addProgramInfo(activity, item, layout);
                 break;
-            case "RecordingGroup":
+            case RecordingGroup:
                 addRecordingCount(activity, item, layout);
                 break;
-            case "MusicArtist":
+            case MusicArtist:
                 Integer artistAlbums = item.getAlbumCount() != null ? item.getAlbumCount() : item.getChildCount();
                 addCount(activity, artistAlbums, layout, artistAlbums != null && artistAlbums == 1 ? activity.getResources().getString(R.string.lbl_album) : activity.getResources().getString(R.string.lbl_albums));
                 return;
-            case "MusicAlbum":
+            case MusicAlbum:
                 String artist = item.getAlbumArtist() != null ? item.getAlbumArtist() : item.getArtists() != null && item.getAlbumArtists().size() > 0 ? item.getArtists().get(0) : null;
                 if (artist != null) {
                     addText(activity, artist+" ", layout, 500);
@@ -80,7 +81,7 @@ public class InfoLayoutHelper {
                 Integer songCount = item.getSongCount() != null ? item.getSongCount() : item.getChildCount();
                 addCount(activity, songCount, layout, songCount == 1 ? activity.getResources().getString(R.string.lbl_song) : activity.getResources().getString(R.string.lbl_songs));
                 return;
-            case "Playlist":
+            case Playlist:
                 if (item.getChildCount() != null) addCount(activity, item.getChildCount(), layout, item.getChildCount() == 1 ? activity.getResources().getString(R.string.lbl_item) : activity.getResources().getString(R.string.lbl_items));
                 if (item.getCumulativeRunTimeTicks() != null) addText(activity, " ("+ TimeUtils.formatMillis(item.getCumulativeRunTimeTicks() / 10000)+")", layout, 300);
                 break;
@@ -263,8 +264,8 @@ public class InfoLayoutHelper {
     private static void addDate(Activity activity, BaseItemDto item, LinearLayout layout) {
         TextView date = new TextView(activity);
         date.setTextSize(textSize);
-        switch (item.getType()) {
-            case "Person":
+        switch (item.getEBaseItemType()) {
+            case Person:
                 StringBuilder sb = new StringBuilder();
                 if (item.getPremiereDate() != null) {
                     sb.append(TvApp.getApplication().getString(R.string.lbl_born));
@@ -287,8 +288,8 @@ public class InfoLayoutHelper {
                 layout.addView(date);
                 break;
 
-            case "Program":
-            case "TvChannel":
+            case Program:
+            case TvChannel:
                 if (item.getStartDate() != null && item.getEndDate() != null) {
                     date.setText(android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(item.getStartDate()))
                             + "-"+ android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(item.getEndDate())));
@@ -296,7 +297,7 @@ public class InfoLayoutHelper {
                     addSpacer(activity, layout, "    ");
                 }
                 break;
-            case "Series":
+            case Series:
                 if (item.getProductionYear() != null && item.getProductionYear() > 0) {
                     date.setText(item.getProductionYear().toString());
                     layout.addView(date);
@@ -343,7 +344,7 @@ public class InfoLayoutHelper {
     }
 
     private static void addSeriesStatus(Activity activity, BaseItemDto item, LinearLayout layout) {
-        if ("Series".equals(item.getType()) && item.getSeriesStatus() != null) {
+        if (item.getEBaseItemType() == EBaseItemType.Series && item.getSeriesStatus() != null) {
             boolean continuing = item.getSeriesStatus() == SeriesStatus.Continuing;
             String status = continuing ? activity.getString(R.string.lbl__continuing) : activity.getString(R.string.lbl_ended);
             addBlockText(activity, layout, status, textSize-4, Color.LTGRAY, continuing ? R.drawable.green_gradient : R.drawable.red_gradient);

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -18,7 +18,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
 import org.jellyfin.apiclient.model.entities.SeriesStatus;
 
@@ -48,7 +48,7 @@ public class InfoLayoutHelper {
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
         layout.removeAllViews();
         addCriticInfo(activity, item, layout);
-        switch (item.getEBaseItemType()) {
+        switch (item.getBaseItemType()) {
             case Episode:
                 addSeasonEpisode(activity, item, layout);
                 addDate(activity, item, layout);
@@ -264,7 +264,7 @@ public class InfoLayoutHelper {
     private static void addDate(Activity activity, BaseItemDto item, LinearLayout layout) {
         TextView date = new TextView(activity);
         date.setTextSize(textSize);
-        switch (item.getEBaseItemType()) {
+        switch (item.getBaseItemType()) {
             case Person:
                 StringBuilder sb = new StringBuilder();
                 if (item.getPremiereDate() != null) {
@@ -344,7 +344,7 @@ public class InfoLayoutHelper {
     }
 
     private static void addSeriesStatus(Activity activity, BaseItemDto item, LinearLayout layout) {
-        if (item.getEBaseItemType() == EBaseItemType.Series && item.getSeriesStatus() != null) {
+        if (item.getBaseItemType() == BaseItemType.Series && item.getSeriesStatus() != null) {
             boolean continuing = item.getSeriesStatus() == SeriesStatus.Continuing;
             String status = continuing ? activity.getString(R.string.lbl__continuing) : activity.getString(R.string.lbl_ended);
             addBlockText(activity, layout, status, textSize-4, Color.LTGRAY, continuing ? R.drawable.green_gradient : R.drawable.red_gradient);

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -27,7 +27,7 @@ import java.util.List;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
@@ -65,7 +65,7 @@ public class KeyProcessor {
         switch (key) {
             case KeyEvent.KEYCODE_MEDIA_PLAY:
             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                if (MediaManager.isPlayingAudio() && (!rowItem.isBaseItem() || rowItem.getBaseItemType() != EBaseItemType.Photo)) {
+                if (MediaManager.isPlayingAudio() && (!rowItem.isBaseItem() || rowItem.getBaseItemType() != BaseItemType.Photo)) {
                     MediaManager.pauseAudio();
                     return true;
                 }
@@ -75,7 +75,7 @@ public class KeyProcessor {
                     case BaseItem:
                         BaseItemDto item = rowItem.getBaseItem();
                         if (!BaseItemUtils.canPlay(item)) return false;
-                        switch (item.getEBaseItemType()) {
+                        switch (item.getBaseItemType()) {
                             case Audio:
                                 if (rowItem instanceof AudioQueueItem) {
                                     createItemMenu(rowItem, item.getUserData(), activity);
@@ -159,7 +159,7 @@ public class KeyProcessor {
                         if (rowItem.getGridButton().getId() == TvApp.VIDEO_QUEUE_OPTION_ID) {
                             //Queue already there - just kick off playback
                             Utils.beep();
-                            EBaseItemType itemType = MediaManager.getCurrentVideoQueue().size() > 0 ? MediaManager.getCurrentVideoQueue().get(0).getEBaseItemType() : null;
+                            BaseItemType itemType = MediaManager.getCurrentVideoQueue().size() > 0 ? MediaManager.getCurrentVideoQueue().get(0).getBaseItemType() : null;
                             Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(itemType));
                             activity.startActivity(intent);
                         }
@@ -181,7 +181,7 @@ public class KeyProcessor {
 
                     case BaseItem:
                         BaseItemDto item = rowItem.getBaseItem();
-                        switch (item.getEBaseItemType()) {
+                        switch (item.getBaseItemType()) {
                             case Movie:
                             case Episode:
                             case TvChannel:
@@ -269,9 +269,9 @@ public class KeyProcessor {
         } else {
             if (BaseItemUtils.canPlay(item)) {
                 if (item.getIsFolderItem()
-                        && item.getEBaseItemType() != EBaseItemType.MusicAlbum
-                        && item.getEBaseItemType() != EBaseItemType.Playlist
-                        && item.getEBaseItemType() != EBaseItemType.MusicArtist
+                        && item.getBaseItemType() != BaseItemType.MusicAlbum
+                        && item.getBaseItemType() != BaseItemType.Playlist
+                        && item.getBaseItemType() != BaseItemType.MusicArtist
                         && userData!= null
                         && userData.getUnplayedItemCount() !=null
                         && userData.getUnplayedItemCount() > 0) {
@@ -283,17 +283,17 @@ public class KeyProcessor {
                 }
             }
 
-            isMusic = item.getEBaseItemType() == EBaseItemType.MusicAlbum
-                    || item.getEBaseItemType() == EBaseItemType.MusicArtist
-                    || item.getEBaseItemType() == EBaseItemType.Audio
-                    || (item.getEBaseItemType() == EBaseItemType.Playlist && "Audio".equals(item.getMediaType()));
+            isMusic = item.getBaseItemType() == BaseItemType.MusicAlbum
+                    || item.getBaseItemType() == BaseItemType.MusicArtist
+                    || item.getBaseItemType() == BaseItemType.Audio
+                    || (item.getBaseItemType() == BaseItemType.Playlist && "Audio".equals(item.getMediaType()));
 
             if (isMusic || !item.getIsFolderItem()) {
                 menu.getMenu().add(0, MENU_ADD_QUEUE, order++, R.string.lbl_add_to_queue);
             }
 
             if (isMusic) {
-                if (item.getEBaseItemType() != EBaseItemType.Playlist) {
+                if (item.getBaseItemType() != BaseItemType.Playlist) {
                     menu.getMenu().add(0, MENU_INSTANT_MIX, order++, R.string.lbl_instant_mix);
                 }
             } else {
@@ -339,7 +339,7 @@ public class KeyProcessor {
     private static void createPlayMenu(BaseItemDto item, boolean isFolder, boolean isMusic, BaseActivity activity) {
         PopupMenu menu = Utils.createPopupMenu(activity, activity.getCurrentFocus(), Gravity.RIGHT);
         int order = 0;
-        if (!isMusic && item.getEBaseItemType() != EBaseItemType.Playlist) {
+        if (!isMusic && item.getBaseItemType() != BaseItemType.Playlist) {
             menu.getMenu().add(0, MENU_PLAY_FIRST_UNWATCHED, order++, R.string.lbl_play_first_unwatched);
         }
         menu.getMenu().add(0, MENU_PLAY, order++, R.string.lbl_play_all);

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
@@ -15,8 +15,8 @@ import java.util.List;
 
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.ChapterInfoDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.entities.LocationType;
@@ -26,21 +26,21 @@ import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
 public class BaseItemUtils {
     // TODO Feature Envy!!! Wants to live in BaseItemDto.
     public static boolean isLiveTv(BaseItemDto item) {
-        return item.getEBaseItemType() == EBaseItemType.Program
-                || item.getEBaseItemType() == EBaseItemType.LiveTvChannel;
+        return item.getBaseItemType() == BaseItemType.Program
+                || item.getBaseItemType() == BaseItemType.LiveTvChannel;
     }
 
     public static boolean canPlay(BaseItemDto item) {
         return item.getPlayAccess().equals(PlayAccess.Full)
                 && ((item.getIsPlaceHolder() == null || !item.getIsPlaceHolder())
-                && (item.getEBaseItemType() != EBaseItemType.Episode || !item.getLocationType().equals(LocationType.Virtual)))
-                && (item.getEBaseItemType() != EBaseItemType.Person)
-                && (item.getEBaseItemType() != EBaseItemType.SeriesTimer)
+                && (item.getBaseItemType() != BaseItemType.Episode || !item.getLocationType().equals(LocationType.Virtual)))
+                && (item.getBaseItemType() != BaseItemType.Person)
+                && (item.getBaseItemType() != BaseItemType.SeriesTimer)
                 && (!item.getIsFolderItem() || item.getChildCount() == null || item.getChildCount() > 0);
     }
 
     public static String getFullName(BaseItemDto item) {
-        switch (item.getEBaseItemType()) {
+        switch (item.getBaseItemType()) {
             case Episode:
                 return item.getSeriesName() + (item.getParentIndexNumber() != null ? " S" + item.getParentIndexNumber() : "") + (item.getIndexNumber() != null ? " E" + item.getIndexNumber() : "") + (item.getIndexNumberEnd() != null ? "-" + item.getIndexNumberEnd() : "");
             case Audio:
@@ -53,7 +53,7 @@ public class BaseItemUtils {
     }
 
     public static String getSubName(BaseItemDto item) {
-        switch (item.getEBaseItemType()) {
+        switch (item.getBaseItemType()) {
             case Episode:
                 String addendum = item.getLocationType().equals(LocationType.Virtual) && item.getPremiereDate() != null ? " (" +  TimeUtils.getFriendlyDate(TimeUtils.convertToLocalDate(item.getPremiereDate())) + ")" : "";
                 return item.getName() + addendum;

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
 import org.jellyfin.apiclient.model.dto.ChapterInfoDto;
+import org.jellyfin.apiclient.model.dto.EBaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.entities.LocationType;
@@ -23,25 +24,27 @@ import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
 
 public class BaseItemUtils {
+    // TODO Feature Envy!!! Wants to live in BaseItemDto.
     public static boolean isLiveTv(BaseItemDto item) {
-        return "Program".equals(item.getType()) || "LiveTvChannel".equals(item.getType());
+        return item.getEBaseItemType() == EBaseItemType.Program
+                || item.getEBaseItemType() == EBaseItemType.LiveTvChannel;
     }
 
     public static boolean canPlay(BaseItemDto item) {
         return item.getPlayAccess().equals(PlayAccess.Full)
                 && ((item.getIsPlaceHolder() == null || !item.getIsPlaceHolder())
-                && (!item.getType().equals("Episode") || !item.getLocationType().equals(LocationType.Virtual)))
-                && (!item.getType().equals("Person"))
-                && (!item.getType().equals("SeriesTimer"))
+                && (item.getEBaseItemType() != EBaseItemType.Episode || !item.getLocationType().equals(LocationType.Virtual)))
+                && (item.getEBaseItemType() != EBaseItemType.Person)
+                && (item.getEBaseItemType() != EBaseItemType.SeriesTimer)
                 && (!item.getIsFolderItem() || item.getChildCount() == null || item.getChildCount() > 0);
     }
 
     public static String getFullName(BaseItemDto item) {
-        switch (item.getType()) {
-            case "Episode":
+        switch (item.getEBaseItemType()) {
+            case Episode:
                 return item.getSeriesName() + (item.getParentIndexNumber() != null ? " S" + item.getParentIndexNumber() : "") + (item.getIndexNumber() != null ? " E" + item.getIndexNumber() : "") + (item.getIndexNumberEnd() != null ? "-" + item.getIndexNumberEnd() : "");
-            case "Audio":
-            case "MusicAlbum":
+            case Audio:
+            case MusicAlbum:
                 // we actually want the artist name if available
                 return (item.getAlbumArtist() != null ? item.getAlbumArtist() + " - " : "") + item.getName();
             default:
@@ -50,15 +53,15 @@ public class BaseItemUtils {
     }
 
     public static String getSubName(BaseItemDto item) {
-        switch (item.getType()) {
-            case "Episode":
+        switch (item.getEBaseItemType()) {
+            case Episode:
                 String addendum = item.getLocationType().equals(LocationType.Virtual) && item.getPremiereDate() != null ? " (" +  TimeUtils.getFriendlyDate(TimeUtils.convertToLocalDate(item.getPremiereDate())) + ")" : "";
                 return item.getName() + addendum;
-            case "Season":
+            case Season:
                 return item.getChildCount() != null && item.getChildCount() > 0 ? item.getChildCount() + " " + TvApp.getApplication().getString(R.string.lbl_episodes) : "";
-            case "MusicAlbum":
+            case MusicAlbum:
                 return item.getChildCount() != null && item.getChildCount() > 0 ? item.getChildCount() + " " + TvApp.getApplication().getString(item.getChildCount() > 1 ? R.string.lbl_songs : R.string.lbl_song) : "";
-            case "Audio":
+            case Audio:
                 return item.getName();
             default:
                 return item.getOfficialRating();

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.EBaseItemType;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.querying.ItemFields;
@@ -33,7 +33,7 @@ public class PlaybackHelper {
         ItemQuery query = new ItemQuery();
         TvApp.getApplication().setPlayingIntros(false);
 
-        switch (mainItem.getEBaseItemType()) {
+        switch (mainItem.getBaseItemType()) {
             case Episode:
                 items.add(mainItem);
                 if (TvApp.getApplication().getPrefs().getBoolean("pref_enable_tv_queuing", true)) {
@@ -101,7 +101,7 @@ public class PlaybackHelper {
                 query.setIsMissing(false);
                 query.setIsVirtualUnaired(false);
                 query.setMediaTypes(new String[]{"Audio"});
-                query.setSortBy(shuffle ? new String[] {ItemSortBy.Random} : mainItem.getEBaseItemType() == EBaseItemType.MusicArtist ? new String[] {ItemSortBy.Album} : new String[] {ItemSortBy.SortName});
+                query.setSortBy(shuffle ? new String[] {ItemSortBy.Random} : mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.Album} : new String[] {ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(150); // guard against too many items
                 query.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Genres});
@@ -180,7 +180,7 @@ public class PlaybackHelper {
                 break;
 
             default:
-                if (allowIntros && !TvApp.getApplication().useExternalPlayer(mainItem.getEBaseItemType()) && TvApp.getApplication().getPrefs().getBoolean("pref_enable_cinema_mode", true)) {
+                if (allowIntros && !TvApp.getApplication().useExternalPlayer(mainItem.getBaseItemType()) && TvApp.getApplication().getPrefs().getBoolean("pref_enable_cinema_mode", true)) {
                     //Intros
                     TvApp.getApplication().getApiClient().GetIntrosAsync(mainItem.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<ItemsResult>() {
                         @Override
@@ -211,10 +211,10 @@ public class PlaybackHelper {
     }
 
     public static void play(final BaseItemDto item, final int pos, final boolean shuffle, final Context activity) {
-        getItemsToPlay(item, pos == 0 && item.getEBaseItemType() == EBaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
+        getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
-                switch (item.getEBaseItemType()) {
+                switch (item.getBaseItemType()) {
                     case MusicAlbum:
                     case MusicArtist:
                         MediaManager.playNow(response);
@@ -224,7 +224,7 @@ public class PlaybackHelper {
                             MediaManager.playNow(response);
 
                         } else {
-                            EBaseItemType itemType = response.size() > 0 ? response.get(0).getEBaseItemType() : null;
+                            BaseItemType itemType = response.size() > 0 ? response.get(0).getBaseItemType() : null;
                             Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(itemType));
                             MediaManager.setCurrentVideoQueue(response);
                             intent.putExtra("Position", pos);
@@ -240,7 +240,7 @@ public class PlaybackHelper {
                         break;
 
                     default:
-                        Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(item.getEBaseItemType()));
+                        Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(item.getBaseItemType()));
                         MediaManager.setCurrentVideoQueue(response);
                         intent.putExtra("Position", pos);
                         if (!(activity instanceof Activity))

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
@@ -22,11 +22,11 @@ public class ReportingHelper {
             TvApp.getApplication().getPlaybackManager().reportPlaybackStopped(info, streamInfo, apiClient.getServerInfo().getId(), TvApp.getApplication().getCurrentUser().getId(), false, apiClient, new EmptyResponse());
 
             TvApp.getApplication().setLastPlayback(Calendar.getInstance());
-            switch (item.getType()) {
-                case "Movie":
+            switch (item.getEBaseItemType()) {
+                case Movie:
                     TvApp.getApplication().setLastMoviePlayback(Calendar.getInstance());
                     break;
-                case "Episode":
+                case Episode:
                     TvApp.getApplication().setLastTvPlayback(Calendar.getInstance());
                     break;
             }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
@@ -22,7 +22,7 @@ public class ReportingHelper {
             TvApp.getApplication().getPlaybackManager().reportPlaybackStopped(info, streamInfo, apiClient.getServerInfo().getId(), TvApp.getApplication().getCurrentUser().getId(), false, apiClient, new EmptyResponse());
 
             TvApp.getApplication().setLastPlayback(Calendar.getInstance());
-            switch (item.getEBaseItemType()) {
+            switch (item.getBaseItemType()) {
                 case Movie:
                     TvApp.getApplication().setLastMoviePlayback(Calendar.getInstance());
                     break;

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ def apiclientLocation = '../jellyfin-apiclient-java'
 if (new File(apiclientLocation).exists()) {
     includeBuild(apiclientLocation) {
         dependencySubstitution {
-            substitute module('com.github.jellyfin.jellyfin-apiclient-java:library:master-SNAPSHOT') with project(':library')
+            substitute module('com.github.jellyfin.jellyfin-apiclient-java:library') with project(':library')
         }
     }
 }


### PR DESCRIPTION
Also fixing dependency substitution now that we use explicit versions

This depends on the related PR jellyfin/jellyfin-apiclient-java#30 , which should be made available as release v0.5.0 before this is merged.

I'm sorry for the person that reviews this and makes sure that all conditional replacements are correct, it was a pain for me to write and review before sending the PR as well :(

Luckily this has to be done only once :)