### PR TITLE
Remove direct play support for avi with libvlc

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/MediaCodecCapabilitiesTest.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/MediaCodecCapabilitiesTest.java
@@ -69,7 +69,7 @@ public class MediaCodecCapabilitiesTest  {
                     }
                 }
             } catch (IllegalArgumentException e) {
-                Timber.e(e);
+                Timber.w(e);
             }
         }
         return false;

--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -172,7 +172,6 @@ public class ProfileHelper {
             ContainerTypes.OGM,
             ContainerTypes.OGV,
             ContainerTypes.M2V,
-            ContainerTypes.AVI,
             ContainerTypes.MPG,
             ContainerTypes.MPEG,
             ContainerTypes.MP4,
@@ -236,20 +235,11 @@ public class ProfileHelper {
                         new ProfileCondition(ProfileConditionType.GreaterThanEqual, ProfileConditionValue.RefFrames, "2"),
                 });
 
-        ContainerProfile videoContainerProfile = new ContainerProfile();
-        videoContainerProfile.setType(DlnaProfileType.Video);
-        videoContainerProfile.setContainer(ContainerTypes.AVI);
-        videoContainerProfile.setConditions(new ProfileCondition[]
-                {
-                        new ProfileCondition(ProfileConditionType.NotEquals, ProfileConditionValue.VideoCodecTag, "xvid"),
-                });
-
         CodecProfile videoAudioCodecProfile = new CodecProfile();
         videoAudioCodecProfile.setType(CodecType.VideoAudio);
         videoAudioCodecProfile.setConditions(new ProfileCondition[]{new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.AudioChannels, "8")});
 
         profile.setCodecProfiles(new CodecProfile[]{getHevcProfile(), h264MainProfile, videoAudioCodecProfile});
-        profile.setContainerProfiles(new ContainerProfile[] {videoContainerProfile});
         profile.setSubtitleProfiles(new SubtitleProfile[]{
                 getSubtitleProfile("srt", SubtitleDeliveryMethod.External),
                 getSubtitleProfile("srt", SubtitleDeliveryMethod.Embed),


### PR DESCRIPTION
**Changes**
Removes direct play support for avi containers from the libvlc profile. This is a workaround for the "tiny video" bug. I'm uncertain if any avi files direct played correctly since any using the xvid video codec were already being transcoded.

**Issues**
#372 
