### PR TITLE
Add space to app name

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/startup/StartupActivity.java
@@ -165,7 +165,7 @@ public class StartupActivity extends FragmentActivity {
                 jsonSerializer,
                 logger,
                 volleyHttpClient,
-                "AndroidTV",
+                "Android TV",
                 BuildConfig.VERSION_NAME,
                 new AndroidDevice(application),
                 capabilities,


### PR DESCRIPTION
Critical fix for issue with app name displayed on Admin dashboard.

Depends on #360 