### PR TITLE
Add support for TV remote subtitle button

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.playback.overlay;
 
 import android.content.Context;
+import android.view.KeyEvent;
 import android.view.View;
 
 import androidx.leanback.media.PlaybackTransportControlGlue;
@@ -249,5 +250,13 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     void updatePlayState() {
         playPauseAction.setIndex(isPlaying() ? PlaybackControlsRow.PlayPauseAction.INDEX_PAUSE : PlaybackControlsRow.PlayPauseAction.INDEX_PLAY);
         notifyActionChanged(playPauseAction);
+    }
+
+    @Override
+    public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (hasSubs() && keyCode == KeyEvent.KEYCODE_CAPTIONS && event.getAction() == KeyEvent.ACTION_UP) {
+            closedCaptionsAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), v);
+        }
+        return super.onKey(v, keyCode, event);
     }
 }


### PR DESCRIPTION
When a user presses the subtitle button on the tv remote (KEYCODE_CAPTIONS) and there are subtitles for the currently playing media it will popup the subtitle chooser. It will just pop up on the right edge of the screen and won't show other controls, I tried showing controls but it did not feel as good.