### PR TITLE
Add relevant linter issues disabled by default

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<lint>
+    <issue id="ConvertToWebp" severity="warning" />
+    <issue id="DuplicateStrings" severity="warning" />
+    <issue id="EasterEgg" severity="fatal" />
+    <issue id="MangledCRLF" severity="warning" />
+    <issue id="MissingRegistered" severity="fatal" />
+    <issue id="NegativeMargin" severity="warning" />
+    <issue id="NoHardKeywords" severity="warning" />
+    <issue id="Registered" severity="warning" />
+    <issue id="RequiredSize" severity="error" />
+    <issue id="UnknownNullness" severity="informational" />
+    <issue id="UnusedIds" severity="warning" />
+</lint>


### PR DESCRIPTION
This PR adds some additional checks to the Android linter that are disabled by default. I look at the reports from time to time to find code smells to fix. Most of our Kotlin code doesn't have any issues at this moment so hopefully the amount of issues will keep going down.

Before adding extra options:
```
Ran lint on variant release: 498 issues found
Ran lint on variant debug: 500 issues found
```

With extra options (Excluding `UnknownNullness`):
```
Ran lint on variant release: 787 issues found
Ran lint on variant debug: 790 issues found
```

With extra options (Including `UnknownNullness`):
```
Ran lint on variant release: 2346 issues found
Ran lint on variant debug: 2349 issues found
```

