### PR TITLE
Fix crash upon loading resumable episodes without runtime field

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/channels/ChannelManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/channels/ChannelManager.kt
@@ -179,6 +179,9 @@ class ChannelManager {
 			item.canResume -> {
 				setWatchNextType(WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
 				setLastPlaybackPositionMillis((item.resumePositionTicks / TICKS_IN_MILLISECOND).toInt())
+			}
+			// Episode runtime has been determined
+			item.runTimeTicks != null -> {
 				setDurationMillis((item.runTimeTicks / TICKS_IN_MILLISECOND).toInt())
 			}
 			// First episode of the season


### PR DESCRIPTION
**Changes**
When using STRM media files, and possibly in other contexts, episode files may be replaced, renamed or otherwise changed in a way that causes Jellyfin to delete stored ffprobe/mediainfo output. However, when this happens user resume data still remains for these episodes, and is sent by Jellyfin to clients normally. Therefore, clients must account for the RunTimeTicks field not being present in the JSON returned by `https://jellyfin.sachk.com/Shows/NextUp` even when the `PlaybackPositionTicks` field is present and non-zero. 

To fix this, I added an extra conditional to ensure runTimeTicks is not null before its value is used to call `setDurationMillis`. This avoids the null pointer error, and seems to entirely resolve this crash.

**Crash log from current master**

```
2020-07-25 12:16:29.251 4806-4902/org.jellyfin.androidtv.debug E/ACRA: ACRA caught a NullPointerException for org.jellyfin.androidtv.debug
    java.lang.NullPointerException: Attempt to invoke virtual method 'long java.lang.Long.longValue()' on a null object reference
        at org.jellyfin.androidtv.channels.ChannelManager.getBaseItemAsWatchNextProgram(ChannelManager.kt:182)
        at org.jellyfin.androidtv.channels.ChannelManager.access$getBaseItemAsWatchNextProgram(ChannelManager.kt:33)
```