### PR TITLE
Introduce new debug versioning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,42 @@
+import java.io.ByteArrayOutputStream
+
 plugins {
 	id("com.android.application")
 	id("kotlin-android")
 	id("kotlin-android-extensions")
+}
+
+fun getGitHash(): String {
+	val stdout = ByteArrayOutputStream()
+	val action = Action<ExecSpec> {
+		commandLine("git", "rev-parse", "--short", "HEAD")
+		standardOutput = stdout
+	}
+
+	exec(action)
+	return stdout.toString().trim()
+}
+
+fun getBranchName(): String {
+	val stdout = ByteArrayOutputStream()
+	val action = Action<ExecSpec> {
+		commandLine("git", "rev-parse", "--abbrev-ref", "HEAD")
+		standardOutput = stdout
+	}
+
+	exec(action)
+	return stdout.toString().trim()
+}
+
+fun isTreeClean(): Boolean {
+	val stdout = ByteArrayOutputStream()
+	val action = Action<ExecSpec> {
+		commandLine("git", "status", "--porcelain")
+		standardOutput = stdout
+	}
+
+	exec(action)
+	return stdout.toString().trim() == ""
 }
 
 android {
@@ -34,6 +69,7 @@ android {
 			// Use different application id to run release and debug at the same time
 			applicationIdSuffix = ".debug"
 			resValue("string", "app_name", "@string/app_name_debug")
+			versionNameSuffix =  "-debug-" + getBranchName() + "-" + getGitHash() + (if (isTreeClean()) "-treeClean" else "-treeDirty")
 		}
 	}
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ android {
 			// Use different application id to run release and debug at the same time
 			applicationIdSuffix = ".debug"
 			resValue("string", "app_name", "@string/app_name_debug")
-			versionNameSuffix =  "-debug-" + getBranchName() + "-" + getGitHash() + (if (isTreeClean()) "-treeClean" else "-treeDirty")
+			versionNameSuffix =  "-debug-" + getBranchName() + "-" + getGitHash() + (if (isTreeClean()) "" else "-dirty")
 		}
 	}
 }


### PR DESCRIPTION
This commit introduces a new versioning schema for debug versions, which makes it obvious which commit hash and branch a debug build was created from. 

This will allow better matching of crash reports of debug builds as well as possibly help us in setting up potential future nightly builds.