### PR TITLE
Update libvlc and reset default audio delay

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 
 	// Media players
 	implementation("com.amazon.android:exoplayer:2.11.3")
-	implementation("org.videolan.android:libvlc-all:3.1.12")
+	implementation("org.videolan.android:libvlc-all:3.2.5")
 
 	// Image utility
 	implementation("com.squareup.picasso:picasso:2.3.2")

--- a/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preferences/UserPreferences.kt
@@ -124,7 +124,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(PreferenceManage
 	/**
 	 * Default audio delay in milliseconds for libVLC
 	 */
-	var libVLCAudioDelay by longPreference("libvlc_audio_delay", -300)
+	var libVLCAudioDelay by longPreference("libvlc_audio_delay", 0)
 
 	/* Live TV */
 	/**


### PR DESCRIPTION
This updates libVLC to the latest version available in the maven repository. In testing, this update fixes the 300ms audio delay, so I changed the default for that to be `0` also. A migration should not be needed since this has not made it into a release yet.

Closes #385 