### PR TITLE
Fix time format for current and resume time

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.util;
 
+import android.annotation.SuppressLint;
 import android.text.format.DateFormat;
 
 import org.jellyfin.androidtv.R;
@@ -9,14 +10,18 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 public class TimeUtils {
     private static final int MILLIS_PER_SEC = 1000;
-    private static final int MILLIS_PER_MIN = 60 * MILLIS_PER_SEC;
-    private static final int MILLIS_PER_HR = 60 * MILLIS_PER_MIN;
+    private static final long MILLIS_PER_MIN = TimeUnit.MINUTES.toMillis(1);
+    private static final long MILLIS_PER_HR = TimeUnit.HOURS.toMillis(1);
 
     private static final int SECS_PER_MIN = 60;
-    private static final int SECS_PER_HR = 60 * SECS_PER_MIN;
+    private static final long SECS_PER_HR = TimeUnit.HOURS.toSeconds(1);
+
+    private static final String DURATION_TIME_FORMAT_NO_HOURS = "%d:%02d";
+    private static final String DURATION_TIME_FORMAT_WITH_HOURS = "%d:%02d:%02d";
 
     public static long secondsToMillis(double seconds) {
         return Math.round(seconds * MILLIS_PER_SEC);
@@ -33,37 +38,22 @@ public class TimeUtils {
     /**
      * Formats time in milliseconds to hh:mm:ss string format.
      *
-     * @param millis
-     * @return
+     * @param millis Time in milliseconds
+     * @return Formatted time
      */
+    @SuppressLint("DefaultLocale")
     public static String formatMillis(long millis) {
-        long hr = millis / MILLIS_PER_HR;
+        long hr = TimeUnit.MILLISECONDS.toHours(millis);
         millis %= MILLIS_PER_HR;
-        long min = millis / MILLIS_PER_MIN;
+        long min = TimeUnit.MILLISECONDS.toMinutes(millis);
         millis %= MILLIS_PER_MIN;
-        long sec = millis / MILLIS_PER_SEC;
+        long sec = TimeUnit.MILLISECONDS.toSeconds(millis);
 
-        StringBuilder builder = new StringBuilder();
-        // Hours
-        if (hr > 0) {
-            builder.append(hr)
-                    .append(":");
+        if(hr > 0) {
+            return String.format(DURATION_TIME_FORMAT_WITH_HOURS, hr, min, sec);
+        } else {
+            return String.format(DURATION_TIME_FORMAT_NO_HOURS, min, sec);
         }
-        // Minutes
-        if (min >= 0) {
-            if (min < 9 && hr > 0) {
-                builder.append("0");
-            }
-            builder.append(min)
-                    .append(":");
-        }
-        // Seconds
-        if (sec < 10) {
-            builder.append("0");
-        }
-        builder.append(sec);
-
-        return builder.toString();
     }
 
     public static String formatSeconds(int seconds) {

--- a/app/src/test/java/org/jellyfin/androidtv/util/TimeUtilsTest.java
+++ b/app/src/test/java/org/jellyfin/androidtv/util/TimeUtilsTest.java
@@ -1,7 +1,8 @@
 package org.jellyfin.androidtv.util;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TimeUtilsTest {
 
@@ -28,9 +29,18 @@ public class TimeUtilsTest {
 
     @Test
     public void formatMillis() {
+        assertEquals("0:00", TimeUtils.formatMillis(0));
         assertEquals("0:13", TimeUtils.formatMillis(13000));
         assertEquals("5:00", TimeUtils.formatMillis(300000));
+        assertEquals("9:01", TimeUtils.formatMillis(541000));
+        assertEquals("9:59", TimeUtils.formatMillis(599000));
+        assertEquals("26:00", TimeUtils.formatMillis(1560000));
+        assertEquals("26:01", TimeUtils.formatMillis(1561000));
+        assertEquals("26:43", TimeUtils.formatMillis(1603000));
         assertEquals("1:00:00", TimeUtils.formatMillis(3600000));
+        assertEquals("1:01:01", TimeUtils.formatMillis(3661000));
+        assertEquals("1:09:15", TimeUtils.formatMillis(4155000));
         assertEquals("1:16:03", TimeUtils.formatMillis(4563489));
+        assertEquals("12:00:00", TimeUtils.formatMillis(43200000));
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Improved current/resume time formatting from milliseconds

**Preview:**
![image](https://user-images.githubusercontent.com/134937/88858827-46a15580-d201-11ea-82ac-9d245781225d.png)

**Issues**
Fixes #505 
