### PR TITLE
Add androidx.fragment as direct dependency, update androidx.preference & update kotlin/android plugins

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,10 +65,11 @@ dependencies {
 
 	// Android(x)
 	implementation("androidx.core:core-ktx:1.2.0")
+	implementation("androidx.fragment:fragment-ktx:1.2.4")
 	val androidxLeanbackVersion = "1.1.0-alpha03"
 	implementation("androidx.leanback:leanback:$androidxLeanbackVersion")
 	implementation("androidx.leanback:leanback-preference:$androidxLeanbackVersion")
-	implementation("androidx.preference:preference:1.1.0")
+	implementation("androidx.preference:preference:1.1.1")
 	implementation("androidx.appcompat:appcompat:1.1.0")
 	implementation("androidx.tvprovider:tvprovider:1.0.0")
 	implementation("androidx.palette:palette:1.0.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
 	}
 
 	dependencies {
-		classpath("com.android.tools.build:gradle:3.6.0")
-		classpath(kotlin("gradle-plugin", "1.3.70"))
+		classpath("com.android.tools.build:gradle:3.6.2")
+		classpath(kotlin("gradle-plugin", "1.3.72"))
 	}
 }
 


### PR DESCRIPTION
I noticed we don't depend directly on the androidx.fragment library but we do use it's classes. It's probably exposed by some other androidx library. I now added it so we can be sure it's the latest version. The updated plugins are just patch version so nothing really changed.

Because the androidx.fragment library got bumped to a newer version additional linter checks are automatically enabled. They pass on master but will fail on the details branch, therefore when this PR is merged I will rebase the details branch and submit a PR for fixing the linter.