### PR TITLE
Remove color vomit card backgrounds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,7 +77,6 @@ dependencies {
 	implementation("androidx.preference:preference-ktx:$androidxPreferenceVersion")
 	implementation("androidx.appcompat:appcompat:1.2.0")
 	implementation("androidx.tvprovider:tvprovider:1.0.0")
-	implementation("androidx.palette:palette:1.0.0")
 	implementation("androidx.constraintlayout:constraintlayout:1.1.3")
 	implementation("androidx.recyclerview:recyclerview:1.1.0")
 	implementation("com.google.android:flexbox:2.0.1")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -1,25 +1,18 @@
 package org.jellyfin.androidtv.ui.presentation;
 
-import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 
-import androidx.annotation.Nullable;
 import androidx.leanback.widget.BaseCardView;
 import androidx.leanback.widget.Presenter;
-import androidx.palette.graphics.Palette;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.DataSource;
-import com.bumptech.glide.load.engine.GlideException;
-import com.bumptech.glide.request.RequestListener;
-import com.bumptech.glide.request.target.Target;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
-import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.constant.ImageType;
+import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
@@ -336,18 +329,7 @@ public class CardPresenter extends Presenter {
                             .load(url)
                             .override(cardWidth, cardHeight)
                             .error(mDefaultCardImage)
-                            .listener(new RequestListener<Bitmap>() {
-                                @Override
-                                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
-                                    return false;
-                                }
-
-                                @Override
-                                public boolean onResourceReady(Bitmap resource, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
-                                    mCardView.setBackgroundColor(Utils.darker(Palette.from(resource).generate().getMutedColor(TvApp.getApplication().getResources().getColor(R.color.lb_basic_card_bg_color)), .6f));
-                                    return false;
-                                }
-                            }).into(mCardView.getMainImageView());
+                            .into(mCardView.getMainImageView());
                 }
             } catch (IllegalArgumentException e) {
                 Timber.i("Image load aborted due to activity closing");

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
-import android.graphics.Color;
 import android.media.AudioManager;
 import android.media.ToneGenerator;
 import android.text.InputType;
@@ -232,20 +231,5 @@ public class Utils {
         }
 
         return (DeviceUtils.isFireTv() && !DeviceUtils.is50()) || get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
-    }
-
-    /**
-     * Returns darker version of specified <code>color</code>.
-     */
-    public static int darker(int color, float factor) {
-        int a = Color.alpha(color);
-        int r = Color.red(color);
-        int g = Color.green(color);
-        int b = Color.blue(color);
-
-        return Color.argb(a,
-                Math.max((int) (r * factor), 0),
-                Math.max((int) (g * factor), 0),
-                Math.max((int) (b * factor), 0));
     }
 }


### PR DESCRIPTION
**Changes**
Removes the functionality that pulls the background color of cards from the image being displayed in the card for a more uniform appearance.

**Before**
![color vomit cards](https://user-images.githubusercontent.com/3450688/94859851-34ab8100-0403-11eb-8a07-597d1c5f311e.png)

**After**
![grey cards](https://user-images.githubusercontent.com/3450688/94859897-455bf700-0403-11eb-914b-3a71d18f671f.png)

**Issues**
N/A
