### PR TITLE
Fix weblate merge error

### DIFF
--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -330,7 +330,6 @@
     <string name="lbl_last_played">"Naposledy videné: "</string>
     <string name="lbl_watched">Videné</string>
     <string name="dpad_pw_cancel">* Podržte na 1 sekundu tlačidlo \'Dole\' a uvolnite ho pokiaľ máte alpha heslo alebo bude potrebná klávesnica pre vstup</string>
-</resources>
     <string name="pref_acra_alwaysaccept_disabled">Pred odoslaním chybového hlásenia sa zobrazí dialóg</string>
     <string name="pref_acra_alwaysaccept_enabled">Hlásenie chýb bude odoslané bez výzvy</string>
     <string name="pref_acra_alwaysaccept">Odoslať hlásenie chýb bez výzvy</string>


### PR DESCRIPTION
A resource tag appeared in the middle of the resource file after a weblate update which resulted in the build failing.