### PR TITLE
Implement a toggle watched action

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.details.actions.BaseAction
 import org.jellyfin.androidtv.details.actions.PlayFromBeginningAction
 import org.jellyfin.androidtv.details.actions.ResumeAction
+import org.jellyfin.androidtv.details.actions.ToggleWatchedAction
 import org.jellyfin.androidtv.model.itemtypes.Episode
 
 private const val LOG_TAG = "EpisodeDetailsFragment"
@@ -56,14 +57,17 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 		}
 		rowsAdapter = ArrayObjectAdapter(selector)
 
-		val actionsAdapter = ArrayObjectAdapter().apply {
-			if (episode.canResume) add(ResumeAction(context!!, episode))
-			add(PlayFromBeginningAction(context!!, episode))
-			add(Action(1, "Set Watched"))
-			add(Action(1, "Add Favorite"))
-			add(Action(1, "Add to Queue"))
-			add(Action(1, "Go to Series"))
-			add(Action(1, "Delete"))
+		val actionsAdapter = SparseArrayObjectAdapter().apply {
+			if (episode.canResume) set(0, ResumeAction(context!!, episode))
+			set(1, PlayFromBeginningAction(context!!, episode))
+			set(2, ToggleWatchedAction(context!!, episode) {
+				if (episode.canResume) set(0, ResumeAction(context!!, episode)) else clear(0)
+				notifyArrayItemRangeChanged(0,6)
+			})
+			set(3, Action(1, "Add Favorite"))
+			set(4, Action(1, "Add to Queue"))
+			set(5, Action(1, "Go to Series"))
+			set(6, Action(1, "Delete"))
 		}
 
 		val detailsOverview = DetailsOverviewRow(episode).also {

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/ActionID.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/ActionID.kt
@@ -3,5 +3,5 @@ package org.jellyfin.androidtv.details.actions
 enum class ActionID(val id: Long) {
 	RESUME(0),
 	PLAY_FROM_BEGINNING(1),
-	TOGGLE_WATCHED_STATUS(2)
+	TOGGLE_WATCHED(2)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/ToggleWatchedAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/ToggleWatchedAction.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.androidtv.details.actions
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.TvApp
+import org.jellyfin.androidtv.model.itemtypes.PlayableItem
+import org.jellyfin.androidtv.util.apiclient.markPlayed
+import org.jellyfin.androidtv.util.apiclient.markUnplayed
+import org.jellyfin.apiclient.model.dto.UserItemDataDto
+
+private val LOG_TAG: String = "ToggleWatchedAction"
+
+class ToggleWatchedAction (context: Context, val item: PlayableItem, private val toggleListener: () -> Unit) : BaseAction(ActionID.TOGGLE_WATCHED.id, context) {
+
+	init {
+	    label1 = if (item.played) context.getString(R.string.lbl_mark_unplayed) else context.getString(R.string.lbl_mark_played)
+	}
+
+	override fun onClick() {
+		GlobalScope.launch(Dispatchers.Main) {
+			val newData : UserItemDataDto? = if (item.played) {
+				TvApp.getApplication().apiClient.markUnplayed(item.id, TvApp.getApplication().currentUser.id)
+			} else {
+				TvApp.getApplication().apiClient.markPlayed(item.id, TvApp.getApplication().currentUser.id, null)
+			}
+
+			if (newData == null) {
+				Log.e(LOG_TAG, "Failed to mark item played / unplayed!")
+				return@launch
+			}
+
+			newData.apply {
+				item.playbackPositionTicks = playbackPositionTicks
+				item.played = played
+				label1 = if (item.played) context.getString(R.string.lbl_mark_unplayed) else context.getString(R.string.lbl_mark_played)
+			}
+
+			toggleListener.invoke()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
@@ -14,14 +14,15 @@ sealed class BaseItem(original: BaseItemDto) {
 }
 
 sealed class PlayableItem(original: BaseItemDto) : BaseItem(original) {
-	val canResume: Boolean = original.canResume
-	val playbackPositionTicks: Long = original.userData.playbackPositionTicks
 	val mediaInfo = MediaInfo(original.mediaSources, original.mediaStreams)
 	val chapters: List<ChapterInfoDto> = original.chapters
+	val canResume: Boolean
+		get() = playbackPositionTicks > 0
+	var playbackPositionTicks: Long = original.userData.playbackPositionTicks
+	var played: Boolean = original.userData.played
 }
 
 class Episode(original: BaseItemDto) : PlayableItem(original) {
-	//TODO: Chapters: ArrayList<ChapterInfoDto>
 	val communityRating: Double = original.communityRating.toDouble()
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
@@ -4,8 +4,10 @@ import org.jellyfin.androidtv.TvApp
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.interaction.Response
 import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.apiclient.model.dto.UserItemDataDto
 import org.jellyfin.apiclient.model.querying.ItemsResult
 import org.jellyfin.apiclient.model.querying.NextUpQuery
+import java.util.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -27,5 +29,19 @@ suspend fun ApiClient.getItem(id: String): BaseItemDto? = suspendCoroutine { con
 	GetItemAsync(id, TvApp.getApplication().currentUser.id, object : Response<BaseItemDto>() {
 		override fun onResponse(response: BaseItemDto?) = continuation.resume(response!!)
 		override fun onError(exception: Exception?) = continuation.resume(null)
+	})
+}
+
+suspend fun ApiClient.markPlayed(itemId: String, userId: String, datePlayed: Date?) : UserItemDataDto? = suspendCoroutine { continuation ->
+	MarkPlayedAsync(itemId, userId, datePlayed, object : Response<UserItemDataDto>() {
+		override fun onResponse(response: UserItemDataDto?) { continuation.resume(response!!) }
+		override fun onError(exception: Exception?) { continuation.resume(null) }
+	})
+}
+
+suspend fun ApiClient.markUnplayed(itemId: String, userId: String) : UserItemDataDto? = suspendCoroutine { continuation ->
+	MarkUnplayedAsync(itemId, userId, object : Response<UserItemDataDto>() {
+		override fun onResponse(response: UserItemDataDto?) { continuation.resume(response!!) }
+		override fun onError(exception: Exception?) { continuation.resume(null) }
 	})
 }


### PR DESCRIPTION
There *could* be a crash right now if the user marks an episode played and then immediately quits the activity. Question is, do we consider this likely enough to go for `LiveData` and the likes or consider this fine for the MVP?