### PR TITLE
Fix audio queue reload

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/AudioEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/AudioEventListener.java
@@ -9,4 +9,5 @@ public class AudioEventListener {
     public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {}
     public void onProgress(long pos) {}
     public void onQueueStatusChanged(boolean hasQueue) {}
+    public void onQueueReplaced(){}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
@@ -203,8 +203,6 @@ public class AudioNowPlayingActivity extends BaseActivity  {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 MediaManager.shuffleAudioQueue();
-                                mRowsAdapter.remove(mQueueRow);
-                                addQueue();
                             }
                         })
                         .setNegativeButton(mActivity.getString(R.string.lbl_no), null)
@@ -381,6 +379,12 @@ public class AudioNowPlayingActivity extends BaseActivity  {
             } else {
                 finish(); // entire queue removed nothing to do here
             }
+        }
+
+        @Override
+        public void onQueueReplaced() {
+            mRowsAdapter.remove(mQueueRow);
+            addQueue();
         }
     };
 

--- a/app/src/main/java/org/jellyfin/androidtv/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/MediaManager.java
@@ -271,6 +271,13 @@ public class MediaManager {
         }
     };
 
+    private static void fireQueueReplaced(){
+        for (AudioEventListener listener : mAudioEventListeners) {
+            TvApp.getApplication().getLogger().Info("Firing queue replaced listener. ");
+            listener.onQueueReplaced();
+        }
+    }
+
     private static void fireQueueStatusChange() {
         for (AudioEventListener listener : mAudioEventListeners) {
             TvApp.getApplication().getLogger().Info("Firing queue state change listener. "+ hasAudioQueueItems());
@@ -472,6 +479,7 @@ public class MediaManager {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             playNowInternal(items);
+                            fireQueueReplaced();
                         }
                     })
                     .setNeutralButton(R.string.lbl_add_to_queue, new DialogInterface.OnClickListener() {
@@ -485,7 +493,6 @@ public class MediaManager {
         } else {
             playNowInternal(items);
         }
-
     }
 
     private static void playNowInternal(List<BaseItemDto> items) {


### PR DESCRIPTION
'MediaManager.shuffleAudioQueue()' returns while the dialog to replace or
add the queue is showing. This causes the reload of the current queue to
fire before the queue has changed.
I implemented a 'onQueueReplaced' event to fix this.