### PR TITLE
Fixed Play on MusicArtists

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -99,13 +99,13 @@ public class PlaybackHelper {
                 //get all songs
                 query.setIsMissing(false);
                 query.setIsVirtualUnaired(false);
-                query.setIncludeItemTypes(new String[]{"Audio"});
+                query.setMediaTypes(new String[]{"Audio"});
                 query.setSortBy(shuffle ? new String[] {ItemSortBy.Random} : "MusicArtist".equals(mainItem.getType()) ? new String[] {ItemSortBy.Album} : new String[] {ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(150); // guard against too many items
                 query.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Genres});
                 query.setUserId(TvApp.getApplication().getCurrentUser().getId());
-                query.setParentId(mainItem.getId());
+                query.setArtistIds(new String[]{mainItem.getId()});
                 TvApp.getApplication().getApiClient().GetItemsAsync(query, new Response<ItemsResult>() {
                     @Override
                     public void onResponse(ItemsResult response) {


### PR DESCRIPTION
Issue: 
Play button on a MusicArtist does not work as intended: Instead of adding all songs into the queue, the queue stays empty.

Fix: 
The get all songs query with ParentId parameter dosent return any elements. Replacing this parameter with ArtistIds solves the issue. I also replaced setIncludeItemTypes parameter with MediaTypes as it is in the query from jellyfin-web.