### PR TITLE
Introduce new config version which when applied enables the acra prompt

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
@@ -77,6 +77,11 @@ public class StartupActivity extends FragmentActivity {
             application.getSystemPrefs().edit().putString("sys_pref_config_version", "5").apply();
         }
 
+        if (Integer.parseInt(application.getConfigVersion()) < 6) {
+                application.getPrefs().edit().putBoolean("acra.enable", true).apply();
+                application.getSystemPrefs().edit().putString("sys_pref_config_version", "6").apply();
+        }
+
         //Ensure we have prefs
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
 


### PR DESCRIPTION
This introduces a new config version which explicitly sets acra into the prompt mode once it is applied. 

**Risks**
* Users that have already manually disabled ACRA reporting have it re-enabled