### PR TITLE
Implementing EpisodeDetailsFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/details/BaseDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/BaseDetailsFragment.kt
@@ -32,7 +32,7 @@ abstract class BaseDetailsFragment<T : BaseItem>(private val initialItem: T) : R
 	@CallSuper
 	open suspend fun onCreateAdapters(rowSelector: ClassPresenterSelector, rowAdapter: ArrayObjectAdapter) {
 		// Add the most used presenters to prevent duplicate code
-		rowSelector.addClassPresenter(DetailsOverviewRow::class.java, DetailsOverviewPresenter())
+		rowSelector.addClassPresenter(DetailsOverviewRow::class.java, DetailsOverviewPresenter(context!!))
 		rowSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsActivity.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.details
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.Fragment
@@ -9,10 +11,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.TvApp
-import org.jellyfin.androidtv.model.itemtypes.Episode
-import org.jellyfin.androidtv.model.itemtypes.LocalTrailer
-import org.jellyfin.androidtv.model.itemtypes.Movie
-import org.jellyfin.androidtv.model.itemtypes.Video
+import org.jellyfin.androidtv.model.itemtypes.*
 import org.jellyfin.androidtv.util.apiclient.getItem
 import org.jellyfin.androidtv.util.apiclient.liftToNewFormat
 
@@ -56,5 +55,11 @@ class DetailsActivity : FragmentActivity() {
 
 	companion object {
 		const val EXTRA_ITEM_ID = "id"
+
+		fun start(context: Context, target: BaseItem) {
+			val intent = Intent(context, DetailsActivity::class.java)
+			intent.putExtra(EXTRA_ITEM_ID, target.id)
+			context.startActivity(intent)
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsActivity.kt
@@ -41,7 +41,7 @@ class DetailsActivity : FragmentActivity() {
 
 			fragment = when (item) {
 				is Movie -> MovieDetailsFragment(item)
-				is Episode -> TODO("Episode details are not yet implemented")
+				is Episode -> EpisodeDetailsFragment(item)
 				is Video -> TODO("Video details are not yet implemented")
 				is LocalTrailer -> TODO("Trailer details are not yet implemented")
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsActivity.kt
@@ -56,10 +56,12 @@ class DetailsActivity : FragmentActivity() {
 	companion object {
 		const val EXTRA_ITEM_ID = "id"
 
-		fun start(context: Context, target: BaseItem) {
+		fun start(context: Context, targetId: String) {
 			val intent = Intent(context, DetailsActivity::class.java)
-			intent.putExtra(EXTRA_ITEM_ID, target.id)
+			intent.putExtra(EXTRA_ITEM_ID, targetId)
 			context.startActivity(intent)
 		}
+
+		fun start(context: Context, target: BaseItem) = start(context, target.id)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.details
 
+import android.content.Context
 import android.text.SpannableStringBuilder
 import android.text.format.DateFormat
 import android.view.LayoutInflater
@@ -16,15 +17,17 @@ import com.bumptech.glide.Glide
 import kotlinx.android.synthetic.main.row_details_description.view.*
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.details.actions.ActionAdapter
+import org.jellyfin.androidtv.model.itemtypes.Episode
 import org.jellyfin.androidtv.model.itemtypes.Movie
 import org.jellyfin.androidtv.model.itemtypes.PlayableItem
+import org.jellyfin.androidtv.model.itemtypes.Ratable
 import org.jellyfin.androidtv.ui.RecyclerViewSpacingDecoration
 import org.jellyfin.androidtv.ui.widget.Rating
 import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.androidtv.util.dp
 import org.jellyfin.apiclient.model.entities.MediaStreamType
 
-class DetailsOverviewPresenter : RowPresenter() {
+class DetailsOverviewPresenter(private val context: Context) : RowPresenter() {
 	private val actionAdapter = ActionAdapter()
 
 	init {
@@ -119,34 +122,36 @@ class DetailsOverviewPresenter : RowPresenter() {
 			viewHolder.subtitle.visibility = View.GONE
 		}
 
-		// rating
-		if (item is Movie) { //todo move those properties to baseitem or something
+		if (item is Movie) {
 			if (item.productionYear != null) {
 				viewHolder.year.text = item.productionYear.toString()
 				viewHolder.year.visibility = View.VISIBLE
-			} else {
-				viewHolder.year.visibility = View.GONE
 			}
+		}
 
+		if (item is Episode) {
+			if (item.premiereDate != null) {
+				val format = DateFormat.getDateFormat(context)
+				viewHolder.year.text = format.format(item.premiereDate)
+				viewHolder.year.visibility = View.VISIBLE
+			}
+		}
+
+		// rating
+		if (item is Ratable) {
 			if (item.officialRating != null) {
 				viewHolder.officialRating.text = item.officialRating
 				viewHolder.officialRating.visibility = View.VISIBLE
-			} else {
-				viewHolder.officialRating.visibility = View.GONE
 			}
 
 			if (item.communityRating != null) {
-				viewHolder.communityRating.value = item.communityRating
+				viewHolder.communityRating.value = item.communityRating!!
 				viewHolder.communityRating.visibility = View.VISIBLE
-			} else {
-				viewHolder.communityRating.visibility = View.GONE
 			}
 
 			if (item.criticsRating != null) {
-				viewHolder.criticsRating.value = item.criticsRating
+				viewHolder.criticsRating.value = item.criticsRating!!
 				viewHolder.criticsRating.visibility = View.VISIBLE
-			} else {
-				viewHolder.criticsRating.visibility = View.GONE
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
@@ -47,7 +47,7 @@ class DetailsOverviewPresenter(private val context: Context) : RowPresenter() {
 		val title: TextView = view.findViewById(R.id.details_description_title)
 		val subtitle: TextView = view.findViewById(R.id.details_description_subtitle)
 
-		val year: TextView = view.details_description_year
+		val premiereDate: TextView = view.details_description_premiere_date
 		val officialRating: TextView = view.details_description_official_rating
 		val communityRating: Rating = view.details_description_community_rating
 		val criticsRating: Rating = view.details_description_critics_rating
@@ -124,33 +124,33 @@ class DetailsOverviewPresenter(private val context: Context) : RowPresenter() {
 
 		if (item is Movie) {
 			if (item.productionYear != null) {
-				viewHolder.year.text = item.productionYear.toString()
-				viewHolder.year.visibility = View.VISIBLE
+				viewHolder.premiereDate.text = item.productionYear.toString()
+				viewHolder.premiereDate.visibility = View.VISIBLE
 			}
 		}
 
 		if (item is Episode) {
 			if (item.premiereDate != null) {
 				val format = DateFormat.getDateFormat(context)
-				viewHolder.year.text = format.format(item.premiereDate)
-				viewHolder.year.visibility = View.VISIBLE
+				viewHolder.premiereDate.text = format.format(item.premiereDate)
+				viewHolder.premiereDate.visibility = View.VISIBLE
 			}
 		}
 
 		// rating
 		if (item is Ratable) {
-			if (item.officialRating != null) {
-				viewHolder.officialRating.text = item.officialRating
+			item.officialRating?.let {
+				viewHolder.officialRating.text = it
 				viewHolder.officialRating.visibility = View.VISIBLE
 			}
 
-			if (item.communityRating != null) {
-				viewHolder.communityRating.value = item.communityRating!!
+			item.communityRating?.let {
+				viewHolder.communityRating.value = it
 				viewHolder.communityRating.visibility = View.VISIBLE
 			}
 
-			if (item.criticsRating != null) {
-				viewHolder.criticsRating.value = item.criticsRating!!
+			item.criticsRating?.let {
+				viewHolder.criticsRating.value = it
 				viewHolder.criticsRating.visibility = View.VISIBLE
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
@@ -86,7 +86,7 @@ class DetailsOverviewPresenter : RowPresenter() {
 
 		// banner
 		//todo hide banner view when none found, support multiple banners
-		item.images.backdrops.firstOrNull()?.let {
+		row.backdrops.firstOrNull()?.let {
 			// Android doesn't crop automatically but Glide does
 			// Picasso can also do this but doesn't read the XML attributes of the target view for it
 			// so the way Glide does it is preferred to avoid duplicate settings
@@ -106,7 +106,7 @@ class DetailsOverviewPresenter : RowPresenter() {
 		}
 
 		// poster
-		item.images.primary?.load(viewHolder.view.context) { viewHolder.poster.setImageBitmap(it) }
+		row.primaryImage?.let { it.load(viewHolder.view.context) { viewHolder.poster.setImageBitmap(it) } }
 
 		// title
 		viewHolder.title.text = item.title

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewPresenter.kt
@@ -123,16 +123,16 @@ class DetailsOverviewPresenter(private val context: Context) : RowPresenter() {
 		}
 
 		if (item is Movie) {
-			if (item.productionYear != null) {
-				viewHolder.premiereDate.text = item.productionYear.toString()
+			item.productionYear.let {
+				viewHolder.premiereDate.text = it.toString()
 				viewHolder.premiereDate.visibility = View.VISIBLE
 			}
 		}
 
 		if (item is Episode) {
-			if (item.premiereDate != null) {
+			item.premiereDate?.let {
 				val format = DateFormat.getDateFormat(context)
-				viewHolder.premiereDate.text = format.format(item.premiereDate)
+				viewHolder.premiereDate.text = format.format(it)
 				viewHolder.premiereDate.visibility = View.VISIBLE
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewRow.kt
@@ -3,5 +3,9 @@ package org.jellyfin.androidtv.details
 import androidx.leanback.widget.Row
 import org.jellyfin.androidtv.details.actions.Action
 import org.jellyfin.androidtv.model.itemtypes.BaseItem
+import org.jellyfin.androidtv.model.itemtypes.ImageCollection
 
-class DetailsOverviewRow(val item: BaseItem, val actions: List<Action>) : Row()
+class DetailsOverviewRow(val item: BaseItem,
+						 val actions: List<Action>,
+						 val primaryImage: ImageCollection.Image?,
+						 val backdrops: List<ImageCollection.Image>) : Row()

--- a/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/DetailsOverviewRow.kt
@@ -5,7 +5,9 @@ import org.jellyfin.androidtv.details.actions.Action
 import org.jellyfin.androidtv.model.itemtypes.BaseItem
 import org.jellyfin.androidtv.model.itemtypes.ImageCollection
 
-class DetailsOverviewRow(val item: BaseItem,
-						 val actions: List<Action>,
-						 val primaryImage: ImageCollection.Image?,
-						 val backdrops: List<ImageCollection.Image>) : Row()
+class DetailsOverviewRow(
+	val item: BaseItem,
+	val actions: List<Action>,
+	val primaryImage: ImageCollection.Image?,
+	val backdrops: List<ImageCollection.Image>
+) : Row()

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -1,0 +1,47 @@
+package org.jellyfin.androidtv.details
+
+import androidx.leanback.widget.ArrayObjectAdapter
+import androidx.leanback.widget.ClassPresenterSelector
+import androidx.lifecycle.MutableLiveData
+import org.jellyfin.androidtv.details.actions.*
+import org.jellyfin.androidtv.model.itemtypes.Episode
+import org.jellyfin.androidtv.presentation.InfoCardPresenter
+import org.jellyfin.androidtv.util.addIfNotEmpty
+
+class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment<Episode>(episode) {
+	// Action definitions
+	private val actions by lazy {
+		val item = MutableLiveData(episode)
+
+		listOf(
+			ResumeAction(context!!, item),
+			PlayFromBeginningAction(context!!, item),
+			ToggleWatchedAction(context!!, item),
+			ToggleFavoriteAction(context!!, item),
+
+			// "More" button
+			SecondariesPopupAction(context!!, listOf(
+				// TODO: Go to Series Button
+				// TODO: Go to Season Button
+				DeleteAction(context!!, item) { activity?.finish() }
+			))
+		)
+	}
+
+	// Row definitions
+	private val detailRow by lazy { DetailsOverviewRow(episode, actions) }
+	// TODO: More from this season row
+	private val chaptersRow by lazy { createListRow("Chapters", episode.chapters, ChapterInfoPresenter(context!!)) }
+	private val streamInfoRow by lazy { createListRow("Media info", episode.mediaInfo.streams, InfoCardPresenter()) }
+
+	override suspend fun onCreateAdapters(rowSelector: ClassPresenterSelector, rowAdapter: ArrayObjectAdapter) {
+		super.onCreateAdapters(rowSelector, rowAdapter)
+
+		// Add rows
+		rowAdapter.apply {
+			add(detailRow)
+			addIfNotEmpty(chaptersRow)
+			addIfNotEmpty(streamInfoRow)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -29,7 +29,7 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 	}
 
 	// Row definitions
-	private val detailRow by lazy { DetailsOverviewRow(episode, actions) }
+	private val detailRow by lazy { DetailsOverviewRow(episode, actions, episode.images.logo, episode.images.backdrops) }
 	// TODO: More from this season row
 	private val chaptersRow by lazy { createListRow("Chapters", episode.chapters, ChapterInfoPresenter(context!!)) }
 	private val streamInfoRow by lazy { createListRow("Media info", episode.mediaInfo.streams, InfoCardPresenter()) }

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -16,7 +16,6 @@ import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.addIfNotEmpty
 import org.jellyfin.androidtv.util.apiclient.getEpisodesOfSeason
 import org.jellyfin.androidtv.util.dp
-import org.jellyfin.apiclient.model.entities.PersonType
 
 class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment<Episode>(episode) {
 	// Action definitions
@@ -64,18 +63,10 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 		)
 	}
 
-	private val guestStars by lazy {
-		createListRow(
-			context!!.getString(R.string.lbl_guest_stars),
-			episode.cast.filter { it.type == PersonType.GuestStar },
-			PersonPresenter(context!!)
-		)
-	}
-
-	private val remainingCast by lazy {
+	private val cast by lazy {
 		createListRow(
 			context!!.getString(R.string.lbl_cast_crew),
-			episode.cast.filter { it.type != PersonType.GuestStar },
+			episode.cast,
 			PersonPresenter(context!!)
 		)
 	}
@@ -98,8 +89,7 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 			add(detailRow)
 			addIfNotEmpty(moreFromThisSeason)
 			addIfNotEmpty(chaptersRow)
-			addIfNotEmpty(guestStars)
-			addIfNotEmpty(remainingCast)
+			addIfNotEmpty(cast)
 			addIfNotEmpty(streamInfoRow)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -31,8 +31,12 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 
 			// "More" button
 			SecondariesPopupAction(context!!, listOfNotNull(
-				episode.seasonId?.let {GoToItemAction(context!!, context!!.getString(R.string.lbl_goto_season), it) },
-				episode.seriesId?.let {GoToItemAction(context!!, context!!.getString(R.string.lbl_goto_series), it) },
+				episode.seasonId?.let {
+					GoToItemAction(context!!, context!!.getString(R.string.lbl_goto_season), it)
+				},
+				episode.seriesId?.let {
+					GoToItemAction(context!!, context!!.getString(R.string.lbl_goto_series), it)
+				},
 				DeleteAction(context!!, item) { activity?.finish() }
 			))
 		)
@@ -40,14 +44,49 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 
 	// Row definitions
 	private val detailRow by lazy {
-		val primary = episode.images.parentPrimary ?: episode.seasonPrimaryImage ?: episode.seriesPrimaryImage ?: episode.images.primary
+		val primary = episode.images.parentPrimary ?: episode.seasonPrimaryImage
+		?: episode.seriesPrimaryImage ?: episode.images.primary
 		val backdrops = episode.images.parentBackdrops ?: episode.images.backdrops
 		DetailsOverviewRow(episode, actions, primary, backdrops)
 	}
-	private val moreFromThisSeason by lazy { createListRow("More from this Season", emptyList(), ItemPresenter(context!!, (ImageUtils.ASPECT_RATIO_16_9 * 140.dp).toInt(), 140.dp, true)) }
-	private val guestStars by lazy { createListRow("Guest Stars", episode.cast.filter { it.type == PersonType.GuestStar }, PersonPresenter(context!!)) }
-	private val chaptersRow by lazy { createListRow("Chapters", episode.chapters, ChapterInfoPresenter(context!!)) }
-	private val streamInfoRow by lazy { createListRow("Media info", episode.mediaInfo.streams, InfoCardPresenter()) }
+	private val moreFromThisSeason by lazy {
+		createListRow(
+			context!!.getString(R.string.lbl_more_from_this_season),
+			emptyList(),
+			ItemPresenter(context!!, (ImageUtils.ASPECT_RATIO_16_9 * 140.dp).toInt(), 140.dp, true)
+		)
+	}
+	private val chaptersRow by lazy {
+		createListRow(
+			context!!.getString(R.string.chapters),
+			episode.chapters,
+			ChapterInfoPresenter(context!!)
+		)
+	}
+
+	private val guestStars by lazy {
+		createListRow(
+			context!!.getString(R.string.lbl_guest_stars),
+			episode.cast.filter { it.type == PersonType.GuestStar },
+			PersonPresenter(context!!)
+		)
+	}
+
+	private val remainingCast by lazy {
+		createListRow(
+			context!!.getString(R.string.lbl_cast_crew),
+			episode.cast.filter { it.type != PersonType.GuestStar },
+			PersonPresenter(context!!)
+		)
+	}
+
+	private val streamInfoRow by lazy {
+		createListRow(
+			context!!.getString(R.string.lbl_media_info),
+			episode.mediaInfo.streams,
+			InfoCardPresenter()
+		)
+	}
 
 	override suspend fun onCreateAdapters(rowSelector: ClassPresenterSelector, rowAdapter: ArrayObjectAdapter) {
 		super.onCreateAdapters(rowSelector, rowAdapter)
@@ -58,8 +97,9 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 		rowAdapter.apply {
 			add(detailRow)
 			addIfNotEmpty(moreFromThisSeason)
-			addIfNotEmpty(guestStars)
 			addIfNotEmpty(chaptersRow)
+			addIfNotEmpty(guestStars)
+			addIfNotEmpty(remainingCast)
 			addIfNotEmpty(streamInfoRow)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -3,11 +3,20 @@ package org.jellyfin.androidtv.details
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ClassPresenterSelector
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.details.actions.*
 import org.jellyfin.androidtv.model.itemtypes.Episode
 import org.jellyfin.androidtv.presentation.InfoCardPresenter
+import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.addIfNotEmpty
+import org.jellyfin.androidtv.util.apiclient.getEpisodesOfSeason
+import org.jellyfin.androidtv.util.dp
+import org.jellyfin.apiclient.model.entities.PersonType
 
 class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment<Episode>(episode) {
 	// Action definitions
@@ -35,18 +44,35 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 		val backdrops = episode.images.parentBackdrops ?: episode.images.backdrops
 		DetailsOverviewRow(episode, actions, primary, backdrops)
 	}
-	// TODO: More from this season row
+	private val moreFromThisSeason by lazy { createListRow("More from this Season", emptyList(), ItemPresenter(context!!, (ImageUtils.ASPECT_RATIO_16_9 * 140.dp).toInt(), 140.dp, true)) }
+	private val guestStars by lazy { createListRow("Guest Stars", episode.cast.filter { it.type == PersonType.GuestStar }, PersonPresenter(context!!)) }
 	private val chaptersRow by lazy { createListRow("Chapters", episode.chapters, ChapterInfoPresenter(context!!)) }
 	private val streamInfoRow by lazy { createListRow("Media info", episode.mediaInfo.streams, InfoCardPresenter()) }
 
 	override suspend fun onCreateAdapters(rowSelector: ClassPresenterSelector, rowAdapter: ArrayObjectAdapter) {
 		super.onCreateAdapters(rowSelector, rowAdapter)
 
+		loadAdditionalInformation()
+
 		// Add rows
 		rowAdapter.apply {
 			add(detailRow)
+			addIfNotEmpty(moreFromThisSeason)
+			addIfNotEmpty(guestStars)
 			addIfNotEmpty(chaptersRow)
 			addIfNotEmpty(streamInfoRow)
 		}
+	}
+
+	private suspend fun loadAdditionalInformation() = withContext(Dispatchers.IO) {
+		// Get additional information asynchronously
+		awaitAll(
+			async {
+				TvApp.getApplication().apiClient.getEpisodesOfSeason(episode)?.let { episodes ->
+					val adapter = (moreFromThisSeason.adapter as ArrayObjectAdapter)
+					adapter.apply { episodes.forEach(::add) }
+				}
+			}
+		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/EpisodeDetailsFragment.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.details
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ClassPresenterSelector
 import androidx.lifecycle.MutableLiveData
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.details.actions.*
 import org.jellyfin.androidtv.model.itemtypes.Episode
 import org.jellyfin.androidtv.presentation.InfoCardPresenter
@@ -20,16 +21,20 @@ class EpisodeDetailsFragment(private val episode: Episode) : BaseDetailsFragment
 			ToggleFavoriteAction(context!!, item),
 
 			// "More" button
-			SecondariesPopupAction(context!!, listOf(
-				// TODO: Go to Series Button
-				// TODO: Go to Season Button
+			SecondariesPopupAction(context!!, listOfNotNull(
+				episode.seasonId?.let {GoToItemAction(context!!, context!!.getString(R.string.lbl_goto_season), it) },
+				episode.seriesId?.let {GoToItemAction(context!!, context!!.getString(R.string.lbl_goto_series), it) },
 				DeleteAction(context!!, item) { activity?.finish() }
 			))
 		)
 	}
 
 	// Row definitions
-	private val detailRow by lazy { DetailsOverviewRow(episode, actions, episode.images.logo, episode.images.backdrops) }
+	private val detailRow by lazy {
+		val primary = episode.images.parentPrimary ?: episode.seasonPrimaryImage ?: episode.seriesPrimaryImage ?: episode.images.primary
+		val backdrops = episode.images.parentBackdrops ?: episode.images.backdrops
+		DetailsOverviewRow(episode, actions, primary, backdrops)
+	}
 	// TODO: More from this season row
 	private val chaptersRow by lazy { createListRow("Chapters", episode.chapters, ChapterInfoPresenter(context!!)) }
 	private val streamInfoRow by lazy { createListRow("Media info", episode.mediaInfo.streams, InfoCardPresenter()) }

--- a/app/src/main/java/org/jellyfin/androidtv/details/MovieDetailsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/MovieDetailsFragment.kt
@@ -1,7 +1,10 @@
 package org.jellyfin.androidtv.details
 
+import androidx.leanback.widget.ArrayObjectAdapter
+import androidx.leanback.widget.ClassPresenterSelector
+import androidx.leanback.widget.HeaderItem
+import androidx.leanback.widget.ListRow
 import androidx.lifecycle.MutableLiveData
-import androidx.leanback.widget.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -42,7 +45,7 @@ class MovieDetailsFragment(private val movie: Movie) : BaseDetailsFragment<Movie
 	}
 
 	// Row definitions
-	private val detailRow by lazy { DetailsOverviewRow(movie, actions) }
+	private val detailRow by lazy { DetailsOverviewRow(movie, actions, movie.images.primary, movie.images.backdrops) }
 	private val chaptersRow by lazy { createListRow("Chapters", movie.chapters, ChapterInfoPresenter(context!!)) }
 	private val specialsRow by lazy { createListRow("Specials", emptyList(), ItemPresenter(context!!, 250.dp, 140.dp, false)) }
 	private val castRow by lazy { createListRow("Cast/Crew", movie.cast, PersonPresenter(context!!)) }

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/Action.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/Action.kt
@@ -9,5 +9,5 @@ interface Action {
 	val text: LiveData<String>
 	val icon: LiveData<Drawable>
 
-	suspend fun onClick(view: View)
+	suspend fun onClick(view: View?)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/AddToQueueAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/AddToQueueAction.kt
@@ -17,7 +17,7 @@ class AddToQueueAction(context: Context, private val item: BaseItem) : Action {
 	override val text = MutableLiveData(context.getString(R.string.lbl_add_to_queue))
 	override val icon = MutableLiveData(context.getDrawable(R.drawable.ic_add)!!)
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		// TODO if audio is implemented, check here wheter we got an audio file and add it to audio queue
 		val retrieved = TvApp.getApplication().apiClient.getItem(item.id)
 		if (retrieved == null) {

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/DeleteAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/DeleteAction.kt
@@ -21,7 +21,7 @@ class DeleteAction(private val context: Context, private val item: LiveData<out 
 	override val text = MutableLiveData(context.getString(R.string.lbl_delete))
 	override val icon = MutableLiveData(context.getDrawable(R.drawable.ic_trash)!!)
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		val itemValue = item.value ?: return
 
 		AlertDialog.Builder(context).apply {

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/GoToItemAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/GoToItemAction.kt
@@ -7,12 +7,14 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.details.DetailsActivity
 import org.jellyfin.androidtv.model.itemtypes.BaseItem
 
-class GoToItemAction(private val context: Context, label: String, private val target: BaseItem) : Action {
+class GoToItemAction(private val context: Context, label: String,private val targetId: String) : Action {
+	constructor(context: Context, label: String, target: BaseItem) : this(context, label, target.id)
+
 	override val visible = MutableLiveData(true)
 	override val text = MutableLiveData(label)
 	override val icon = MutableLiveData(context.getDrawable(R.drawable.ic_folder)!!)
 
 	override suspend fun onClick(view: View?) {
-		DetailsActivity.start(context, target)
+		DetailsActivity.start(context, targetId)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/GoToItemAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/GoToItemAction.kt
@@ -1,0 +1,18 @@
+package org.jellyfin.androidtv.details.actions
+
+import android.content.Context
+import android.view.View
+import androidx.lifecycle.MutableLiveData
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.details.DetailsActivity
+import org.jellyfin.androidtv.model.itemtypes.BaseItem
+
+class GoToItemAction(private val context: Context, label: String, private val target: BaseItem) : Action {
+	override val visible = MutableLiveData(true)
+	override val text = MutableLiveData(label)
+	override val icon = MutableLiveData(context.getDrawable(R.drawable.ic_folder)!!)
+
+	override suspend fun onClick(view: View?) {
+		DetailsActivity.start(context, target)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/GoToItemAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/GoToItemAction.kt
@@ -7,7 +7,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.details.DetailsActivity
 import org.jellyfin.androidtv.model.itemtypes.BaseItem
 
-class GoToItemAction(private val context: Context, label: String,private val targetId: String) : Action {
+class GoToItemAction(private val context: Context, label: String, private val targetId: String) : Action {
 	constructor(context: Context, label: String, target: BaseItem) : this(context, label, target.id)
 
 	override val visible = MutableLiveData(true)

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/PlayFromBeginningAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/PlayFromBeginningAction.kt
@@ -15,7 +15,7 @@ class PlayFromBeginningAction(private val context: Context, val item: LiveData<o
 	override val text = MutableLiveData(context.getString(R.string.lbl_play))
 	override val icon = MutableLiveData(context.getDrawable(R.drawable.ic_play)!!)
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		Log.i(LOG_TAG, "Play from Beginning clicked!")
 
 		val value = item.value ?: return

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/ResumeAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/ResumeAction.kt
@@ -22,7 +22,7 @@ class ResumeAction(private val context: Context, val item: LiveData<out Playable
 	//	override val description = context.getString(R.string.lbl_resume_from, TimeUtils.formatMillis(actualPlaybackPositionInMillis))
 
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		Log.i(LOG_TAG, "Resume Clicked!")
 
 		val itemValue = item.value ?: return

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/SecondariesPopupAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/SecondariesPopupAction.kt
@@ -21,7 +21,7 @@ class SecondariesPopupAction(private val context: Context, private val children:
 	override val text = MutableLiveData(context.getString(R.string.lbl_more_actions))
 	override val icon = MutableLiveData(context.getDrawable(R.drawable.ic_more)!!)
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		PopupMenu(context, view).apply {
 			children
 				.filter { it.visible.value == true }

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/ToggleFavoriteAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/ToggleFavoriteAction.kt
@@ -19,7 +19,7 @@ class ToggleFavoriteAction(val context: Context, val item: MutableLiveData<out B
 		addSource(item) { value = it.favorite }
 	}
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		val itemValue = item.value ?: return
 		val application = TvApp.getApplication()
 

--- a/app/src/main/java/org/jellyfin/androidtv/details/actions/ToggleWatchedAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/details/actions/ToggleWatchedAction.kt
@@ -18,7 +18,7 @@ class ToggleWatchedAction(context: Context, val item: MutableLiveData<out Playab
 		addSource(item) { value = it.played }
 	}
 
-	override suspend fun onClick(view: View) {
+	override suspend fun onClick(view: View?) {
 		val itemValue = item.value ?: return
 		val application = TvApp.getApplication()
 

--- a/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/BriefPersonData.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/BriefPersonData.kt
@@ -7,7 +7,7 @@ import org.jellyfin.apiclient.model.entities.PersonType
 class BriefPersonData(original: BaseItemPerson) {
 	val id: String = original.id
 	val name: String = original.name
-	val role: String = original.role
+	val role: String? = original.role
 	val type: PersonType = original.personType
 	val primaryImage: ImageCollection.Image? = original.primaryImageTag?.let { ImageCollection.Image(original.id, ImageType.Primary, it) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/ImageCollection.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/ImageCollection.kt
@@ -17,11 +17,13 @@ class ImageCollection(original: BaseItemDto) {
 	val primary = original.imageTags[ImageType.Primary]?.let { Image(original.id, ImageType.Primary, it) }
 	val logo = original.imageTags[ImageType.Logo]?.let { Image(original.id, ImageType.Logo, it) }
 	val backdrops = original.backdropImageTags.map { Image(original.id, ImageType.Backdrop, it) }.toList()
+	val parentPrimary = original.parentPrimaryImageItemId?.let { Image(original.parentId, ImageType.Primary, it) }
+	val parentBackdrops = original.parentBackdropImageTags?.let{ it.map {Image(original.parentBackdropItemId, ImageType.Backdrop, it)}.toList() }
 
 	class Image(
 		private val itemId: String,
 		private val type: ImageType,
-		private val tag: String,
+		private val tag: String?,
 		private val index: Int? = null
 	) {
 		val url: String by lazy {

--- a/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
@@ -15,7 +15,9 @@ val FIELDS_REQUIRED_FOR_LIFT = arrayOf(
 	ItemFields.People,
 	ItemFields.Genres,
 	ItemFields.Tags,
-	ItemFields.RemoteTrailers
+	ItemFields.RemoteTrailers,
+	ItemFields.CanDelete,
+	ItemFields.People
 )
 
 sealed class BaseItem(original: BaseItemDto) : ObservableParent() {
@@ -53,7 +55,7 @@ class Episode(original: BaseItemDto) : PlayableItem(original) {
 	val seasonPrimaryImage: ImageCollection.Image? = original.seasonId?.let {
 		ImageCollection.Image(it, org.jellyfin.apiclient.model.entities.ImageType.Primary, "")
 	}
-	val studio = original.seriesStudio
+	val cast: List<BriefPersonData> = original.people.map(::BriefPersonData)
 }
 
 class Movie(original: BaseItemDto, externalTrailerLifter: BaseTrailerLifter) : PlayableItem(original) {

--- a/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
@@ -44,7 +44,17 @@ sealed class PlayableItem(original: BaseItemDto) : BaseItem(original) {
 		get() = playbackPositionTicks > 0L
 }
 
-class Episode(original: BaseItemDto) : PlayableItem(original)
+class Episode(original: BaseItemDto) : PlayableItem(original) {
+	val seasonId: String? = original.seasonId
+	val seriesId: String? = original.seriesId
+	val seriesPrimaryImage: ImageCollection.Image? = original.seriesPrimaryImageTag?.let {
+		 ImageCollection.Image(original.seriesId, org.jellyfin.apiclient.model.entities.ImageType.Primary, it)
+	}
+	val seasonPrimaryImage: ImageCollection.Image? = original.seasonId?.let {
+		ImageCollection.Image(it, org.jellyfin.apiclient.model.entities.ImageType.Primary, "")
+	}
+	val studio = original.seriesStudio
+}
 
 class Movie(original: BaseItemDto, externalTrailerLifter: BaseTrailerLifter) : PlayableItem(original) {
 	var productionYear: Int? = original.productionYear

--- a/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/model/itemtypes/LiftedItems.kt
@@ -20,6 +20,12 @@ val FIELDS_REQUIRED_FOR_LIFT = arrayOf(
 	ItemFields.People
 )
 
+interface Ratable {
+	val officialRating: String?
+	val communityRating: Float?
+	val criticsRating: Float?
+}
+
 sealed class BaseItem(original: BaseItemDto) : ObservableParent() {
 	val id: String = original.id
 	val title: String = original.name
@@ -46,25 +52,33 @@ sealed class PlayableItem(original: BaseItemDto) : BaseItem(original) {
 		get() = playbackPositionTicks > 0L
 }
 
-class Episode(original: BaseItemDto) : PlayableItem(original) {
+class Episode(original: BaseItemDto) : PlayableItem(original), Ratable {
 	val seasonId: String? = original.seasonId
 	val seriesId: String? = original.seriesId
 	val seriesPrimaryImage: ImageCollection.Image? = original.seriesPrimaryImageTag?.let {
-		 ImageCollection.Image(original.seriesId, org.jellyfin.apiclient.model.entities.ImageType.Primary, it)
+		ImageCollection.Image(original.seriesId, org.jellyfin.apiclient.model.entities.ImageType.Primary, it)
 	}
 	val seasonPrimaryImage: ImageCollection.Image? = original.seasonId?.let {
 		ImageCollection.Image(it, org.jellyfin.apiclient.model.entities.ImageType.Primary, "")
 	}
+
+	override val officialRating: String? = original.officialRating
+	override val communityRating: Float? = original.communityRating
+	override val criticsRating: Float? = original.criticRating
+
 	val cast: List<BriefPersonData> = original.people.map(::BriefPersonData)
+	val premiereDate: Date? = original.premiereDate
 }
 
-class Movie(original: BaseItemDto, externalTrailerLifter: BaseTrailerLifter) : PlayableItem(original) {
+class Movie(original: BaseItemDto, externalTrailerLifter: BaseTrailerLifter) : PlayableItem(original), Ratable {
 	var productionYear: Int? = original.productionYear
 	val cast: List<BriefPersonData> = original.people.map(::BriefPersonData)
-	val officialRating: String? = original.officialRating
-	val communityRating: Float? = original.communityRating
-	val criticsRating: Float? = original.criticRating
 	val localTrailerCount: Int = original.localTrailerCount
+
+	override val officialRating: String? = original.officialRating
+	override val communityRating: Float? = original.communityRating
+	override val criticsRating: Float? = original.criticRating
+
 	val externalTrailers: List<ExternalTrailer> = original.remoteTrailers.mapNotNull { externalTrailerLifter.lift(it) }
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.querying.StdItemQuery
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.interaction.Response
 import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.apiclient.model.dto.BaseItemType
 import org.jellyfin.apiclient.model.dto.UserItemDataDto
 import org.jellyfin.apiclient.model.querying.ItemsResult
 import org.jellyfin.apiclient.model.querying.NextUpQuery
@@ -83,7 +84,7 @@ suspend fun ApiClient.getSimilarItems(item: BaseItem, limit: Int = 25): List<Bas
 			continuation.resume(response?.items.orEmpty().map { baseItemDto -> baseItemDto.liftToNewFormat() })
 		}
 
-		override fun onError(exception: java.lang.Exception?) {
+		override fun onError(exception: Exception?) {
 			continuation.resume(null)
 		}
 	})
@@ -95,7 +96,7 @@ suspend fun ApiClient.getSpecialFeatures(item: BaseItem): List<BaseItem>? = susp
 			continuation.resume(response!!.map { baseItemDto -> baseItemDto.liftToNewFormat() })
 		}
 
-		override fun onError(exception: java.lang.Exception?) {
+		override fun onError(exception: Exception?) {
 			continuation.resume(null)
 		}
 	})
@@ -107,7 +108,7 @@ suspend fun ApiClient.getLocalTrailers(item: BaseItem): List<LocalTrailer>? = su
 			continuation.resume(response!!.map { baseItemDto -> baseItemDto.liftToNewFormat() as LocalTrailer })
 		}
 
-		override fun onError(exception: java.lang.Exception?) {
+		override fun onError(exception: Exception?) {
 			continuation.resume(null)
 		}
 	})
@@ -119,17 +120,17 @@ private suspend fun ApiClient.getEpisodesOfSeason(seasonId: String): List<Episod
 	continuation ->
 	val query = StdItemQuery()
 	query.parentId = seasonId
-	query.includeItemTypes = arrayOf("Episode")
+	query.includeItemTypes = arrayOf(BaseItemType.Episode.name)
 	query.startIndex = 0
 	query.fields = FIELDS_REQUIRED_FOR_LIFT
 	query.userId = this.currentUserId
 
-	this.GetItemsAsync(query, object : Response<ItemsResult>() {
+	GetItemsAsync(query, object : Response<ItemsResult>() {
 		override fun onResponse(response: ItemsResult?) {
 			continuation.resume(response?.items?.map {it.liftToNewFormat() as Episode }?.toList())
 		}
 
-		override fun onError(exception: java.lang.Exception?) {
+		override fun onError(exception: Exception?) {
 			continuation.resume(null)
 		}
 	})

--- a/app/src/main/res/layout/row_details_description.xml
+++ b/app/src/main/res/layout/row_details_description.xml
@@ -119,7 +119,9 @@
             android:id="@+id/details_description_year"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="2006-2008" />
+            android:visibility="gone"
+            tools:text="2006-2008"
+            tools:visibility="visible" />
 
         <Space
             android:layout_width="8dp"
@@ -136,7 +138,9 @@
             android:paddingBottom="2dp"
             android:textColor="#0e0f2d"
             android:textSize="12sp"
-            tools:text="PG-13" />
+            android:visibility="gone"
+            tools:text="PG-13"
+            tools:visibility="visible" />
 
         <Space
             android:layout_width="8dp"
@@ -146,8 +150,10 @@
             android:id="@+id/details_description_community_rating"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             app:type="community"
-            tools:value="9.8" />
+            tools:value="9.8"
+            tools:visibility="visible" />
 
         <Space
             android:layout_width="8dp"
@@ -157,8 +163,10 @@
             android:id="@+id/details_description_critics_rating"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             app:type="critics"
-            tools:value="15" />
+            tools:value="15"
+            tools:visibility="visible" />
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/row_details_description.xml
+++ b/app/src/main/res/layout/row_details_description.xml
@@ -116,7 +116,7 @@
         app:layout_constraintTop_toBottomOf="@id/details_description_subtitle">
 
         <TextView
-            android:id="@+id/details_description_year"
+            android:id="@+id/details_description_premiere_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,4 +372,6 @@
     <string name="lbl_local">Local</string>
     <string name="domain_youtube">youtube.com</string>
     <string name="lbl_goto_season">Go to Season</string>
+    <string name="lbl_more_from_this_season">More from this Season</string>
+    <string name="lbl_media_info">Media Info</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,4 +371,5 @@
     <string name="toast_no_trailer_handler">No playback app found for trailer.</string>
     <string name="lbl_local">Local</string>
     <string name="domain_youtube">youtube.com</string>
+    <string name="lbl_goto_season">Go to Season</string>
 </resources>


### PR DESCRIPTION
This draft PR is created early to coordinate work on implementing the new details screens to avoid duplication of work.

Features needed for this Fragment:

- [x] Labellable `GoToItemAction` (For `Go to Series` and `Go to Season`)
- [x] More from this Season Row
- [x] Letting the fragment define the backdrop and primary image
- [x] Hiding unavailable Ratings (Score and recommended viewer age)

If any of these are needed for a different Fragment as well, please tell me and I will implement them first.