### PR TITLE
Add LeakCanary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,9 @@ dependencies {
 	// Logging
 	implementation("com.jakewharton.timber:timber:4.7.1")
 
+	// Debugging
+	debugImplementation("com.squareup.leakcanary:leakcanary-android:2.6")
+
 	// Testing
 	testImplementation("junit:junit:4.12")
 	testImplementation("org.mockito:mockito-core:3.2.4")


### PR DESCRIPTION
Although fixing them is difficult with the 100% static MediaManager, this PR adds LeakCanary so we can start investigating memory leaks in the app.
Because our app is for ATV some things are different from the mobile version;
- Leaks are notified using a Toast
- The "Leaks" app doesn't show up, you need to manually open it using adb
  When a leak is found the adb command is logged in logcat:
  `adb shell am start -n "org.jellyfin.androidtv.debug/leakcanary.internal.activity.LeakLauncherActivity"`

[LeakCanary docs about ATV](https://square.github.io/leakcanary/recipes/#android-tv)

It will only run in debug builds.