### PR TITLE
Update ndk version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
 
 android {
 	compileSdkVersion(29)
-	ndkVersion = "21.1.6352462"
+	// Explicitly specify ndk version for Azure
+	// Can be removed when version 4.1.x of the Android Gradle plugin is relased
+	ndkVersion = "21.2.6472646"
 
 	defaultConfig {
 		// Android version targets


### PR DESCRIPTION
Hopefully this will fix the build failing.

According to [this](https://issuetracker.google.com/issues/144111441) issue in the google issue tracker a proper solution will be added to the next version of the gradle build tools.