### PR TITLE
Disable LeakCanary by default and add option to gradle properties to enable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,7 +127,8 @@ dependencies {
 	implementation("com.jakewharton.timber:timber:4.7.1")
 
 	// Debugging
-	debugImplementation("com.squareup.leakcanary:leakcanary-android:2.6")
+	if (getProperty("leakcanary.enable")?.toBoolean() == true)
+		debugImplementation("com.squareup.leakcanary:leakcanary-android:2.6")
 
 	// Testing
 	testImplementation("junit:junit:4.12")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,6 @@ kotlin.incremental=true
 # Android
 android.enableJetifier=true
 android.useAndroidX=true
+
+# Enable LeakCanary
+leakcanary.enable=false


### PR DESCRIPTION
Simple change, will disable LeakCanary by default, we should probably enable it by default after the playback rewrite since most of the leaks come from there.