### PR TITLE
ci(deps): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Description

While irregularly checking on dependabot I stumbled over the announcement that it now supports build.gradle.kts.
I tested it very briefly, so I cannot guaranty that it would update all the dependencies, however to my eye it did so here the PR to add it.

Note: I took the liberty of creating this PR in all 3 repositories in the Jellyfin Org. that I know of using build.gradle.kts. I duplicated this text too.

### Changes

*add dependabot config

### Issues

* n/a
