### PR TITLE
Add noisy background for "BrowseHeaders" in home screen

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -45,4 +45,8 @@
         <item name="android:paddingEnd">16dp</item>
         <item name="android:minHeight">0dp</item>
     </style>
+
+    <style name="Widget.Jellyfin.BrowseHeaders" parent="Widget.Leanback.Headers.VerticalGridView">
+        <item name="android:background">@drawable/noise</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,6 +24,7 @@
         <!-- Custom Styles for Elements -->
         <item name="android:datePickerStyle">@style/DatePickerCustom</item>
         <item name="rowHeaderStyle">@style/Widget.Jellyfin.Row.Header</item>
+        <item name="headersVerticalGridStyle">@style/Widget.Jellyfin.BrowseHeaders</item>
 
         <item name="preferenceTheme">@style/PreferenceThemeOverlayLeanback</item>
     </style>


### PR DESCRIPTION
_**10% more cool**_

Uses the noise drawable used in the "play next" thingy as background for the sidebar in the home screen. This will make the backdrop visible and make the app look 10% more cool.

Before:  
![image](https://user-images.githubusercontent.com/2305178/79106495-ec27da80-7d72-11ea-95e7-0737acc9339e.png)  
After:  
![image](https://user-images.githubusercontent.com/2305178/79106547-08c41280-7d73-11ea-9256-a01b2db83803.png)
