### PR TITLE
Live TV improvements

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.ui;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.AbsListView;
@@ -13,6 +14,7 @@ import com.bumptech.glide.Glide;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
+import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -27,15 +29,16 @@ public class GuideChannelHeader extends RelativeLayout {
 
     private ImageView mChannelImage;
     private ChannelInfoDto mChannel;
-    private Context mActivity;
+    private Context mContext;
+    private CustomPlaybackOverlayFragment mActivity;
 
-    public GuideChannelHeader(Context context, ChannelInfoDto channel) {
+    public GuideChannelHeader(Context context, CustomPlaybackOverlayFragment fragment, ChannelInfoDto channel, boolean focusable) {
         super(context);
-        initComponent(context, channel);
+        initComponent(context, fragment, channel, focusable);
     }
 
-    private void initComponent(Context context, ChannelInfoDto channel) {
-        mActivity = context;
+    private void initComponent(Context context, CustomPlaybackOverlayFragment fragment, ChannelInfoDto channel, boolean focusable) {
+        mContext = context;
         mChannel = channel;
         LayoutInflater inflater = LayoutInflater.from(context);
         View v = inflater.inflate(R.layout.channel_header, this, false);
@@ -45,14 +48,39 @@ public class GuideChannelHeader extends RelativeLayout {
         ((TextView) findViewById(R.id.channelName)).setText(channel.getName());
         ((TextView) findViewById(R.id.channelNumber)).setText(channel.getNumber());
         mChannelImage = (ImageView) findViewById(R.id.channelImage);
+
+        if (fragment != null) {
+            mActivity = fragment;
+            this.setFocusable(focusable);
+            setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    fragment.switchChannelKeepGuide(channel.getId());
+                }
+            });
+        }
     }
 
     public void loadImage() {
-        Glide.with(mActivity)
+        Glide.with(mContext)
                 .load(ImageUtils.getPrimaryImageUrl(mChannel, get(ApiClient.class)))
                 .override(IMAGE_WIDTH, IMAGE_HEIGHT)
                 .centerInside()
                 .into(mChannelImage);
+    }
+
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+
+        if (gainFocus) {
+            setBackgroundColor(Utils.getThemeColor(getContext(), android.R.attr.colorAccent));
+
+            mActivity.setSelectedProgram(this);
+        } else {
+            setBackground(getResources().getDrawable(R.drawable.light_border));
+        }
+//        TvApp.getApplication().getLogger().Debug("Focus on " + mProgram.getName() + " was " + (gainFocus ? "gained" : "lost"));
     }
 
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -80,7 +80,6 @@ public class GuideChannelHeader extends RelativeLayout {
         } else {
             setBackground(getResources().getDrawable(R.drawable.light_border));
         }
-//        TvApp.getApplication().getLogger().Debug("Focus on " + mProgram.getName() + " was " + (gainFocus ? "gained" : "lost"));
     }
 
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -55,7 +55,7 @@ public class GuideChannelHeader extends RelativeLayout {
             setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    fragment.switchChannelKeepGuide(channel.getId());
+                    fragment.switchChannel(channel.getId(), false);
                 }
             });
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
@@ -36,14 +36,14 @@ public class ProgramGridCell extends RelativeLayout implements IRecordingIndicat
     private boolean isFirst;
     private final int IND_HEIGHT = Utils.convertDpToPixel(TvApp.getApplication(), 10);
 
-    public ProgramGridCell(Context context, ILiveTvGuide activity, BaseItemDto program) {
+    public ProgramGridCell(Context context, ILiveTvGuide activity, BaseItemDto program, boolean keyListen) {
         super(context);
-        initComponent((Activity) context, activity, program);
+        initComponent((Activity) context, activity, program, keyListen);
     }
 
-    private void initComponent(Activity context, ILiveTvGuide activity, BaseItemDto program) {
+    private void initComponent(Activity context, ILiveTvGuide activity, BaseItemDto program, boolean keyListen) {
         mActivity = activity;
-        mProgram = program;
+
         LayoutInflater inflater = LayoutInflater.from(context);
         View v = inflater.inflate(R.layout.program_grid_cell, this, false);
         this.addView(v);
@@ -101,12 +101,15 @@ public class ProgramGridCell extends RelativeLayout implements IRecordingIndicat
             mRecIndicator.setImageResource(R.drawable.ic_record_red);
         }
 
-        setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mActivity.showProgramOptions();
-            }
-        });
+
+        if (keyListen) {
+            setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mActivity.showProgramOptions();
+                }
+            });
+        }
 
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/ILiveTvGuide.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/ILiveTvGuide.java
@@ -2,8 +2,6 @@ package org.jellyfin.androidtv.ui.livetv;
 
 import android.widget.RelativeLayout;
 
-import org.jellyfin.androidtv.ui.ProgramGridCell;
-
 public interface ILiveTvGuide {
     public void displayChannels(int start, int max);
     public long getCurrentLocalStartDate();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/ILiveTvGuide.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/ILiveTvGuide.java
@@ -1,10 +1,12 @@
 package org.jellyfin.androidtv.ui.livetv;
 
+import android.widget.RelativeLayout;
+
 import org.jellyfin.androidtv.ui.ProgramGridCell;
 
 public interface ILiveTvGuide {
     public void displayChannels(int start, int max);
     public long getCurrentLocalStartDate();
     public void showProgramOptions();
-    public void setSelectedProgram(ProgramGridCell programView);
+    public void setSelectedProgram(RelativeLayout programView);
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -815,7 +815,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
                 empty.setName("  " + getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*slot) * 60000))));
-                empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30+(slot+1)) * 60000))));
+                empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
                 ProgramGridCell cell = new ProgramGridCell(this, this, empty, false);
                 cell.setId(currentCellId++);
                 cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, ROW_HEIGHT));
@@ -826,7 +826,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
                 if (slot == (minutes / 30) - 1)
                     cell.setLast();
                 slot++;
-            } while((30*slot)*60000 < minutes*60000);
+            } while((30*slot) < minutes);
             return programRow;
         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -327,7 +327,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
                     Date curUTC = TimeUtils.convertToUtcDate(new Date());
-                    if (mSelectedProgram.getStartDate().before(curUTC) && mSelectedProgram.getEndDate().after(curUTC))
+                    if (mSelectedProgram.getStartDate().before(curUTC))
                         PlaybackHelper.retrieveAndPlay(mSelectedProgram.getChannelId(), false, this);
                     else
                         showProgramOptions();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -237,7 +237,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
     }
 
     private void reload() {
-        fillTimeLine(mCurrentLocalGuideStart, getGuideHours());
+        fillTimeLine(System.currentTimeMillis(), getGuideHours());
         displayChannels(mCurrentDisplayChannelStartNdx, PAGE_SIZE);
         mLastLoad = System.currentTimeMillis();
     }
@@ -249,7 +249,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
         if (mLoadLastChannel) {
             mLoadLastChannel = false;
             String channel = TvManager.getLastLiveTvChannel();
-            if (channel != null) {
+            if (TvManager.getAllChannelsIndex(channel) != -1) {
                 PlaybackHelper.retrieveAndPlay(channel, false, this);
             } else {
                 doLoad();
@@ -260,7 +260,10 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
     }
 
     protected void doLoad() {
-        if (TvManager.shouldForceReload() || System.currentTimeMillis() > mLastLoad + 3600000) {
+        Calendar curTime = Calendar.getInstance();
+        curTime.setTime(new Date());
+
+        if (TvManager.shouldForceReload() || curTime.getTimeInMillis() >= mCurrentLocalGuideStart + 1800000) {
             if (mAllChannels == null) {
                 mAllChannels = TvManager.getAllChannels();
                 if (mAllChannels == null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -771,10 +771,14 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
 
         LinearLayout programRow = new LinearLayout(this);
 
+        //TODO replace all <No Program....> with resource string
+
         if (programs.size() == 0) {
             if (mFilters.any()) return null; // don't show rows with no program data
 
             BaseItemDto empty = new BaseItemDto();
+            //TODO split into 30min segments
+
             int duration = ((Long)((mCurrentLocalGuideEnd - mCurrentLocalGuideStart) / 60000)).intValue();
             empty.setName("  <No Program Data Available>");
             empty.setChannelId(channelId);
@@ -912,13 +916,14 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
 
         mTitle.setText(mSelectedProgram.getName());
         mSummary.setText(mSelectedProgram.getOverview());
+
+        //info row
+        InfoLayoutHelper.addInfoRow(mActivity, mSelectedProgram, mInfoRow, false, false);
+
         if (mSelectedProgram.getId() != null) {
             mDisplayDate.setText(TimeUtils.getFriendlyDate(TimeUtils.convertToLocalDate(mSelectedProgram.getStartDate())));
             String url = ImageUtils.getPrimaryImageUrl(mSelectedProgram, get(ApiClient.class));
             Glide.with(mActivity).load(url).override(IMAGE_SIZE, IMAGE_SIZE).centerInside().into(mImage);
-
-            //info row
-            InfoLayoutHelper.addInfoRow(mActivity, mSelectedProgram, mInfoRow, false, false);
 
             if (Utils.isTrue(mSelectedProgram.getIsNews())) {
                 mBackdrop.setImageResource(R.drawable.banner_news);
@@ -936,7 +941,6 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
                 mBackdrop.setImageResource(R.drawable.banner_tv);
             }
         } else {
-            mInfoRow.removeAllViews();
             mBackdrop.setImageResource(R.drawable.banner_tv);
             mImage.setImageResource(R.drawable.blank10x10);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -601,6 +601,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
             mHd.setChecked(prefs.showHDIndicator);
             mRepeat.setChecked(prefs.showRepeatIndicator);
             mLive.setChecked(prefs.showLiveIndicator);
+            mFavTop.setChecked(prefs.favsAtTop);
             mNew.setChecked(prefs.showNewIndicator);
             mRepeat.setChecked(prefs.showRepeatIndicator);
             mColorCode.setChecked(prefs.colorCodeGuide);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -775,22 +775,27 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
 
         if (programs.size() == 0) {
             if (mFilters.any()) return null; // don't show rows with no program data
-
-            BaseItemDto empty = new BaseItemDto();
             //TODO split into 30min segments
 
-            int duration = ((Long)((mCurrentLocalGuideEnd - mCurrentLocalGuideStart) / 60000)).intValue();
-            empty.setName("  <No Program Data Available>");
-            empty.setChannelId(channelId);
-            empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart)));
-            empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart+(duration*60000))));
-            ProgramGridCell cell = new ProgramGridCell(this, this, empty);
-            cell.setId(currentCellId++);
-            cell.setLayoutParams(new ViewGroup.LayoutParams(duration * PIXELS_PER_MINUTE, ROW_HEIGHT));
-            cell.setFocusable(true);
-            programRow.addView(cell);
-            cell.setLast();
-            cell.setFirst();
+            int minutes = ((Long)((mCurrentLocalGuideEnd - mCurrentLocalGuideStart) / 60000)).intValue();
+            int slot = 0;
+            do {
+                BaseItemDto empty = new BaseItemDto();
+                empty.setName("  " + getString(R.string.no_program_data));
+                empty.setChannelId(channelId);
+                empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*slot) * 60000))));
+                empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30+(slot+1)) * 60000))));
+                ProgramGridCell cell = new ProgramGridCell(this, this, empty);
+                cell.setId(currentCellId++);
+                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, ROW_HEIGHT));
+                cell.setFocusable(true);
+                programRow.addView(cell);
+                if (slot == 0)
+                    cell.setFirst();
+                if (slot == 17)
+                    cell.setLast();
+                slot++;
+            } while((30*slot)*60000 < minutes*60000);
             return programRow;
         }
 
@@ -803,7 +808,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
             if (start > prevEnd) {
                 // fill empty time slot
                 BaseItemDto empty = new BaseItemDto();
-                empty.setName("  <No Program Data Available>");
+                empty.setName("  " + getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
                 Long duration = (start - prevEnd);
@@ -842,7 +847,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
         if (prevEnd < mCurrentLocalGuideEnd) {
             // fill empty time slot
             BaseItemDto empty = new BaseItemDto();
-            empty.setName("  <No Program Data Available>");
+            empty.setName("  " + getString(R.string.no_program_data));
             empty.setChannelId(channelId);
             empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
             Long duration = (mCurrentLocalGuideEnd - prevEnd);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -260,10 +260,8 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
     }
 
     protected void doLoad() {
-        Calendar curTime = Calendar.getInstance();
-        curTime.setTime(new Date());
 
-        if (TvManager.shouldForceReload() || curTime.getTimeInMillis() >= mCurrentLocalGuideStart + 1800000  || mChannels.getChildCount() == 0) {
+        if (TvManager.shouldForceReload() || System.currentTimeMillis() >= mCurrentLocalGuideStart + 1800000  || mChannels.getChildCount() == 0) {
             if (mAllChannels == null) {
                 mAllChannels = TvManager.getAllChannels();
                 if (mAllChannels == null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -324,10 +324,13 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
                 // bring up filter selection
                 showFilterOptions();
                 break;
-                //TODO look more into this
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
-                    PlaybackHelper.retrieveAndPlay(mSelectedProgram.getChannelId(), false, this);
+                    Date curUTC = TimeUtils.convertToUtcDate(new Date());
+                    if (mSelectedProgram.getStartDate().before(curUTC) && mSelectedProgram.getEndDate().after(curUTC))
+                        PlaybackHelper.retrieveAndPlay(mSelectedProgram.getChannelId(), false, this);
+                    else
+                        showProgramOptions();
                     return true;
                 }
             case KeyEvent.KEYCODE_MEDIA_PLAY:
@@ -878,7 +881,6 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
         //If not at end of time period - fill in the rest
         if (prevEnd < mCurrentLocalGuideEnd) {
             // fill empty time slot
-            //TODO fill with 30 min slots
             BaseItemDto empty = new BaseItemDto();
             empty.setName("  " + getString(R.string.no_program_data));
             empty.setChannelId(channelId);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -263,7 +263,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
         Calendar curTime = Calendar.getInstance();
         curTime.setTime(new Date());
 
-        if (TvManager.shouldForceReload() || curTime.getTimeInMillis() >= mCurrentLocalGuideStart + 1800000) {
+        if (TvManager.shouldForceReload() || curTime.getTimeInMillis() >= mCurrentLocalGuideStart + 1800000  || mChannels.getChildCount() == 0) {
             if (mAllChannels == null) {
                 mAllChannels = TvManager.getAllChannels();
                 if (mAllChannels == null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -248,6 +248,15 @@ public class TvManager {
                 }));
             }
 
+            if (prefs.favsAtTop) {
+                Collections.sort(allChannels, new Comparator<ChannelInfoDto>() {
+                    @Override
+                    public int compare(ChannelInfoDto channelInfoDto, ChannelInfoDto t1) {
+                        return -Boolean.compare(channelInfoDto.getUserData().getIsFavorite(), t1.getUserData().getIsFavorite());
+                    }
+                });
+            }
+
             //And  fill in channel IDs
             ndx = fillChannelIds();
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -251,8 +251,10 @@ public class TvManager {
             if (prefs.favsAtTop) {
                 Collections.sort(allChannels, new Comparator<ChannelInfoDto>() {
                     @Override
-                    public int compare(ChannelInfoDto channelInfoDto, ChannelInfoDto t1) {
-                        return -Boolean.compare(channelInfoDto.getUserData().getIsFavorite(), t1.getUserData().getIsFavorite());
+                    public int compare(ChannelInfoDto channelOne, ChannelInfoDto channelTwo) {
+                        boolean channelOneFav = channelOne.getUserData() != null && channelOne.getUserData().getIsFavorite();
+                        boolean channelTwoFav = channelTwo.getUserData() != null && channelTwo.getUserData().getIsFavorite();
+                        return -Boolean.compare(channelOneFav, channelTwoFav);
                     }
                 });
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -866,7 +866,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             if (start > prevEnd) {
                 // fill empty time slot
                 BaseItemDto empty = new BaseItemDto();
-                empty.setName("  <No Program Data Available>");
+                empty.setName("  " + getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
                 Long duration = (start - prevEnd);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -926,7 +926,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 empty.setName("  " + getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*slot) * 60000))));
-                empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30+(slot+1)) * 60000))));
+                empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
                 ProgramGridCell cell = new ProgramGridCell(mActivity, this, empty, false);
                 cell.setId(currentCellId++);
                 cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
@@ -937,7 +937,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 if (slot == (minutes / 30) - 1)
                     cell.setLast();
                 slot++;
-            } while((30*slot)*60000 < minutes*60000);
+            } while((30*slot) < minutes);
 
             return programRow;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -468,7 +468,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
             if (mGuideVisible && mSelectedProgram != null && mSelectedProgram.getChannelId() != null) {
                 Date curUTC = TimeUtils.convertToUtcDate(new Date());
-                if (mSelectedProgram.getStartDate().before(curUTC) && mSelectedProgram.getEndDate().after(curUTC))
+                if (mSelectedProgram.getStartDate().before(curUTC))
                     switchChannel(mSelectedProgram.getChannelId());
                 else
                     showProgramOptions();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -762,27 +762,24 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     private void loadGuide() {
         mGuideSpinner.setVisibility(View.VISIBLE);
         fillTimeLine(mGuideHours);
-        if (mAllChannels == null) {
-            TvManager.loadAllChannels(new Response<Integer>() {
-                @Override
-                public void onResponse(Integer ndx) {
-                    if (ndx >= PAGE_SIZE) {
-                        // last channel is not in first page so grab a set where it will be in the middle
-                        ndx = ndx - (PAGE_SIZE / 2);
-                    } else {
-                        ndx = 0; // just start at beginning
-                    }
-
-                    mAllChannels = TvManager.getAllChannels();
-                    if (mAllChannels.size() > 0) {
-                        displayChannels(ndx, PAGE_SIZE);
-                    } else {
-                        mGuideSpinner.setVisibility(View.GONE);
-                    }
+        TvManager.loadAllChannels(new Response<Integer>() {
+            @Override
+            public void onResponse(Integer ndx) {
+                if (ndx >= PAGE_SIZE) {
+                    // last channel is not in first page so grab a set where it will be in the middle
+                    ndx = ndx - (PAGE_SIZE / 2);
+                } else {
+                    ndx = 0; // just start at beginning
                 }
-            });
 
-        }
+                mAllChannels = TvManager.getAllChannels();
+                if (mAllChannels.size() > 0) {
+                    displayChannels(ndx, PAGE_SIZE);
+                } else {
+                    mGuideSpinner.setVisibility(View.GONE);
+                }
+            }
+        });
     }
 
     public void displayChannels(int start, int max) {
@@ -903,7 +900,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             mFilterStatus.setText(" for next " + mGuideHours + " hours");
             mFilterStatus.setTextColor(Color.GRAY);
 
-            mGuideSpinner.setVisibility(View.GONE);
             if (firstRow != null) firstRow.requestFocus();
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -464,6 +464,20 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         }
     };
 
+    public boolean onKeyUp(int keyCode, KeyEvent event){
+        if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
+            if (mGuideVisible && mSelectedProgram != null && mSelectedProgram.getChannelId() != null)
+                switchChannel(mSelectedProgram.getChannelId());
+            return true;
+        }
+        return false;
+    }
+
+    public boolean onKeyLongPress(int keyCode, KeyEvent event){
+        showProgramOptions();
+        return true;
+    }
+
     private View.OnKeyListener keyListener = new View.OnKeyListener() {
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
@@ -908,7 +922,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*slot) * 60000))));
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30+(slot+1)) * 60000))));
-                ProgramGridCell cell = new ProgramGridCell(mActivity, this, empty, true);
+                ProgramGridCell cell = new ProgramGridCell(mActivity, this, empty, false);
                 cell.setId(currentCellId++);
                 cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
                 cell.setFocusable(true);
@@ -938,7 +952,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
                 Long duration = (start - prevEnd);
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(prevEnd + duration)));
-                ProgramGridCell cell = new ProgramGridCell(mActivity, mFragment, empty, true);
+                ProgramGridCell cell = new ProgramGridCell(mActivity, mFragment, empty, false);
                 cell.setId(currentCellId++);
                 cell.setLayoutParams(new ViewGroup.LayoutParams(((Long) (duration / 60000)).intValue() * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
                 cell.setFocusable(true);
@@ -949,7 +963,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             prevEnd = end;
             Long duration = (end - start) / 60000;
             if (duration > 0) {
-                ProgramGridCell program = new ProgramGridCell(mActivity, mFragment, item, true);
+                ProgramGridCell program = new ProgramGridCell(mActivity, mFragment, item, false);
                 program.setId(currentCellId++);
                 program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
                 program.setFocusable(true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -896,8 +896,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 mProgramRows.addView(new GuidePagingButton(mActivity, mFragment, mCurrentDisplayChannelEndNdx + 1, getString(R.string.lbl_load_channels) + mAllChannels.get(mCurrentDisplayChannelEndNdx + 1).getNumber() + " - " + mAllChannels.get(pageDnEnd).getNumber()));
             }
 
-            mChannelStatus.setText(displayedChannels + " of " + mAllChannels.size() + " channels");
-            mFilterStatus.setText(" for next " + mGuideHours + " hours");
+            mChannelStatus.setText(getResources().getString(R.string.lbl_tv_channel_status, displayedChannels, mAllChannels.size()));
+            mFilterStatus.setText(getResources().getString(R.string.lbl_tv_filter_status, mGuideHours));
             mFilterStatus.setTextColor(Color.GRAY);
 
             if (firstRow != null) firstRow.requestFocus();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -26,9 +26,9 @@ import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
-import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
@@ -352,6 +352,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             }
         });
 
+        mActivity.getOnBackPressedDispatcher().addCallback(backPressedCallback);
+
 
         Intent intent = mActivity.getIntent();
         int startPos = intent.getIntExtra("Position", 0);
@@ -443,6 +445,25 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         }
     };
 
+    private OnBackPressedCallback backPressedCallback = new OnBackPressedCallback(true) {
+
+        @Override
+        public void handleOnBackPressed() {
+            if (mPopupPanelVisible) {
+                // back should just hide the popup panel
+                hidePopupPanel();
+                leanbackOverlayFragment.hideOverlay();
+
+                // also close this if live tv
+                if (mPlaybackController.isLiveTv()) hide();
+            } else if (mGuideVisible) {
+                hideGuide();
+            } else {
+                mActivity.finish();
+            }
+        }
+    };
+
     private View.OnKeyListener keyListener = new View.OnKeyListener() {
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
@@ -459,14 +480,19 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                     return true;
                 }
 
-                if (mPopupPanelVisible && (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_ESCAPE)) {
-                    // back should just hide the popup panel
-                    hidePopupPanel();
-                    leanbackOverlayFragment.hideOverlay();
+                if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_ESCAPE) {
+                    if (mPopupPanelVisible) {
+                        // back should just hide the popup panel
+                        hidePopupPanel();
+                        leanbackOverlayFragment.hideOverlay();
 
-                    // also close this if live tv
-                    if (mPlaybackController.isLiveTv()) hide();
-                    return true;
+                        // also close this if live tv
+                        if (mPlaybackController.isLiveTv()) hide();
+                        return true;
+                    } else if (mGuideVisible) {
+                        hideGuide();
+                        return true;
+                    }
                 }
 
                 if (mPlaybackController.isLiveTv() && !mPopupPanelVisible && !mGuideVisible && keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -121,7 +121,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     private LinearLayout mChannels;
     private LinearLayout mTimeline;
     private LinearLayout mProgramRows;
-    private ScrollView mChannelScroller;
+    private ObservableScrollView mChannelScroller;
     private HorizontalScrollView mTimelineScroller;
     private View mGuideSpinner;
 
@@ -313,6 +313,13 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             @Override
             public void onScrollChanged(ObservableScrollView scrollView, int x, int y, int oldx, int oldy) {
                 mChannelScroller.scrollTo(x, y);
+            }
+        });
+
+        mChannelScroller.setScrollViewListener(new ScrollViewListener() {
+            @Override
+            public void onScrollChanged(ObservableScrollView scrollView, int x, int y, int oldx, int oldy) {
+                programVScroller.scrollTo(x, y);
             }
         });
 
@@ -713,6 +720,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             Calendar needLoadTime = (Calendar) mCurrentGuideStart.clone();
             needLoadTime.add(Calendar.MINUTE, 30);
             needLoad = now.after(needLoadTime);
+            if (mSelectedProgramView != null)
+                mSelectedProgramView.requestFocus();
         }
         if (needLoad) {
             loadGuide();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -466,9 +466,14 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     public boolean onKeyUp(int keyCode, KeyEvent event){
         if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
-            if (mGuideVisible && mSelectedProgram != null && mSelectedProgram.getChannelId() != null)
-                switchChannel(mSelectedProgram.getChannelId());
-            return true;
+            if (mGuideVisible && mSelectedProgram != null && mSelectedProgram.getChannelId() != null) {
+                Date curUTC = TimeUtils.convertToUtcDate(new Date());
+                if (mSelectedProgram.getStartDate().before(curUTC) && mSelectedProgram.getEndDate().after(curUTC))
+                    switchChannel(mSelectedProgram.getChannelId());
+                else
+                    showProgramOptions();
+                return true;
+            }
         }
         return false;
     }
@@ -632,7 +637,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         } else {
             mPlaybackController.stop();
             if (hideGuide)
-            hideGuide();
+                hideGuide();
             apiClient.getValue().GetItemAsync(id, mApplication.getCurrentUser().getId(), new Response<BaseItemDto>() {
                 @Override
                 public void onResponse(BaseItemDto response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -947,13 +947,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     private void detailUpdateInternal() {
         mGuideTitle.setText(mSelectedProgram.getName());
         mSummary.setText(mSelectedProgram.getOverview());
+        //info row
+        InfoLayoutHelper.addInfoRow(mActivity, mSelectedProgram, mGuideInfoRow, false, false);
         if (mSelectedProgram.getId() != null) {
             mDisplayDate.setText(TimeUtils.getFriendlyDate(TimeUtils.convertToLocalDate(mSelectedProgram.getStartDate())));
-
-            //info row
-            InfoLayoutHelper.addInfoRow(mActivity, mSelectedProgram, mGuideInfoRow, false, false);
-        } else {
-            mGuideInfoRow.removeAllViews();
         }
 
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -605,39 +605,19 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         return mCurrentLocalGuideEnd;
     }
 
-    public void switchChannelKeepGuide(String id) {
-        if (id == null) return;
-        if (mPlaybackController.getCurrentlyPlayingItem().getId().equals(id)) {
-            // same channel, just dismiss overlay
-            //hideGuide();
-        } else {
-            mPlaybackController.stop();
-            //hideGuide();
-            apiClient.getValue().GetItemAsync(id, mApplication.getCurrentUser().getId(), new Response<BaseItemDto>() {
-                @Override
-                public void onResponse(BaseItemDto response) {
-                    List<BaseItemDto> items = new ArrayList<BaseItemDto>();
-                    items.add(response);
-                    mPlaybackController.setItems(items);
-                    mPlaybackController.play(0);
-                }
-
-                @Override
-                public void onError(Exception exception) {
-                    Utils.showToast(mApplication, R.string.msg_video_playback_error);
-                    finish();
-                }
-            });
-        }
+    public void switchChannel(String id) {
+        switchChannel(id, true);
     }
 
-    public void switchChannel(String id) {
+    public void switchChannel(String id, boolean hideGuide) {
         if (id == null) return;
         if (mPlaybackController.getCurrentlyPlayingItem().getId().equals(id)) {
             // same channel, just dismiss overlay
-            hideGuide();
+            if (hideGuide)
+                hideGuide();
         } else {
             mPlaybackController.stop();
+            if (hideGuide)
             hideGuide();
             apiClient.getValue().GetItemAsync(id, mApplication.getCurrentUser().getId(), new Response<BaseItemDto>() {
                 @Override
@@ -756,7 +736,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     private void hideGuide() {
         mTvGuide.setVisibility(View.GONE);
-        mPlaybackController.mVideoManager.setVideoFullSize();
+        mPlaybackController.mVideoManager.setVideoFullSize(true);
         mGuideVisible = false;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
@@ -32,6 +32,15 @@ class PlaybackOverlayActivity : BaseActivity() {
 		if (keyListener?.onKey(currentFocus, keyCode, event) == true)
 			return true
 
+		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+			val frag = supportFragmentManager.fragments.get(0)
+			if (frag is CustomPlaybackOverlayFragment) {
+				frag.onKeyUp(keyCode, event)
+				return true
+			}
+
+		}
+
 		val playbackController = TvApp.getApplication().playbackController
 
 		when (keyCode) {
@@ -46,5 +55,27 @@ class PlaybackOverlayActivity : BaseActivity() {
 		}
 
 		return true
+	}
+
+	override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+			event?.startTracking()
+			return true
+		}
+
+		return super.onKeyDown(keyCode, event)
+	}
+
+	override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
+		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+			val frag = supportFragmentManager.fragments.get(0)
+			if (frag is CustomPlaybackOverlayFragment) {
+				frag.onKeyLongPress(keyCode, event)
+				return true
+			}
+
+		}
+
+		return super.onKeyLongPress(keyCode, event)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -103,12 +103,12 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             mSubtitlesSurface.setVisibility(View.GONE);
         }
 
-        mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication(), new DefaultRenderersFactory(TvApp.getApplication()) {
+        mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication(), (new DefaultRenderersFactory(TvApp.getApplication()) {
             @Override
             protected void buildTextRenderers(Context context, TextOutput output, Looper outputLooper, int extensionRendererMode, ArrayList<Renderer> out) {
                 // Do not add text renderers since we handle subtitles
             }
-        }).build();
+        }).setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)).build();
 
 
         mExoPlayerView = view.findViewById(R.id.exoPlayerView);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -103,12 +103,12 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             mSubtitlesSurface.setVisibility(View.GONE);
         }
 
-        mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication(), (new DefaultRenderersFactory(TvApp.getApplication()) {
+        mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication(), new DefaultRenderersFactory(TvApp.getApplication()) {
             @Override
             protected void buildTextRenderers(Context context, TextOutput output, Looper outputLooper, int extensionRendererMode, ArrayList<Renderer> out) {
                 // Do not add text renderers since we handle subtitles
             }
-        }).setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)).build();
+        }).build();
 
 
         mExoPlayerView = view.findViewById(R.id.exoPlayerView);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -584,11 +584,20 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
     }
 
-    public void setVideoFullSize() {
+    public void setVideoFullSize(){
+        setVideoFullSize(false);
+    }
+
+    public void setVideoFullSize(boolean force) {
         if (normalHeight == 0) return;
         FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) (nativeMode ? mExoPlayerView.getLayoutParams() : mSurfaceView.getLayoutParams());
-        lp.height = normalHeight;
-        lp.width = normalWidth;
+        if (force) {
+            lp.height = -1;
+            lp.width = -1;
+        } else {
+            lp.height = normalHeight;
+            lp.width = normalWidth;
+        }
         if (nativeMode) {
             lp.rightMargin = 0;
             lp.bottomMargin = 0;

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -41,16 +41,15 @@ public class InfoLayoutHelper {
         }
     }
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
+        layout.removeAllViews();
         if (item.getId() != null) {
             addInfoRow(activity, item, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
         }else{
-            layout.removeAllViews();
             addProgramChannel(activity, item, layout);
         }
     }
 
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
-        layout.removeAllViews();
         addCriticInfo(activity, item, layout);
         switch (item.getBaseItemType()) {
             case Episode:

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -41,7 +41,12 @@ public class InfoLayoutHelper {
         }
     }
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
-        addInfoRow(activity, item, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
+        if (item.getId() != null) {
+            addInfoRow(activity, item, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
+        }else{
+            layout.removeAllViews();
+            addProgramChannel(activity, item, layout);
+        }
     }
 
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
@@ -166,6 +171,13 @@ public class InfoLayoutHelper {
             layout.addView(textView);
 
         }
+    }
+
+    private static void addProgramChannel(Activity activity, BaseItemDto item, LinearLayout layout){
+        TextView name = new TextView(activity);
+        name.setTextSize(textSize);
+        name.setText(BaseItemUtils.getProgramUnknownChannelName(item));
+        layout.addView(name);
     }
 
     private static void addProgramInfo(Activity activity, BaseItemDto item, LinearLayout layout) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.java
@@ -6,6 +6,7 @@ import android.text.format.DateFormat;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.model.ChapterItemInfo;
+import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -70,6 +71,10 @@ public class BaseItemUtils {
                 return item.getOfficialRating();
         }
 
+    }
+
+    public static String getProgramUnknownChannelName(BaseItemDto baseItem) {
+        return TvManager.getChannel(TvManager.getAllChannelsIndex(baseItem.getChannelId())).getName();
     }
 
     public static String getProgramSubText(BaseItemDto baseItem) {

--- a/app/src/main/res/layout/overlay_tv_guide.xml
+++ b/app/src/main/res/layout/overlay_tv_guide.xml
@@ -12,7 +12,7 @@
         android:scaleType="center"
         android:alpha=".6" />
 
-    <ScrollView
+    <org.jellyfin.androidtv.ui.ObservableScrollView
         android:layout_width="160sp"
         android:layout_height="match_parent"
         android:id="@+id/channelScroller"
@@ -30,7 +30,7 @@
             android:focusable="false"
             android:focusableInTouchMode="false"
             android:id="@+id/channels"/>
-    </ScrollView>
+    </org.jellyfin.androidtv.ui.ObservableScrollView>
 
     <org.jellyfin.androidtv.ui.ObservableScrollView
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,6 +329,8 @@
     <string name="title_suggestions_holiday">Happy Holidays!</string>
     <string name="desc_suggestions_holiday">Try some of our holiday suggestions</string>
     <string name="lbl_latest_tv_shows">Latest TV Shows</string>
+    <string name="lbl_tv_channel_status">%1$d of %2$d channels</string>
+    <string name="lbl_tv_filter_status"> for next %1$d hours</string>
     <string name="lbl_news">News</string>
     <string name="lbl_new_only">New Only</string>
     <string name="lbl_audio_delay">Audio Delay</string>


### PR DESCRIPTION
### Changes
- Added channel name to info bar for programs with no data.
- Ignore programs that fill time slots that have already been filled by a previous program.
- Change live tv guide from 6 hours to 9 hours of programming to be consistent with non live guide.
- Channel surf using channel headers in live guide
- Long/short press in non-live guide and live guide
- Added full back button handling properly
- Split no program data into 30 minute slots for easier side scrolling
- Fixed favorite programs not sorting to the top when the preference is checked

### Known Issues
- ~~When watching live TV the live guide is set to force refresh every 30 minutes, it appears when it is supposed to refresh the loading spinner will not disappear.~~

### Possible Issues(I can't reproduce)
- None

### To do (hopefully):
- [x] Address issue #284 
~~1. Look into channel sorting~~ **My guide data is so bad I can't get good results no matter what here**
~~2. Lazy load channels~~ **Will work on in different commit**
~~3. If program is in a time slot that conflicted with another program then highlight the background to signify we don't know if this is what is actually playing~~ **Scrapped for now**

### Finished:
- [x] Replace \<No Prorgam Data\> with resource string
- [x] Skip program data if another program has filled the time slot
- [x] Channel headers can be used to surf in guide
- [x] Short press to play channel, long press for detail screen
- [x] Split no program data in 30 minute slots

**Maybe implement in the far off future**
- Do not refresh entire player when switching channels by channel header, this appears to only happen if channel doesn't work with the player(libVlc or exoplayer) currently being used
- Split \<No Program Data\> shows into 30 minute segments for the filler slot