### PR TITLE
Remove NextUpActivity from displaying after intro videos or trailers

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1048,7 +1048,9 @@ public class PlaybackController {
         if (nextItem != null) {
             Timber.d("Moving to next queue item. Index: " + (mCurrentIndex + 1));
 
-            if (userPreferences.getValue().get(UserPreferences.Companion.getNextUpEnabled())) {
+            BaseItemDto curItem = getCurrentlyPlayingItem();
+
+            if (userPreferences.getValue().get(UserPreferences.Companion.getNextUpEnabled()) && curItem.getBaseItemType() != BaseItemType.Trailer) {
                 // Show "Next Up" fragment
                 spinnerOff = false;
                 mFragment.showNextUp(nextItem.getId());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1050,7 +1050,7 @@ public class PlaybackController {
 
             BaseItemDto curItem = getCurrentlyPlayingItem();
 
-            if (userPreferences.getValue().get(UserPreferences.Companion.getNextUpEnabled()) && curItem.getBaseItemType() != BaseItemType.Trailer) {
+            if (userPreferences.getValue().get(UserPreferences.Companion.getNextUpEnabled()) && (curItem == null || curItem.getBaseItemType() != BaseItemType.Trailer)) {
                 // Show "Next Up" fragment
                 spinnerOff = false;
                 mFragment.showNextUp(nextItem.getId());

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -218,7 +218,7 @@ public class PlaybackHelper {
                         public void onResponse(ItemsResult response) {
                             if (response.getTotalRecordCount() > 0){
 
-                                for(BaseItemDto intro : response.getItems()){
+                                for (BaseItemDto intro : response.getItems()) {
                                     intro.setBaseItemType(BaseItemType.Trailer);
                                     items.add(intro);
                                 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -217,7 +217,11 @@ public class PlaybackHelper {
                         @Override
                         public void onResponse(ItemsResult response) {
                             if (response.getTotalRecordCount() > 0){
-                                Collections.addAll(items, response.getItems());
+
+                                for(BaseItemDto intro : response.getItems()){
+                                    intro.setBaseItemType(BaseItemType.Trailer);
+                                    items.add(intro);
+                                }
                                 Timber.i("%d intro items added for playback.", response.getTotalRecordCount());
                             }
                             //Finally, the main item including subsequent parts


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Removes the next up activity from showing up after the intro and trailer videos.

This works by setting intro videos manually to the trailer type and immediately playing the next item in the queue if the current item is a trailer.

This is the default behavior of v0.11

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
