### PR TITLE
Fix Exoplayer Caching

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
 
 	// HTTP utility
 	// NOTE: This is used by Picasso through reflection and can cause weird caching issues if removed!
-	val okhttpVersion = "2.7.0"
+	val okhttpVersion = "2.7.5"
 	implementation("com.squareup.okhttp:okhttp:$okhttpVersion")
 	implementation("com.squareup.okhttp:okhttp-urlconnection:$okhttpVersion")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
 	implementation("com.flaviofaria:kenburnsview:1.0.6")
 
 	// HTTP utility
+	// NOTE: This is used by Picasso through reflection and can cause weird caching issues if removed!
 	val okhttpVersion = "2.7.0"
 	implementation("com.squareup.okhttp:okhttp:$okhttpVersion")
 	implementation("com.squareup.okhttp:okhttp-urlconnection:$okhttpVersion")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,11 @@ dependencies {
 	implementation("com.github.bumptech.glide:glide:3.7.0")
 	implementation("com.flaviofaria:kenburnsview:1.0.6")
 
+	// HTTP utility
+	val okhttpVersion = "2.7.0"
+	implementation("com.squareup.okhttp:okhttp:$okhttpVersion")
+	implementation("com.squareup.okhttp:okhttp-urlconnection:$okhttpVersion")
+
 	// Crash Reporting
 	val acraVersion = "5.4.0"
 	implementation("ch.acra:acra-http:$acraVersion")


### PR DESCRIPTION
It turns out Picasso was actually using OkHttp through reflection. It seems that without it, Picasso was setting up some crazy caching to disk behavior on the default HTTP stack. This caused streams played by Exoplayer to be cached to disk when we updated Exoplayer from 2.10.6 to 2.11.3.

![what](https://user-images.githubusercontent.com/3450688/79035687-f12c3480-7b8e-11ea-8f87-6b1035a82f77.gif)

Fixes #417 