### PR TITLE
Remove live tv mode 

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -135,11 +135,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 
 		/* Live TV */
 		/**
-		 * Open live tv when opening the app
-		 */
-		var liveTvMode = Preference.boolean("pref_live_tv_mode", false)
-
-		/**
 		 * Use direct play
 		 */
 		var liveTvDirectPlayEnabled = Preference.boolean("pref_live_direct", true)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.ui.home
 
 import android.app.AlertDialog
-import android.content.Intent
 import android.os.Bundle
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.Presenter
@@ -24,7 +23,6 @@ import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.androidtv.ui.browsing.IRowLoader
 import org.jellyfin.androidtv.ui.browsing.StdBrowseFragment
-import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity
 import org.jellyfin.androidtv.ui.playback.AudioEventListener
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
@@ -84,15 +82,6 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 
 		// Subscribe to Audio messages
 		MediaManager.addAudioEventListener(this)
-
-		// TODO Move this (should be in the startup code when deciding the activity to open)
-		if (get<UserPreferences>()[UserPreferences.liveTvMode]) {
-			// Open guide activity and tell it to start last channel
-			val guide = Intent(activity, LiveTvGuideActivity::class.java).apply {
-				putExtra("loadLast", true) // TODO use constant
-			}
-			startActivity(guide)
-		}
 	}
 
 	override fun onResume() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -111,7 +111,6 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
     private int mCurrentDisplayChannelStartNdx = 0;
     private int mCurrentDisplayChannelEndNdx = 0;
     private long mLastFocusChanged;
-    private boolean mLoadLastChannel;
 
     private Handler mHandler = new Handler();
 
@@ -220,9 +219,6 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
                 if (message.equals(CustomMessage.ActionComplete)) dismissProgramOptions();
             }
         });
-
-        //auto launch channel if indicated
-        mLoadLastChannel = getIntent().getBooleanExtra("loadLast", false);
     }
 
     private int getGuideHours() {
@@ -271,17 +267,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
     protected void onResume() {
         super.onResume();
 
-        if (mLoadLastChannel) {
-            mLoadLastChannel = false;
-            String channel = TvManager.getLastLiveTvChannel();
-            if (TvManager.getAllChannelsIndex(channel) != -1) {
-                PlaybackHelper.retrieveAndPlay(channel, false, this);
-            } else {
-                doLoad();
-            }
-        } else {
-            doLoad();
-        }
+        doLoad();
     }
 
     protected void doLoad() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/authentication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/authentication.kt
@@ -46,10 +46,4 @@ fun OptionsScreen.authenticationCategory(
 		setContent(R.string.pref_alt_pw_entry_desc)
 		bind(userPreferences, UserPreferences.passwordDPadEnabled)
 	}
-
-	checkbox {
-		setTitle(R.string.pref_live_tv_mode)
-		setContent(R.string.pref_live_tv_mode_desc)
-		bind(userPreferences, UserPreferences.liveTvMode)
-	}
 }


### PR DESCRIPTION
Depends on #684

**Changes**
Removed live tv mode. I think we managed to break it in the auth rewrite as it crashed the app after signing in. I think this feature is useless because it wasn't thought out. You couldn't go back to the home view.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
