### PR TITLE
Change the background of the control overlay from dark to light

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/overlay/LeanbackOverlayFragment.java
@@ -20,6 +20,8 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        setBackgroundType(BG_LIGHT);
+
         TvApp application = TvApp.getApplication();
         PlaybackController playbackController = application.getPlaybackController();
 


### PR DESCRIPTION
This is just a small thing but I found the dark background really annoying, especially when continuing playback and not being able to see much until the controls fade out.