### PR TITLE
Fix crash dialog (backport)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/base/AuthenticatedUserCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/base/AuthenticatedUserCallbacks.kt
@@ -40,7 +40,8 @@ class AuthenticatedUserCallbacks : Application.ActivityLifecycleCallbacks {
 			is DpadPwActivity,
 			is SelectServerActivity,
 			is SelectUserActivity,
-			is StartupActivity -> return
+			is StartupActivity,
+			is org.acra.dialog.CrashReportDialog -> return
 			// All other activities should have a current user
 			else -> {
 				TvApp.getApplication().apply {


### PR DESCRIPTION
<font color=red><marquee><blink><h1>Targets the release branch</h1></blink></marquee></font>

This backports the crash dialog fix to the 0.11.x release branch.