### PR TITLE
Add default audio delay for libVLC

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
@@ -441,7 +441,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
     }
 
-    public long getAudioDelay() { return mVlcPlayer != null ? mVlcPlayer.getAudioDelay() / 1000 : 0;}
+    public long getAudioDelay() {
+        return mVlcPlayer != null ? mVlcPlayer.getAudioDelay() / 1000 : 0;
+    }
 
     public void setCompatibleAudio() {
          if (!nativeMode) {
@@ -503,6 +505,8 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             }
 //            options.add("--subsdec-encoding");
 //            options.add("Universal (UTF-8)");
+            options.add("--audio-desync");
+            options.add(String.valueOf(TvApp.getApplication().getUserPreferences().getLibVLCAudioDelay()));
             options.add("-v");
 
             mLibVLC = new LibVLC(TvApp.getApplication(), options);
@@ -511,7 +515,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             mVlcPlayer = new org.videolan.libvlc.MediaPlayer(mLibVLC);
             mVlcPlayer.setAudioOutput(Utils.downMixAudio() ? "opensles_android" : "android_audiotrack");
             mVlcPlayer.setAudioOutputDevice("hdmi");
-
 
             mSurfaceHolder.addCallback(mSurfaceCallback);
             mVlcPlayer.setEventListener(mVlcHandler);

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/SharedPreferenceStore.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/SharedPreferenceStore.kt
@@ -54,6 +54,24 @@ abstract class SharedPreferenceStore(
 			sharedPreferences.edit().putInt(key, value).apply()
 		}
 	}
+	
+	/**
+	 * Delegated property function for longs
+	 *
+	 * @param key Key used to store setting as
+	 * @param default Default value
+	 *
+	 * @return Delegated property
+	 */
+	protected fun longPreference(key: String, default: Long) = object : ReadWriteProperty<SharedPreferenceStore, Long> {
+		override fun getValue(thisRef: SharedPreferenceStore, property: KProperty<*>): Long {
+			return sharedPreferences.getLong(key, default)
+		}
+
+		override fun setValue(thisRef: SharedPreferenceStore, property: KProperty<*>, value: Long) {
+			sharedPreferences.edit().putLong(key, value).apply()
+		}
+	}
 
 	/**
 	 * Delegated property function for booleans

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
@@ -126,6 +126,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(PreferenceManage
 	 */
 	var ac3Enabled by booleanPreference("pref_bitstream_ac3", true)
 
+	/**
+	 * Default audio delay for libVLC
+	 */
+	var libVLCAudioDelay by longPreference("libvlc_audio_delay", -300)
+
 	/* Live TV */
 	/**
 	 * Open live tv when opening the app

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
@@ -127,7 +127,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(PreferenceManage
 	var ac3Enabled by booleanPreference("pref_bitstream_ac3", true)
 
 	/**
-	 * Default audio delay for libVLC
+	 * Default audio delay in milliseconds for libVLC
 	 */
 	var libVLCAudioDelay by longPreference("libvlc_audio_delay", -300)
 

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/ui/EditLongPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/ui/EditLongPreference.kt
@@ -3,14 +3,8 @@ package org.jellyfin.androidtv.preferences.ui
 import android.content.Context
 import android.util.AttributeSet
 import androidx.preference.EditTextPreference
-import androidx.preference.PreferenceViewHolder
 
-class EditLongPreference : EditTextPreference {
-	constructor(context: Context?, attributeSet: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attributeSet, defStyleAttr, defStyleRes)
-	constructor(context: Context?, attributeSet: AttributeSet?, defStyleAttr: Int) : super(context, attributeSet, defStyleAttr)
-	constructor(context: Context?, attributeSet: AttributeSet?) : super(context, attributeSet)
-	constructor(context: Context?) : super(context)
-
+class EditLongPreference(context: Context, attrs: AttributeSet?) : EditTextPreference(context, attrs) {
 	override fun getPersistedString(defaultReturnValue: String?): String {
 		return getPersistedLong(-1).toString()
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/ui/EditLongPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/ui/EditLongPreference.kt
@@ -1,0 +1,25 @@
+package org.jellyfin.androidtv.preferences.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceViewHolder
+
+class EditLongPreference : EditTextPreference {
+	constructor(context: Context?, attributeSet: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attributeSet, defStyleAttr, defStyleRes)
+	constructor(context: Context?, attributeSet: AttributeSet?, defStyleAttr: Int) : super(context, attributeSet, defStyleAttr)
+	constructor(context: Context?, attributeSet: AttributeSet?) : super(context, attributeSet)
+	constructor(context: Context?) : super(context)
+
+	override fun getPersistedString(defaultReturnValue: String?): String {
+		return getPersistedLong(-1).toString()
+	}
+
+	override fun persistString(value: String?): Boolean {
+		return try {
+			persistLong(value!!.toLong())
+		} catch (e: NumberFormatException) {
+			false
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/ui/UserPreferencesFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/ui/UserPreferencesFragment.kt
@@ -134,6 +134,12 @@ class UserPreferencesFragment : LeanbackSettingsFragmentCompat() {
 			findPreference<EditTextPreference>("version")?.summaryProvider = Preference.SummaryProvider<EditTextPreference> {
 				Utils.getVersionString()
 			}
+
+			val audioDelayPreference = findPreference<EditLongPreference>("libvlc_audio_delay")
+			audioDelayPreference?.text = TvApp.getApplication().userPreferences.libVLCAudioDelay.toString()
+			audioDelayPreference?.summaryProvider = Preference.SummaryProvider<EditLongPreference> {
+				"${it.text} ms"
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/ui/UserPreferencesFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/ui/UserPreferencesFragment.kt
@@ -135,10 +135,11 @@ class UserPreferencesFragment : LeanbackSettingsFragmentCompat() {
 				Utils.getVersionString()
 			}
 
-			val audioDelayPreference = findPreference<EditLongPreference>("libvlc_audio_delay")
-			audioDelayPreference?.text = TvApp.getApplication().userPreferences.libVLCAudioDelay.toString()
-			audioDelayPreference?.summaryProvider = Preference.SummaryProvider<EditLongPreference> {
-				"${it.text} ms"
+			findPreference<EditLongPreference>("libvlc_audio_delay")?.apply {
+				text = TvApp.getApplication().userPreferences.libVLCAudioDelay.toString()
+				summaryProvider = Preference.SummaryProvider<EditLongPreference> {
+					"${it.text} ms"
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/AudioDelayPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AudioDelayPopup.java
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
@@ -13,43 +12,36 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.util.Utils;
 
-/**
- * Created by Eric on 8/23/2015.
- */
 public class AudioDelayPopup {
-
-    final int WIDTH = Utils.convertDpToPixel(TvApp.getApplication(), 240);
-    final int HEIGHT = Utils.convertDpToPixel(TvApp.getApplication(), 130);
-
-    PopupWindow mPopup;
-    View mAnchor;
-    NumberSpinner mDelaySpinner;
+    private PopupWindow mPopup;
+    private View mAnchor;
+    private NumberSpinner mDelaySpinner;
 
     public AudioDelayPopup(Context context, View anchor, ValueChangedListener<Long> listener) {
-        LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LayoutInflater inflater = LayoutInflater.from(context);
         View layout = inflater.inflate(R.layout.audio_delay_popup, null);
-        mPopup = new PopupWindow(layout, WIDTH, HEIGHT);
+
+        int width = Utils.convertDpToPixel(TvApp.getApplication(), 240);
+        int height = Utils.convertDpToPixel(TvApp.getApplication(), 130);
+
+        mPopup = new PopupWindow(layout, width, height);
         mPopup.setFocusable(true);
         mPopup.setOutsideTouchable(true);
         mPopup.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT)); // necessary for popup to dismiss
 
         mAnchor = anchor;
 
-        mDelaySpinner = (NumberSpinner) layout.findViewById(R.id.numberSpinner);
+        mDelaySpinner = layout.findViewById(R.id.numberSpinner);
         mDelaySpinner.setOnChangeListener(listener);
     }
-    
-    
 
     public boolean isShowing() {
         return (mPopup != null && mPopup.isShowing());
     }
 
     public void show(long value) {
-
         mDelaySpinner.setValue(value);
-        mPopup.showAtLocation(mAnchor, Gravity.CENTER_VERTICAL, mAnchor.getRight()-60, mAnchor.getTop());
-
+        mPopup.showAtLocation(mAnchor, Gravity.CENTER_VERTICAL, mAnchor.getRight() - 60, mAnchor.getTop());
     }
 
     public void dismiss() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,4 +355,5 @@
     <string name="watch_now">Watch now</string>
     <string name="pref_next_up_enabled_summary">Previews the next queued item before playing</string>
     <string name="pref_next_up_enabled_title">Enable Next Up screen</string>
+    <string name="pref_libvlc_audio_delay_title">Default Audio Delay for libVLC</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -127,6 +127,10 @@
             android:defaultValue="true"
             android:key="pref_refresh_switching"
             android:title="@string/lbl_refresh_switching" />
+        <org.jellyfin.androidtv.preferences.ui.EditLongPreference
+            android:inputType="number|numberSigned"
+            android:key="libvlc_audio_delay"
+            android:title="@string/pref_libvlc_audio_delay_title" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_send_path_external"


### PR DESCRIPTION
libVLC audio always seems to be 300ms out of sync from the video. This adds a user preference to adjust that and sets `-300` as the default.

Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/144

![nsync](https://user-images.githubusercontent.com/3450688/75069730-ce9b6a80-54bf-11ea-8297-5ada39339df0.gif)
