### PR TITLE
Add Stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 120
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 21
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - enhancement
+  - confirmed
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.
+
+  If you're the original submitter of this issue, please comment confirming if this issue still affects you in the latest release or master branch, or close the issue if it has been fixed. If you're another user also affected by this bug, please comment confirming so. Either action will remove the stale label.
+
+  This bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
**Changes**

  - Adds the configuration from the server repo with some small changes
    - Changed the `exemptLabels` to suit the labels of this repo
    - Slightly changed the `markComment` to use "master branch" instead of "nightlies".

**Issues**

_None_

**Additional notes**
  - This will probably trigger a bunch of notifications in the coming hours/days. According to the stale documentation it will only comment to 30 issues per hour.
  - I've already added the `confirmed` label to the repository
  - A core member might need to activate the bot depending on how it's currently installed
  - I kept the `daysUntilStale` and `daysUntilClose` from the server as our current release schedule is even less then server,