### PR TITLE
Add channel name to info row in LiveTV guide

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -937,6 +937,12 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
             }
         } else {
             mInfoRow.removeAllViews();
+
+            TextView channelName = new TextView(mActivity);
+            channelName.setTextSize(16);
+            channelName.setText(TvManager.getChannel(TvManager.getAllChannelsIndex(mSelectedProgram.getChannelId())).getName());
+            mInfoRow.addView(channelName);
+
             mBackdrop.setImageResource(R.drawable.banner_tv);
             mImage.setImageResource(R.drawable.blank10x10);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -954,6 +954,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             InfoLayoutHelper.addInfoRow(mActivity, mSelectedProgram, mGuideInfoRow, false, false);
         } else {
             mGuideInfoRow.removeAllViews();
+
+            TextView channelName = new TextView(mActivity);
+            channelName.setTextSize(16);
+            channelName.setText(TvManager.getChannel(TvManager.getAllChannelsIndex(mSelectedProgram.getChannelId())).getName());
+            mGuideInfoRow.addView(channelName);
         }
 
     }


### PR DESCRIPTION
**Changes**
- Add the name of the channel in the info row for any channels that display "\<No Program Data\>"

Can this get merged and pushed to Play Store ASAP please? It's a huge QoL improvement for channels that have no EPG data in the Program Guide.
