### PR TITLE
Fix NPE when finished playing media

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -126,7 +126,7 @@ public class PlaybackController {
     }
 
     public BaseItemDto getCurrentlyPlayingItem() {
-        return mItems.get(mCurrentIndex);
+        return mItems.size() > mCurrentIndex ? mItems.get(mCurrentIndex) : null;
     }
     public MediaSourceInfo getCurrentMediaSource() { return mCurrentStreamInfo != null && mCurrentStreamInfo.getMediaSource() != null ? mCurrentStreamInfo.getMediaSource() : getCurrentlyPlayingItem().getMediaSources().get(0);}
     public StreamInfo getCurrentStreamInfo() { return mCurrentStreamInfo; }
@@ -952,13 +952,19 @@ public class PlaybackController {
         mReportLoop = new Runnable() {
             @Override
             public void run() {
+                BaseItemDto currentItem = getCurrentlyPlayingItem();
+                if (currentItem == null) {
+                    // Loop was called while nothing was playing!
+                    stopReportLoop();
+                    return;
+                }
 
                 long currentTime = isLiveTv ? getTimeShiftedProgress() : mVideoManager.getCurrentPosition();
                 if (isLiveTv && !directStreamLiveTv) {
                     mFragment.setSecondaryTime(getRealTimeProgress());
                 }
 
-                ReportingHelper.reportProgress(getCurrentlyPlayingItem(), getCurrentStreamInfo(), currentTime * 10000, true);
+                ReportingHelper.reportProgress(currentItem, getCurrentStreamInfo(), currentTime * 10000, true);
                 mHandler.postDelayed(this, PROGRESS_REPORTING_PAUSE_INTERVAL);
             }
         };


### PR DESCRIPTION
should fix
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.get(ArrayList.java:437)
	at org.jellyfin.androidtv.playback.PlaybackController.getCurrentlyPlayingItem(PlaybackController.java:129)
	at org.jellyfin.androidtv.playback.PlaybackController$15.run(PlaybackController.java:962)
	at android.os.Handler.handleCallback(Handler.java:789)
	at android.os.Handler.dispatchMessage(Handler.java:98)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6541)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```