### PR TITLE
Don't attach the background manager when it's already attached

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CustomBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CustomBrowseFragment.java
@@ -21,14 +21,14 @@ import androidx.leanback.widget.RowPresenter;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
-import org.jellyfin.androidtv.ui.shared.BaseActivity;
+import org.jellyfin.androidtv.constant.QueryType;
+import org.jellyfin.androidtv.data.querying.ViewQuery;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
-import org.jellyfin.androidtv.constant.QueryType;
-import org.jellyfin.androidtv.data.querying.ViewQuery;
+import org.jellyfin.androidtv.ui.shared.BaseActivity;
 import org.jellyfin.androidtv.util.BackgroundManagerExtensionsKt;
 
 import java.util.ArrayList;
@@ -189,12 +189,14 @@ public class CustomBrowseFragment extends Fragment implements IRowLoader {
     }
 
     private void prepareBackgroundManager() {
+        final BackgroundManager backgroundManager = BackgroundManager.getInstance(requireActivity());
 
-        final BackgroundManager backgroundManager = BackgroundManager.getInstance(getActivity());
-        backgroundManager.attach(getActivity().getWindow());
+        if (!backgroundManager.isAttached()) {
+            backgroundManager.attach(requireActivity().getWindow());
+        }
 
         mMetrics = new DisplayMetrics();
-        getActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
     }
 
     protected void setupUIElements() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -35,9 +35,6 @@ import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.querying.ViewQuery;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.ui.GridButton;
-import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IKeyListener;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
 import org.jellyfin.androidtv.ui.itemdetail.ItemListActivity;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
@@ -47,6 +44,9 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.search.SearchActivity;
+import org.jellyfin.androidtv.ui.shared.BaseActivity;
+import org.jellyfin.androidtv.ui.shared.IKeyListener;
+import org.jellyfin.androidtv.ui.shared.IMessageListener;
 import org.jellyfin.androidtv.util.BackgroundManagerExtensionsKt;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
@@ -598,11 +598,14 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
     };
 
     private void prepareBackgroundManager() {
-        final BackgroundManager backgroundManager = BackgroundManager.getInstance(getActivity());
-        backgroundManager.attach(getActivity().getWindow());
+        final BackgroundManager backgroundManager = BackgroundManager.getInstance(requireActivity());
+
+        if (!backgroundManager.isAttached()) {
+            backgroundManager.attach(requireActivity().getWindow());
+        }
 
         mMetrics = new DisplayMetrics();
-        getActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
     }
 
     protected void updateBackground(String url) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
@@ -235,14 +235,14 @@ public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoad
     }
 
     private void prepareBackgroundManager() {
+        final BackgroundManager backgroundManager = BackgroundManager.getInstance(requireActivity());
 
-        final BackgroundManager backgroundManager = BackgroundManager.getInstance(getActivity());
-        if (!backgroundManager.isAttached())
-            backgroundManager.attach(getActivity().getWindow());
+        if (!backgroundManager.isAttached()) {
+            backgroundManager.attach(requireActivity().getWindow());
+        }
 
         mMetrics = new DisplayMetrics();
-        getActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
-
+        requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
     }
 
     protected void setupUIElements() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -56,9 +56,6 @@ import org.jellyfin.androidtv.ui.DisplayPrefsPopup;
 import org.jellyfin.androidtv.ui.GridFragment;
 import org.jellyfin.androidtv.ui.ImageButton;
 import org.jellyfin.androidtv.ui.JumpList;
-import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IKeyListener;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
@@ -66,6 +63,9 @@ import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.HorizontalGridPresenter;
 import org.jellyfin.androidtv.ui.search.SearchActivity;
+import org.jellyfin.androidtv.ui.shared.BaseActivity;
+import org.jellyfin.androidtv.ui.shared.IKeyListener;
+import org.jellyfin.androidtv.ui.shared.IMessageListener;
 import org.jellyfin.androidtv.util.BackgroundManagerExtensionsKt;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.Utils;
@@ -345,12 +345,14 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
 
     }
     private void prepareBackgroundManager() {
+        final BackgroundManager backgroundManager = BackgroundManager.getInstance(requireActivity());
 
-        final BackgroundManager backgroundManager = BackgroundManager.getInstance(getActivity());
-        backgroundManager.attach(getActivity().getWindow());
+        if (!backgroundManager.isAttached()) {
+            backgroundManager.attach(requireActivity().getWindow());
+        }
 
         mMetrics = new DisplayMetrics();
-        getActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
     }
 
     protected ImageButton mSortButton;


### PR DESCRIPTION
Fixes an application crash

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Fixes resuming activities that use the `prepareBackgroundManager` function. Hurray duplicate code everywhere.

Fun fact: I apparently already fixed this crash in #483 for the home screen.

```
java.lang.IllegalStateException: Already attached to DecorView@22feb4[]
	at androidx.leanback.app.BackgroundManager.attachToViewInternal(BackgroundManager.java:676)
	at androidx.leanback.app.BackgroundManager.attach(BackgroundManager.java:650)
	at org.jellyfin.androidtv.ui.browsing.StdGridFragment.prepareBackgroundManager(StdGridFragment.java:350)
	at org.jellyfin.androidtv.ui.browsing.StdGridFragment.onActivityCreated(StdGridFragment.java:180)
	at org.jellyfin.androidtv.ui.browsing.BrowseGridFragment.onActivityCreated(BrowseGridFragment.java:22)
	at androidx.fragment.app.Fragment.performActivityCreated(Fragment.java:2718)
	at androidx.fragment.app.FragmentStateManager.activityCreated(FragmentStateManager.java:346)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1200)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1368)
	at androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(FragmentManager.java:1446)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1509)
	at androidx.fragment.app.BackStackRecord.executeOps(BackStackRecord.java:447)
	at androidx.fragment.app.FragmentManager.executeOps(FragmentManager.java:2181)
	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2004)
	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1959)
	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2641)
	at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:2589)
	at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:247)
	at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:541)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1421)
	at android.app.Activity.performStart(Activity.java:7673)
	at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3126)
	at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
	at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1929)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:209)
	at android.app.ActivityThread.main(ActivityThread.java:7021)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:486)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:872)
```