### PR TITLE
Disable text expansion for empty textview

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/ExpandableTextView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ExpandableTextView.kt
@@ -32,4 +32,11 @@ class ExpandableTextView(context: Context, attrs: AttributeSet?) : AppCompatText
 			activity.startActivity(intent, options.toBundle())
 		}
 	}
+
+	override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
+		super.onTextChanged(text, start, lengthBefore, lengthAfter)
+
+		isFocusable = !text.isNullOrBlank()
+		isClickable = !text.isNullOrBlank()
+	}
 }


### PR DESCRIPTION
**Changes**
I think I broke this a while ago, simply said textviews in the details screens are expandable. This should only be allowed when the textview is overflowing though. This PR makes it so it only allows expansion if the text is not-empty.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
