### PR TITLE
Add MediaSources and MediaStreams to additional queries

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
@@ -13,7 +13,9 @@ public class StdItemQuery extends ItemQuery {
                     ItemFields.Overview,
                     ItemFields.ItemCounts,
                     ItemFields.DisplayPreferencesId,
-                    ItemFields.ChildCount
+                    ItemFields.ChildCount,
+                    ItemFields.MediaStreams,
+                    ItemFields.MediaSources
             };
         }
         setUserId(TvApp.getApplication().getCurrentUser().getId());

--- a/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
@@ -13,9 +13,7 @@ public class StdItemQuery extends ItemQuery {
                     ItemFields.Overview,
                     ItemFields.ItemCounts,
                     ItemFields.DisplayPreferencesId,
-                    ItemFields.ChildCount,
-                    ItemFields.MediaStreams,
-                    ItemFields.MediaSources
+                    ItemFields.ChildCount
             };
         }
         setUserId(TvApp.getApplication().getCurrentUser().getId());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -26,7 +26,9 @@ public class BrowseGridFragment extends StdGridFragment {
     protected void setupQueries(IGridLoader gridLoader) {
         StdItemQuery query = new StdItemQuery(new ItemFields[] {
                 ItemFields.PrimaryImageAspectRatio,
-                ItemFields.ChildCount
+                ItemFields.ChildCount,
+                ItemFields.MediaSources,
+                ItemFields.MediaStreams
         });
         query.setParentId(mParentId);
         if (mFolder.getBaseItemType() == BaseItemType.UserView || mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -59,7 +59,15 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 itemTypeString = "Movie";
 
                 //Resume
-                StdItemQuery resumeMovies = new StdItemQuery();
+                StdItemQuery resumeMovies = new StdItemQuery(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ItemCounts,
+                        ItemFields.DisplayPreferencesId,
+                        ItemFields.ChildCount,
+                        ItemFields.MediaStreams,
+                        ItemFields.MediaSources
+                });
                 resumeMovies.setIncludeItemTypes(new String[]{"Movie"});
                 resumeMovies.setRecursive(true);
                 resumeMovies.setParentId(mFolder.getId());
@@ -87,7 +95,15 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 mRows.add(new BrowseRowDef(mApplication.getString(R.string.lbl_latest), latestMovies, new ChangeTriggerType[]{ChangeTriggerType.MoviePlayback, ChangeTriggerType.LibraryUpdated}));
 
                 //Favorites
-                StdItemQuery favorites = new StdItemQuery();
+                StdItemQuery favorites = new StdItemQuery(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ItemCounts,
+                        ItemFields.DisplayPreferencesId,
+                        ItemFields.ChildCount,
+                        ItemFields.MediaStreams,
+                        ItemFields.MediaSources
+                });
                 favorites.setIncludeItemTypes(new String[]{"Movie"});
                 favorites.setRecursive(true);
                 favorites.setParentId(mFolder.getId());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -77,7 +77,9 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 latestMovies.setFields(new ItemFields[]{
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.Overview,
-                        ItemFields.ChildCount
+                        ItemFields.ChildCount,
+                        ItemFields.MediaSources,
+                        ItemFields.MediaStreams
                 });
                 latestMovies.setParentId(mFolder.getId());
                 latestMovies.setLimit(50);
@@ -120,7 +122,9 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 nextUpQuery.setFields(new ItemFields[]{
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.Overview,
-                        ItemFields.ChildCount
+                        ItemFields.ChildCount,
+                        ItemFields.MediaSources,
+                        ItemFields.MediaStreams
                 });
                 mRows.add(new BrowseRowDef(mApplication.getResources().getString(R.string.lbl_next_up), nextUpQuery, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
 
@@ -152,7 +156,9 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 latestSeries.setFields(new ItemFields[]{
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.Overview,
-                        ItemFields.ChildCount
+                        ItemFields.ChildCount,
+                        ItemFields.MediaSources,
+                        ItemFields.MediaStreams
                 });
                 latestSeries.setIncludeItemTypes(new String[]{"Episode"});
                 latestSeries.setGroupItems(true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.apiclient.model.querying.ItemFields;
 
 public class CollectionFragment extends EnhancedBrowseFragment {
 
@@ -17,7 +18,15 @@ public class CollectionFragment extends EnhancedBrowseFragment {
     @Override
     protected void setupQueries(IRowLoader rowLoader) {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
-            StdItemQuery movies = new StdItemQuery();
+            StdItemQuery movies = new StdItemQuery(new ItemFields[]{
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Overview,
+                    ItemFields.ItemCounts,
+                    ItemFields.DisplayPreferencesId,
+                    ItemFields.ChildCount,
+                    ItemFields.MediaStreams,
+                    ItemFields.MediaSources
+            });
             movies.setParentId(mFolder.getId());
             movies.setIncludeItemTypes(new String[]{"Movie"});
             mRows.add(new BrowseRowDef(mApplication.getString(R.string.lbl_movies), movies, 100));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
@@ -44,7 +44,9 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
                     similar.setFields(new ItemFields[] {
                             ItemFields.PrimaryImageAspectRatio,
                             ItemFields.Overview,
-                            ItemFields.ChildCount
+                            ItemFields.ChildCount,
+                            ItemFields.MediaStreams,
+                            ItemFields.MediaSources
                     });
                     similar.setLimit(7);
                     mRows.add(new BrowseRowDef(mApplication.getString(R.string.lbl_because_you_watched)+item.getName(), similar, QueryType.SimilarMovies));

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -39,6 +39,7 @@ public class InfoLayoutHelper {
                 break;
         }
     }
+
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
         layout.removeAllViews();
         if (item.getId() != null) {


### PR DESCRIPTION
**Changes**
Add `ItemFields.MediaSources` and `ItemFields.MediaStreams` to more queries so this info will be added to the infoRow in browsing fragments/views

**Issues**
#633


I _think_ this info is now grabbed every where it should be. I do not have collections/box sets though and I have never seen a favorites row so I can not test those.