### PR TITLE
Use PreferredVideoPlayer enum for live tv preference

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -269,7 +269,7 @@ public class TvApp extends Application {
                 return getUserPreferences().getVideoPlayer() == PreferredVideoPlayer.EXTERNAL;
             case TvChannel:
             case Program:
-                return getUserPreferences().getLiveTvUseExternalPlayer();
+                return getUserPreferences().getLiveTvVideoPlayer() == PreferredVideoPlayer.EXTERNAL;
             default:
                 return false;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/ExternalPlayerActivity.java
@@ -138,7 +138,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
                     public void onClick(DialogInterface dialog, int which) {
                         UserPreferences prefs = mApplication.getUserPreferences();
                         prefs.setVideoPlayer(PreferredVideoPlayer.AUTO);
-                        prefs.setLiveTvUseExternalPlayer(false);
+                        prefs.setLiveTvVideoPlayer(PreferredVideoPlayer.AUTO);
                     }
                 })
                 .setOnDismissListener(new DialogInterface.OnDismissListener() {

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -424,7 +424,7 @@ public class PlaybackController {
             updateTvProgramInfo();
             TvManager.setLastLiveTvChannel(item.getId());
             //Choose appropriate player now to avoid opening two streams
-            if (!directStreamLiveTv || !mApplication.getUserPreferences().getLiveTvUseVlc()) {
+            if (!directStreamLiveTv || mApplication.getUserPreferences().getLiveTvVideoPlayer() != PreferredVideoPlayer.VLC) {
                 //internal/exo player
                 mApplication.getLogger().Info("Using internal player for Live TV");
                 mApplication.getPlaybackManager().getVideoStreamInfo(apiClient.getServerInfo().getId(), internalOptions, position * 10000, false, apiClient, new Response<StreamInfo>() {

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
@@ -127,14 +127,9 @@ class UserPreferences(context: Context) : SharedPreferenceStore(PreferenceManage
 	var liveTvDirectPlayEnabled by booleanPreference("pref_live_direct", true)
 
 	/**
-	 * Use VLC for live TV playback
+	 * Preferred video player for live TV
 	 */
-	var liveTvUseVlc by booleanPreference("pref_enable_vlc_livetv", false)
-
-	/**
-	 * Use external player for live TV playback
-	 */
-	var liveTvUseExternalPlayer by booleanPreference("pref_live_tv_use_external", false)
+	var liveTvVideoPlayer by enumPreference("live_tv_video_player", PreferredVideoPlayer.AUTO)
 
 	/* ACRA */
 	/**
@@ -169,6 +164,15 @@ class UserPreferences(context: Context) : SharedPreferenceStore(PreferenceManage
 
 			// Migrate to login behavior enum
 			putEnum("login_behavior", if (it.getString("pref_login_behavior", "0") == "1") LoginBehavior.AUTO_LOGIN else LoginBehavior.SHOW_LOGIN)
+		}
+
+		migration(toVersion = 4) {
+			putEnum("live_tv_video_player",
+				when {
+					it.getBoolean("pref_live_tv_use_external", false) -> PreferredVideoPlayer.EXTERNAL
+					it.getBoolean("pref_enable_vlc_livetv", false) -> PreferredVideoPlayer.VLC
+					else -> PreferredVideoPlayer.AUTO
+				})
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
@@ -164,9 +164,8 @@ class UserPreferences(context: Context) : SharedPreferenceStore(PreferenceManage
 
 			// Migrate to login behavior enum
 			putEnum("login_behavior", if (it.getString("pref_login_behavior", "0") == "1") LoginBehavior.AUTO_LOGIN else LoginBehavior.SHOW_LOGIN)
-		}
 
-		migration(toVersion = 4) {
+			// Migrate live tv player to use enum
 			putEnum("live_tv_video_player",
 				when {
 					it.getBoolean("pref_live_tv_use_external", false) -> PreferredVideoPlayer.EXTERNAL

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,4 +349,5 @@
     <string name="pref_video_player_vlc">libVLC</string>
     <string name="pref_video_player_external">External app</string>
     <string name="pref_about_title">About</string>
+    <string name="pref_media_player">Preferred media player</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -84,7 +84,7 @@
             android:entries="@array/pref_video_player_entries"
             android:entryValues="@array/pref_video_player_values"
             android:key="video_player"
-            android:title="Preferred media player"
+            android:title="@string/pref_media_player"
             app:useSimpleSummaryProvider="true" />
         <CheckBoxPreference
             android:defaultValue="true"
@@ -121,21 +121,14 @@
     <PreferenceCategory
         android:key="pref_live_tv_category"
         android:title="@string/pref_live_tv_cat">
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:disableDependentsState="true"
-            android:key="pref_live_tv_use_external"
-            android:summary="@string/pref_external_live_tv_summary"
-            android:title="@string/pref_external_live_tv_title" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:dependency="pref_live_tv_use_external"
-            android:key="pref_enable_vlc_livetv"
-            android:summary="@string/desc_use_vlc_livetv"
-            android:title="@string/lbl_use_vlc_livetv" />
+        <ListPreference
+            android:entries="@array/pref_video_player_entries"
+            android:entryValues="@array/pref_video_player_values"
+            android:key="live_tv_video_player"
+            android:title="@string/pref_media_player"
+            app:useSimpleSummaryProvider="true" />
         <CheckBoxPreference
             android:defaultValue="true"
-            android:dependency="pref_live_tv_use_external"
             android:key="pref_live_direct"
             android:title="@string/lbl_direct_stream_live" />
     </PreferenceCategory>


### PR DESCRIPTION
This updates the video player preferences for live tv to use the same method as for regular videos.

![spiderman double](https://user-images.githubusercontent.com/3450688/74570624-b751ff80-4f4a-11ea-901a-74e73c51cf16.gif)
