### PR TITLE
Add GitHub action to validate the Gradle Wrapper blob

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Gradle Wrapper Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
I'd rather add it using the DevOps Pipeline to stay consistent but unfortunately this action is only available on GitHub.

See: https://github.com/gradle/wrapper-validation-action