### PR TITLE
Fix VLC audio passthrough

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/MediaManager.java
@@ -227,8 +227,12 @@ public class MediaManager {
                 mLibVLC = new LibVLC(TvApp.getApplication(), options);
 
                 mVlcPlayer = new org.videolan.libvlc.MediaPlayer(mLibVLC);
-                mVlcPlayer.setAudioOutput(Utils.downMixAudio() ? "opensles_android" : "android_audiotrack");
-                mVlcPlayer.setAudioOutputDevice("hdmi");
+                if(!Utils.downMixAudio()) {
+                    mVlcPlayer.setAudioDigitalOutputEnabled(true);
+                } else {
+                    mVlcPlayer.setAudioOutput("opensles_android");
+                }
+
 
                 mVlcHandler.setOnProgressListener(new PlaybackListener() {
                     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/playback/VideoManager.java
@@ -108,6 +108,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             }
         }).build();
 
+
         mExoPlayerView = view.findViewById(R.id.exoPlayerView);
         mExoPlayerView.setPlayer(mExoPlayer);
         mExoPlayer.addListener(new Player.EventListener() {
@@ -442,16 +443,24 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     public void setCompatibleAudio() {
-         if (!nativeMode) {
-             mVlcPlayer.setAudioOutput("opensles_android");
-             mVlcPlayer.setAudioOutputDevice("hdmi");
-         }
+        if (!nativeMode) {
+            mVlcPlayer.setAudioOutput("opensles_android");
+            mVlcPlayer.setAudioOutputDevice("hdmi");
+        }
     }
 
     public void setAudioMode() {
         if (!nativeMode) {
-            mVlcPlayer.setAudioOutput(Utils.downMixAudio() ? "opensles_android" : "android_audiotrack");
-            mVlcPlayer.setAudioOutputDevice("hdmi");
+            setVlcAudioOptions();
+        }
+    }
+
+    private void setVlcAudioOptions() {
+
+        if(!Utils.downMixAudio()) {
+            mVlcPlayer.setAudioDigitalOutputEnabled(true);
+        } else {
+            mVlcPlayer.setAudioOutput("opensles_android");
         }
     }
 
@@ -509,8 +518,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             Timber.i("Network buffer set to %d", buffer);
 
             mVlcPlayer = new org.videolan.libvlc.MediaPlayer(mLibVLC);
-            mVlcPlayer.setAudioOutput(Utils.downMixAudio() ? "opensles_android" : "android_audiotrack");
-            mVlcPlayer.setAudioOutputDevice("hdmi");
+            setVlcAudioOptions();
 
             mSurfaceHolder.addCallback(mSurfaceCallback);
             mVlcPlayer.setEventListener(mVlcHandler);

--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -49,12 +49,12 @@ public class ProfileHelper {
 //            transProfile.setProtocol(MediaTypes.HLS);
 //
 //        } else {
-            transProfile.setContainer(ContainerTypes.MKV);
-            transProfile.setVideoCodec(CodecTypes.H264);
-            transProfile.setAudioCodec(Utils.join(",", CodecTypes.AAC, CodecTypes.MP3));
-            transProfile.setType(DlnaProfileType.Video);
-            transProfile.setContext(EncodingContext.Streaming);
-            transProfile.setCopyTimestamps(true);
+        transProfile.setContainer(ContainerTypes.MKV);
+        transProfile.setVideoCodec(CodecTypes.H264);
+        transProfile.setAudioCodec(Utils.join(",", CodecTypes.AAC, CodecTypes.MP3));
+        transProfile.setType(DlnaProfileType.Video);
+        transProfile.setContext(EncodingContext.Streaming);
+        transProfile.setCopyTimestamps(true);
 
 //        }
 
@@ -93,26 +93,26 @@ public class ProfileHelper {
 
         DirectPlayProfile videoDirectPlayProfile = new DirectPlayProfile();
         List<String> containers = Arrays.asList(
-            ContainerTypes.M4V,
-            ContainerTypes._3GP,
-            ContainerTypes.TS,
-            ContainerTypes.MPEGTS,
-            ContainerTypes.MOV,
-            ContainerTypes.XVID,
-            ContainerTypes.VOB,
-            ContainerTypes.MKV,
-            ContainerTypes.WMV,
-            ContainerTypes.ASF,
-            ContainerTypes.OGM,
-            ContainerTypes.OGV,
-            ContainerTypes.M2V,
-            ContainerTypes.AVI,
-            ContainerTypes.MPG,
-            ContainerTypes.MPEG,
-            ContainerTypes.MP4,
-            ContainerTypes.WEBM,
-            ContainerTypes.DVR_MS,
-            ContainerTypes.WTV
+                ContainerTypes.M4V,
+                ContainerTypes._3GP,
+                ContainerTypes.TS,
+                ContainerTypes.MPEGTS,
+                ContainerTypes.MOV,
+                ContainerTypes.XVID,
+                ContainerTypes.VOB,
+                ContainerTypes.MKV,
+                ContainerTypes.WMV,
+                ContainerTypes.ASF,
+                ContainerTypes.OGM,
+                ContainerTypes.OGV,
+                ContainerTypes.M2V,
+                ContainerTypes.AVI,
+                ContainerTypes.MPG,
+                ContainerTypes.MPEG,
+                ContainerTypes.MP4,
+                ContainerTypes.WEBM,
+                ContainerTypes.DVR_MS,
+                ContainerTypes.WTV
         );
         videoDirectPlayProfile.setContainer(Utils.join(",", containers));
         videoDirectPlayProfile.setType(DlnaProfileType.Video);
@@ -139,17 +139,17 @@ public class ProfileHelper {
 
         profile.setTranscodingProfiles(transcodingProfiles.toArray(new TranscodingProfile[transcodingProfiles.size()]));
         profile.setSubtitleProfiles(new SubtitleProfile[] {
-            getSubtitleProfile("srt", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("subrip", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("ass", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("ssa", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("pgs", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("pgssub", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("dvdsub", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("vtt", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("sub", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("idx", SubtitleDeliveryMethod.Embed),
-            getSubtitleProfile("smi", SubtitleDeliveryMethod.Embed)
+                getSubtitleProfile("srt", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("subrip", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("ass", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("ssa", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("pgs", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("pgssub", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("dvdsub", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("vtt", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("sub", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("idx", SubtitleDeliveryMethod.Embed),
+                getSubtitleProfile("smi", SubtitleDeliveryMethod.Embed)
         });
 
         return profile;
@@ -161,42 +161,42 @@ public class ProfileHelper {
         DirectPlayProfile videoDirectPlayProfile = new DirectPlayProfile();
 
         List<String> videoContainers = Arrays.asList(
-            ContainerTypes.M4V,
-            ContainerTypes._3GP,
-            ContainerTypes.TS,
-            ContainerTypes.MPEGTS,
-            ContainerTypes.MOV,
-            ContainerTypes.XVID,
-            ContainerTypes.VOB,
-            ContainerTypes.MKV,
-            ContainerTypes.WMV,
-            ContainerTypes.ASF,
-            ContainerTypes.OGM,
-            ContainerTypes.OGV,
-            ContainerTypes.M2V,
-            ContainerTypes.AVI,
-            ContainerTypes.MPG,
-            ContainerTypes.MPEG,
-            ContainerTypes.MP4,
-            ContainerTypes.WEBM,
-            ContainerTypes.WTV
+                ContainerTypes.M4V,
+                ContainerTypes._3GP,
+                ContainerTypes.TS,
+                ContainerTypes.MPEGTS,
+                ContainerTypes.MOV,
+                ContainerTypes.XVID,
+                ContainerTypes.VOB,
+                ContainerTypes.MKV,
+                ContainerTypes.WMV,
+                ContainerTypes.ASF,
+                ContainerTypes.OGM,
+                ContainerTypes.OGV,
+                ContainerTypes.M2V,
+                ContainerTypes.AVI,
+                ContainerTypes.MPG,
+                ContainerTypes.MPEG,
+                ContainerTypes.MP4,
+                ContainerTypes.WEBM,
+                ContainerTypes.WTV
         );
         videoDirectPlayProfile.setContainer(Utils.join(",", videoContainers));
         List<String> audioCodecs = new ArrayList<>(Arrays.asList(
-            CodecTypes.AAC,
-            CodecTypes.MP3,
-            CodecTypes.MP2,
-            CodecTypes.AC3,
-            CodecTypes.WMA,
-            CodecTypes.WMAV2,
-            CodecTypes.DCA,
-            CodecTypes.DTS,
-            CodecTypes.PCM,
-            CodecTypes.PCM_S16LE,
-            CodecTypes.PCM_S24LE,
-            CodecTypes.OPUS,
-            CodecTypes.FLAC,
-            CodecTypes.TRUEHD
+                CodecTypes.AAC,
+                CodecTypes.MP3,
+                CodecTypes.MP2,
+                CodecTypes.AC3,
+                CodecTypes.WMA,
+                CodecTypes.WMAV2,
+                CodecTypes.DCA,
+                CodecTypes.DTS,
+                CodecTypes.PCM,
+                CodecTypes.PCM_S16LE,
+                CodecTypes.PCM_S24LE,
+                CodecTypes.OPUS,
+                CodecTypes.FLAC,
+                CodecTypes.TRUEHD
         ));
         if (!Utils.downMixAudio() && isLiveTv) {
             audioCodecs.add(CodecTypes.AAC_LATM);
@@ -206,17 +206,17 @@ public class ProfileHelper {
 
         DirectPlayProfile audioDirectPlayProfile = new DirectPlayProfile();
         List<String> audioContainers = Arrays.asList(
-            CodecTypes.FLAC,
-            CodecTypes.AAC,
-            CodecTypes.MP3,
-            CodecTypes.MPA,
-            CodecTypes.WAV,
-            CodecTypes.WMA,
-            CodecTypes.MP2,
-            ContainerTypes.OGG,
-            ContainerTypes.OGA,
-            ContainerTypes.WEBMA,
-            CodecTypes.APE
+                CodecTypes.FLAC,
+                CodecTypes.AAC,
+                CodecTypes.MP3,
+                CodecTypes.MPA,
+                CodecTypes.WAV,
+                CodecTypes.WMA,
+                CodecTypes.MP2,
+                ContainerTypes.OGG,
+                ContainerTypes.OGA,
+                ContainerTypes.WEBMA,
+                CodecTypes.APE
         );
         audioDirectPlayProfile.setContainer(Utils.join(",", audioContainers));
         audioDirectPlayProfile.setType(DlnaProfileType.Audio);
@@ -248,7 +248,7 @@ public class ProfileHelper {
 
         CodecProfile videoAudioCodecProfile = new CodecProfile();
         videoAudioCodecProfile.setType(CodecType.VideoAudio);
-        videoAudioCodecProfile.setConditions(new ProfileCondition[]{new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.AudioChannels, "6")});
+        videoAudioCodecProfile.setConditions(new ProfileCondition[]{new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.AudioChannels, "8")});
 
         profile.setCodecProfiles(new CodecProfile[]{getHevcProfile(), h264MainProfile, videoAudioCodecProfile});
         profile.setContainerProfiles(new ContainerProfile[] {videoContainerProfile});
@@ -280,36 +280,36 @@ public class ProfileHelper {
                 containers.add(ContainerTypes.MPEGTS);
             }
             containers.addAll(Arrays.asList(
-                ContainerTypes.M4V,
-                ContainerTypes.MOV,
-                ContainerTypes.XVID,
-                ContainerTypes.VOB,
-                ContainerTypes.MKV,
-                ContainerTypes.WMV,
-                ContainerTypes.ASF,
-                ContainerTypes.OGM,
-                ContainerTypes.OGV,
-                ContainerTypes.MP4,
-                ContainerTypes.WEBM
+                    ContainerTypes.M4V,
+                    ContainerTypes.MOV,
+                    ContainerTypes.XVID,
+                    ContainerTypes.VOB,
+                    ContainerTypes.MKV,
+                    ContainerTypes.WMV,
+                    ContainerTypes.ASF,
+                    ContainerTypes.OGM,
+                    ContainerTypes.OGV,
+                    ContainerTypes.MP4,
+                    ContainerTypes.WEBM
             ));
             videoDirectPlayProfile.setContainer(Utils.join(",", containers));
             List<String> videoCodecs;
             if (DeviceUtils.isShield() || DeviceUtils.isNexus() || DeviceUtils.isBeyondTv()) {
                 videoCodecs = Arrays.asList(
-                    CodecTypes.H264,
-                    CodecTypes.HEVC,
-                    CodecTypes.VP8,
-                    CodecTypes.VP9,
-                    ContainerTypes.MPEG,
-                    CodecTypes.MPEG2VIDEO
+                        CodecTypes.H264,
+                        CodecTypes.HEVC,
+                        CodecTypes.VP8,
+                        CodecTypes.VP9,
+                        ContainerTypes.MPEG,
+                        CodecTypes.MPEG2VIDEO
                 );
             } else {
                 videoCodecs = Arrays.asList(
-                    CodecTypes.H264,
-                    CodecTypes.VP8,
-                    CodecTypes.VP9,
-                    ContainerTypes.MPEG,
-                    CodecTypes.MPEG2VIDEO
+                        CodecTypes.H264,
+                        CodecTypes.VP8,
+                        CodecTypes.VP9,
+                        ContainerTypes.MPEG,
+                        CodecTypes.MPEG2VIDEO
                 );
             }
             videoDirectPlayProfile.setVideoCodec(Utils.join(",", videoCodecs));
@@ -319,12 +319,12 @@ public class ProfileHelper {
                 videoDirectPlayProfile.setAudioCodec(Utils.join(",", CodecTypes.AAC, CodecTypes.MP3, CodecTypes.MP2));
             } else {
                 List<String> audioCodecs = new ArrayList<>(Arrays.asList(
-                    CodecTypes.AAC,
-                    CodecTypes.AC3,
-                    CodecTypes.EAC3,
-                    CodecTypes.AAC_LATM,
-                    CodecTypes.MP3,
-                    CodecTypes.MP2
+                        CodecTypes.AAC,
+                        CodecTypes.AC3,
+                        CodecTypes.EAC3,
+                        CodecTypes.AAC_LATM,
+                        CodecTypes.MP3,
+                        CodecTypes.MP2
                 ));
                 if (allowDTS) {
                     audioCodecs.add(CodecTypes.DCA);
@@ -338,17 +338,17 @@ public class ProfileHelper {
 
         DirectPlayProfile audioDirectPlayProfile = new DirectPlayProfile();
         List<String> audioContainers = Arrays.asList(
-            CodecTypes.AAC,
-            CodecTypes.MP3,
-            CodecTypes.MPA,
-            CodecTypes.WAV,
-            CodecTypes.WMA,
-            CodecTypes.MP2,
-            ContainerTypes.OGG,
-            ContainerTypes.OGA,
-            ContainerTypes.WEBMA,
-            CodecTypes.APE,
-            CodecTypes.OPUS
+                CodecTypes.AAC,
+                CodecTypes.MP3,
+                CodecTypes.MPA,
+                CodecTypes.WAV,
+                CodecTypes.WMA,
+                CodecTypes.MP2,
+                ContainerTypes.OGG,
+                ContainerTypes.OGA,
+                ContainerTypes.WEBMA,
+                CodecTypes.APE,
+                CodecTypes.OPUS
         );
         audioDirectPlayProfile.setContainer(Utils.join(",", audioContainers));
         audioDirectPlayProfile.setType(DlnaProfileType.Audio);


### PR DESCRIPTION
Noticed some issues with VLC audio passthrough on the nvidia shield which caused Atmos to not work correctly. Believe this was due to an overall slight misconfiguration of VLC audio passthrough.

**Changes**
This slightly changes the way audio is configured for libvlc to be more in-line with the way https://github.com/videolan/vlc-android works.

**Issues**
https://github.com/jellyfin/jellyfin-androidtv/issues/281
