### PR TITLE
Remove more unnecessary popups

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -1468,21 +1468,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         public void onClick(final View v) {
             final UserItemDataDto data = mBaseItem.getUserData();
             if (mBaseItem.getIsFolderItem()) {
-                new AlertDialog.Builder(mActivity)
-                        .setTitle(getString(data.getPlayed() ? R.string.lbl_mark_unplayed : R.string.lbl_mark_played))
-                        .setMessage(getString(data.getPlayed() ? R.string.lbl_confirm_mark_unwatched : R.string.lbl_confirm_mark_watched))
-                        .setNegativeButton(getString(R.string.lbl_no), new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-
-                            }
-                        }).setPositiveButton(getString(R.string.lbl_yes), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                            if (data.getPlayed())  markUnPlayed(); else markPlayed();
-                    }
-                }).show();
-
+                if (data.getPlayed())
+                    markUnPlayed();
+                else
+                    markPlayed();
             } else {
                 if (data.getPlayed()) {
                     markUnPlayed();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -1,8 +1,6 @@
 package org.jellyfin.androidtv.ui.playback;
 
 import android.animation.ObjectAnimator;
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -192,17 +190,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
         mShuffleButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                new AlertDialog.Builder(mActivity)
-                        .setTitle(R.string.lbl_shuffle)
-                        .setMessage(R.string.msg_reshuffle_audio_queue)
-                        .setPositiveButton(mActivity.getString(R.string.lbl_yes), new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                MediaManager.shuffleAudioQueue();
-                            }
-                        })
-                        .setNegativeButton(mActivity.getString(R.string.lbl_no), null)
-                        .show();
+               MediaManager.shuffleAudioQueue();
             }
         });
         mShuffleButton.setGotFocusListener(mainAreaFocusListener);

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -1,7 +1,5 @@
 package org.jellyfin.androidtv.util;
 
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -420,47 +418,10 @@ public class KeyProcessor {
                     toggleFavorite(false);
                     return true;
                 case MENU_MARK_PLAYED:
-                    if (currentItemIsFolder) {
-                        // confirm
-                        new AlertDialog.Builder(mCurrentActivity)
-                                .setTitle(R.string.lbl_mark_played)
-                                .setMessage(mCurrentActivity.getString(R.string.lbl_confirm_mark_watched))
-                                .setNegativeButton(mCurrentActivity.getString(R.string.lbl_no), new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int which) {
-
-                                    }
-                                }).setPositiveButton(mCurrentActivity.getString(R.string.lbl_yes), new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                    markPlayed();
-                            }
-                        }).show();
-
-                    } else {
-                        markPlayed();
-                    }
+                    markPlayed();
                     return true;
                 case MENU_UNMARK_PLAYED:
-                    if (currentItemIsFolder) {
-                        // confirm
-                        new AlertDialog.Builder(mCurrentActivity)
-                                .setTitle(R.string.lbl_mark_unplayed)
-                                .setMessage(mCurrentActivity.getString(R.string.lbl_confirm_mark_unwatched))
-                                .setNegativeButton(mCurrentActivity.getString(R.string.lbl_no), new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int which) {
-
-                                    }
-                                }).setPositiveButton(mCurrentActivity.getString(R.string.lbl_yes), new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                markUnplayed();
-                            }
-                        }).show();
-                    } else {
-                        markUnplayed();
-                    }
+                    markUnplayed();
                     return true;
                 case MENU_LIKE:
                     toggleLikes(true);


### PR DESCRIPTION
**Changes**
- You can now mark shows as watched without a stupid popup
  - You can just unmark it again if it was not intended, but why would you press the button without intention anyway!?
- Shuffle music is now 10% easier (removed a stupid popup)
- Marking played/unplayed in that hidden menu that nobody knows about was improved too
  - I removed the popup

TL;DR: Searched for all "AlertDialog.Builder" instances in the code and picked a bunch that I 100% think should be removed.
