### PR TITLE
Only enable ACRA in release builds

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -122,7 +122,9 @@ public class TvApp extends Application {
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
 
-        ACRA.init(this);
+        if (!BuildConfig.DEBUG) {
+            ACRA.init(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
I just had ACRA run in a debug build, this check is supposed to only enable it in non-debug builds.