### PR TITLE
Add child count to requested fields in queries

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseGridFragment.java
@@ -10,12 +10,7 @@ import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 
-/**
- * Created by Eric on 8/16/2015.
- */
 public class BrowseGridFragment extends StdGridFragment {
-
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -24,12 +19,14 @@ public class BrowseGridFragment extends StdGridFragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
     }
 
     @Override
     protected void setupQueries(IGridLoader gridLoader) {
-        StdItemQuery query = new StdItemQuery(new ItemFields[] {ItemFields.PrimaryImageAspectRatio});
+        StdItemQuery query = new StdItemQuery(new ItemFields[] {
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         query.setParentId(mParentId);
         if (mFolder.getBaseItemType() == BaseItemType.UserView || mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {
             String type = mFolder.getCollectionType() != null ? mFolder.getCollectionType().toLowerCase() : "";
@@ -54,7 +51,11 @@ public class BrowseGridFragment extends StdGridFragment {
                     if ("AlbumArtist".equals(includeType)) {
                         ArtistsQuery albumArtists = new ArtistsQuery();
                         albumArtists.setUserId(TvApp.getApplication().getCurrentUser().getId());
-                        albumArtists.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.ItemCounts});
+                        albumArtists.setFields(new ItemFields[]{
+                                ItemFields.PrimaryImageAspectRatio,
+                                ItemFields.ItemCounts,
+                                ItemFields.ChildCount
+                        });
                         albumArtists.setParentId(mParentId);
                         mRowDef = new BrowseRowDef("", albumArtists, 150, new ChangeTriggerType[] {});
                         gridLoader.loadGrid(mRowDef);
@@ -70,5 +71,4 @@ public class BrowseGridFragment extends StdGridFragment {
 
         gridLoader.loadGrid(mRowDef);
     }
-
 }

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseRecordingsFragment.java
@@ -28,25 +28,23 @@ import org.jellyfin.apiclient.model.livetv.TimerQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.results.TimerInfoDtoResult;
 
-/**
- * Created by Eric on 9/3/2015.
- */
 public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
-
     @Override
     public void onResume() {
         super.onResume();
-
     }
 
     @Override
     protected void setupQueries(final IRowLoader rowLoader) {
-
         showViews = true;
         mTitle.setText(TvApp.getApplication().getResources().getString(R.string.lbl_loading_elipses));
         //Latest Recordings
         RecordingQuery recordings = new RecordingQuery();
-        recordings.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+        recordings.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         recordings.setUserId(TvApp.getApplication().getCurrentUser().getId());
         recordings.setEnableImages(true);
         recordings.setLimit(40);
@@ -54,7 +52,11 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
         //Movies
         RecordingQuery movies = new RecordingQuery();
-        movies.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+        movies.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         movies.setUserId(TvApp.getApplication().getCurrentUser().getId());
         movies.setEnableImages(true);
         movies.setIsMovie(true);
@@ -62,7 +64,11 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
         //Shows
         RecordingQuery shows = new RecordingQuery();
-        shows.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+        shows.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         shows.setUserId(TvApp.getApplication().getCurrentUser().getId());
         shows.setEnableImages(true);
         shows.setIsSeries(true);
@@ -79,7 +85,11 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
         //Sports
         RecordingQuery sports = new RecordingQuery();
-        sports.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+        sports.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         sports.setUserId(TvApp.getApplication().getCurrentUser().getId());
         sports.setEnableImages(true);
         sports.setIsSports(true);
@@ -87,7 +97,11 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
         //Kids
         RecordingQuery kids = new RecordingQuery();
-        kids.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+        kids.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         kids.setUserId(TvApp.getApplication().getCurrentUser().getId());
         kids.setEnableImages(true);
         kids.setIsKids(true);
@@ -150,7 +164,6 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                     }
 
         });
-
     }
 
     @Override
@@ -162,6 +175,5 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         gridRowAdapter.add(new GridButton(SCHEDULE, TvApp.getApplication().getString(R.string.lbl_schedule), R.drawable.tile_port_time));
         gridRowAdapter.add(new GridButton(SERIES, mActivity.getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer));
         rowAdapter.add(new ListRow(gridHeader, gridRowAdapter));
-
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/BrowseViewFragment.java
@@ -64,7 +64,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Latest
                 LatestItemsQuery latestMovies = new LatestItemsQuery();
-                latestMovies.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+                latestMovies.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ChildCount
+                });
                 latestMovies.setParentId(mFolder.getId());
                 latestMovies.setLimit(50);
                 latestMovies.setImageTypeLimit(1);
@@ -82,6 +86,9 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Collections
                 StdItemQuery collections = new StdItemQuery();
+                collections.setFields(new ItemFields[]{
+                        ItemFields.ChildCount
+                });
                 collections.setIncludeItemTypes(new String[]{"BoxSet"});
                 collections.setRecursive(true);
                 collections.setImageTypeLimit(1);
@@ -100,12 +107,21 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 nextUpQuery.setLimit(50);
                 nextUpQuery.setParentId(mFolder.getId());
                 nextUpQuery.setImageTypeLimit(1);
-                nextUpQuery.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+                nextUpQuery.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ChildCount
+                });
                 mRows.add(new BrowseRowDef(mApplication.getResources().getString(R.string.lbl_next_up), nextUpQuery, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
 
                 //Premieres
                 if (mApplication.getUserPreferences().getPremieresEnabled()) {
-                    StdItemQuery newQuery = new StdItemQuery(new ItemFields[]{ItemFields.DateCreated, ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+                    StdItemQuery newQuery = new StdItemQuery(new ItemFields[]{
+                            ItemFields.DateCreated,
+                            ItemFields.PrimaryImageAspectRatio,
+                            ItemFields.Overview,
+                            ItemFields.ChildCount
+                    });
                     newQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
                     newQuery.setIncludeItemTypes(new String[]{"Episode"});
                     newQuery.setParentId(mFolder.getId());
@@ -123,7 +139,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Latest content added
                 LatestItemsQuery latestSeries = new LatestItemsQuery();
-                latestSeries.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+                latestSeries.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ChildCount
+                });
                 latestSeries.setIncludeItemTypes(new String[]{"Episode"});
                 latestSeries.setGroupItems(true);
                 latestSeries.setParentId(mFolder.getId());
@@ -147,7 +167,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Latest
                 LatestItemsQuery latestAlbums = new LatestItemsQuery();
-                latestAlbums.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+                latestAlbums.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ChildCount
+                });
                 latestAlbums.setIncludeItemTypes(new String[]{"Audio"});
                 latestAlbums.setGroupItems(true);
                 latestAlbums.setImageTypeLimit(1);
@@ -179,7 +203,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 mRows.add(new BrowseRowDef(mApplication.getString(R.string.lbl_favorites), favAlbums, 60, false, true, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
 
                 //AudioPlaylists
-                StdItemQuery playlists = new StdItemQuery(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.CumulativeRunTimeTicks});
+                StdItemQuery playlists = new StdItemQuery(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.CumulativeRunTimeTicks,
+                        ItemFields.ChildCount
+                });
                 playlists.setIncludeItemTypes(new String[]{"Playlist"});
                 playlists.setImageTypeLimit(1);
                 playlists.setRecursive(true);
@@ -196,7 +224,12 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 //On now
                 RecommendedProgramQuery onNow = new RecommendedProgramQuery();
                 onNow.setIsAiring(true);
-                onNow.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio, ItemFields.ChannelInfo});
+                onNow.setFields(new ItemFields[]{
+                        ItemFields.Overview,
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChannelInfo,
+                        ItemFields.ChildCount
+                });
                 onNow.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 onNow.setImageTypeLimit(1);
                 onNow.setEnableTotalRecordCount(false);
@@ -206,7 +239,12 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 //Upcoming
                 RecommendedProgramQuery upcomingTv = new RecommendedProgramQuery();
                 upcomingTv.setUserId(TvApp.getApplication().getCurrentUser().getId());
-                upcomingTv.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio, ItemFields.ChannelInfo});
+                upcomingTv.setFields(new ItemFields[]{
+                        ItemFields.Overview,
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChannelInfo,
+                        ItemFields.ChildCount
+                });
                 upcomingTv.setIsAiring(false);
                 upcomingTv.setHasAired(false);
                 upcomingTv.setImageTypeLimit(1);
@@ -229,7 +267,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Latest Recordings
                 RecordingQuery recordings = new RecordingQuery();
-                recordings.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+                recordings.setFields(new ItemFields[]{
+                        ItemFields.Overview,
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 recordings.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 recordings.setEnableImages(true);
                 recordings.setLimit(40);
@@ -288,7 +330,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                                     //First put all recordings in and retrieve
                                     //All Recordings
                                     RecordingQuery recordings = new RecordingQuery();
-                                    recordings.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+                                    recordings.setFields(new ItemFields[]{
+                                            ItemFields.Overview,
+                                            ItemFields.PrimaryImageAspectRatio,
+                                            ItemFields.ChildCount
+                                    });
                                     recordings.setUserId(TvApp.getApplication().getCurrentUser().getId());
                                     recordings.setEnableImages(true);
                                     mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_recent_recordings), recordings, 50));

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/GenericFolderFragment.java
@@ -33,7 +33,10 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
             RecordingQuery query = new RecordingQuery();
             query.setUserId(TvApp.getApplication().getCurrentUser().getId());
             query.setGroupId(mFolder.getId());
-            query.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio});
+            query.setFields(new ItemFields[] {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.ChildCount
+            });
             mRows.add(new BrowseRowDef(mApplication.getResources().getString(R.string.lbl_all_items), query));
             rowLoader.loadRows(mRows);
         } else {

--- a/app/src/main/java/org/jellyfin/androidtv/browsing/SuggestedMoviesFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/browsing/SuggestedMoviesFragment.java
@@ -15,11 +15,7 @@ import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.querying.SimilarItemsQuery;
 
-/**
- * Created by Eric on 12/4/2014.
- */
 public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
-
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         showViews = false;
@@ -28,7 +24,6 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
 
     @Override
     protected void setupQueries(final IRowLoader rowLoader) {
-
         StdItemQuery lastPlayed = new StdItemQuery();
         lastPlayed.setParentId(mFolder.getId());
         lastPlayed.setIncludeItemTypes(new String[]{"Movie"});
@@ -44,7 +39,11 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
                 for (BaseItemDto item : response.getItems()) {
                     SimilarItemsQuery similar = new SimilarItemsQuery();
                     similar.setId(item.getId());
-                    similar.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+                    similar.setFields(new ItemFields[] {
+                            ItemFields.PrimaryImageAspectRatio,
+                            ItemFields.Overview,
+                            ItemFields.ChildCount
+                    });
                     similar.setLimit(7);
                     mRows.add(new BrowseRowDef(mApplication.getString(R.string.lbl_because_you_watched)+item.getName(), similar, QueryType.SimilarMovies));
                 }
@@ -52,8 +51,5 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
                 rowLoader.loadRows(mRows);
             }
         });
-
     }
-
-
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -534,7 +534,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
                 //Similar
                 SimilarItemsQuery similar = new SimilarItemsQuery();
-                similar.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio});
+                similar.setFields(new ItemFields[] {
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 similar.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 similar.setId(mBaseItem.getId());
                 similar.setLimit(10);
@@ -554,7 +557,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
                 //Similar
                 SimilarItemsQuery similarTrailer = new SimilarItemsQuery();
-                similarTrailer.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio});
+                similarTrailer.setFields(new ItemFields[] {
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 similarTrailer.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 similarTrailer.setId(mBaseItem.getId());
                 similarTrailer.setLimit(10);
@@ -566,7 +572,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             case Person:
 
                 ItemQuery personMovies = new ItemQuery();
-                personMovies.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio});
+                personMovies.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 personMovies.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 personMovies.setPersonIds(new String[] {mBaseItem.getId()});
                 personMovies.setRecursive(true);
@@ -575,7 +584,11 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 addItemRow(adapter, personMoviesAdapter, 0, mApplication.getString(R.string.lbl_movies));
 
                 ItemQuery personSeries = new ItemQuery();
-                personSeries.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId});
+                personSeries.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.DisplayPreferencesId,
+                        ItemFields.ChildCount
+                });
                 personSeries.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 personSeries.setPersonIds(new String[] {mBaseItem.getId()});
                 personSeries.setRecursive(true);
@@ -587,7 +600,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             case MusicArtist:
 
                 ItemQuery artistAlbums = new ItemQuery();
-                artistAlbums.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio});
+                artistAlbums.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 artistAlbums.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 artistAlbums.setArtistIds(new String[]{mBaseItem.getId()});
                 artistAlbums.setRecursive(true);
@@ -600,21 +616,31 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 NextUpQuery nextUpQuery = new NextUpQuery();
                 nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 nextUpQuery.setSeriesId(mBaseItem.getId());
-                nextUpQuery.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio});
+                nextUpQuery.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 ItemRowAdapter nextUpAdapter = new ItemRowAdapter(nextUpQuery, false, new CardPresenter(), adapter);
                 addItemRow(adapter, nextUpAdapter, 0, mApplication.getString(R.string.lbl_next_up));
 
                 SeasonQuery seasons = new SeasonQuery();
                 seasons.setSeriesId(mBaseItem.getId());
                 seasons.setUserId(TvApp.getApplication().getCurrentUser().getId());
-                seasons.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId});
+                seasons.setFields(new ItemFields[] {
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.DisplayPreferencesId,
+                        ItemFields.ChildCount
+                });
                 ItemRowAdapter seasonsAdapter = new ItemRowAdapter(seasons, new CardPresenter(), adapter);
                 addItemRow(adapter, seasonsAdapter, 1, getString(R.string.lbl_seasons));
 
                 UpcomingEpisodesQuery upcoming = new UpcomingEpisodesQuery();
                 upcoming.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 upcoming.setParentId(mBaseItem.getId());
-                upcoming.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio});
+                upcoming.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 ItemRowAdapter upcomingAdapter = new ItemRowAdapter(upcoming, new CardPresenter(), adapter);
                 addItemRow(adapter, upcomingAdapter, 2, getString(R.string.lbl_upcoming));
 
@@ -625,7 +651,11 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 }
 
                 SimilarItemsQuery similarSeries = new SimilarItemsQuery();
-                similarSeries.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId});
+                similarSeries.setFields(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.DisplayPreferencesId,
+                        ItemFields.ChildCount
+                });
                 similarSeries.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 similarSeries.setId(mBaseItem.getId());
                 similarSeries.setLimit(20);

--- a/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/ItemListActivity.java
@@ -344,7 +344,6 @@ public class ItemListActivity extends BaseActivity {
         }
 
         menu.show();
-
     }
 
     private void loadItem(String id) {
@@ -411,7 +410,11 @@ public class ItemListActivity extends BaseActivity {
             switch (mItemId) {
                 case FAV_SONGS:
                     //Get favorited and liked songs from this area
-                    StdItemQuery favSongs = new StdItemQuery(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Genres});
+                    StdItemQuery favSongs = new StdItemQuery(new ItemFields[] {
+                            ItemFields.PrimaryImageAspectRatio,
+                            ItemFields.Genres,
+                            ItemFields.ChildCount
+                    });
                     favSongs.setParentId(getIntent().getStringExtra("ParentId"));
                     favSongs.setIncludeItemTypes(new String[] {"Audio"});
                     favSongs.setRecursive(true);
@@ -431,7 +434,12 @@ public class ItemListActivity extends BaseActivity {
                     PlaylistItemQuery playlistSongs = new PlaylistItemQuery();
                     playlistSongs.setId(mBaseItem.getId());
                     playlistSongs.setUserId(TvApp.getApplication().getCurrentUser().getId());
-                    playlistSongs.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Genres, ItemFields.Chapters});
+                    playlistSongs.setFields(new ItemFields[]{
+                            ItemFields.PrimaryImageAspectRatio,
+                            ItemFields.Genres,
+                            ItemFields.Chapters,
+                            ItemFields.ChildCount
+                    });
                     playlistSongs.setLimit(150);
                     TvApp.getApplication().getApiClient().GetPlaylistItems(playlistSongs, itemResponse);
                     break;
@@ -440,14 +448,16 @@ public class ItemListActivity extends BaseActivity {
             StdItemQuery songs = new StdItemQuery();
             songs.setParentId(mBaseItem.getId());
             songs.setRecursive(true);
-            songs.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Genres});
+            songs.setFields(new ItemFields[]{
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Genres,
+                    ItemFields.ChildCount
+            });
             songs.setIncludeItemTypes(new String[]{"Audio"});
             songs.setSortBy(new String[] {ItemSortBy.SortName});
             songs.setLimit(200);
             mApplication.getApiClient().GetItemsAsync(songs, itemResponse);
         }
-
-
     }
 
     private Response<ItemsResult> itemResponse = new Response<ItemsResult>() {
@@ -766,5 +776,4 @@ public class ItemListActivity extends BaseActivity {
                     .into(mBackgroundTarget);
         }
     }
-
 }

--- a/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/eventhandling/TvApiEventListener.java
@@ -29,11 +29,7 @@ import org.jellyfin.apiclient.model.session.SessionInfoDto;
 import java.util.Arrays;
 import java.util.Calendar;
 
-/**
- * Created by Eric on 2/14/2015.
- */
 public class TvApiEventListener extends ApiEventListener {
-
     @Override
     public void onPlaybackStopped(ApiClient client, SessionInfoDto info) {
         TvApp app = TvApp.getApplication();
@@ -130,7 +126,10 @@ public class TvApiEventListener extends ApiEventListener {
                 TvApp.getApplication().getLogger().Error("No current activity.  Cannot play");
                 return;
             }
-            StdItemQuery query = new StdItemQuery(new ItemFields[]{ItemFields.MediaSources});
+            StdItemQuery query = new StdItemQuery(new ItemFields[]{
+                    ItemFields.MediaSources,
+                    ItemFields.ChildCount
+            });
             query.setIds(command.getItemIds());
             TvApp.getApplication().getApiClient().GetItemsAsync(query, new Response<ItemsResult>() {
                 @Override

--- a/app/src/main/java/org/jellyfin/androidtv/querying/StdItemQuery.java
+++ b/app/src/main/java/org/jellyfin/androidtv/querying/StdItemQuery.java
@@ -7,13 +7,15 @@ import org.jellyfin.apiclient.model.querying.ItemQuery;
 
 public class StdItemQuery extends ItemQuery {
     public StdItemQuery(ItemFields[] fields) {
-        if (fields == null) fields = new ItemFields[] {
-                ItemFields.PrimaryImageAspectRatio,
-                ItemFields.Overview,
-                ItemFields.ItemCounts,
-                ItemFields.DisplayPreferencesId,
-                ItemFields.ChildCount
-        };
+        if (fields == null) {
+            fields = new ItemFields[]{
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Overview,
+                    ItemFields.ItemCounts,
+                    ItemFields.DisplayPreferencesId,
+                    ItemFields.ChildCount
+            };
+        }
         setUserId(TvApp.getApplication().getCurrentUser().getId());
         setFields(fields);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/querying/StdItemQuery.java
+++ b/app/src/main/java/org/jellyfin/androidtv/querying/StdItemQuery.java
@@ -5,13 +5,15 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
 
-/**
- * Created by Eric on 12/5/2014.
- */
 public class StdItemQuery extends ItemQuery {
-
     public StdItemQuery(ItemFields[] fields) {
-        if (fields == null) fields = new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Overview, ItemFields.ItemCounts, ItemFields.DisplayPreferencesId};
+        if (fields == null) fields = new ItemFields[] {
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.Overview,
+                ItemFields.ItemCounts,
+                ItemFields.DisplayPreferencesId,
+                ItemFields.ChildCount
+        };
         setUserId(TvApp.getApplication().getCurrentUser().getId());
         setFields(fields);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemListView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemListView.java
@@ -6,7 +6,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
@@ -20,9 +19,6 @@ import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 
-/**
- * Created by Eric on 11/21/2015.
- */
 public class ItemListView extends FrameLayout {
     Context mContext;
     LinearLayout mList;
@@ -83,7 +79,10 @@ public class ItemListView extends FrameLayout {
     public void refresh() {
         //update watched state for all items
         //get them in batch for better performance
-        StdItemQuery query = new StdItemQuery(new ItemFields[] {ItemFields.MediaSources});
+        StdItemQuery query = new StdItemQuery(new ItemFields[] {
+                ItemFields.MediaSources,
+                ItemFields.ChildCount
+        });
         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
         String[] ids = new String[mItemIds.size()];
         query.setIds(mItemIds.toArray(ids));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.java
@@ -339,7 +339,11 @@ public class HomeFragment extends StdBrowseFragment {
 
     private HomeFragmentRow loadLatestLiveTvRecordings() {
         RecordingQuery query = new RecordingQuery();
-        query.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+        query.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChildCount
+        });
         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
         query.setEnableImages(true);
         query.setLimit(40);
@@ -352,7 +356,11 @@ public class HomeFragment extends StdBrowseFragment {
         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
         query.setImageTypeLimit(1);
         query.setLimit(50);
-        query.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+        query.setFields(new ItemFields[]{
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.Overview,
+                ItemFields.ChildCount
+        });
 
         return new HomeFragmentBrowseRowDefRow(new BrowseRowDef(mApplication.getString(R.string.lbl_next_up), query, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
     }
@@ -360,7 +368,12 @@ public class HomeFragment extends StdBrowseFragment {
     private HomeFragmentRow loadOnNow() {
         RecommendedProgramQuery query = new RecommendedProgramQuery();
         query.setIsAiring(true);
-        query.setFields(new ItemFields[]{ItemFields.Overview, ItemFields.PrimaryImageAspectRatio, ItemFields.ChannelInfo});
+        query.setFields(new ItemFields[]{
+                ItemFields.Overview,
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.ChannelInfo,
+                ItemFields.ChildCount
+        });
         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
         query.setImageTypeLimit(1);
         query.setEnableTotalRecordCount(false);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.java
@@ -44,7 +44,11 @@ class HomeFragmentLatestRow extends HomeFragmentRow {
 
             // Create query and add row
             LatestItemsQuery query = new LatestItemsQuery();
-            query.setFields(new ItemFields[]{ItemFields.PrimaryImageAspectRatio, ItemFields.Overview});
+            query.setFields(new ItemFields[]{
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Overview,
+                    ItemFields.ChildCount
+            });
             query.setImageTypeLimit(1);
             query.setParentId(item.getId());
             query.setGroupItems(true);

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -44,7 +44,15 @@ public class PlaybackHelper {
                         query.setMinIndexNumber(mainItem.getIndexNumber() + 1);
                         query.setSortBy(new String[] {ItemSortBy.SortName});
                         query.setIncludeItemTypes(new String[]{"Episode"});
-                        query.setFields(new ItemFields[] {ItemFields.MediaSources, ItemFields.MediaStreams, ItemFields.Path, ItemFields.Chapters, ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+                        query.setFields(new ItemFields[] {
+                                ItemFields.MediaSources,
+                                ItemFields.MediaStreams,
+                                ItemFields.Path,
+                                ItemFields.Chapters,
+                                ItemFields.Overview,
+                                ItemFields.PrimaryImageAspectRatio,
+                                ItemFields.ChildCount
+                        });
                         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
                         TvApp.getApplication().getApiClient().GetItemsAsync(query, new Response<ItemsResult>() {
                             @Override
@@ -84,7 +92,15 @@ public class PlaybackHelper {
                 query.setSortBy(new String[]{shuffle ? ItemSortBy.Random : ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(50); // guard against too many items
-                query.setFields(new ItemFields[] {ItemFields.MediaSources, ItemFields.MediaStreams, ItemFields.Chapters, ItemFields.Path, ItemFields.Overview, ItemFields.PrimaryImageAspectRatio});
+                query.setFields(new ItemFields[] {
+                        ItemFields.MediaSources,
+                        ItemFields.MediaStreams,
+                        ItemFields.Chapters,
+                        ItemFields.Path,
+                        ItemFields.Overview,
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 query.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 TvApp.getApplication().getApiClient().GetItemsAsync(query, new Response<ItemsResult>() {
                     @Override
@@ -103,7 +119,11 @@ public class PlaybackHelper {
                 query.setSortBy(shuffle ? new String[] {ItemSortBy.Random} : mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.Album} : new String[] {ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(150); // guard against too many items
-                query.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Genres});
+                query.setFields(new ItemFields[] {
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Genres,
+                        ItemFields.ChildCount
+                });
                 query.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 query.setArtistIds(new String[]{mainItem.getId()});
                 TvApp.getApplication().getApiClient().GetItemsAsync(query, new Response<ItemsResult>() {
@@ -124,7 +144,14 @@ public class PlaybackHelper {
                 if (shuffle) query.setSortBy(new String[] {ItemSortBy.Random});
                 query.setRecursive(true);
                 query.setLimit(150); // guard against too many items
-                query.setFields(new ItemFields[] {ItemFields.MediaSources, ItemFields.MediaStreams, ItemFields.Chapters, ItemFields.Path, ItemFields.PrimaryImageAspectRatio});
+                query.setFields(new ItemFields[] {
+                        ItemFields.MediaSources,
+                        ItemFields.MediaStreams,
+                        ItemFields.Chapters,
+                        ItemFields.Path,
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.ChildCount
+                });
                 query.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 TvApp.getApplication().getApiClient().GetItemsAsync(query, new Response<ItemsResult>() {
                     @Override
@@ -287,7 +314,11 @@ public class PlaybackHelper {
         SimilarItemsQuery query = new SimilarItemsQuery();
         query.setId(seedId);
         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
-        query.setFields(new ItemFields[] {ItemFields.PrimaryImageAspectRatio, ItemFields.Genres});
+        query.setFields(new ItemFields[] {
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.Genres,
+                ItemFields.ChildCount
+        });
         TvApp.getApplication().getApiClient().GetInstantMixFromItem(query, new Response<ItemsResult>() {
             @Override
             public void onResponse(ItemsResult response) {


### PR DESCRIPTION
Jellyfin adds `ChildCount` to the list of requested fields for particular app names. That is dumb, we should just request the fields we need. I added `ChildCount` to all queries since that seems to be what what was happening server side although it's probably not strictly needed for all of them.

https://github.com/jellyfin/jellyfin/blob/a6f883345f1941bf99db1667e84c1caf0b370479/MediaBrowser.Api/BaseApiService.cs#L157-L171

This will allow us to _finally_ add a space to the app name because that has been annoying me for far too long. :laughing: