### PR TITLE
Fix crash when selecting a music artist in search results

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/itemhandling/ItemLauncher.java
@@ -271,7 +271,7 @@ public class ItemLauncher {
                 application.getApiClient().GetItemAsync(hint.getItemId(), application.getCurrentUser().getId(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
-                        if ((response.getIsFolderItem() && response.getBaseItemType() != BaseItemType.Series) || response.getBaseItemType() == BaseItemType.MusicArtist) {
+                        if (response.getIsFolderItem() && response.getBaseItemType() != BaseItemType.Series) {
                             // open generic folder browsing
                             Intent intent = new Intent(activity, GenericGridActivity.class);
                             intent.putExtra("Folder", TvApp.getApplication().getSerializer().SerializeToString(response));

--- a/app/src/main/java/org/jellyfin/androidtv/presentation/HorizontalGridPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/presentation/HorizontalGridPresenter.java
@@ -205,7 +205,9 @@ public class HorizontalGridPresenter extends Presenter {
         vh.getGridView().setOnChildViewHolderSelectedListener(new OnChildViewHolderSelectedListener() {
             @Override
             public void onChildViewHolderSelected(RecyclerView parent, RecyclerView.ViewHolder child, int position, int subposition) {
-                selectChildView(gridViewHolder, child.itemView);
+                if (child != null) {
+                    selectChildView(gridViewHolder, child.itemView);
+                }
             }
         });
 


### PR DESCRIPTION
For some reason selecting a music artist in search results would attempt to open the wrong activity and cause the app to crash. Removing this check for MusicArtist causes it to open the detail activity as expected.

![crash dummy](https://user-images.githubusercontent.com/3450688/74804456-514cdb80-52ae-11ea-8695-4d3692e85477.gif)
