### PR TITLE
Stop progress report if playback was already stopped

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackController.java
@@ -959,6 +959,11 @@ public class PlaybackController {
                     return;
                 }
 
+                if (mPlaybackState != PlaybackState.PLAYING) {
+                    // Playback was stopped, don't report progress anymore
+                    return;
+                }
+
                 long currentTime = isLiveTv ? getTimeShiftedProgress() : mVideoManager.getCurrentPosition();
                 if (isLiveTv && !directStreamLiveTv) {
                     mFragment.setSecondaryTime(getRealTimeProgress());


### PR DESCRIPTION
It often happened to me that after stopping playback on the android tv client I found the media still shown with progress where I stopped it in the Dashboard. After debugging it seems that sometimes the report progress loop would run one more time after the stop method was called. I'm not sure if there is a better method of preventing that, but seeing as the loop right above this one also checks the mPlaybackState I thought this might be fine.