### PR TITLE
Fix playback activity crashing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/CustomPlaybackOverlayFragment.java
@@ -77,6 +77,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
@@ -154,6 +155,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     int mCurrentDuration;
     private LeanbackOverlayFragment leanbackOverlayFragment;
+    private VideoManager videoManager = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -202,7 +204,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.vlc_player_interface, container);
+        ViewGroup root = (ViewGroup) inflater.inflate(R.layout.vlc_player_interface, container, false);
 
         // inject the RowsSupportFragment in the popup container
         if (getChildFragmentManager().findFragmentById(R.id.rows_area) == null) {
@@ -239,6 +241,24 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         });
 
         return root;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        if (TvApp.getApplication().getPlaybackController() != null) {
+            videoManager = new VideoManager(mActivity, view);
+            TvApp.getApplication().getPlaybackController().init(videoManager);
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        if (videoManager != null)
+            videoManager.destroy();
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackOverlayActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/PlaybackOverlayActivity.kt
@@ -12,7 +12,6 @@ import org.jellyfin.androidtv.base.BaseActivity
  * PlaybackOverlayActivity for video playback that loads PlaybackOverlayFragment
  */
 class PlaybackOverlayActivity : BaseActivity() {
-	private var videoManager: VideoManager? = null
 	var keyListener: View.OnKeyListener? = null
 
 	public override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,17 +25,6 @@ class PlaybackOverlayActivity : BaseActivity() {
 			.beginTransaction()
 			.replace(android.R.id.content, CustomPlaybackOverlayFragment())
 			.commit()
-
-		if (TvApp.getApplication().playbackController != null) {
-			videoManager = VideoManager(this, findViewById(android.R.id.content))
-			TvApp.getApplication().playbackController.init(videoManager)
-		}
-	}
-
-	public override fun onDestroy() {
-		super.onDestroy()
-
-		videoManager?.destroy()
 	}
 
 	override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {


### PR DESCRIPTION
**Changes**
- Cleaned the cleaned code
- When creating the view of the fragment it will now **not** attach to the root ([as it should be](https://developer.android.com/guide/components/fragments#UI))
  - This caused a new issue
- Moved the code that created the videomanager and pushed it to the playbackcontroller
  - It's now created as soon as the view in the fragment is created ([lifecycle](https://developer.android.com/guide/components/fragments#Creating))
  - This also cleans the activity a bit (which is nice because it will be easier to switch to less activities in the future)

**Issues**
- none!
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

🤡 
