### PR TITLE
Hide empty rows

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/details/BaseDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/BaseDetailsFragment.kt
@@ -27,18 +27,18 @@ abstract class BaseDetailsFragment<T : BaseItem>(private val initialItem: T) : D
 		GlobalScope.launch(Dispatchers.Main) {
 			// Create adapter
 			val selector = ClassPresenterSelector()
-			val adapter = ArrayObjectAdapter(selector)
+			val adapter = StateObjectAdapter<Row>(selector)
 			onCreateAdapter(adapter, selector)
-
-			// Set item values (todo make everything suspended?)
-			setItem(initialItem)
-			initialItem.addChangeListener(::changeListener)
 
 			// Set adapter
 			this@BaseDetailsFragment.adapter = adapter
 
 			// Setup self as item click listener
 			this@BaseDetailsFragment.onItemViewClickedListener = this@BaseDetailsFragment
+
+			// Set item values (todo make everything suspended?)
+			setItem(initialItem)
+			initialItem.addChangeListener(::changeListener)
 		}
 	}
 
@@ -54,7 +54,7 @@ abstract class BaseDetailsFragment<T : BaseItem>(private val initialItem: T) : D
 	}
 
 	@CallSuper
-	protected open fun onCreateAdapter(adapter: ArrayObjectAdapter, selector: ClassPresenterSelector) {
+	protected open fun onCreateAdapter(adapter: StateObjectAdapter<Row>, selector: ClassPresenterSelector) {
 		selector.addClassPresenter(DetailsOverviewRow::class.java, FullWidthDetailsOverviewRowPresenter(
 			DetailsDescriptionPresenter(),
 			DetailsOverviewLogoPresenter()

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -1,14 +1,14 @@
 package org.jellyfin.androidtv.details
 
-import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ClassPresenterSelector
 import androidx.leanback.widget.DetailsOverviewRow
+import androidx.leanback.widget.Row
 import org.jellyfin.androidtv.model.itemtypes.Episode
 
 class EpisodeDetailsFragment(item: Episode) : BaseDetailsFragment<Episode>(item) {
 	private val detailsRow by lazy { DetailsOverviewRow("") }
 
-	override fun onCreateAdapter(adapter: ArrayObjectAdapter, selector: ClassPresenterSelector) {
+	override fun onCreateAdapter(adapter: StateObjectAdapter<Row>, selector: ClassPresenterSelector) {
 		super.onCreateAdapter(adapter, selector)
 
 		adapter.add(detailsRow)

--- a/app/src/main/java/org/jellyfin/androidtv/details/MovieDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/MovieDetailsFragment.kt
@@ -22,7 +22,7 @@ class MovieDetailsFragment(item: Movie) : BaseDetailsFragment<Movie>(item) {
 	private val localTrailersRow by lazy { ListRow(HeaderItem("Trailers"), ArrayObjectAdapter(ItemPresenter(this.context!!, 250.dp, 140.dp, false))) }
 	private val mediaInfoRow by lazy { ListRow(HeaderItem("Media info"), ArrayObjectAdapter(InfoCardPresenter())) }
 
-	override fun onCreateAdapter(adapter: ArrayObjectAdapter, selector: ClassPresenterSelector) {
+	override fun onCreateAdapter(adapter: StateObjectAdapter<Row>, selector: ClassPresenterSelector) {
 		super.onCreateAdapter(adapter, selector)
 
 		// Add presenters
@@ -67,40 +67,48 @@ class MovieDetailsFragment(item: Movie) : BaseDetailsFragment<Movie>(item) {
 
 		detailsRow.setImageBitmap(context!!, item.images.primary?.getBitmap(context!!))
 
-		val specials = TvApp.getApplication().apiClient.getSpecialFeatures(item)
+		//todo hacky way to get the adapter..
+		val adapter = adapter as StateObjectAdapter<Row>
+		val specials = TvApp.getApplication().apiClient.getSpecialFeatures(item).orEmpty()
+		adapter.setVisibility(specialsRow, specials.isNotEmpty())
 		specialsRow.adapter.also {
 			it as ArrayObjectAdapter
 			it.clear()
-			specials?.forEach(it::add)
+			specials.forEach(it::add)
 		}
 
+		adapter.setVisibility(chaptersRow, item.chapters.isNotEmpty())
 		chaptersRow.adapter.also {
 			it as ArrayObjectAdapter
 			it.clear()
 			item.chapters.forEach(it::add)
 		}
 
+		adapter.setVisibility(charactersRow, item.cast.isNotEmpty())
 		charactersRow.adapter.also {
 			it as ArrayObjectAdapter
 			it.clear()
 			item.cast.forEach(it::add)
 		}
 
-		val similarMovies = TvApp.getApplication().apiClient.getSimilarItems(item)?.filterIsInstance<Movie>()
+		val similarMovies = TvApp.getApplication().apiClient.getSimilarItems(item).orEmpty().filterIsInstance<Movie>()
+		adapter.setVisibility(similarsRow, similarMovies.isNotEmpty())
 		similarsRow.adapter.also {
 			it as ArrayObjectAdapter
 			it.clear()
-			similarMovies?.forEach(it::add)
+			similarMovies.forEach(it::add)
 		}
 
-		val localTrailers = TvApp.getApplication().apiClient.getLocalTrailers(item)
+		val localTrailers = TvApp.getApplication().apiClient.getLocalTrailers(item).orEmpty()
+		adapter.setVisibility(localTrailersRow, localTrailers.isNotEmpty())
 		localTrailersRow.adapter.also {
 			it as ArrayObjectAdapter
 			it.clear()
-			localTrailers?.forEach(it::add)
+			localTrailers.forEach(it::add)
 		}
 
 		// Update media info data
+		adapter.setVisibility(mediaInfoRow, TvApp.getApplication().userPreferences.debuggingEnabled)
 		mediaInfoRow.adapter.also {
 			it as ArrayObjectAdapter
 			it.clear()

--- a/app/src/main/java/org/jellyfin/androidtv/details/StateObjectAdapter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/StateObjectAdapter.kt
@@ -1,0 +1,30 @@
+package org.jellyfin.androidtv.details
+
+import androidx.leanback.widget.ObjectAdapter
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.PresenterSelector
+
+class StateObjectAdapter<T> : ObjectAdapter where T : Any {
+	constructor() : super()
+	constructor(presenter: Presenter) : super(presenter)
+	constructor(presenterSelector: PresenterSelector) : super(presenterSelector)
+
+	private val items = mutableListOf<ItemHolder<T>>()
+
+	override fun size() = items.count { it.visible }
+	override fun get(position: Int) = items.filter { it.visible }[position].item
+
+	fun add(item: T) = items.add(ItemHolder(item))
+
+	fun setVisibility(item: T, visible: Boolean) {
+		items.forEachIndexed { index, holder ->
+			if (holder.item == item && holder.visible != visible) {
+				holder.visible = visible
+			}
+		}
+
+		notifyChanged()
+	}
+
+	private data class ItemHolder<T>(val item: T, var visible: Boolean = true)
+}


### PR DESCRIPTION
We want to hide rows when there is not content. I tried to implement it by creating a custom adapter that allows rows to be made visible or invisible.

This works but does come with some quirks:
- View is re-created multiple times (not sure if this is caused by the adapter)
- Explicit call to `.setVisible` needs to be made
- The current implementation is made quickly and time needs to be spent to improve performance