### PR TITLE
Remove Kotlin Android Extensions Gradle Plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
 	id("com.android.application")
 	kotlin("android")
-	kotlin("android.extensions")
 	kotlin("plugin.serialization")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,10 @@ android {
 		versionCode = getVersionCode(versionName!!)
 	}
 
+	buildFeatures {
+		viewBinding = true
+	}
+
 	compileOptions {
 		// Use Java 1.8 features
 		sourceCompatibility = JavaVersion.VERSION_1_8

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ExpandedTextActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ExpandedTextActivity.kt
@@ -1,8 +1,8 @@
 package org.jellyfin.androidtv.ui.itemdetail
 
 import android.os.Bundle
+import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
-import kotlinx.android.synthetic.main.activity_expanded_text.*
 import org.jellyfin.androidtv.R
 
 class ExpandedTextActivity : FragmentActivity() {
@@ -11,8 +11,10 @@ class ExpandedTextActivity : FragmentActivity() {
 
 		setContentView(R.layout.activity_expanded_text)
 
-		expanded_text_content.transitionName = TRANSITION_NAME
-		expanded_text_content.text = intent.getStringExtra(EXTRA_TEXT)
+		findViewById<TextView>(R.id.expanded_text_content).apply {
+			transitionName = TRANSITION_NAME
+			text = intent.getStringExtra(EXTRA_TEXT)
+		}
 	}
 
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -5,7 +5,8 @@ import android.os.CountDownTimer
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
-import kotlinx.android.synthetic.main.fragment_next_up_buttons.view.*
+import android.widget.ProgressBar
+import androidx.appcompat.widget.AppCompatButton
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.koin.core.component.KoinApiExtension
@@ -26,7 +27,7 @@ class NextUpButtons(
 
 	init {
 		addView(view)
-		view.fragment_next_up_buttons_play_next.apply {
+		view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next).apply {
 			// Stop timer when unfocused
 			setOnFocusChangeListener { _, focused -> if (!focused) stopTimer() }
 
@@ -44,13 +45,15 @@ class NextUpButtons(
 		// Create timer
 		countdownTimer = object : CountDownTimer(duration, 1) {
 			override fun onTick(millisUntilFinished: Long) {
-				fragment_next_up_buttons_play_next_progress.max = duration.toInt()
-				fragment_next_up_buttons_play_next_progress.progress = (duration - millisUntilFinished).toInt()
+				view.findViewById<ProgressBar>(R.id.fragment_next_up_buttons_play_next_progress).apply {
+					max = duration.toInt()
+					progress = (duration - millisUntilFinished).toInt()
+				}
 			}
 
 			override fun onFinish() {
 				// Perform a click so the event handler will activate
-				view.fragment_next_up_buttons_play_next.performClick()
+				view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next).performClick()
 			}
 		}.start()
 	}
@@ -59,19 +62,21 @@ class NextUpButtons(
 		countdownTimer?.cancel()
 
 		// Hide progress bar
-		fragment_next_up_buttons_play_next_progress.max = 0
-		fragment_next_up_buttons_play_next_progress.progress = 0
+		view.findViewById<ProgressBar>(R.id.fragment_next_up_buttons_play_next_progress).apply {
+			max = 0
+			progress = 0
+		}
 	}
 
 	fun setPlayNextListener(listener: (() -> Unit)?) {
-		val button = view.fragment_next_up_buttons_play_next
+		val button = view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next)
 
 		if (listener == null) button.setOnClickListener(null)
 		else button.setOnClickListener { listener() }
 	}
 
 	fun setCancelListener(listener: () -> Unit) {
-		val button = view.fragment_next_up_buttons_cancel
+		val button = view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next)
 
 		if (listener == null) button.setOnClickListener(null)
 		else button.setOnClickListener { listener() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.CountDownTimer
 import android.util.AttributeSet
 import android.view.View
+import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import androidx.appcompat.widget.AppCompatButton
@@ -76,7 +77,7 @@ class NextUpButtons(
 	}
 
 	fun setCancelListener(listener: () -> Unit) {
-		val button = view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next)
+		val button = view.findViewById<Button>(R.id.fragment_next_up_buttons_cancel)
 
 		if (listener == null) button.setOnClickListener(null)
 		else button.setOnClickListener { listener() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -5,10 +5,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.leanback.app.BackgroundManager
-import kotlinx.android.synthetic.main.fragment_next_up.*
-import kotlinx.android.synthetic.main.fragment_next_up.view.*
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity
 import org.jellyfin.androidtv.util.toHtmlSpanned
@@ -18,12 +18,12 @@ class NextUpFragment(private val data: NextUpItemData) : Fragment() {
 		return inflater.inflate(R.layout.fragment_next_up, container, false).apply {
 			BackgroundManager.getInstance(activity).setBitmap(data.backdrop)
 
-			logo.setImageBitmap(data.logo)
-			image.setImageBitmap(data.thumbnail)
-			title.text = data.title
-			description.text = data.description?.toHtmlSpanned()
+			findViewById<ImageView>(R.id.logo).setImageBitmap(data.logo)
+			findViewById<ImageView>(R.id.image).setImageBitmap(data.thumbnail)
+			findViewById<TextView>(R.id.title).text = data.title
+			findViewById<TextView>(R.id.description).text = data.description?.toHtmlSpanned()
 
-			fragment_next_up_buttons.apply {
+			findViewById<NextUpButtons>(R.id.fragment_next_up_buttons).apply {
 				setPlayNextListener {
 					startActivity(Intent(activity, PlaybackOverlayActivity::class.java))
 					activity?.finish()
@@ -38,12 +38,12 @@ class NextUpFragment(private val data: NextUpItemData) : Fragment() {
 	override fun onResume() {
 		super.onResume()
 
-		fragment_next_up_buttons.startTimer()
+		requireView().findViewById<NextUpButtons>(R.id.fragment_next_up_buttons).startTimer()
 	}
 
 	override fun onPause() {
 		super.onPause()
 
-		fragment_next_up_buttons.stopTimer()
+		requireView().findViewById<NextUpButtons>(R.id.fragment_next_up_buttons).stopTimer()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -5,45 +5,47 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.leanback.app.BackgroundManager
-import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.databinding.FragmentNextUpBinding
 import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity
 import org.jellyfin.androidtv.util.toHtmlSpanned
 
 class NextUpFragment(private val data: NextUpItemData) : Fragment() {
+	private lateinit var binding: FragmentNextUpBinding
+
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		return inflater.inflate(R.layout.fragment_next_up, container, false).apply {
-			BackgroundManager.getInstance(activity).setBitmap(data.backdrop)
+		binding = FragmentNextUpBinding.inflate(inflater, container, false)
 
-			findViewById<ImageView>(R.id.logo).setImageBitmap(data.logo)
-			findViewById<ImageView>(R.id.image).setImageBitmap(data.thumbnail)
-			findViewById<TextView>(R.id.title).text = data.title
-			findViewById<TextView>(R.id.description).text = data.description?.toHtmlSpanned()
+		BackgroundManager.getInstance(activity).setBitmap(data.backdrop)
 
-			findViewById<NextUpButtons>(R.id.fragment_next_up_buttons).apply {
-				setPlayNextListener {
-					startActivity(Intent(activity, PlaybackOverlayActivity::class.java))
-					activity?.finish()
-				}
-				setCancelListener {
-					activity?.finish()
-				}
+		binding.logo.setImageBitmap(data.logo)
+		binding.image.setImageBitmap(data.thumbnail)
+		binding.title.text = data.title
+		binding.description.text = data.description?.toHtmlSpanned()
+
+		binding.fragmentNextUpButtons.apply {
+			setPlayNextListener {
+				startActivity(Intent(activity, PlaybackOverlayActivity::class.java))
+				activity?.finish()
+			}
+			setCancelListener {
+				activity?.finish()
 			}
 		}
+
+		return binding.root
 	}
 
 	override fun onResume() {
 		super.onResume()
 
-		requireView().findViewById<NextUpButtons>(R.id.fragment_next_up_buttons).startTimer()
+		binding.fragmentNextUpButtons.startTimer()
 	}
 
 	override fun onPause() {
 		super.onPause()
 
-		requireView().findViewById<NextUpButtons>(R.id.fragment_next_up_buttons).stopTimer()
+		binding.fragmentNextUpButtons.stopTimer()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
@@ -2,9 +2,9 @@ package org.jellyfin.androidtv.ui.preference.custom
 
 import android.os.Bundle
 import android.view.*
+import android.widget.Button
+import android.widget.TextView
 import androidx.leanback.preference.LeanbackPreferenceDialogFragmentCompat
-import kotlinx.android.synthetic.main.button_remap_preference.*
-import kotlinx.android.synthetic.main.button_remap_preference.view.*
 import org.jellyfin.androidtv.R
 
 class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
@@ -30,7 +30,7 @@ class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 		else {
 			this.keyCode = keyCode
 			setKeyCodeText()
-			requireView().buttonSave.isEnabled = this.keyCode != originalKeyCode
+			requireView().findViewById<Button>(R.id.buttonSave).isEnabled = this.keyCode != originalKeyCode
 			true
 		}
 	}
@@ -73,30 +73,38 @@ class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 
 		val buttonRemapPreference = preference as ButtonRemapPreference
 
-		decor_title.text = preference.title
-		message.visibility = View.VISIBLE
-		message.text = getString(R.string.pref_button_remapping_description)
-
-		buttonSave.setOnClickListener { _ ->
-			buttonRemapPreference.keyCode = keyCode
-			parentFragmentManager.popBackStack()
+		requireView().findViewById<Button>(R.id.decor_title).text = preference.title
+		requireView().findViewById<Button>(R.id.message).apply {
+			visibility = View.VISIBLE
+			text = getString(R.string.pref_button_remapping_description)
 		}
-		buttonSave.isEnabled = false
-		buttonSave.setOnKeyListener(checkKeys)
 
-		buttonReset.setOnClickListener { _ ->
-			setKeyCodeText()
-			buttonRemapPreference.keyCode = buttonRemapPreference.defaultKeyCode
-			parentFragmentManager.popBackStack()
+		requireView().findViewById<Button>(R.id.buttonSave).apply {
+			setOnClickListener { _ ->
+				buttonRemapPreference.keyCode = keyCode
+				parentFragmentManager.popBackStack()
+			}
+
+			isEnabled = false
+			setOnKeyListener(checkKeys)
 		}
-		buttonReset.setOnKeyListener(checkKeys)
-		buttonReset.requestFocus()
+
+		requireView().findViewById<Button>(R.id.buttonReset).apply {
+			setOnClickListener { _ ->
+				setKeyCodeText()
+				buttonRemapPreference.keyCode = buttonRemapPreference.defaultKeyCode
+				parentFragmentManager.popBackStack()
+			}
+
+			setOnKeyListener(checkKeys)
+			requestFocus()
+		}
 
 		setKeyCodeText()
 	}
 
 	private fun setKeyCodeText() {
-		textViewKeyCode.text = ButtonRemapPreference.ButtonRemapSummaryProvider.instance.getKeycodeName(requireContext(), keyCode)
+		requireView().findViewById<TextView>(R.id.textViewKeyCode).text = ButtonRemapPreference.ButtonRemapSummaryProvider.instance.getKeycodeName(requireContext(), keyCode)
 	}
 
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
@@ -4,9 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.fragment_alert_dialog.view.*
 import org.jellyfin.androidtv.R
 
 @Suppress("LongParameterList")
@@ -22,17 +23,17 @@ open class AlertFragment(
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		val view = super.onCreateView(inflater, container, savedInstanceState)!!
 
-		val titleView = view.title
+		val titleView = view.findViewById<TextView>(R.id.title)
 		titleView.setText(title)
 
-		val descriptionView = view.description
+		val descriptionView = view.findViewById<TextView>(R.id.description)
 		if (description != null) {
 			descriptionView.setText(description)
 		} else {
 			descriptionView.visibility = View.GONE
 		}
 
-		val confirmButton = view.confirm
+		val confirmButton = view.findViewById<Button>(R.id.confirm)
 		if (confirmButtonText != null) confirmButton.setText(confirmButtonText)
 		confirmButton.requestFocus()
 		confirmButton.setOnClickListener {
@@ -40,7 +41,7 @@ open class AlertFragment(
 			onClose()
 		}
 
-		val cancelButton = view.cancel
+		val cancelButton = view.findViewById<Button>(R.id.cancel)
 		if (cancelButtonText != null) cancelButton.setText(cancelButtonText)
 		cancelButton.setOnClickListener {
 			onCancelCallback()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/ToolbarView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/ToolbarView.kt
@@ -5,7 +5,8 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import kotlinx.android.synthetic.main.view_toolbar.view.*
+import android.widget.LinearLayout
+import android.widget.TextClock
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
@@ -16,31 +17,31 @@ class ToolbarView(context: Context, attrs: AttributeSet) : FrameLayout(context, 
 		inflate(context, R.layout.view_toolbar, this)
 		val clockBehavior = get(UserPreferences::class.java)[UserPreferences.clockBehavior]
 		if (clockBehavior == ClockBehavior.NEVER || clockBehavior == ClockBehavior.IN_VIDEO)
-			toolbar_clock.visibility = GONE
+			findViewById<TextClock>(R.id.toolbar_clock).visibility = GONE
 	}
 
 	// Add child views to the content slot
 	override fun addView(child: View) =
 		if (child.id == R.id.toolbar_root) super.addView(child)
-		else toolbar_content.addView(child)
+		else findViewById<LinearLayout>(R.id.toolbar_content).addView(child)
 
 	override fun addView(child: View, params: ViewGroup.LayoutParams) =
 		if (child.id == R.id.toolbar_root) super.addView(child, params)
-		else toolbar_content.addView(child, params)
+		else findViewById<LinearLayout>(R.id.toolbar_content).addView(child, params)
 
 	override fun addView(child: View, index: Int) =
 		if (child.id == R.id.toolbar_root) super.addView(child, index)
-		else toolbar_content.addView(child, index)
+		else findViewById<LinearLayout>(R.id.toolbar_content).addView(child, index)
 
 	override fun addView(child: View, width: Int, height: Int) =
 		if (child.id == R.id.toolbar_root) super.addView(child, width, height)
-		else toolbar_content.addView(child, width, height)
+		else findViewById<LinearLayout>(R.id.toolbar_content).addView(child, width, height)
 
 	override fun addView(child: View, index: Int, params: ViewGroup.LayoutParams) =
 		if (child.id == R.id.toolbar_root) super.addView(child, index, params)
-		else toolbar_content.addView(child, index, params)
+		else findViewById<LinearLayout>(R.id.toolbar_content).addView(child, index, params)
 
 	override fun removeView(child: View) =
 		if (child.id == R.id.toolbar_root) super.removeView(child)
-		else toolbar_content.removeView(child)
+		else findViewById<LinearLayout>(R.id.toolbar_content).removeView(child)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerFragment.kt
@@ -5,9 +5,10 @@ import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
-import kotlinx.android.synthetic.main.fragment_alert_dialog.view.*
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.model.ConnectedState
 import org.jellyfin.androidtv.auth.model.ConnectingState
@@ -43,14 +44,14 @@ class AddServerFragment(
 		address.requestFocus()
 
 		// Add the url field to the content view
-		view.content.addView(address)
+		view.findViewById<LinearLayout>(R.id.content).addView(address)
 
 		// Build the error text field
 		val errorText = TextView(requireContext())
-		view.content.addView(errorText)
+		view.findViewById<LinearLayout>(R.id.content).addView(errorText)
 
 		// Override the default confirm button click listener to return the address field text
-		view.confirm.setOnClickListener {
+		view.findViewById<Button>(R.id.confirm).setOnClickListener {
 			if (address.text.isNotBlank()) {
 				loginViewModel.addServer(address.text.toString()).observe(viewLifecycleOwner) { state ->
 					when (state) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupToolbarFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupToolbarFragment.kt
@@ -2,8 +2,8 @@ package org.jellyfin.androidtv.ui.startup
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.fragment_toolbar_startup.view.*
 import org.jellyfin.androidtv.R
 
 class StartupToolbarFragment(
@@ -12,7 +12,7 @@ class StartupToolbarFragment(
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 		super.onViewCreated(view, savedInstanceState)
 
-		view.add_server.setOnClickListener {
+		view.findViewById<Button>(R.id.add_server).setOnClickListener {
 			onAddServerClicked()
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginFragment.kt
@@ -6,9 +6,10 @@ import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
-import kotlinx.android.synthetic.main.fragment_alert_dialog.view.*
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.model.*
 import org.jellyfin.androidtv.ui.shared.AlertFragment
@@ -29,7 +30,7 @@ class UserLoginFragment(
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		val view = super.onCreateView(inflater, container, savedInstanceState)!!
 
-		view.content.minimumWidth = 360
+		view.findViewById<LinearLayout>(R.id.content).minimumWidth = 360
 
 		// Build the username field
 		val username = EditText(activity)
@@ -44,7 +45,7 @@ class UserLoginFragment(
 			username.requestFocus()
 		}
 		// Add the username field to the content view
-		view.content.addView(username)
+		view.findViewById<LinearLayout>(R.id.content).addView(username)
 
 		// Build the password field
 		val password = EditText(activity)
@@ -56,14 +57,14 @@ class UserLoginFragment(
 		password.typeface = Typeface.DEFAULT
 		if (user != null) password.requestFocus()
 		// Add the password field to the content view
-		view.content.addView(password)
+		view.findViewById<LinearLayout>(R.id.content).addView(password)
 
 		// Build the error text field
 		val errorText = TextView(requireContext())
-		view.content.addView(errorText)
+		view.findViewById<LinearLayout>(R.id.content).addView(errorText)
 
 		// Override the default confirm button click listener to return the address field text
-		view.confirm.setOnClickListener {
+		view.findViewById<Button>(R.id.confirm).setOnClickListener {
 			if (username.text.isNotBlank()) {
 				loginViewModel.login(server, username.text.toString(), password.text.toString()).observe(viewLifecycleOwner) { state ->
 					println(state)


### PR DESCRIPTION
**Changes**
- Remove Kotlin Android Extensions Gradle Plugin
- Replaced all synthetic uses with findViewById
- Added viewbinding for the NextUpFragment
  - Other fragments/views/activities etc. won't be done in this PR, this is purely to show how it works.

I'd like to use viewbinding for everything in the future but this PR focuses on replacing the kotlin extension.

**Issues**

Closes #661
