### PR TITLE
Upgrade Kotlin to 1.3.70

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
 
 	dependencies {
 		classpath("com.android.tools.build:gradle:3.6.0")
-		classpath(kotlin("gradle-plugin", "1.3.61"))
+		classpath(kotlin("gradle-plugin", "1.3.70"))
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sun Feb 09 19:36:45 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -29,6 +29,9 @@ if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 


### PR DESCRIPTION
Kotlin 1.3.70 was released today 🎉 

Some changed in the stdlib could be useful for our codebase (Mostly the collection builders). And editing Gradle files should work better now as we're using Kotlin based Gradle scripts.

[Release notes](https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/)

----
Gradle 6.2 was released not too long ago 🎉 . The wrapper is now updated to version 6.2.1 (the latest) to keep everything up-to-date.