### PR TITLE
Fix shuffle all option for albums

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -578,7 +578,10 @@ public class ItemListActivity extends BaseActivity {
                     @Override
                     public void onClick(View v) {
                         if (mItems.size() > 0) {
-                            if (mBaseItem.getId().equals(VIDEO_QUEUE) || mBaseItem.getId().equals(FAV_SONGS) || "Playlist".equals(mBaseItem.getType())) {
+                            if (mBaseItem.getId().equals(VIDEO_QUEUE)
+                                    || mBaseItem.getId().equals(FAV_SONGS)
+                                    || mBaseItem.getBaseItemType() == BaseItemType.Playlist
+                                    || mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum) {
                                 List<BaseItemDto> shuffled = new ArrayList<>(mItems);
                                 Collections.shuffle(shuffled);
                                 play(shuffled);


### PR DESCRIPTION
Selecting "Shuffle All" when viewing an album would open an `AudioNowPlayingActivity` with no items in the queue.

![no soup for you](https://user-images.githubusercontent.com/3450688/74804669-e94ac500-52ae-11ea-8921-ae6e6370d3e6.gif)
