### PR TITLE
Add Detekt support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ subprojects {
 
 	detekt {
 		buildUponDefaultConfig = true
+		ignoreFailures = true
 		config = files("$rootDir/detekt.yml")
 	}
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,3 +20,17 @@ allprojects {
 		maven("https://dl.bintray.com/videolan/Android")
 	}
 }
+
+plugins {
+	id("io.gitlab.arturbosch.detekt").version("1.9.1")
+}
+
+// Detekt configuration
+subprojects {
+	plugins.apply("io.gitlab.arturbosch.detekt")
+
+	detekt {
+		buildUponDefaultConfig = true
+		config = files("$rootDir/detekt.yml")
+	}
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,2 @@
+build:
+  maxIssues: 0


### PR DESCRIPTION
Added Detekt as Gradle plugin. Can be executed via `gradlew detekt` or via the lint task.
It will use the default detekt configuration and options can be overwritten using the `detekt.yml` file.

The maximum amount of issues is currently set to `0` which means it will fail if it finds an issue. Depending on how the pipeline will be configured in #492 this number might change.