### PR TITLE
Add books to excluded types in latest row fragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.java
@@ -18,7 +18,8 @@ import androidx.leanback.widget.ArrayObjectAdapter;
 
 class HomeFragmentLatestRow extends HomeFragmentRow {
     // See: https://github.com/jellyfin/jellyfin-web/blob/bbf1f8d5df66a58c29f07969caa476852d86ab4a/src/components/homesections/homesections.js#L292
-    private static final List<String> EXCLUDED_COLLECTION_TYPES = Arrays.asList("playlists", "livetv", "boxsets", "channels");
+    // Added books since they are currently broken and no plans on adding support
+    private static final List<String> EXCLUDED_COLLECTION_TYPES = Arrays.asList("playlists", "livetv", "boxsets", "channels", "books");
 
     private final ItemsResult views;
 


### PR DESCRIPTION
The Latest Books row would just display a never ending loading element. I don't think we have any plans to support book libraries on TVs so let's just exclude them for now. :smile: 