### PR TITLE
Upgrade Android Gradle build tools to version 3.6.0 (latest)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 android {
 	compileSdkVersion(29)
+	ndkVersion = "21.0.6113669"
 
 	defaultConfig {
 		// Android version targets

--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -224,7 +224,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                                     if (mResumeButton != null) {
                                         mResumeButton.setVisibility((mBaseItem.getBaseItemType() == BaseItemType.Series && ! mBaseItem.getUserData().getPlayed()) || response.getCanResume() ? View.VISIBLE : View.GONE);
                                         if (response.getCanResume()){
-                                            mResumeButton.setText(String.format(getString(R.string.lbl_resume_from), TimeUtils.formatMillis((response.getUserData().getPlaybackPositionTicks()/10000) - mApplication.getResumePreroll())));
+                                            mResumeButton.setText(getString(R.string.lbl_resume_from, TimeUtils.formatMillis((response.getUserData().getPlaybackPositionTicks()/10000) - mApplication.getResumePreroll())));
                                         }
                                         showMoreButtonIfNeeded();
                                     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
@@ -5,6 +5,7 @@ import android.text.Html
 import android.text.Spanned
 
 fun String.toHtmlSpanned(): Spanned {
+	@Suppress("DEPRECATION")
 	return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
 		Html.fromHtml(this, Html.FROM_HTML_MODE_COMPACT)
 	else

--- a/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
@@ -170,7 +170,7 @@ public class TimeUtils {
                 return cal.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.getDefault());
             }
             if (relative) {
-                return String.format(TvApp.getApplication().getString(R.string.lbl_in_x_days), cal.get(Calendar.DAY_OF_YEAR) - now.get(Calendar.DAY_OF_YEAR));
+                return TvApp.getApplication().getString(R.string.lbl_in_x_days, cal.get(Calendar.DAY_OF_YEAR) - now.get(Calendar.DAY_OF_YEAR));
             }
         }
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -213,7 +213,7 @@
     <string name="desc_seasonal_themes">Povolit speciální barvy a návrhy dle období roku</string>
     <string name="lbl_switch_server">Přepnout server</string>
     <string name="lbl_instant_mix">Okamžitý mix</string>
-    <string name="lbl_in_x_days">Za %s dní</string>
+    <string name="lbl_in_x_days">Za %d dní</string>
     <string name="lbl_bitstream_dts">Bitstream DTS zvuk</string>
     <string name="desc_premieres">Zobrazit řadu nových úvodních epizod pro každý seriál, který sledujete</string>
     <string name="lbl_show_premieres">Na úvodní stránce zobrazovat premiéry nových sérií</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -298,7 +298,7 @@
     <string name="pref_live_tv_mode_desc">Direkt zum zuletzt abgespielten Live-TV-Kanal springen</string>
     <string name="pref_live_tv_mode">Live TV Modus</string>
     <string name="lbl_select_date">Datum auswählen</string>
-    <string name="lbl_in_x_days">In %s Tagen</string>
+    <string name="lbl_in_x_days">In %d Tagen</string>
     <string name="msg_external_path">Diese Funktion wird nur dann funktionieren wenn die Bibliothek auf dem Server korrekt mit Netzwerkpfaden oder Pfadsubtitutionen eingerichtet wurde und der verwendete Client direkt über das Netzwerk auf sie zugreifen kann.</string>
     <string name="lbl_warning">Warnung</string>
     <string name="lbl_now_playing_album">von %s</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -139,7 +139,7 @@
     <string name="lbl_seconds">Seconds</string>
     <string name="lbl_at_any_time">At Any Time</string>
     <string name="lbl_select_date">Select Date</string>
-    <string name="lbl_in_x_days">In %s days</string>
+    <string name="lbl_in_x_days">In %d days</string>
     <string name="lbl_bitstream_dts">Bitstream DTS Audio</string>
     <string name="desc_premieres">Show a row of new episode pilots for any series you watch</string>
     <string name="lbl_show_premieres">Show Season Premieres on Home Screen</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -298,7 +298,7 @@
     <string name="lbl_kids">Niños</string>
     <string name="no_program_data">&lt;No hay datos del programa disponibles&gt;</string>
     <string name="msg_record_entire_series">¿Grabar series completas\?</string>
-    <string name="lbl_in_x_days">En %s días</string>
+    <string name="lbl_in_x_days">En %d días</string>
     <string name="lbl_warning">Advertencia</string>
     <string name="lbl_now_playing_album">de %s</string>
     <string name="lbl_now_playing_track">%s de %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -228,7 +228,7 @@
     <string name="pref_live_tv_mode_desc">Ir directamente al último canal de televisión en vivo reproducido</string>
     <string name="pref_live_tv_mode">Modo televisión en vivo</string>
     <string name="lbl_select_date">Seleccionar fecha</string>
-    <string name="lbl_in_x_days">En %s días</string>
+    <string name="lbl_in_x_days">En %d días</string>
     <string name="desc_premieres">Muestre una fila de nuevos episodios piloto para cualquier serie que vea</string>
     <string name="lbl_show_premieres">Mostrar estrenos de temporada en la pantalla de inicio</string>
     <string name="desc_use_vlc_livetv">Usa VLC para la transmisión directa de televisión en vivo cuando esté disponible</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -261,7 +261,7 @@
     <string name="lbl_guide_option_played">Dernier élément joué</string>
     <string name="lbl_hour">Heure</string>
     <string name="lbl_hours">Heures</string>
-    <string name="lbl_in_x_days">Dans %s jours</string>
+    <string name="lbl_in_x_days">Dans %d jours</string>
     <string name="lbl_just_this_once">Juste une fois</string>
     <string name="lbl_live">Direct</string>
     <string name="lbl_minute">Minute</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -265,7 +265,7 @@
     <string name="lbl_suggestions_holiday">休日のおすすめ</string>
     <string name="pref_live_tv_mode">ライブTVモード</string>
     <string name="lbl_bitstream_dts">ビットストリームDTSオーディオ</string>
-    <string name="lbl_in_x_days">%s 日で</string>
+    <string name="lbl_in_x_days">%d 日で</string>
     <string name="lbl_refresh_switching">リフレッシュレート切り替え中</string>
     <string name="lbl_current_queue">現在のキュー</string>
     <string name="btn_set_compatible_audio">ダウンミックスをセットする</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -249,7 +249,7 @@
     <string name="lbl_bitstream_dts">DTS dybysty tasymaldaý</string>
     <string name="lbl_album_name">Álbom aty</string>
     <string name="lbl_more_like_this">Osy sıaqty kóbirek</string>
-    <string name="lbl_resume_from">{0} bastap jalǵastyrý</string>
+    <string name="lbl_resume_from">%s bastap jalǵastyrý</string>
     <string name="lbl_guide_option_number">Arna nómiri</string>
     <string name="lbl_show_indicators">Mynaý úshin belgilerdi kórsetý</string>
     <string name="lbl_sort_by">Suryptaý tásili</string>
@@ -273,7 +273,7 @@
     <string name="lbl_kids">Balalyq</string>
     <string name="lbl_sports">Sport</string>
     <string name="pref_live_tv_mode">Efırlik rejim</string>
-    <string name="lbl_in_x_days">%s kúnde</string>
+    <string name="lbl_in_x_days">%d kúnde</string>
     <string name="lbl_now_playing_album">%s ishinen</string>
     <string name="lbl_now_playing_track">%s - %s ishinen</string>
     <string name="lbl_watched">Qaralǵan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -269,7 +269,7 @@
     <string name="pref_live_tv_mode_desc">Gå rett til siste spilte direkte-TV-kanal</string>
     <string name="pref_live_tv_mode">Direkte-TV-modus</string>
     <string name="lbl_select_date">Velg dato</string>
-    <string name="lbl_in_x_days">Om %s dager</string>
+    <string name="lbl_in_x_days">Om %d dager</string>
     <string name="lbl_bitstream_dts">Bitstream DTS-lyd</string>
     <string name="desc_premieres">Vis en rad med nye pilotepisoder for alle serier du ser på</string>
     <string name="lbl_show_premieres">Vis sesongpremierer på hovedskjermen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -235,7 +235,7 @@
     <string name="lbl_series">Series</string>
     <string name="pref_authentication_cat">Authenticatie</string>
     <string name="loading">Laden…</string>
-    <string name="lbl_in_x_days">Over %s dagen</string>
+    <string name="lbl_in_x_days">Over %d dagen</string>
     <string name="lbl_bitstream_dts">DTS Audio bitstream</string>
     <string name="desc_premieres">Toon een rij van nieuwe afleveringspiloten voor een serie die je bekijkt</string>
     <string name="lbl_show_premieres">Seizoenpremières op het startscherm weergeven</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -289,7 +289,7 @@
     <string name="pref_live_tv_mode_desc">Vá diretamente para o último canal de TV ao vivo reproduzido</string>
     <string name="pref_live_tv_mode">Modo TV ao Vivo</string>
     <string name="lbl_select_date">Selecionar data</string>
-    <string name="lbl_in_x_days">Em %s dias</string>
+    <string name="lbl_in_x_days">Em %d dias</string>
     <string name="msg_external_path">Esse recurso só funcionará se você tiver configurado corretamente sua biblioteca no servidor com locais de rede ou locais alternativos e o cliente que você está usando possui permissão de acesso a esses locais pela rede.</string>
     <string name="lbl_warning">Aviso</string>
     <string name="lbl_now_playing_album">de %s</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -314,7 +314,7 @@
     <string name="pref_live_tv_mode_desc">Ir directamente para o último canal visto na televisão em directo</string>
     <string name="pref_live_tv_mode">Modo televisão em directo</string>
     <string name="lbl_select_date">Selecionar data</string>
-    <string name="lbl_in_x_days">Em %s dias</string>
+    <string name="lbl_in_x_days">Em %d dias</string>
     <string name="lbl_show_premieres">Mostrar Temporadas \'Premieres\' no Menu Incial</string>
     <string name="desc_use_vlc_livetv">Usar VLC para a reprodução de Televisão em Directo quando disponível</string>
     <string name="lbl_use_vlc_livetv">Pedir para usar o VLC para Televisão em Directo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -201,7 +201,7 @@
     <string name="pref_live_tv_mode_desc">Accesați direct ultimul canal de televiziune redat</string>
     <string name="pref_live_tv_mode">Mod Live TV</string>
     <string name="lbl_select_date">Selectați data</string>
-    <string name="lbl_in_x_days">În %s zile</string>
+    <string name="lbl_in_x_days">În %d zile</string>
     <string name="lbl_bitstream_dts">Flux Audio DTS</string>
     <string name="desc_premieres">Afișează un rând de episoade pilot noi pentru orice serie vizionată</string>
     <string name="lbl_show_premieres">Arată premierele de sezon pe ecranul de start</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -278,7 +278,7 @@
     <string name="msg_record_entire_series">Записать весь сериал\?</string>
     <string name="pref_live_tv_mode">Режим эфира</string>
     <string name="lbl_select_date">Выбор даты</string>
-    <string name="lbl_in_x_days">За %s дней</string>
+    <string name="lbl_in_x_days">За %d дней</string>
     <string name="lbl_warning">Предупреждение</string>
     <string name="lbl_now_playing_album">из %s</string>
     <string name="lbl_now_playing_track">%s из %s</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -237,7 +237,7 @@
     <string name="pref_live_tv_mode_desc">Ísť priamo na posledný prehraný živý TV kanál</string>
     <string name="pref_live_tv_mode">Režim živej TV</string>
     <string name="lbl_select_date">Vyberte dátum</string>
-    <string name="lbl_in_x_days">Za %s dní</string>
+    <string name="lbl_in_x_days">Za %d dní</string>
     <string name="lbl_bitstream_dts">Bitstream DTS zvuk</string>
     <string name="desc_premieres">Zobraziť riadok nových pilotných epizód pre každý seriál, ktorý pozeráte</string>
     <string name="lbl_show_premieres">Zobraziť premiéry sérií seriálov na domovskej obrazovke</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -107,7 +107,7 @@
     <string name="pref_live_tv_mode_desc">Gå direkt till senast spelad live TV kanal</string>
     <string name="pref_live_tv_mode">Live TV Läge</string>
     <string name="lbl_select_date">Välj datum</string>
-    <string name="lbl_in_x_days">Om %s dagar</string>
+    <string name="lbl_in_x_days">Om %d dagar</string>
     <string name="lbl_bitstream_dts">Bitstream DTS Ljud</string>
     <string name="desc_premieres">Visa en rad av nya avsnitt för serier du tittar på</string>
     <string name="lbl_show_premieres">Visa säsongpremiärer på Hemskärm</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -192,7 +192,7 @@
     <string name="pref_live_tv_mode_desc">直接到最后一个直播的电视频道</string>
     <string name="pref_live_tv_mode">电视直播模式</string>
     <string name="lbl_select_date">选择日期</string>
-    <string name="lbl_in_x_days">在 %s 天里</string>
+    <string name="lbl_in_x_days">在 %d 天里</string>
     <string name="lbl_bitstream_dts">比特流DTS音频</string>
     <string name="desc_premieres">为你所观看的任何系列节目展示一排新的试播集</string>
     <string name="lbl_show_premieres">该剧季将在主屏幕上首播</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,7 +263,7 @@
     <string name="lbl_show_premieres">Show Season Premieres on Home Screen</string>
     <string name="desc_premieres">Show a row of new episode pilots for any series you watch</string>
     <string name="lbl_bitstream_dts">Bitstream DTS Audio</string>
-    <string name="lbl_in_x_days">In %s days</string>
+    <string name="lbl_in_x_days">In %d days</string>
     <string name="lbl_select_date">Select Date</string>
     <string name="pref_live_tv_mode">Live TV Mode</string>
     <string name="pref_live_tv_mode_desc">Go directly to the last played live TV channel</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath("com.android.tools.build:gradle:3.5.3")
+		classpath("com.android.tools.build:gradle:3.6.0")
 		classpath(kotlin("gradle-plugin", "1.3.61"))
 	}
 }


### PR DESCRIPTION
Simple PR that upgrades the build tools version 3.6.0 (released today!). Some interesting changed for us include:
- The new default packaging tool, this might speed up build times for local development and CI
- Simplified R class generation, this might speed up build times for local development and CI
- Remove resources missing from default configuration, this should help with compile errors when Weblate makes a mistake

[Android release notes](https://developer.android.com/studio/releases/gradle-plugin#3-6-0)

**Note:** We should watch CI for the next few commits to master to make sure everything works fine. Local testing is also needed to make sure no weird errors happen. Although I expect everything to work fine.

**Additional note:** Because of new linting checks some issues in the various translations needed to be fixed and therefore a lot of `strings.xml` files have changed. This _might_ introduce Weblate errors.