### PR TITLE
Fix broken logger calls

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -207,7 +207,7 @@ public class TvApp extends Application {
 
     public void setAudioMuted(boolean value) {
         audioMuted = value;
-        getLogger().Info("Setting mute state to: "+audioMuted);
+        getLogger().Info("Setting mute state to: %b", audioMuted);
         if (DeviceUtils.is60()) {
             audioManager.adjustVolume(audioMuted ? AudioManager.ADJUST_MUTE : AudioManager.ADJUST_UNMUTE, 0);
 
@@ -443,7 +443,7 @@ public class TvApp extends Application {
     public void updateDisplayPrefs(String app, DisplayPreferences preferences) {
         displayPrefsCache.put(preferences.getId(), preferences);
         getApiClient().UpdateDisplayPreferencesAsync(preferences, getCurrentUser().getId(), app, new EmptyResponse());
-        logger.Debug("Display prefs updated for "+preferences.getId()+" isFavorite: "+preferences.getCustomPrefs().get("FavoriteOnly"));
+        logger.Debug("Display prefs updated for %s isFavorite: %s", preferences.getId(), preferences.getCustomPrefs().get("FavoriteOnly"));
     }
 
     public void getDisplayPrefsAsync(String key, Response<DisplayPreferences> response) {
@@ -452,7 +452,7 @@ public class TvApp extends Application {
 
     public void getDisplayPrefsAsync(final String key, String app, final Response<DisplayPreferences> outerResponse) {
         if (displayPrefsCache.containsKey(key)) {
-            logger.Debug("Display prefs loaded from cache "+key);
+            logger.Debug("Display prefs loaded from cache %s", key);
             outerResponse.onResponse(displayPrefsCache.get(key));
         } else {
             getApiClient().GetDisplayPreferencesAsync(key, getCurrentUser().getId(), app, new Response<DisplayPreferences>(){
@@ -461,7 +461,7 @@ public class TvApp extends Application {
                     if (response.getSortBy() == null) response.setSortBy("SortName");
                     if (response.getCustomPrefs() == null) response.setCustomPrefs(new HashMap<String, String>());
                     displayPrefsCache.put(key, response);
-                    logger.Debug("Display prefs loaded and saved in cache " + key);
+                    logger.Debug("Display prefs loaded and saved in cache %s", key);
                     outerResponse.onResponse(response);
                 }
 
@@ -490,7 +490,7 @@ public class TvApp extends Application {
             @Override
             public void onResponse(Long response) {
                 autoBitrate = response.intValue();
-                logger.Info("Auto bitrate set to: "+autoBitrate);
+                logger.Info("Auto bitrate set to: %d", autoBitrate);
             }
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/CustomViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/CustomViewFragment.java
@@ -13,7 +13,7 @@ public class CustomViewFragment extends BrowseFolderFragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         includeType = getActivity().getIntent().getStringExtra("IncludeType");
-        TvApp.getApplication().getLogger().Debug("Item type: "+includeType);
+        TvApp.getApplication().getLogger().Debug("Item type: %s", includeType);
         showViews = false;
 
         super.onActivityCreated(savedInstanceState);

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/StdBrowseFragment.java
@@ -402,7 +402,7 @@ public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoad
 
     private void refreshCurrentItem() {
         if (mCurrentItem != null && mCurrentItem.getBaseItemType() != BaseItemType.UserView && mCurrentItem.getBaseItemType() != BaseItemType.CollectionFolder) {
-            TvApp.getApplication().getLogger().Debug("Refresh item "+mCurrentItem.getFullName());
+            TvApp.getApplication().getLogger().Debug("Refresh item \"%s\"", mCurrentItem.getFullName());
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override
                 public void onResponse() {

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/StdGridFragment.java
@@ -265,7 +265,7 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
                         mCardHeight = autoHeight;
                         setNumberOfRows();
                         createGrid();
-                        TvApp.getApplication().getLogger().Debug("Auto card height is "+mCardHeight);
+                        TvApp.getApplication().getLogger().Debug("Auto card height is %d", mCardHeight);
                         buildAdapter(rowDef);
                     }
                     mGridAdapter.setSortBy(getSortOption(mDisplayPrefs.getSortBy()));
@@ -294,7 +294,7 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
     }
 
     protected int getAutoCardHeight(Integer size) {
-        TvApp.getApplication().getLogger().Debug("Result size for auto card height is " + size);
+        TvApp.getApplication().getLogger().Debug("Result size for auto card height is %d", size);
         if (size > 35)
             return getCardHeight(PosterSize.SMALL);
         else if (size > 10)
@@ -592,7 +592,7 @@ public class StdGridFragment extends HorizontalGridFragment implements IGridLoad
         }
         if (mCurrentItem != null && mCurrentItem.getBaseItemType() != BaseItemType.Photo && mCurrentItem.getBaseItemType() != BaseItemType.PhotoAlbum
                 && mCurrentItem.getBaseItemType() != BaseItemType.MusicArtist && mCurrentItem.getBaseItemType() != BaseItemType.MusicAlbum) {
-            TvApp.getApplication().getLogger().Debug("Refresh item "+mCurrentItem.getFullName());
+            TvApp.getApplication().getLogger().Debug("Refresh item \"%s\"", mCurrentItem.getFullName());
             mCurrentItem.refresh(new EmptyResponse() {
                 @Override
                 public void onResponse() {

--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -505,7 +505,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     protected void addAdditionalRows(ArrayObjectAdapter adapter) {
-        TvApp.getApplication().getLogger().Debug("Item type: " + mBaseItem.getBaseItemType());
+        TvApp.getApplication().getLogger().Debug("Item type: %s", mBaseItem.getBaseItemType().toString());
         switch (mBaseItem.getBaseItemType()) {
             case Movie:
 

--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -260,7 +260,7 @@ public class ItemListActivity extends BaseActivity {
     private AudioEventListener mAudioEventListener = new AudioEventListener() {
         @Override
         public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {
-            TvApp.getApplication().getLogger().Info("Got playback state change event "+newState+" for item "+(currentItem != null ? currentItem.getName() : "<unknown>"));
+            TvApp.getApplication().getLogger().Info("Got playback state change event %s for item %s", newState.toString(), currentItem != null ? currentItem.getName() : "<unknown>");
 
             if (newState != PlaybackController.PlaybackState.PLAYING || currentItem == null) {
                 if (mCurrentlyPlayingRow != null) mCurrentlyPlayingRow.updateCurrentTime(-1);

--- a/app/src/main/java/org/jellyfin/androidtv/details/PhotoPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/PhotoPlayerActivity.java
@@ -350,7 +350,7 @@ public class PhotoPlayerActivity extends BaseActivity {
                         public void onSuccess() {
                             if (target == nextImage) isLoadingNext = false;
                             if (target == prevImage) isLoadingPrev = false;
-                            TvApp.getApplication().getLogger().Debug("Loaded item "+photo.getName());
+                            TvApp.getApplication().getLogger().Debug("Loaded item %s", photo.getName());
                             if (play){
                                 currentImageView().resume();
                                 handler.postDelayed(new Runnable() {
@@ -366,7 +366,7 @@ public class PhotoPlayerActivity extends BaseActivity {
                         public void onError() {
                             if (target == nextImage) isLoadingNext = false;
                             if (target == prevImage) isLoadingPrev = false;
-                            TvApp.getApplication().getLogger().Debug("Error loading item "+photo.getName());
+                            TvApp.getApplication().getLogger().Debug("Error loading item %s", photo.getName());
                         }
                     });
         }

--- a/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
@@ -60,7 +60,7 @@ public class TvApiEventListener extends ApiEventListener {
 
     @Override
     public void onGeneralCommand(ApiClient client, GeneralCommand command) {
-        TvApp.getApplication().getLogger().Info("General command is: "+command.getName());
+        TvApp.getApplication().getLogger().Info("General command is: %s", command.getName());
         switch (command.getName().toLowerCase()) {
             case "mute":
                 TvApp.getApplication().setAudioMuted(true);

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
@@ -51,7 +51,7 @@ public class ItemLauncher {
             case BaseItem:
                 final BaseItemDto baseItem = rowItem.getBaseItem();
                 try {
-                    TvApp.getApplication().getLogger().Debug("Item selected: " + rowItem.getIndex() + " - " + baseItem.getName() + " (" + baseItem.getBaseItemType() + ")");
+                    TvApp.getApplication().getLogger().Debug("Item selected: %d - %s (%s)", rowItem.getIndex(), baseItem.getName(), baseItem.getBaseItemType().toString());
                 } catch (Exception e) {
                     //swallow it
                 }
@@ -67,12 +67,12 @@ public class ItemLauncher {
                                 if (baseItem.getCollectionType() == null) {
                                     baseItem.setCollectionType("unknown");
                                 }
-                                TvApp.getApplication().getLogger().Debug("**** Collection type: " + baseItem.getCollectionType());
+                                TvApp.getApplication().getLogger().Debug("**** Collection type: %s", baseItem.getCollectionType());
                                 switch (baseItem.getCollectionType()) {
                                     case "movies":
                                     case "tvshows":
                                     case "music":
-                                        TvApp.getApplication().getLogger().Debug("**** View Type Pref: " + response.getCustomPrefs().get("DefaultView"));
+                                        TvApp.getApplication().getLogger().Debug("**** View Type Pref: %s", response.getCustomPrefs().get("DefaultView"));
                                         if (ViewType.GRID.equals(response.getCustomPrefs().get("DefaultView"))) {
                                             // open grid browsing
                                             Intent folderIntent = new Intent(activity, GenericGridActivity.class);

--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemRowAdapter.java
@@ -512,7 +512,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         }
 
         if (pos >= itemsLoaded - 20) {
-            TvApp.getApplication().getLogger().Debug("Loading more items starting at " + itemsLoaded);
+            TvApp.getApplication().getLogger().Debug("Loading more items starting at %d", itemsLoaded);
             RetrieveNext();
         }
 
@@ -606,7 +606,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         }
 
         if (retrieve) {
-            TvApp.getApplication().getLogger().Info("Re-retrieving row of type " + queryType);
+            TvApp.getApplication().getLogger().Info("Re-retrieving row of type %s", queryType.toString());
             Retrieve();
         }
 
@@ -1124,12 +1124,12 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                                             }
                                         }
                                         if (existing == null) {
-                                            TvApp.getApplication().getLogger().Debug("Adding new episode 1 to premieres " + item.getSeriesName());
+                                            TvApp.getApplication().getLogger().Debug("Adding new episode 1 to premieres %s", item.getSeriesName());
                                             adapter.add(new BaseRowItem(i++, item, preferParentThumb, true));
 
                                         } else if (existing.getBaseItem().getParentIndexNumber() > item.getParentIndexNumber()) {
                                             //Replace the newer item with the earlier season
-                                            TvApp.getApplication().getLogger().Debug("Replacing newer episode 1 with an older season for " + item.getSeriesName());
+                                            TvApp.getApplication().getLogger().Debug("Replacing newer episode 1 with an older season for %s", item.getSeriesName());
                                             adapter.replace(existingPos, new BaseRowItem(i++, item, preferParentThumb, false));
                                         } // otherwise, just ignore this newer season premiere since we have the older one already
 

--- a/app/src/main/java/org/jellyfin/androidtv/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/livetv/LiveTvGuideActivity.java
@@ -389,7 +389,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
 
     private void pageGuideTo(long startTime) {
         if (startTime < System.currentTimeMillis()) startTime = System.currentTimeMillis(); // don't allow the past
-        TvApp.getApplication().getLogger().Info("page to "+new Date(startTime));
+        TvApp.getApplication().getLogger().Info("page to %s", (new Date(startTime)).toString());
         TvManager.forceReload(); // don't allow cache
         if (mSelectedProgram != null) {
             mFirstFocusChannelId = mSelectedProgram.getChannelId();

--- a/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
@@ -352,7 +352,7 @@ public class AudioNowPlayingActivity extends BaseActivity  {
     private AudioEventListener audioEventListener = new AudioEventListener() {
         @Override
         public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {
-            mApplication.getLogger().Debug("**** Got playstate change: " + newState);
+            mApplication.getLogger().Debug("**** Got playstate change: %s" + newState.toString());
             if (newState == PlaybackController.PlaybackState.PLAYING && currentItem != mBaseItem) {
                 // new item started
                 loadItem();
@@ -406,7 +406,7 @@ public class AudioNowPlayingActivity extends BaseActivity  {
         if (posterHeight < 10) posterWidth = Utils.convertDpToPixel(mActivity, 150);  //Guard against zero size images causing picasso to barf
 
         String primaryImageUrl = ImageUtils.getPrimaryImageUrl(mBaseItem, mApplication.getApiClient(), false, posterHeight);
-        mApplication.getLogger().Debug("Audio Poster url: " + primaryImageUrl);
+        mApplication.getLogger().Debug("Audio Poster url: %s", primaryImageUrl);
         Picasso.with(mActivity)
                 .load(primaryImageUrl)
                 .skipMemoryCache()

--- a/app/src/main/java/org/jellyfin/androidtv/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/CustomPlaybackOverlayFragment.java
@@ -767,7 +767,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
         // give back audio focus
         mAudioManager.abandonAudioFocus(mAudioFocusChanged);
-        mApplication.getLogger().Debug("Fragment pausing. IsFinishing: "+mActivity.isFinishing());
+        mApplication.getLogger().Debug("Fragment pausing. IsFinishing: %b", mActivity.isFinishing());
         if (!mActivity.isFinishing()) mActivity.finish(); // user hit "home" we want to back out
     }
 
@@ -1355,7 +1355,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         boolean hasMultiAudio = StreamHelper.getAudioStreams(mPlaybackController.getCurrentMediaSource()).size() > 1;
 
         if (hasMultiAudio) {
-            mApplication.getLogger().Debug("Multiple Audio tracks found: "+ StreamHelper.getAudioStreams(mPlaybackController.getCurrentMediaSource()).size());
+            mApplication.getLogger().Debug("Multiple Audio tracks found: %d", StreamHelper.getAudioStreams(mPlaybackController.getCurrentMediaSource()).size());
             mButtonRow.addView(new ImageButton(mActivity, R.drawable.ic_select_audio, mButtonSize, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -1388,7 +1388,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                     audioMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                         @Override
                         public boolean onMenuItemClick(MenuItem item) {
-                            mApplication.getLogger().Debug("Selected stream " + item.getTitle());
+                            mApplication.getLogger().Debug("Selected stream %s", item.getTitle().toString());
                             mPlaybackController.switchAudioStream(item.getItemId());
                             return true;
                         }
@@ -1401,7 +1401,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         }
 
         if (hasSubs) {
-            mApplication.getLogger().Debug("Subtitle tracks found: " + mPlaybackController.getSubtitleStreams().size());
+            mApplication.getLogger().Debug("Subtitle tracks found: %d", mPlaybackController.getSubtitleStreams().size());
             mButtonRow.addView(new ImageButton(mActivity, R.drawable.ic_select_subtitle, mButtonSize, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -1430,7 +1430,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                     subMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                         @Override
                         public boolean onMenuItemClick(MenuItem item) {
-                            mApplication.getLogger().Debug("Selected subtitle " + item.getTitle());
+                            mApplication.getLogger().Debug("Selected subtitle %s", item.getTitle().toString());
                             mPlaybackController.switchSubtitleStream(item.getItemId());
                             return true;
                         }
@@ -1525,10 +1525,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     private int getCurrentChapterIndex(BaseItemDto item, long pos) {
         int ndx = 0;
-        TvApp.getApplication().getLogger().Debug("*** looking for chapter at pos: "+pos);
+        TvApp.getApplication().getLogger().Debug("*** looking for chapter at pos: %d", pos);
         if (item.getChapters() != null) {
             for (ChapterInfoDto chapter : item.getChapters()) {
-                TvApp.getApplication().getLogger().Debug("*** chapter "+ndx+" has pos: "+chapter.getStartPositionTicks());
+                TvApp.getApplication().getLogger().Debug("*** chapter %d has pos: %d", ndx, chapter.getStartPositionTicks());
                 if (chapter.getStartPositionTicks() > pos) return ndx - 1;
                 ndx++;
             }
@@ -1756,7 +1756,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     @Override
     public void nextItemThresholdHit(BaseItemDto nextItem) {
-        mApplication.getLogger().Debug("Next Item is " + nextItem.getName());
+        mApplication.getLogger().Debug("Next Item is %s", nextItem.getName());
         // need to retrieve full item for all info
         mApplication.getApiClient().GetItemAsync(nextItem.getId(), mApplication.getCurrentUser().getId(), new Response<BaseItemDto>() {
             @Override

--- a/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
@@ -66,10 +66,10 @@ public class ExternalPlayerActivity extends FragmentActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         long playerFinishedTime = System.currentTimeMillis();
-        mApplication.getLogger().Debug("Returned from player... "+ resultCode);
+        mApplication.getLogger().Debug("Returned from player... %d", resultCode);
         //MX Player will return position
         int pos = data != null ? data.getIntExtra("position", 0) : 0;
-        if (pos > 0) mApplication.getLogger().Info("Player returned position: "+pos);
+        if (pos > 0) mApplication.getLogger().Info("Player returned position: %d", pos);
         Long reportPos = (long) pos * 10000;
 
         stopReportLoop();

--- a/app/src/main/java/org/jellyfin/androidtv/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/MediaManager.java
@@ -140,11 +140,11 @@ public class MediaManager {
 
     public static void addAudioEventListener(AudioEventListener listener) {
         mAudioEventListeners.add(listener);
-        TvApp.getApplication().getLogger().Debug("Added event listener.  Total listeners: "+mAudioEventListeners.size());
+        TvApp.getApplication().getLogger().Debug("Added event listener.  Total listeners: %d", mAudioEventListeners.size());
     }
     public static void removeAudioEventListener(AudioEventListener listener) {
         mAudioEventListeners.remove(listener);
-        TvApp.getApplication().getLogger().Debug("Removed event listener.  Total listeners: " + mAudioEventListeners.size());
+        TvApp.getApplication().getLogger().Debug("Removed event listener.  Total listeners: %d", mAudioEventListeners.size());
     }
 
     public static boolean initAudio() {
@@ -190,7 +190,7 @@ public class MediaManager {
 
         //fire external listener if there
         for (AudioEventListener listener : mAudioEventListeners) {
-            TvApp.getApplication().getLogger().Info("Firing playback state change listener for item completion. "+ mCurrentAudioItem.getName());
+            TvApp.getApplication().getLogger().Info("Firing playback state change listener for item completion. %s", mCurrentAudioItem.getName());
             listener.onPlaybackStateChange(PlaybackController.PlaybackState.IDLE, mCurrentAudioItem);
         }
 
@@ -304,7 +304,7 @@ public class MediaManager {
 
     private static void fireQueueStatusChange() {
         for (AudioEventListener listener : mAudioEventListeners) {
-            TvApp.getApplication().getLogger().Info("Firing queue state change listener. "+ hasAudioQueueItems());
+            TvApp.getApplication().getLogger().Info("Firing queue state change listener. %b", hasAudioQueueItems());
             listener.onQueueStatusChanged(hasAudioQueueItems());
         }
 
@@ -354,7 +354,7 @@ public class MediaManager {
 
                             @Override
                             public void onError(Exception exception) {
-                                TvApp.getApplication().getLogger().Debug(exception.toString());
+                                TvApp.getApplication().getLogger().ErrorException("Exception creating playlist", exception);
                             }
                         });
                     }
@@ -593,7 +593,7 @@ public class MediaManager {
                     mExoPlayer.setPlayWhenReady(true);
                     mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(response.ToUrl(apiClient.getApiUrl(), apiClient.getAccessToken()))));
                 } else {
-                    TvApp.getApplication().getLogger().Info("Playback attempt via VLC of " + response.getMediaUrl());
+                    TvApp.getApplication().getLogger().Info("Playback attempt via VLC of %s", response.getMediaUrl());
                     Media media = new Media(mLibVLC, Uri.parse(response.getMediaUrl()));
                     media.parse();
                     mVlcPlayer.setMedia(media);
@@ -612,7 +612,7 @@ public class MediaManager {
 
                 ReportingHelper.reportStart(item, mCurrentAudioPosition * 10000);
                 for (AudioEventListener listener : mAudioEventListeners) {
-                    TvApp.getApplication().getLogger().Info("Firing playback state change listener for item start. " + mCurrentAudioItem.getName());
+                    TvApp.getApplication().getLogger().Info("Firing playback state change listener for item start. %s", mCurrentAudioItem.getName());
                     listener.onPlaybackStateChange(PlaybackController.PlaybackState.PLAYING, mCurrentAudioItem);
                 }
             }

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -210,7 +210,7 @@ public class PlaybackController {
         mDisplayModes = display.getSupportedModes();
         mApplication.getLogger().Info("** Available display refresh rates:");
         for (Display.Mode mDisplayMode : mDisplayModes) {
-            mApplication.getLogger().Info(Float.toString(mDisplayMode.getRefreshRate()));
+            mApplication.getLogger().Info("%f", mDisplayMode.getRefreshRate());
         }
 
     }
@@ -259,7 +259,7 @@ public class PlaybackController {
     }
 
     private void play(long position, int transcodedSubtitle) {
-        mApplication.getLogger().Debug("Play called with pos: " + position + " and sub index: "+transcodedSubtitle);
+        mApplication.getLogger().Debug("Play called with pos: %d and sub index: %d", position, transcodedSubtitle);
 
         if (position < 0) {
             mApplication.getLogger().Info("Negative start requested - adjusting to zero");
@@ -375,7 +375,7 @@ public class PlaybackController {
                 internalOptions.setProfile(internalProfile);
 
                 mDefaultSubIndex = transcodedSubtitle;
-                TvApp.getApplication().getLogger().Debug("Max bitrate is: " + Utils.getMaxBitrate());
+                TvApp.getApplication().getLogger().Debug("Max bitrate is: %d", Utils.getMaxBitrate());
 
                 playInternal(getCurrentlyPlayingItem(), position, vlcOptions, internalOptions);
                 mPlaybackState = PlaybackState.BUFFERING;
@@ -400,7 +400,7 @@ public class PlaybackController {
                             //std 30 min episode or less
                             mNextItemThreshold = duration - NEXT_UP_DURATION;
                         }
-                        TvApp.getApplication().getLogger().Debug("Next item threshold set to " + mNextItemThreshold);
+                        TvApp.getApplication().getLogger().Debug("Next item threshold set to %d", mNextItemThreshold);
                     } else {
                         mNextItemThreshold = Long.MAX_VALUE;
                     }
@@ -465,11 +465,11 @@ public class PlaybackController {
             mApplication.getPlaybackManager().getVideoStreamInfo(apiClient.getServerInfo().getId(), vlcOptions, position * 10000, false, apiClient, new Response<StreamInfo>() {
                 @Override
                 public void onResponse(final StreamInfo vlcResponse) {
-                    mApplication.getLogger().Info("VLC would " + (vlcResponse.getPlayMethod().equals(PlayMethod.Transcode) ? "transcode" : "direct stream"));
+                    mApplication.getLogger().Info("VLC would %s", vlcResponse.getPlayMethod().equals(PlayMethod.Transcode) ? "transcode" : "direct stream");
                     mApplication.getPlaybackManager().getVideoStreamInfo(apiClient.getServerInfo().getId(), internalOptions, position * 10000, false, apiClient, new Response<StreamInfo>() {
                         @Override
                         public void onResponse(StreamInfo internalResponse) {
-                            mApplication.getLogger().Info("Internal player would " + (internalResponse.getPlayMethod().equals(PlayMethod.Transcode) ? "transcode" : "direct stream"));
+                            mApplication.getLogger().Info("Internal player would %s", internalResponse.getPlayMethod().equals(PlayMethod.Transcode) ? "transcode" : "direct stream");
                             boolean useDeinterlacing = vlcResponse.getMediaSource().getVideoStream() != null &&
                                     vlcResponse.getMediaSource().getVideoStream().getIsInterlaced() &&
                                     (vlcResponse.getMediaSource().getVideoStream().getWidth() == null ||
@@ -478,7 +478,7 @@ public class PlaybackController {
 
                             String preferredVideoPlayer = mApplication.getPrefs().getString("pref_video_player", "auto");
 
-                            mApplication.getLogger().Info("User preferred player is: " + preferredVideoPlayer);
+                            mApplication.getLogger().Info("User preferred player is: %s", preferredVideoPlayer);
 
                             if (preferredVideoPlayer.equals("vlc")) {
                                 // Force VLC
@@ -695,7 +695,7 @@ public class PlaybackController {
         mCurrentOptions.setAudioStreamIndex(index);
         if (mVideoManager.isNativeMode()) {
             startSpinner();
-            mApplication.getLogger().Debug("Setting audio index to: " + index);
+            mApplication.getLogger().Debug("Setting audio index to: %d", index);
             mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
             stop();
             playInternal(getCurrentlyPlayingItem(), mCurrentPosition, mCurrentOptions, mCurrentOptions);
@@ -709,7 +709,7 @@ public class PlaybackController {
     private boolean burningSubs = false;
 
     public void switchSubtitleStream(int index) {
-        mApplication.getLogger().Debug("Setting subtitle index to: " + index);
+        mApplication.getLogger().Debug("Setting subtitle index to: %d", index);
         mCurrentOptions.setSubtitleStreamIndex(index >= 0 ? index : null);
 
         if (index < 0) {
@@ -853,7 +853,7 @@ public class PlaybackController {
         if (mCurrentIndex < mItems.size() - 1) {
             stop();
             mCurrentIndex++;
-            mApplication.getLogger().Debug("Moving to index: " + mCurrentIndex + " out of " + mItems.size() + " total items.");
+            mApplication.getLogger().Debug("Moving to index: %d out of %d total items.", mCurrentIndex, mItems.size());
             spinnerOff = false;
             play(0);
         }
@@ -864,8 +864,8 @@ public class PlaybackController {
     }
 
     public void seek(final long pos) {
-        mApplication.getLogger().Debug("Seeking to " + pos);
-        mApplication.getLogger().Debug("Container: "+mCurrentStreamInfo.getContainer());
+        mApplication.getLogger().Debug("Seeking to %d", pos);
+        mApplication.getLogger().Debug("Container: %s", mCurrentStreamInfo.getContainer());
         if (mPlaybackMethod == PlayMethod.Transcode && ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer())) {
             //mkv transcodes require re-start of stream for seek
             mVideoManager.stopPlayback();
@@ -1067,7 +1067,7 @@ public class PlaybackController {
         if (mCurrentIndex < mItems.size() - 1) {
             // move to next in queue
             mCurrentIndex++;
-            mApplication.getLogger().Debug("Moving to next queue item. Index: "+mCurrentIndex);
+            mApplication.getLogger().Debug("Moving to next queue item. Index: %d", mCurrentIndex);
             spinnerOff = false;
             play(0);
         } else {
@@ -1093,7 +1093,7 @@ public class PlaybackController {
                     mFragment.finish();
                 } else {
                     String msg = mApplication.getString(R.string.video_error_unknown_error);
-                    mApplication.getLogger().Error("Playback error - " + msg);
+                    mApplication.getLogger().Error("Playback error - %s", msg);
                     playerErrorEncountered();
                 }
 
@@ -1123,7 +1123,7 @@ public class PlaybackController {
                         if (currentIndex != null && currentIndex == mDefaultSubIndex) {
                             mApplication.getLogger().Info("Not selecting default subtitle stream because it is already selected");
                         } else {
-                            mApplication.getLogger().Info("Selecting default sub stream: " + mDefaultSubIndex);
+                            mApplication.getLogger().Info("Selecting default sub stream: %d", mDefaultSubIndex);
                             switchSubtitleStream(mDefaultSubIndex);
                         }
                     } else {
@@ -1132,7 +1132,7 @@ public class PlaybackController {
                     }
 
                     if (!mVideoManager.isNativeMode() && mDefaultAudioIndex >= 0) {
-                        TvApp.getApplication().getLogger().Info("Selecting default audio stream: " + mDefaultAudioIndex);
+                        TvApp.getApplication().getLogger().Info("Selecting default audio stream: %d", mDefaultAudioIndex);
                         switchAudioStream(mDefaultAudioIndex);
                     }
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/playback/SubtitleHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/SubtitleHelper.java
@@ -49,7 +49,7 @@ public class SubtitleHelper {
 
         String url = (stream.getIsExternalUrl() != null && !stream.getIsExternalUrl()) ? apiClient.GetApiUrl(stream.getDeliveryUrl()) : stream.getDeliveryUrl();
 
-        TvApp.getApplication().getLogger().Info("Subtitle url: "+url);
+        TvApp.getApplication().getLogger().Info("Subtitle url: %s", url);
 
         apiClient.getResponseStream(url, new Response<ResponseStreamInfo>(response){
 

--- a/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
@@ -281,14 +281,14 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     public long seekTo(long pos) {
         if (nativeMode) {
             Long intPos = pos;
-            TvApp.getApplication().getLogger().Info("Exo length in seek is: " + mExoPlayer.getDuration());
+            TvApp.getApplication().getLogger().Info("Exo length in seek is: %d", mExoPlayer.getDuration());
             mExoPlayer.seekTo(intPos.intValue());
             return pos;
         } else {
             if (mVlcPlayer == null || !mVlcPlayer.isSeekable()) return -1;
             mForcedTime = pos;
             mLastTime = mVlcPlayer.getTime();
-            TvApp.getApplication().getLogger().Info("VLC length in seek is: " + mVlcPlayer.getLength());
+            TvApp.getApplication().getLogger().Info("VLC length in seek is: %d", mVlcPlayer.getLength());
             try {
                 if (getDuration() > 0) mVlcPlayer.setPosition((float)pos / getDuration()); else mVlcPlayer.setTime(pos);
 
@@ -305,7 +305,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     public void setVideoPath(String path) {
         mCurrentVideoPath = path;
         try {
-            TvApp.getApplication().getLogger().Info("Video path set to: "+path);
+            TvApp.getApplication().getLogger().Info("Video path set to: %s", path);
 
         } catch(Exception e){
             TvApp.getApplication().getLogger().ErrorException("Error writing path to log",e);
@@ -376,7 +376,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 return false;
             }
 
-            TvApp.getApplication().getLogger().Info("Setting Vlc sub to "+vlcSub.name);
+            TvApp.getApplication().getLogger().Info("Setting Vlc sub to %s", vlcSub.name);
             return mVlcPlayer.setSpuTrack(vlcSub.id);
 
         }
@@ -415,9 +415,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 return;
             }
             //debug
-            TvApp.getApplication().getLogger().Debug("Setting VLC audio track index to: "+vlcIndex + "/" + vlcTrack.id);
+            TvApp.getApplication().getLogger().Debug("Setting VLC audio track index to: %d / %d", vlcIndex, vlcTrack.id);
             for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
-                TvApp.getApplication().getLogger().Debug("VLC Audio Track: "+track.name+"/"+track.id);
+                TvApp.getApplication().getLogger().Debug("VLC Audio Track: %s / %d", track.name, track.id);
             }
             //
             if (mVlcPlayer.setAudioTrack(vlcTrack.id)) {
@@ -436,7 +436,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             if (!mVlcPlayer.setAudioDelay(value * 1000)) {
                 TvApp.getApplication().getLogger().Error("Error setting audio delay");
             } else {
-                TvApp.getApplication().getLogger().Info("Audio delay set to "+value);
+                TvApp.getApplication().getLogger().Info("Audio delay set to %d", value);
             }
         }
     }
@@ -461,7 +461,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         if (!nativeMode && mediaSource != null && mediaSource.getMediaStreams() != null) {
             for (MediaStream stream : mediaSource.getMediaStreams()) {
                 if (stream.getType() == MediaStreamType.Video && stream.getIndex() >= 0) {
-                    TvApp.getApplication().getLogger().Debug("Setting video index to: "+stream.getIndex());
+                    TvApp.getApplication().getLogger().Debug("Setting video index to: %d", stream.getIndex());
                     mVlcPlayer.setVideoTrack(stream.getIndex());
                     return;
                 }
@@ -506,7 +506,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             options.add("-v");
 
             mLibVLC = new LibVLC(TvApp.getApplication(), options);
-            TvApp.getApplication().getLogger().Info("Network buffer set to " + buffer);
+            TvApp.getApplication().getLogger().Info("Network buffer set to %d", buffer);
 
             mVlcPlayer = new org.videolan.libvlc.MediaPlayer(mLibVLC);
             mVlcPlayer.setAudioOutput(Utils.downMixAudio() ? "opensles_android" : "android_audiotrack");
@@ -654,7 +654,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
         }
 
-        TvApp.getApplication().getLogger().Debug("Surface sized "+ lp.width+"x"+lp.height);
+        TvApp.getApplication().getLogger().Debug("Surface sized %d x %d ", lp.width, lp.height);
         mSurfaceView.invalidate();
         if (hasSubtitlesSurface) mSubtitlesSurface.invalidate();
     }

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/PositionableListRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/PositionableListRowPresenter.java
@@ -27,7 +27,7 @@ public class PositionableListRowPresenter extends CustomListRowPresenter impleme
     }
 
     public void setPosition(int ndx) {
-        TvApp.getApplication().getLogger().Debug("Setting position to: "+ndx);
+        TvApp.getApplication().getLogger().Debug("Setting position to: %d", ndx);
         if (viewHolder != null && viewHolder.getGridView() != null) viewHolder.getGridView().setSelectedPosition(ndx);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -174,7 +174,7 @@ public class KeyProcessor {
                 break;
             case KeyEvent.KEYCODE_MENU:
             case KeyEvent.KEYCODE_BUTTON_Y:
-                TvApp.getApplication().getLogger().Debug("Menu for: "+rowItem.getFullName());
+                TvApp.getApplication().getLogger().Debug("Menu for: %s", rowItem.getFullName());
 
                 //Create a contextual menu based on item
                 switch (rowItem.getItemType()) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/MediaCodecCapabilitiesTest.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/MediaCodecCapabilitiesTest.java
@@ -33,8 +33,7 @@ public class MediaCodecCapabilitiesTest  {
 
     private boolean checkDecoder(String mime, int profile, int level) {
         if (!hasDecoder(mime, profile, level)) {
-            TvApp.getApplication().getLogger().Info("no " + mime + " decoder for profile "
-                    + profile + " and level " + level);
+            TvApp.getApplication().getLogger().Info("no %s decoder for profile %d and level %d", mime, profile, level);
             return false;
         }
         return true;

--- a/app/src/main/java/org/jellyfin/androidtv/util/MediaUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/MediaUtils.java
@@ -14,13 +14,13 @@ public class MediaUtils {
 
     public static boolean check(boolean result, String message) {
         if (!result) {
-            TvApp.getApplication().getLogger().Info(message);
+            TvApp.getApplication().getLogger().Info("%s", message);
         }
         return result;
     }
     public static boolean canDecode(MediaFormat format) {
         if (sMCL.findDecoderForFormat(format) == null) {
-            TvApp.getApplication().getLogger().Info("no decoder for " + format);
+            TvApp.getApplication().getLogger().Info("no decoder for %s", format.toString());
             return false;
         }
         return true;
@@ -31,7 +31,7 @@ public class MediaUtils {
     private static boolean hasCodecForMimes(boolean encoder, String[] mimes) {
         for (String mime : mimes) {
             if (!hasCodecForMime(encoder, mime)) {
-                TvApp.getApplication().getLogger().Info("no " + (encoder ? "encoder" : "decoder") + " for mime " + mime);
+                TvApp.getApplication().getLogger().Info("no %s for %s", encoder ? "encoder" : "decoder", mime);
                 return false;
             }
         }
@@ -44,7 +44,7 @@ public class MediaUtils {
             }
             for (String type : info.getSupportedTypes()) {
                 if (type.equalsIgnoreCase(mime)) {
-                    TvApp.getApplication().getLogger().Info("found codec " + info.getName() + " for mime " + mime);
+                    TvApp.getApplication().getLogger().Info("found codec %s for mime %s", info.getName(), mime);
                     return true;
                 }
             }

--- a/app/src/main/java/org/jellyfin/androidtv/util/RemoteControlReceiver.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/RemoteControlReceiver.java
@@ -20,7 +20,7 @@ public class RemoteControlReceiver extends BroadcastReceiver {
             //Respond to media button presses
             if (Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
                 KeyEvent event = intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
-                TvApp.getApplication().getLogger().Debug("****** In remote receiver.  Keycode: " + event.getKeyCode());
+                TvApp.getApplication().getLogger().Debug("****** In remote receiver.  Keycode: %d", event.getKeyCode());
                 switch (event.getKeyCode()) {
                     case KeyEvent.KEYCODE_MEDIA_PAUSE:
                     case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
@@ -50,7 +50,7 @@ public class AuthenticationHelper {
                 }).setPositiveButton(activity.getString(R.string.lbl_ok), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String addressValue = address.getText().toString();
-                TvApp.getApplication().getLogger().Debug("Entered address: " + addressValue);
+                TvApp.getApplication().getLogger().Debug("Entered address: %s", addressValue);
                 if (!addressValue.isEmpty()) {
                     signInToServer(TvApp.getApplication().getConnectionManager(), addressValue, activity);
                 }
@@ -71,7 +71,7 @@ public class AuthenticationHelper {
                 }).setPositiveButton(activity.getString(R.string.lbl_ok), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String userValue = userName.getText().toString();
-                TvApp.getApplication().getLogger().Debug("Entered user: " + userValue);
+                TvApp.getApplication().getLogger().Debug("Entered user: %s", userValue);
                 final EditText userPw = new EditText(activity);
                 userPw.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
                 new AlertDialog.Builder(activity)
@@ -120,7 +120,7 @@ public class AuthenticationHelper {
                         activity.startActivity(userIntent);
                         break;
                     default:
-                        TvApp.getApplication().getLogger().Error("Unexpected response " + serverResult.getState() + " trying to sign in to specific server " + address);
+                        TvApp.getApplication().getLogger().Error("Unexpected response %s trying to sign in to specific server %s", serverResult.getState().toString(), address);
                         Utils.showToast(activity, activity.getString(R.string.msg_error_connecting_server));
                 }
             }
@@ -154,7 +154,7 @@ public class AuthenticationHelper {
             @Override
             public void onResponse(AuthenticationResult authenticationResult) {
                 TvApp application = TvApp.getApplication();
-                application.getLogger().Debug("Signed in as " + authenticationResult.getUser().getName());
+                application.getLogger().Debug("Signed in as %s", authenticationResult.getUser().getName());
                 application.setCurrentUser(authenticationResult.getUser());
                 if (directEntryItemId == null) {
                     Intent intent = new Intent(activity, MainActivity.class);
@@ -215,7 +215,7 @@ public class AuthenticationHelper {
                 Utils.showToast(activity, R.string.msg_error_server_unavailable);
                 break;
             case ServerSignIn:
-                logger.Debug("Sign in with server " + response.getServers().get(0).getName() + " total: " + response.getServers().size());
+                logger.Debug("Sign in with server %s total: %d", response.getServers().get(0).getName(), response.getServers().size());
                 signInToServer(connectionManager, response.getServers().get(0).getAddress(), activity);
                 break;
             case SignedIn:

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -187,7 +187,7 @@ public class PlaybackHelper {
                         public void onResponse(ItemsResult response) {
                             if (response.getTotalRecordCount() > 0){
                                 Collections.addAll(items, response.getItems());
-                                TvApp.getApplication().getLogger().Info(response.getTotalRecordCount() + " intro items added for playback.");
+                                TvApp.getApplication().getLogger().Info("%d intro items added for playback.", response.getTotalRecordCount());
                                 TvApp.getApplication().setPlayingIntros(true);
                             } else {
                                 TvApp.getApplication().setPlayingIntros(false);

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
@@ -38,7 +38,7 @@ public class ReportingHelper {
         startInfo.setItemId(item.getId());
         startInfo.setPositionTicks(pos);
         TvApp.getApplication().getPlaybackManager().reportPlaybackStart(startInfo, false, TvApp.getApplication().getApiClient(), new EmptyResponse());
-        TvApp.getApplication().getLogger().Info("Playback of " + item.getName() + " started.");
+        TvApp.getApplication().getLogger().Info("Playback of %s started.", item.getName());
     }
 
     public static void reportProgress(BaseItemDto item, StreamInfo currentStreamInfo, Long position, boolean isPaused) {


### PR DESCRIPTION
So, turns out that there were a *lot* of incorrect usages of the `ILogger` interface that may lead to crashes due to format string injections via them.