### PR TITLE
Add mutable object adapter

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
@@ -1,0 +1,30 @@
+package org.jellyfin.androidtv.ui.presentation
+
+import androidx.leanback.widget.ObjectAdapter
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.PresenterSelector
+
+/**
+ * A leanback ObjectAdapter using a Kotlin list as backend. Implements Iterable to allow collection
+ * operations. And uses generics for strong typing. Uses a MutableList as internal stucture.
+ */
+class MutableObjectAdapter<T : Any> : ObjectAdapter, Iterable<T> {
+	private val data = mutableListOf<T>()
+
+	// Constructors
+	constructor(presenterSelector: PresenterSelector) : super(presenterSelector)
+	constructor(presenter: Presenter) : super(presenter)
+	constructor() : super()
+
+	// ObjectAdapter
+	override fun size(): Int = data.size
+	override fun get(index: Int): T? = data.getOrNull(index)
+
+	// Iterable
+	override fun iterator(): Iterator<T> = data.iterator()
+
+	// Custom
+	fun add(element: T) = data.add(element)
+	fun add(index: Int, element: T) = data.add(index, element)
+	fun remove(element: T) = data.remove(element)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
@@ -24,7 +24,32 @@ class MutableObjectAdapter<T : Any> : ObjectAdapter, Iterable<T> {
 	override fun iterator(): Iterator<T> = data.iterator()
 
 	// Custom
-	fun add(element: T) = data.add(element)
-	fun add(index: Int, element: T) = data.add(index, element)
-	fun remove(element: T) = data.remove(element)
+	fun add(element: T) {
+		data.add(element)
+		notifyItemRangeInserted(data.size - 1, 1)
+	}
+
+	fun add(index: Int, element: T) {
+		data.add(index, element)
+		notifyItemRangeInserted(index, 1)
+	}
+
+	fun set(index: Int, element: T) {
+		data.set(index, element)
+		notifyItemRangeChanged(index, 1)
+	}
+
+	fun clear() {
+		val size = data.size
+		if (size == 0) return
+
+		notifyItemRangeRemoved(0, size)
+		data.clear()
+	}
+
+	fun remove(element: T): Boolean {
+		val removed = data.remove(element)
+		if (removed) notifyChanged()
+		return removed
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/ListServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/ListServerFragment.kt
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.auth.model.*
 import org.jellyfin.androidtv.ui.GridButton
 import org.jellyfin.androidtv.ui.presentation.CustomListRowPresenter
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter
+import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import timber.log.Timber
 
@@ -76,7 +77,7 @@ class ListServerFragment : RowsSupportFragment() {
 	}
 
 	private fun buildRows(servers: Map<Server, Set<User>>) {
-		val rowAdapter = ArrayObjectAdapter(CustomListRowPresenter())
+		val rowAdapter = MutableObjectAdapter<ListRow>(CustomListRowPresenter())
 
 		servers.forEach { (server, users) ->
 			Timber.d("Adding server row %s", server.name)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/ListServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/ListServerFragment.kt
@@ -83,7 +83,10 @@ class ListServerFragment : RowsSupportFragment() {
 
 	private fun buildRows(servers: Map<Server, Set<User>>) {
 		servers.forEach { (server, users) ->
-			val exists = rowAdapter.any { it.id == server.id.mostSignificantBits and Long.MAX_VALUE }
+			// Convert the UUID of the server to a long to get a unique id
+			// to make sure a server can't be added multiple times
+			val uniqueRowId = server.id.mostSignificantBits and Long.MAX_VALUE
+			val exists = rowAdapter.any { it.id == uniqueRowId }
 			// Already added, don't add it again
 			if (exists) return@forEach
 
@@ -98,7 +101,7 @@ class ListServerFragment : RowsSupportFragment() {
 			userListAdapter.add(AddUserGridButton(server, ADD_USER, requireContext().getString(R.string.lbl_manual_login), R.drawable.tile_edit))
 
 			val row = ListRow(
-				server.id.mostSignificantBits and Long.MAX_VALUE,
+				uniqueRowId,
 				HeaderItem(if (server.name.isNotBlank()) server.name else server.address),
 				userListAdapter
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/ListServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/ListServerFragment.kt
@@ -8,7 +8,6 @@ import androidx.annotation.DrawableRes
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.leanback.app.RowsSupportFragment
-import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.HeaderItem
 import androidx.leanback.widget.ListRow
 import androidx.leanback.widget.OnItemViewClickedListener
@@ -28,6 +27,7 @@ class ListServerFragment : RowsSupportFragment() {
 	}
 
 	private val loginViewModel: LoginViewModel by sharedViewModel()
+	private val rowAdapter = MutableObjectAdapter<ListRow>(CustomListRowPresenter())
 
 	private val itemViewClickedListener = OnItemViewClickedListener { _, item, _, _ ->
 		if (item is UserGridButton) {
@@ -60,14 +60,19 @@ class ListServerFragment : RowsSupportFragment() {
 		}
 	}
 
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+
+		adapter = rowAdapter
+		onItemViewClickedListener = itemViewClickedListener
+	}
+
 	override fun onActivityCreated(savedInstanceState: Bundle?) {
 		super.onActivityCreated(savedInstanceState)
 
 		loginViewModel.servers.observe(viewLifecycleOwner) { servers ->
 			buildRows(servers)
 		}
-
-		onItemViewClickedListener = itemViewClickedListener
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -77,26 +82,30 @@ class ListServerFragment : RowsSupportFragment() {
 	}
 
 	private fun buildRows(servers: Map<Server, Set<User>>) {
-		val rowAdapter = MutableObjectAdapter<ListRow>(CustomListRowPresenter())
-
 		servers.forEach { (server, users) ->
-			Timber.d("Adding server row %s", server.name)
+			val exists = rowAdapter.any { it.id == server.id.mostSignificantBits and Long.MAX_VALUE }
+			// Already added, don't add it again
+			if (exists) return@forEach
 
-			val userListAdapter = ArrayObjectAdapter(GridButtonPresenter())
+			Timber.d("Creating server row %s", server.name)
+
+			val userListAdapter = MutableObjectAdapter<GridButton>(GridButtonPresenter())
+
 			users.forEach { user ->
 				userListAdapter.add(UserGridButton(server, user, SELECT_USER, user.name, R.drawable.tile_port_person))
 			}
 
 			userListAdapter.add(AddUserGridButton(server, ADD_USER, requireContext().getString(R.string.lbl_manual_login), R.drawable.tile_edit))
 
-			rowAdapter.add(ListRow(
-				HeaderItem(
-					if (server.name.isNotBlank()) server.name else server.address),
+			val row = ListRow(
+				server.id.mostSignificantBits and Long.MAX_VALUE,
+				HeaderItem(if (server.name.isNotBlank()) server.name else server.address),
 				userListAdapter
-			))
+			)
+
+			rowAdapter.add(row)
 		}
 
-		adapter = rowAdapter
 		// Ensure the server rows get focus
 		requireView().requestFocus()
 	}


### PR DESCRIPTION
**Changes**

The default ObjectAdapter's from Leanback are:
1. Not type safe (no generic used, returns "Any" / "Object")
2. Not null-safe
3. Incompatible with Kotlin collections

To fix this I made a new adapter called the "MutableObjectAdapter". It uses a generic to set the element type, this fixes 1 and 2. It then implements Iterable for 3.
To illustrate the abilities of this new adapter I made some changes in the ListServerFragment that uses it, and while I was at it I changes the behavior of the server list to not reset itself but instead only append.
Items in the adapter now have a id, the Row class in leanback likes to use a Long for that so I convert uuid->long now. I might create a custom row class so we can set the id using generics or something later.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
