### PR TITLE
Fix top margin on card title

### DIFF
--- a/app/src/main/res/layout/image_card_view.xml
+++ b/app/src/main/res/layout/image_card_view.xml
@@ -155,7 +155,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
-                android:layout_marginTop="@dimen/lb_basic_card_info_text_margin"
                 android:layout_marginStart="@dimen/lb_basic_card_info_text_margin"
                 android:fontFamily="sans-serif-condensed"
                 android:textColor="@color/lb_basic_card_title_text_color"


### PR DESCRIPTION
This fixes a small display issue where a 1px bar would be shown above the title when it has the marque effect active. See the bar above the "ne" in the following image.

![screen](https://user-images.githubusercontent.com/3450688/71613283-81f87a80-2b73-11ea-9719-1162516cda1f.png)
