### PR TITLE
Add HEVC support for BeyondTV

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -7,6 +7,7 @@ public class DeviceUtils {
     private static final String FIRE_STICK_MODEL = "AFTM";
     private static final String NEXUS_MODEL = "Nexus Player";
     private static final String SHIELD_MODEL = "SHIELD Android TV";
+    private static final String BEYONDTV_MODEL = "BeyondTV";
 
     public static boolean isFireTv() {
         return Build.MODEL.startsWith(FIRE_TV_PREFIX);
@@ -22,6 +23,10 @@ public class DeviceUtils {
 
     public static boolean isNexus() {
         return Build.MODEL.equals(NEXUS_MODEL);
+    }
+
+    public static boolean isBeyondTv() {
+        return Build.MODEL.equals(BEYONDTV_MODEL);
     }
 
     public static boolean is50() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -292,7 +292,7 @@ public class ProfileHelper {
             ));
             videoDirectPlayProfile.setContainer(Utils.join(",", containers));
             List<String> videoCodecs;
-            if (DeviceUtils.isShield() || DeviceUtils.isNexus()) {
+            if (DeviceUtils.isShield() || DeviceUtils.isNexus() || DeviceUtils.isBeyondTv()) {
                 videoCodecs = Arrays.asList(
                     CodecTypes.H264,
                     CodecTypes.HEVC,


### PR DESCRIPTION
TCL EP66x Android TVs (BeyondTV) are HEVC HDR compatible.
This PR add it on Jellyfin Android TV application.