### PR TITLE
Remove removed strings

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="error">Chyba</string>
-    <string name="ok">Ok</string>
     <string name="video_error_unknown_error">Nepodařilo se načíst video</string>
     <string name="txt_loading">Načítá se…</string>
     <string name="title_activity_select_user">Vybrat aktivitu uživatele</string>
@@ -185,7 +183,6 @@
     <string name="lbl_no_recordings">Žádné nahrávky</string>
     <string name="lbl_live_tv_guide">Průvodce Live TV</string>
     <string name="lbl_recorded_tv">TV nahrávky</string>
-    <string name="btn_ok">Ok</string>
     <string name="pref_live_tv_cat">LIVE TV</string>
     <string name="lbl_programs">Programy</string>
     <string name="lbl_albums">Alba</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="error">Fehler</string>
-    <string name="ok">Ok</string>
     <string name="video_error_unknown_error">Fehler beim Laden des Videos</string>
     <string name="txt_loading">Lade…</string>
     <string name="title_activity_select_user">AuswahlBenutzerAktivität</string>
@@ -26,7 +24,6 @@
     <string name="pref_general">ALLGEMEIN</string>
     <string name="lbl_settings">Einstellungen</string>
     <string name="lbl_logout">Ausloggen</string>
-    <string name="lbl_send_logs">Sende Berichte</string>
     <string name="lbl_library">Bibliothek</string>
     <string name="lbl_continue_watching">Weiter anschauen</string>
     <string name="lbl_latest_movies">Zuletzt hinzugefügte Filme</string>

--- a/app/src/main/res/values-es-rDO/strings.xml
+++ b/app/src/main/res/values-es-rDO/strings.xml
@@ -9,6 +9,4 @@
     <string name="loading">Cargando…</string>
     <string name="video_error_unknown_error">No se pudo cargar el video</string>
     <string name="play">Reproducir</string>
-    <string name="ok">Ok</string>
-    <string name="error">Error</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="error">Error</string>
-    <string name="ok">Ok</string>
     <string name="video_error_unknown_error">Fallo al cargar el vídeo</string>
     <string name="txt_loading">Cargando…</string>
     <string name="title_activity_select_user">SeleccionarActividadDelUsuario</string>
@@ -321,7 +319,6 @@
     <string name="desc_suggestions_halloween">Intenta algunas de nuestras sugerenecias espeluznantes</string>
     <string name="title_suggestions_halloween">¡Feliz Halloween!</string>
     <string name="lbl_suggestions_halloween">Sugerencias Espeluznante</string>
-    <string name="pref_use_external_player_summary">Requiere un App con capacidad de reproducir video</string>
     <string name="lbl_resume_preroll">Resumir pre-introducción</string>
     <string name="title_activity_expanded_text">Actividad de Texto Expandido</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,7 +24,6 @@
     <string name="pref_general">Général</string>
     <string name="lbl_settings">Paramètres</string>
     <string name="lbl_logout">Déconnexion</string>
-    <string name="lbl_send_logs">Envoyer les journaux d\'événements</string>
     <string name="lbl_library">Médiathèque</string>
     <string name="lbl_continue_watching">Continuer la lecture</string>
     <string name="lbl_latest_movies">Films les plus récents</string>
@@ -197,7 +196,6 @@
     <string name="lbl_enable_cinema_mode">Activer le mode Cinéma</string>
     <string name="sum_enable_cinema_mode">Si la fonction est activée sur le serveur, activer les introductions et les extraits avant le visionnage</string>
     <string name="lbl_playlists">Listes de lecture</string>
-    <string name="lbl_of">de</string>
     <string name="msg_added_item_to_queue">"Éléments ajoutés dans la file d'attente "</string>
     <string name="msg_items_added">" éléments ajoutés"</string>
     <string name="msg_total_items_in_queue">" éléments dans la liste de lecture"</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -16,6 +16,4 @@
     <string name="loading">Betöltés…</string>
     <string name="video_error_unknown_error">Nem sikerült betölteni a videót</string>
     <string name="play">Lejátszás</string>
-    <string name="ok">Rendben</string>
-    <string name="error">Hiba</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -250,7 +250,6 @@
     <string name="msg_error_server_unavailable">サーバー利用不可</string>
     <string name="pref_use_direct_path_summary">ストリーミングURLの代わりにシステムパスを使用</string>
     <string name="pref_external_live_tv_title">ライブTVに外部のプレイヤーを使用</string>
-    <string name="pref_use_external_player_title">動画に外部のプレイヤーを使用</string>
     <string name="lbl_resume_from">%s から再開</string>
     <string name="lbl_guide_option_number">チャンネル番号</string>
     <string name="lbl_premiere">プレミア</string>
@@ -293,8 +292,6 @@
     <string name="lbl_recorded_tv">録画されたTV</string>
     <string name="lbl_live_tv_guide">ライブTVガイド</string>
     <string name="msg_unable_load_subs">字幕のロードが出来ません</string>
-    <string name="desc_sideline_color">カテゴリサイドラインの色</string>
-    <string name="lbl_sideline_color">サイドライン色</string>
     <string name="lbl_goto_series">シリーズに移動</string>
     <string name="pref_audio_compat">ステレオにダウンミックス</string>
     <string name="lbl_repeat_options">リピート設定</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -153,9 +153,6 @@
     <string name="pref_audio_compat">Miks ned til stereo</string>
     <string name="lbl_audio_output">Lydutgang</string>
     <string name="lbl_goto_series">Gå til serie</string>
-    <string name="lbl_select_color">Velg farge</string>
-    <string name="lbl_sideline_color">Sidelinjefarge</string>
-    <string name="desc_sideline_color">Fargen på kategorisidelinjepanelet</string>
     <string name="lbl_show_info_panel">Vis informasjonspanel</string>
     <string name="lbl_enable_debug">Feilsøkingsvalg</string>
     <string name="desc_info_panel">Vis et panel med detaljer om gjeldende element på skjermer uten detaljert informasjon</string>
@@ -231,8 +228,6 @@
     <string name="pref_use_direct_path_title">Send nettverksbane til ekstern avspiller</string>
     <string name="pref_external_live_tv_summary">Krever en støttet app for å spille av direktestrømmer</string>
     <string name="pref_external_live_tv_title">Bruk ekstern spiller for direkte-TV</string>
-    <string name="pref_use_external_player_summary">Krever en støttet app for å spille av videotyper</string>
-    <string name="pref_use_external_player_title">Bruk ekstern spiller for videoer</string>
     <string name="lbl_song_title">Låtnavn</string>
     <string name="lbl_album_name">Albumnavn</string>
     <string name="lbl_next_episode">Neste episode</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="error">Fout</string>
-    <string name="ok">Ok</string>
     <string name="video_error_unknown_error">Laden video is mislukt</string>
     <string name="txt_loading">Laden…</string>
     <string name="title_activity_select_user">KiesGebruikerActiviteit</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="error">Erro</string>
-    <string name="ok">Ok</string>
     <string name="play">Reproduzir</string>
     <string name="loading">A Carregar…</string>
     <string name="video_error_unknown_error">Falha ao carregar o vídeo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="btn_ok">Ok</string>
     <string name="lbl_albums">Albume</string>
     <string name="lbl_artists">Artiști</string>
     <string name="lbl_song">Cântec</string>
@@ -107,7 +106,6 @@
     <string name="lbl_latest_movies">Ultimele filme</string>
     <string name="lbl_continue_watching">Continuă vizionarea</string>
     <string name="lbl_library">Librărie</string>
-    <string name="lbl_send_logs">Trimite logurile</string>
     <string name="lbl_logout">Deconectare</string>
     <string name="lbl_settings">Setări</string>
     <string name="pref_general">General</string>
@@ -133,8 +131,6 @@
     <string name="loading">Se încarcă…</string>
     <string name="video_error_unknown_error">Încărcare video eșuată</string>
     <string name="play">Rulează</string>
-    <string name="ok">Ok</string>
-    <string name="error">Eroare</string>
     <string name="lbl_rating">Evaluare</string>
     <string name="pref_audio_direct">Direcție</string>
     <string name="lbl_like">Îmi place</string>
@@ -163,8 +159,6 @@
     <string name="pref_use_direct_path_title">Treceți calea directă</string>
     <string name="pref_external_live_tv_summary">Necesită o aplicație capabilă să redea fluxuri live</string>
     <string name="pref_external_live_tv_title">Utilizați soft extern pentru TV live</string>
-    <string name="pref_use_external_player_summary">Necesită o aplicație capabilă să redea tipuri de videoclipuri</string>
-    <string name="pref_use_external_player_title">Utilizați soft extern pentru videoclipuri</string>
     <string name="lbl_song_title">Titlul Melodiei</string>
     <string name="lbl_album_name">Numele albumului</string>
     <string name="lbl_next_episode">Episodul Următor</string>
@@ -268,9 +262,6 @@
     <string name="desc_info_panel">Afișați un panou cu detalii despre articolul curent pentru ecrane fără informații detaliate</string>
     <string name="lbl_enable_debug">Opțiuni de depanare</string>
     <string name="lbl_show_info_panel">Afișați panoul de informații</string>
-    <string name="desc_sideline_color">Culoarea panoului lateral al categoriei</string>
-    <string name="lbl_sideline_color">Culoare Laterală</string>
-    <string name="lbl_select_color">Selectați Culoarea</string>
     <string name="lbl_goto_series">Mergi la Serial</string>
     <string name="lbl_audio_output">Ieșire Audio</string>
     <string name="pref_audio_compat">Downmix la Stereo</string>
@@ -329,10 +320,7 @@
     <string name="msg_error_server_unavailable">Server indisponibil</string>
     <string name="msg_error_connecting_server">Eroare de conectare la server</string>
     <string name="lbl_yes">Da</string>
-    <string name="msg_report_not_sent">Raportul NU a fost trimis</string>
     <string name="lbl_no">Nu</string>
-    <string name="lbl_report_msg_question">Doriți să trimiteți un raport dezvoltatorului\?</string>
-    <string name="msg_report_sent">Raport trimis dezvoltatorului. Mulțumesc.</string>
     <string name="msg_little_longer">Acest lucru durează puțin mai mult decât se aștepta ...</string>
     <string name="lbl_enter_user_pw">Introduceți parola utilizatorului</string>
     <string name="lbl_enter_user_name">Introduceti numele de utilizator</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name" translatable="false">Jellyfin</string>
-    <string name="error">Chyba</string>
-    <string name="ok">Ok</string>
     <string name="home_title">Domov</string>
     <string name="btn_cancel">Zrušiť</string>
     <string name="byletter_letters">ABCDEFGHIJKLMNOPQRSTUVWXYZ</string>
@@ -57,9 +55,6 @@
     <string name="lbl_showing">Zobrazenie</string>
     <string name="lbl_enable_debug">Debugovacie nastavenia</string>
     <string name="lbl_show_info_panel">Zobraziť informačný panel</string>
-    <string name="desc_sideline_color">Farba kategórie postranného panelu</string>
-    <string name="lbl_sideline_color">Postranná farba</string>
-    <string name="lbl_select_color">Vyberte farbu</string>
     <string name="lbl_goto_series">Prejsť na seriály</string>
     <string name="lbl_audio_output">Zvukový výstup</string>
     <string name="pref_audio_compat">Downmix na Stereo</string>
@@ -104,10 +99,7 @@
     <string name="msg_error_server_unavailable">Server nedostupný</string>
     <string name="msg_error_connecting_server">Chyba pripojenia k serveru</string>
     <string name="lbl_yes">Áno</string>
-    <string name="msg_report_not_sent">Hlásenie NEBOLO odoslané</string>
     <string name="lbl_no">Nie</string>
-    <string name="lbl_report_msg_question">Chceli by ste odoslať hlásenie vývojárovi\?</string>
-    <string name="msg_report_sent">Hlásenie odoslané vývojárovi. Ďakujeme.</string>
     <string name="msg_little_longer">Toto trvá trochu dlhšie, než sme čakali...</string>
     <string name="lbl_enter_user_pw">Zadajte používateľské heslo</string>
     <string name="lbl_enter_user_name">Zadajte používateľské meno</string>
@@ -169,7 +161,6 @@
     <string name="lbl_views">Zobrazenie</string>
     <string name="lbl_on_now">Práve teraz</string>
     <string name="lbl_next_up_tv">Nasleduje v TV</string>
-    <string name="lbl_send_logs">Odoslať logy</string>
     <string name="pref_general">Všeobecné</string>
     <string name="pref_alt_pw_entry_desc">Číselné heslo s použitím len kláves D-Padu</string>
     <string name="pref_alt_pw_entry">Vlastné D-Pad zadanie hesla</string>
@@ -206,8 +197,6 @@
     <string name="pref_use_direct_path_title">Prepustiť priamu cestu</string>
     <string name="pref_external_live_tv_summary">Vyžaduje aplikáciu schopnú prehrať živé streamy</string>
     <string name="pref_external_live_tv_title">Použiť externý prehrávač pre živú TV</string>
-    <string name="pref_use_external_player_summary">Vyžaduje aplikáciu schopnú prehrať tieto video typy</string>
-    <string name="pref_use_external_player_title">Použiť externý prehrávač pre videá</string>
     <string name="lbl_song_title">Názov piesne</string>
     <string name="lbl_album_name">Názov albumu</string>
     <string name="lbl_next_episode">Nasledujúca epizóda</string>
@@ -301,7 +290,6 @@
     <string name="msg_total_items_in_queue">" položiek celkovo vo fronte"</string>
     <string name="msg_items_added">" položky pridané"</string>
     <string name="msg_added_item_to_queue">"Položka pridaná do fronty na pozíciu "</string>
-    <string name="lbl_of">z</string>
     <string name="lbl_warning">Varovanie</string>
     <string name="lbl_playlists">Playlist</string>
     <string name="sum_enable_cinema_mode">Zobraziť intrá a ukážky pred prehratím filmu, pokiaľ je to povolené na serveri</string>
@@ -316,7 +304,6 @@
     <string name="lbl_direct_stream_live">Priamy stream živej TV</string>
     <string name="msg_error_live_stream">Chyba počas streamovania živej TV. Opakovanie pokusu...</string>
     <string name="pref_live_tv_cat">Živá TV</string>
-    <string name="btn_ok">Ok</string>
     <string name="lbl_recorded_tv">TV nahrávky</string>
     <string name="lbl_live_tv_guide">Sprievodca živou TV</string>
     <string name="lbl_no_recordings">Žiadne dostupné nahrávky</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -23,10 +23,7 @@
     <string name="msg_error_server_unavailable">Strežnik ni na voljo</string>
     <string name="msg_error_connecting_server">Napaka pri vzpostavljanju povezave s strežnikom</string>
     <string name="lbl_yes">Da</string>
-    <string name="msg_report_not_sent">Poročilo NI bilo poslano</string>
     <string name="lbl_no">Ne</string>
-    <string name="lbl_report_msg_question">Ali bi rad poslal poročilo razvijalcu\?</string>
-    <string name="msg_report_sent">Poročilo poslano razvijalcu. Hvala.</string>
     <string name="msg_little_longer">To potrebuje več časa kot pričakovano...</string>
     <string name="lbl_enter_user_pw">Vnesi geslo</string>
     <string name="lbl_enter_user_name">Vnesi uporabniško ime</string>
@@ -99,7 +96,6 @@
     <string name="lbl_latest_movies">Najnovejši filmi</string>
     <string name="lbl_continue_watching">Nadaljuj z gledanjem</string>
     <string name="lbl_library">Knjižnica</string>
-    <string name="lbl_send_logs">Pošlji dnevnik</string>
     <string name="lbl_logout">Odjava</string>
     <string name="lbl_settings">Nastavitve</string>
     <string name="pref_general">Splošno</string>
@@ -119,8 +115,6 @@
     <string name="loading">Nalagam…</string>
     <string name="video_error_unknown_error">Napaka pri nalaganju videa</string>
     <string name="play">Predvajaj</string>
-    <string name="ok">Ok</string>
-    <string name="error">Napaka</string>
     <string name="lbl_play_from_here">Predvajaj od tukaj</string>
     <string name="lbl_now_playing">Trenutno se predvaja</string>
     <string name="lbl_shuffle">Premešaj</string>
@@ -139,7 +133,6 @@
     <string name="lbl_direct_stream_live">Neposredno pretakaj TV v živo</string>
     <string name="msg_error_live_stream">Napaka pri pretakanju TV v živo. Poskušamo znova...</string>
     <string name="pref_live_tv_cat">TV v živo</string>
-    <string name="btn_ok">V redu</string>
     <string name="lbl_recorded_tv">Posneta TV</string>
     <string name="lbl_live_tv_guide">Vodič TV v živo</string>
     <string name="lbl_no_recordings">Noben posnetek ni na voljo</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -58,7 +58,6 @@
     <string name="lbl_latest_movies">Најновији филмови</string>
     <string name="lbl_continue_watching">Настави гледање</string>
     <string name="lbl_library">Библиотека</string>
-    <string name="lbl_send_logs">Пошаљи записнике</string>
     <string name="lbl_logout">Одјављивање</string>
     <string name="lbl_settings">Поставке</string>
     <string name="pref_general">Опште</string>
@@ -80,6 +79,4 @@
     <string name="loading">Учитавам…</string>
     <string name="video_error_unknown_error">Не могу да учитам видео</string>
     <string name="play">Пусти</string>
-    <string name="ok">У реду</string>
-    <string name="error">Грешка</string>
 </resources>


### PR DESCRIPTION
Since we can't seem to do this with Weblate. I think the only way forward is to remove these strings and hope the changes get pulled into Weblate before any further edits are made.

![where](https://user-images.githubusercontent.com/3450688/73190117-786f1d80-40f3-11ea-8ecb-0cd9c083cdb2.gif)
