### PR TITLE
Update ProfileHelper.java to embed .ASS subtitles in external players

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -138,8 +138,8 @@ public class ProfileHelper {
         profile.setSubtitleProfiles(new SubtitleProfile[] {
             getSubtitleProfile("srt", SubtitleDeliveryMethod.Embed),
             getSubtitleProfile("subrip", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("ass", SubtitleDeliveryMethod.Encode),
-            getSubtitleProfile("ssa", SubtitleDeliveryMethod.Encode),
+            getSubtitleProfile("ass", SubtitleDeliveryMethod.Embed),
+            getSubtitleProfile("ssa", SubtitleDeliveryMethod.Embed),
             getSubtitleProfile("pgs", SubtitleDeliveryMethod.Embed),
             getSubtitleProfile("pgssub", SubtitleDeliveryMethod.Embed),
             getSubtitleProfile("dvdsub", SubtitleDeliveryMethod.Embed),


### PR DESCRIPTION
Leaving the subtitle delivery method as encode caused external players to crash with .ass subtitles. 