### PR TITLE
Remove audio mute features

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -28,7 +28,6 @@ import org.jellyfin.androidtv.playback.PlaybackController;
 import org.jellyfin.androidtv.playback.PlaybackManager;
 import org.jellyfin.androidtv.playback.PlaybackOverlayActivity;
 import org.jellyfin.androidtv.search.SearchActivity;
-import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
@@ -110,7 +109,6 @@ public class TvApp extends Application {
 
     private GradientDrawable currentBackgroundGradient;
 
-    private boolean audioMuted;
     private boolean playingIntros;
     private DisplayPriorityType displayPriority = DisplayPriorityType.Movies;
 
@@ -204,19 +202,6 @@ public class TvApp extends Application {
     public void setLoginApiClient(ApiClient loginApiClient) {
         this.loginApiClient = loginApiClient;
     }
-
-    public void setAudioMuted(boolean value) {
-        audioMuted = value;
-        getLogger().Info("Setting mute state to: %b", audioMuted);
-        if (DeviceUtils.is60()) {
-            audioManager.adjustVolume(audioMuted ? AudioManager.ADJUST_MUTE : AudioManager.ADJUST_UNMUTE, 0);
-
-        } else {
-            audioManager.setStreamMute(AudioManager.STREAM_MUSIC, audioMuted);
-        }
-    }
-
-    public boolean isAudioMuted() { return audioMuted; }
 
     public PlaybackController getPlaybackController() {
         return playbackController;

--- a/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
@@ -11,10 +11,6 @@ import org.jellyfin.androidtv.playback.MediaManager;
 import org.jellyfin.androidtv.querying.StdItemQuery;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
-
-import java.util.Arrays;
-import java.util.Calendar;
-
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.ApiEventListener;
 import org.jellyfin.apiclient.interaction.Response;
@@ -23,10 +19,12 @@ import org.jellyfin.apiclient.model.entities.LibraryUpdateInfo;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.session.BrowseRequest;
-import org.jellyfin.apiclient.model.session.GeneralCommand;
 import org.jellyfin.apiclient.model.session.PlayRequest;
 import org.jellyfin.apiclient.model.session.PlaystateRequest;
 import org.jellyfin.apiclient.model.session.SessionInfoDto;
+
+import java.util.Arrays;
+import java.util.Calendar;
 
 /**
  * Created by Eric on 2/14/2015.
@@ -56,22 +54,6 @@ public class TvApiEventListener extends ApiEventListener {
     public void onLibraryChanged(ApiClient client, LibraryUpdateInfo info) {
         TvApp.getApplication().getLogger().Debug("Library Changed. Added %o items. Removed %o items. Changed %o items.", info.getItemsAdded().size(), info.getItemsRemoved().size(), info.getItemsUpdated().size());
         if (info.getItemsAdded().size() > 0 || info.getItemsRemoved().size() > 0) TvApp.getApplication().setLastLibraryChange(Calendar.getInstance());
-    }
-
-    @Override
-    public void onGeneralCommand(ApiClient client, GeneralCommand command) {
-        TvApp.getApplication().getLogger().Info("General command is: %s", command.getName());
-        switch (command.getName().toLowerCase()) {
-            case "mute":
-                TvApp.getApplication().setAudioMuted(true);
-                break;
-            case "unmute":
-                TvApp.getApplication().setAudioMuted(false);
-                break;
-            case "togglemute":
-                TvApp.getApplication().setAudioMuted(!TvApp.getApplication().isAudioMuted());
-                break;
-        }
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -839,10 +839,6 @@ public class PlaybackController {
                 // update the actual items resume point
                 getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
             }
-
-            // be sure to unmute audio in case it was muted
-            TvApp.getApplication().setAudioMuted(false);
-
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackOverlayActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackOverlayActivity.java
@@ -51,13 +51,6 @@ public class PlaybackOverlayActivity extends BaseActivity {
     }
 
     @Override
-    protected void onPause() {
-        super.onPause();
-        // be sure to unmute audio in case it was muted
-        TvApp.getApplication().setAudioMuted(false);
-    }
-
-    @Override
     public void onDestroy() {
         super.onDestroy();
         if (mVideoManager != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
@@ -140,9 +140,6 @@ public class StartupActivity extends FragmentActivity {
         playableTypes.add("Audio");
         ArrayList<String> supportedCommands = new ArrayList<>();
         supportedCommands.add(GeneralCommandType.DisplayContent.toString());
-        supportedCommands.add(GeneralCommandType.Mute.toString());
-        supportedCommands.add(GeneralCommandType.Unmute.toString());
-        supportedCommands.add(GeneralCommandType.ToggleMute.toString());
 
         capabilities.setPlayableMediaTypes(playableTypes);
         capabilities.setSupportsContentUploading(false);

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
@@ -2,15 +2,14 @@ package org.jellyfin.androidtv.util.apiclient;
 
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.model.compat.StreamInfo;
-
-import java.util.Calendar;
-
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.session.PlaybackProgressInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStartInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStopInfo;
+
+import java.util.Calendar;
 
 public class ReportingHelper {
     public static void reportStopped(BaseItemDto item, StreamInfo streamInfo, long pos) {
@@ -49,7 +48,6 @@ public class ReportingHelper {
             info.setPositionTicks(position);
             info.setIsPaused(isPaused);
             info.setCanSeek(currentStreamInfo.getRunTimeTicks() != null && currentStreamInfo.getRunTimeTicks() > 0);
-            info.setIsMuted(TvApp.getApplication().isAudioMuted());
             info.setPlayMethod(currentStreamInfo.getPlayMethod());
             if (TvApp.getApplication().getPlaybackController() != null && TvApp.getApplication().getPlaybackController().isPlaying()) {
                 info.setAudioStreamIndex(TvApp.getApplication().getPlaybackController().getAudioStreamIndex());


### PR DESCRIPTION
Applications shouldn't change the device audio except when it's caused by user interaction. The app does not contain any UI elements to do this but we still have code to mute/unmute the device.

This PR removes the `setAudioMuted` method from the `TvApp` class and all references to it.

There is at least one issue in Tracepot that will be solved with this PR.
Maybe fix #309