### PR TITLE
Set Kotlin JVM target to Java 1.8 (from 1.6) to support inline functions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,10 @@ android {
 		targetCompatibility = JavaVersion.VERSION_1_8
 	}
 
+	kotlinOptions {
+		jvmTarget = compileOptions.targetCompatibility.toString()
+	}
+
 	buildTypes {
 		getByName("release") {
 			isMinifyEnabled = false


### PR DESCRIPTION
Cherrypicked from the details branch (needed to fix compile errors).

This configures the Kotlin compiler to use Java 1.8 instead of the default, 1.6, when compiling. This is needed for certain features like inline functions.