### PR TITLE
Partially revert #656

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -34,7 +34,6 @@ import timber.log.Timber;
 import static org.koin.java.KoinJavaComponent.get;
 
 public class CardPresenter extends Presenter {
-    private static final String TAG = "CardPresenter";
     private static final double ASPECT_RATIO_BANNER = 5.414;
 
     private int mStaticHeight = 300;
@@ -318,10 +317,6 @@ public class CardPresenter extends Presenter {
             return mItem;
         }
 
-        public MyImageCardView getCardView() {
-            return mCardView;
-        }
-
         protected void updateCardViewImage(@Nullable String url) {
             try {
                 if (url == null) {
@@ -337,6 +332,14 @@ public class CardPresenter extends Presenter {
             } catch (IllegalArgumentException e) {
                 Timber.i("Image load aborted due to activity closing");
             }
+        }
+
+        protected void resetCardView() {
+            mCardView.clearBanner();
+            mCardView.setUnwatchedCount(-1);
+            mCardView.setProgress(0);
+
+            mCardView.getMainImageView().setImageResource(R.drawable.loading);
         }
     }
 
@@ -398,6 +401,7 @@ public class CardPresenter extends Presenter {
 
     @Override
     public void onUnbindViewHolder(Presenter.ViewHolder viewHolder) {
+        ((ViewHolder) viewHolder).resetCardView();
     }
 
     @Override


### PR DESCRIPTION
The watched state wasn't reset properly. I thought the unbind function was useless but the restore functionality is not implemented properly so it would re-use the watched state when the view is used in another place.

Some additional context: When a card from the card presenter is offscreen the card element will be re-used in another row to avoid unnecessary allocations. Unfortunately our code doesn't work properly when it restores a state so this is a fix until we rewrite all presenters.

Also removed some unused code.