### PR TITLE
Fix ChannelManager crash on older API levels

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,8 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
 [{*.kts, *.kt}]
 charset = utf-8
-end_of_line = crlf
-insert_final_newline = true
 indent_style = tab
 tab_width = 4

--- a/app/src/main/java/org/jellyfin/androidtv/channels/ChannelManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/channels/ChannelManager.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.channels
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.tvprovider.media.tv.TvContractCompat.WatchNextPrograms
 import androidx.tvprovider.media.tv.WatchNextProgram
 import kotlinx.coroutines.Dispatchers
@@ -33,9 +34,10 @@ class ChannelManager {
 	private val application = TvApp.getApplication()
 
 	/**
-	 * Check if the app can use Leanback features
+	 * Check if the app can use Leanback features and is API level 26 or higher
 	 */
-	private val isSupported = application.packageManager.hasSystemFeature("android.software.leanback")
+	private val isSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+		&& application.packageManager.hasSystemFeature("android.software.leanback")
 
 	/**
 	 * Update all channels for the currently authenticated user


### PR DESCRIPTION
This method for recommendations is only supported on API level 26 or later, so it was causing a crash on older OS versions.

https://developer.android.com/training/tv/discovery/recommendations-channel