### PR TITLE
Remove "end_of_line" rule from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
 [*]
-end_of_line = lf
 insert_final_newline = true
 
 [{*.kts, *.kt}]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
+*.kt text eol=lf
+*.kts text eol=lf
+*.java text eol=lf
+*.xml text eol=lf
+
 CONTRIBUTORS.md merge=union
 app/src/main/res/values*/strings.xml merge=union


### PR DESCRIPTION
It caused issues in Android Studio on Windows where it would "detect" changed files but there were none. git will automatically convert line endings on windows so this should not cause any problems.