### PR TITLE
Use string formatter via `getString` instead of `String.format`.

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/details/FullDetailsActivity.java
@@ -846,7 +846,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             if (mBaseItem.getCanResume()) {
                 startPos = (mBaseItem.getUserData().getPlaybackPositionTicks()/10000) - mApplication.getResumePreroll();
             }
-            buttonLabel = String.format(getString(R.string.lbl_resume_from), TimeUtils.formatMillis(startPos));
+            buttonLabel = getString(R.string.lbl_resume_from, TimeUtils.formatMillis(startPos));
         }
         mResumeButton = new TextUnderButton(this, R.drawable.ic_resume, buttonSize, 2, buttonLabel, new View.OnClickListener() {
             @Override

--- a/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/AudioNowPlayingActivity.java
@@ -8,16 +8,6 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
-import androidx.leanback.app.BackgroundManager;
-import androidx.leanback.app.RowsSupportFragment;
-import androidx.leanback.widget.ArrayObjectAdapter;
-import androidx.leanback.widget.HeaderItem;
-import androidx.leanback.widget.ListRow;
-import androidx.leanback.widget.OnItemViewClickedListener;
-import androidx.leanback.widget.OnItemViewSelectedListener;
-import androidx.leanback.widget.Presenter;
-import androidx.leanback.widget.Row;
-import androidx.leanback.widget.RowPresenter;
 import android.util.DisplayMetrics;
 import android.view.KeyEvent;
 import android.view.View;
@@ -48,8 +38,18 @@ import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
-
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+
+import androidx.leanback.app.BackgroundManager;
+import androidx.leanback.app.RowsSupportFragment;
+import androidx.leanback.widget.ArrayObjectAdapter;
+import androidx.leanback.widget.HeaderItem;
+import androidx.leanback.widget.ListRow;
+import androidx.leanback.widget.OnItemViewClickedListener;
+import androidx.leanback.widget.OnItemViewSelectedListener;
+import androidx.leanback.widget.Presenter;
+import androidx.leanback.widget.Row;
+import androidx.leanback.widget.RowPresenter;
 
 public class AudioNowPlayingActivity extends BaseActivity  {
 
@@ -460,10 +460,8 @@ public class AudioNowPlayingActivity extends BaseActivity  {
         if (item != null) {
             mArtistName.setText(getArtistName(item));
             mSongTitle.setText(item.getName());
-            mAlbumTitle.setText(String.format(getResources().getString(R.string.lbl_now_playing_album), item.getAlbum()));
-            mCurrentNdx.setText(String.format(getResources().getString(R.string.lbl_now_playing_track),
-                    MediaManager.getCurrentAudioQueueDisplayPosition(),
-                    MediaManager.getCurrentAudioQueueDisplaySize()));
+            mAlbumTitle.setText(getResources().getString(R.string.lbl_now_playing_album, item.getAlbum()));
+            mCurrentNdx.setText(getResources().getString(R.string.lbl_now_playing_track, MediaManager.getCurrentAudioQueueDisplayPosition(), MediaManager.getCurrentAudioQueueDisplaySize()));
             mCurrentDuration = ((Long)((item.getRunTimeTicks() != null ? item.getRunTimeTicks() : 0) / 10000)).intValue();
             //set progress to match duration
             mCurrentProgress.setMax(mCurrentDuration);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingBug.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingBug.java
@@ -21,7 +21,6 @@ import org.jellyfin.androidtv.playback.MediaManager;
 import org.jellyfin.androidtv.playback.PlaybackController;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
-
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
 /**
@@ -135,7 +134,7 @@ public class NowPlayingBug extends FrameLayout {
     }
 
     private void setStatus(long pos) {
-        npStatus.setText(String.format(getResources().getString(R.string.lbl_status), TimeUtils.formatMillis(pos), currentDuration));
+        npStatus.setText(getResources().getString(R.string.lbl_status, TimeUtils.formatMillis(pos), currentDuration));
     }
 
     public boolean manageVisibility() {


### PR DESCRIPTION
This fixes a small code smell. The getString() function already supports formatting strings