### PR TITLE
Fix invalid id reference causing lintVitalRelease to fail

### DIFF
--- a/app/src/main/res/layout/overlay_tv_guide.xml
+++ b/app/src/main/res/layout/overlay_tv_guide.xml
@@ -137,15 +137,15 @@
         android:layout_alignRight="@+id/guideInfoRow" />
 
     <TextView
+        android:id="@+id/channelsStatus"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/channelsStatus"
-        android:layout_alignStart="@+id/programImage"
+        android:layout_alignStart="@id/guideCurrentTitle"
         android:layout_alignParentBottom="true"
-        android:layout_marginBottom="2sp"
         android:layout_marginLeft="2sp"
-        android:textSize="12sp"
-        android:textColor="@color/gray_gradient_end" />
+        android:layout_marginBottom="2sp"
+        android:textColor="@color/gray_gradient_end"
+        android:textSize="12sp" />
 
     <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
The `programImage` id did not exist in this layout which caused the release build to fail linting when running `assembleRelease`, but not when running `build`.

![but why](https://user-images.githubusercontent.com/3450688/73008157-f40f5880-3ddb-11ea-91a2-d232927ea70e.gif)
