### PR TITLE
Fix authenticator store account type

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,12 +35,22 @@ android {
 		getByName("release") {
 			isMinifyEnabled = false
 			proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+
+			// Add applicationId as string for XML resources
+			resValue("string", "app_id", "org.jellyfin.androidtv")
+
+			// Set flavored application name
 			resValue("string", "app_name", "@string/app_name_release")
 		}
 
 		getByName("debug") {
 			// Use different application id to run release and debug at the same time
 			applicationIdSuffix = ".debug"
+
+			// Add applicationId as string for XML resources
+			resValue("string", "app_id", "org.jellyfin.androidtv.debug")
+
+			// Set flavored application name
 			resValue("string", "app_name", "@string/app_name_debug")
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AccountManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AccountManagerHelper.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.auth
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.os.Bundle
+import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.auth.model.AccountManagerAccount
 import org.jellyfin.androidtv.util.toUUID
 import org.jellyfin.androidtv.util.toUUIDOrNull
@@ -14,11 +15,11 @@ class AccountManagerHelper(
 	private val accountManager: AccountManager
 ) {
 	companion object {
-		const val ACCOUNT_TYPE = "org.jellyfin.v1"
+		const val ACCOUNT_TYPE = BuildConfig.APPLICATION_ID
 		const val ACCOUNT_DATA_ID = "$ACCOUNT_TYPE.id"
 		const val ACCOUNT_DATA_SERVER = "$ACCOUNT_TYPE.server"
 		const val ACCOUNT_DATA_NAME = "$ACCOUNT_TYPE.name"
-		const val ACCOUNT_ACCESS_TOKEN_TYPE = "$ACCOUNT_TYPE.access_token.v1"
+		const val ACCOUNT_ACCESS_TOKEN_TYPE = "$ACCOUNT_TYPE.access_token"
 	}
 
 	private fun getAccountData(account: Account): AccountManagerAccount = AccountManagerAccount(

--- a/app/src/main/res/xml/authenticator.xml
+++ b/app/src/main/res/xml/authenticator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <account-authenticator xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accountType="org.jellyfin.v1"
+    android:accountType="@string/app_id"
     android:icon="@drawable/ic_jellyfin"
     android:label="@string/app_name"
     android:smallIcon="@drawable/ic_jellyfin" />


### PR DESCRIPTION
When both the debug and release version are installed on the same device, only the first app that tries to use the authentication store can claim the account type because it was hardcoded to "org.jellyfin.v1". This PR changes it to be based on the application id, which means that the debug and release version use a different type to store the accounts.

Sidenote: since the type changed all currently stored accounts won't be used anymore, you can remove them manually from your device settings.

| flavor   | before | after |
| -------- | --- | --- |
| debug  | org.jellyfin.v1 | org.jellyfin.androidtv.debug |
| release | org.jellyfin.v1 | org.jellyfin.androidtv |

I've also removed the versioning part since that's a pain to support anyway.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
