### PR TITLE
Fixed playlist query

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
  - [BnMcG](https://github.com/bnmcg)
  - [Letroll](https://github.com/letroll)
  - [AndreasGB](https://github.com/andreasgb)
+ - [joern-h](https://github.com/joern-h)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
@@ -181,7 +181,6 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 //AudioPlaylists
                 StdItemQuery playlists = new StdItemQuery(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.CumulativeRunTimeTicks});
                 playlists.setIncludeItemTypes(new String[]{"Playlist"});
-                playlists.setMediaTypes(new String[]{"Audio"});
                 playlists.setImageTypeLimit(1);
                 playlists.setRecursive(true);
                 playlists.setSortBy(new String[]{ItemSortBy.DateCreated});

--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -578,7 +578,7 @@ public class ItemListActivity extends BaseActivity {
                     @Override
                     public void onClick(View v) {
                         if (mItems.size() > 0) {
-                            if (mBaseItem.getId().equals(VIDEO_QUEUE) || mBaseItem.getId().equals(FAV_SONGS)) {
+                            if (mBaseItem.getId().equals(VIDEO_QUEUE) || mBaseItem.getId().equals(FAV_SONGS) || "Playlist".equals(mBaseItem.getType())) {
                                 List<BaseItemDto> shuffled = new ArrayList<>(mItems);
                                 Collections.shuffle(shuffled);
                                 play(shuffled);


### PR DESCRIPTION
Issue: 
Playlists in music library are missing, only the playlist with the favorites was present.

![Before](https://user-images.githubusercontent.com/23190970/69890062-83285480-12f4-11ea-86ac-7283a6848639.png)


Fix: 
The playlist query with MediaTypes=Audio dosent return any elements. Removing this argument solves it. This argument also does not exist in the jellyfin-web playlist query.

![After](https://user-images.githubusercontent.com/23190970/69890069-87ed0880-12f4-11ea-8772-f296334053fc.png)
