### PR TITLE
Upgrade to ExoPlayer 2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,26 +27,12 @@ android {
             debuggable true
         }
     }
-
-    flavorDimensions "version"
-    productFlavors {
-        google {
-            dimension = "version"
-            versionName = version + "g"
-        }
-        amazon {
-            dimension = "version"
-            versionName = version + "a"
-        }
-    }
 }
 
 dependencies {
     def acraVersion = '5.4.0'
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    amazonImplementation 'com.amazon.android:exoplayer:2.10.6'
-    googleImplementation 'com.google.android.exoplayer:exoplayer:2.10.6'
 
     // This is split like this because this is a modular gradle project on jitpack
     // see https://github.com/jitpack/gradle-modular
@@ -55,6 +41,7 @@ dependencies {
     // is better than nothing.
     implementation 'com.github.jellyfin.jellyfin-apiclient-java:android:master-SNAPSHOT'
     implementation 'com.github.jellyfin.jellyfin-apiclient-java:library:master-SNAPSHOT'
+    implementation 'com.amazon.android:exoplayer:2.10.6'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.leanback:leanback:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,10 +45,8 @@ dependencies {
     def acraVersion = '5.4.0'
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    amazonImplementation 'com.github.jellyfin:exomedia:amazon~2.5.6-SNAPSHOT'
-    amazonImplementation 'com.github.amzn:exoplayer-amazon-port:amazon-r1.5.6-SNAPSHOT'
-    googleImplementation 'com.devbrackets.android:exomedia:2.5.6'
-    googleImplementation 'com.google.android.exoplayer:exoplayer:r1.5.6'
+    amazonImplementation 'com.amazon.android:exoplayer:2.10.6'
+    googleImplementation 'com.google.android.exoplayer:exoplayer:2.10.6'
 
     // This is split like this because this is a modular gradle project on jitpack
     // see https://github.com/jitpack/gradle-modular

--- a/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
@@ -503,15 +503,22 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     private void releasePlayer() {
-        if (mVlcPlayer == null) return;
+        if (mVlcPlayer != null) {
+            mVlcPlayer.setEventListener(null);
+            mVlcPlayer.stop();
+            mVlcPlayer.getVLCVout().detachViews();
+            mVlcPlayer.release();
+            mLibVLC.release();
+            mLibVLC = null;
+            mVlcPlayer = null;
+        }
 
-        mVlcPlayer.setEventListener(null);
-        mVlcPlayer.stop();
-        mVlcPlayer.getVLCVout().detachViews();
-        mVlcPlayer.release();
-        mLibVLC.release();
-        mLibVLC = null;
-        mVlcPlayer = null;
+        if (mExoPlayer != null) {
+            mExoPlayerView.setPlayer(null);
+            mExoPlayer.release();
+            mExoPlayer = null;
+        }
+
         mSurfaceView.setKeepScreenOn(false);
     }
 

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -29,9 +29,11 @@
 
         </FrameLayout>
 
-        <com.devbrackets.android.exomedia.EMVideoView
-            android:id="@+id/videoView" android:layout_width="fill_parent"
-            android:layout_height="match_parent" android:layout_gravity="center" android:visibility="gone" />
+        <com.google.android.exoplayer2.ui.PlayerView
+            android:id="@+id/exoPlayerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
 
             <TextView
                 android:id="@+id/offLine_subtitleText"

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/black">
 
     <FrameLayout
@@ -33,7 +34,8 @@
             android:id="@+id/exoPlayerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="gone" />
+            android:visibility="gone"
+            app:use_controller="false" />
 
             <TextView
                 android:id="@+id/offLine_subtitleText"


### PR DESCRIPTION
The goal of this PR is to upgrade ExoPlayer to the latest revision supported by the Amazon port, which is currently [2.10.6](https://github.com/amzn/exoplayer-amazon-port/tree/amazon/r2.10.6). In addition ExoMedia will be removed.

The goal is **not** to refactor the player code. Everything should work as it did before with minimal changes. In the future we should consider rebuilding all player code however.

Current progress:
 - Audio playback kinda works, progression is not tracked properly
 - Video playback works quite well with some minor issues