### PR TITLE
Convert ChannelManager to work manager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
 	implementation("androidx.tvprovider:tvprovider:1.0.0")
 	implementation("androidx.constraintlayout:constraintlayout:2.0.4")
 	implementation("androidx.recyclerview:recyclerview:1.1.0")
+	implementation("androidx.work:work-runtime-ktx:2.4.0")
 	implementation("com.google.android:flexbox:2.0.1")
 
 	// Dependency Injection
@@ -83,6 +84,7 @@ dependencies {
 	implementation("org.koin:koin-android:$koinVersion")
 	implementation("org.koin:koin-androidx-viewmodel:$koinVersion")
 	implementation("org.koin:koin-androidx-fragment:$koinVersion")
+	implementation("org.koin:koin-androidx-workmanager:$koinVersion")
 
 	// Lifecycle extensions
 	implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.2.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,6 +127,11 @@
         <activity android:name=".ui.playback.nextup.NextUpActivity"
             android:noHistory="true"
             android:screenOrientation="landscape" />
+
+        <provider
+            android:name="androidx.work.impl.WorkManagerInitializer"
+            android:authorities="${applicationId}.workmanager-init"
+            tools:node="remove" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.di
 
+import androidx.work.WorkManager
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
 import org.jellyfin.androidtv.BuildConfig
@@ -10,6 +11,7 @@ import org.jellyfin.androidtv.data.repository.ServerRepositoryImpl
 import org.jellyfin.androidtv.data.repository.UserRepository
 import org.jellyfin.androidtv.data.repository.UserRepositoryImpl
 import org.jellyfin.androidtv.data.source.CredentialsFileSource
+import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.jellyfin.androidtv.ui.startup.LoginViewModel
 import org.jellyfin.apiclient.AppInfo
 import org.jellyfin.apiclient.Jellyfin
@@ -21,7 +23,9 @@ import org.jellyfin.apiclient.model.apiclient.ServerInfo
 import org.jellyfin.apiclient.serialization.GsonJsonSerializer
 import org.jellyfin.apiclient.serialization.ServerInfoDeserializer
 import org.koin.android.ext.koin.androidApplication
+import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -72,4 +76,8 @@ val appModule = module {
 	}
 
 	single { DataRefreshService() }
+
+	worker { LeanbackChannelWorker(get(), get(), get()) }
+
+	single { WorkManager.getInstance(androidContext()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -43,8 +43,8 @@ class LeanbackChannelWorker(
 		 */
 		private const val TICKS_IN_MILLISECOND = 10000
 
-		const val SINGLE_UPDATE_REQUEST_NAME = "channelUpdateRequest"
-		const val PERIODIC_UPDATE_REQUEST_NAME = "channelUpdateRequest"
+		const val SINGLE_UPDATE_REQUEST_NAME = "LeanbackChannelSingleUpdateRequest"
+		const val PERIODIC_UPDATE_REQUEST_NAME = "LeanbackChannelPeriodicUpdateRequest"
 	}
 
 	private val application = TvApp.getApplication()

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -9,9 +9,9 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.tvprovider.media.tv.*
 import androidx.tvprovider.media.tv.TvContractCompat.WatchNextPrograms
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.TvApp
@@ -32,14 +32,19 @@ import org.jellyfin.apiclient.model.querying.NextUpQuery
  *
  * More info: https://developer.android.com/training/tv/discovery/recommendations-channel
  */
-class ChannelManager(
+class LeanbackChannelWorker(
+	context: Context,
+	val workerParams: WorkerParameters,
 	private val apiClient: ApiClient
-) {
-	private companion object {
+) : CoroutineWorker(context, workerParams) {
+	companion object {
 		/**
 		 * Amount of ticks found in a millisecond, used for calculation
 		 */
 		private const val TICKS_IN_MILLISECOND = 10000
+
+		const val SINGLE_UPDATE_REQUEST_NAME = "channelUpdateRequest"
+		const val PERIODIC_UPDATE_REQUEST_NAME = "channelUpdateRequest"
 	}
 
 	private val application = TvApp.getApplication()
@@ -53,14 +58,18 @@ class ChannelManager(
 	/**
 	 * Update all channels for the currently authenticated user
 	 */
-	fun update() {
-		// Don't do anything if not supported
-		if (!isSupported) return
-
-		// Launch in separate coroutine scope
-		GlobalScope.launch {
+	override suspend fun doWork(): Result = when {
+		// Fail when not supported
+		!isSupported -> Result.failure()
+		// Retry later if no authenticated user is found
+		application.currentUser == null -> Result.retry()
+		else -> {
+			// Update various channels
 			updateMyMedia()
 			updateWatchNext()
+
+			// Success!
+			Result.success()
 		}
 	}
 


### PR DESCRIPTION
The ChannelManager is an asynchronous background job to update information in the OS. The current implementation relied on the app running and calling the `.update()` function (in the home activity). This PR changes it to use the androidx work manager library so we can start updating the channels when the app is not running. This can hopefully be finished after the new auto-sign in code is merged so it actually works with the app in the background. Since we use Koin for dependency injection I used that as backend for the workers.

**References**
- [Koin release notes explaining workmanager in DI](https://medium.com/koin-developers/whats-next-with-koin-2-2-3-0-releases-6c5464ae5e3d)
- [WorkManager class reference](https://developer.android.com/reference/androidx/work/WorkManager)
- [Work manager docs](https://developer.android.com/topic/libraries/architecture/workmanager/advanced/custom-configuration)
- [Work manager tutorial](https://medium.com/androiddevelopers/workmanager-basics-beba51e94048)

**Draft state**

I want to test this change on my own television before marking it as ready. 