### PR TITLE
Enable hevc support universally

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -5,9 +5,6 @@ import android.os.Build;
 public class DeviceUtils {
     private static final String FIRE_TV_PREFIX = "AFT";
     private static final String FIRE_STICK_MODEL = "AFTM";
-    private static final String NEXUS_MODEL = "Nexus Player";
-    private static final String SHIELD_MODEL = "SHIELD Android TV";
-    private static final String BEYONDTV_MODEL = "BeyondTV";
 
     public static boolean isFireTv() {
         return Build.MODEL.startsWith(FIRE_TV_PREFIX);
@@ -15,18 +12,6 @@ public class DeviceUtils {
 
     public static boolean isFireTvStick() {
         return Build.MODEL.equals(FIRE_STICK_MODEL);
-    }
-
-    public static boolean isShield() {
-        return Build.MODEL.equals(SHIELD_MODEL);
-    }
-
-    public static boolean isNexus() {
-        return Build.MODEL.equals(NEXUS_MODEL);
-    }
-
-    public static boolean isBeyondTv() {
-        return Build.MODEL.equals(BEYONDTV_MODEL);
     }
 
     public static boolean is50() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -280,25 +280,14 @@ public class ProfileHelper {
                 ContainerTypes.WEBM
             ));
             videoDirectPlayProfile.setContainer(Utils.join(",", containers));
-            List<String> videoCodecs;
-            if (DeviceUtils.isShield() || DeviceUtils.isNexus() || DeviceUtils.isBeyondTv()) {
-                videoCodecs = Arrays.asList(
-                    CodecTypes.H264,
-                    CodecTypes.HEVC,
-                    CodecTypes.VP8,
-                    CodecTypes.VP9,
-                    ContainerTypes.MPEG,
-                    CodecTypes.MPEG2VIDEO
-                );
-            } else {
-                videoCodecs = Arrays.asList(
-                    CodecTypes.H264,
-                    CodecTypes.VP8,
-                    CodecTypes.VP9,
-                    ContainerTypes.MPEG,
-                    CodecTypes.MPEG2VIDEO
-                );
-            }
+            List<String> videoCodecs = Arrays.asList(
+                CodecTypes.H264,
+                CodecTypes.HEVC,
+                CodecTypes.VP8,
+                CodecTypes.VP9,
+                ContainerTypes.MPEG,
+                CodecTypes.MPEG2VIDEO
+            );
             videoDirectPlayProfile.setVideoCodec(Utils.join(",", videoCodecs));
             if (Utils.downMixAudio()) {
                 //compatible audio mode - will need to transcode dts and ac3


### PR DESCRIPTION
**Changes**
This enables support for HEVC universally. According to [this](https://developer.android.com/guide/topics/media/media-formats#video-codecs) it should be supported on anything running Android 5+ which is the minimum version we support in the app. I did notice that some of the first gen Amazon Fire devices do not support it, so we should probably add some specific exclusions for those.

**Issues**
Should help with #49 
