### PR TITLE
Fixed misleading login error message

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/AuthenticationHelper.java
@@ -22,6 +22,8 @@ import org.jellyfin.apiclient.serialization.GsonJsonSerializer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 import timber.log.Timber;
 
@@ -109,7 +111,17 @@ public class AuthenticationHelper {
             public void onError(Exception exception) {
                 super.onError(exception);
                 Timber.e(exception, "Error logging in");
-                Utils.showToast(activity, activity.getString(R.string.msg_invalid_id_pw));
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                exception.printStackTrace(pw);
+                String sStackTrace = sw.toString(); // stack trace as a string
+                if (sStackTrace.contains("no protocol") && sStackTrace.contains("Bad URL")) {
+                    Utils.showToast(activity, activity.getString(R.string.msg_enter_protocol));
+                    enterManualServerAddress(activity);
+                } else  {
+                    Utils.showToast(activity, activity.getString(R.string.msg_invalid_id_pw));
+                    enterManualServerAddress(activity);
+                }
             }
         });
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,7 +112,7 @@
     <string name="msg_error_signin">There was an error signing in with your saved credentials.</string>
     <string name="msg_invalid_id_pw">Invalid User ID or password</string>
     <string name="lbl_version">"Version "</string>
-    <string name="lbl_ip_hint">192.168.1.100:8096 or https://myserver.com</string>
+    <string name="lbl_ip_hint">http://192.168.1.100:8096 or https://myserver.com</string>
     <string name="lbl_enter_server_address">Enter Server Address</string>
     <string name="lbl_valid_server_address">Please enter the server address (IP or domain/machine name)</string>
     <string name="lbl_ok">Ok</string>
@@ -403,4 +403,5 @@
     <string name="not_deleted">Item NOT Deleted</string>
     <string name="turn_off">Turn this option off</string>
     <string name="just_one">Just this one</string>
+    <string name="msg_enter_protocol">Please enter http or https to beginning of address</string>
 </resources>


### PR DESCRIPTION
When I enter a server address of 192.xxx.xx.xxx:8096, I get wrong username or pass error while they are corect because when you check the logcat, it is actually bad url, no protocol error from Volley library. This is misleading and causes people to search for solutions. A simple message output such "Please put an http protocol to beginning of address" can easily save people from searching for solution.

I just made a pull request for this as it is not a huge change, please let me know if something needs a change.
I am using jellyfin all the time and looking to contribute more.

**Changes**
Changed address hint on user login.
Added a more clear error message for wrong url or missing protocol error.


