### PR TITLE
Use FragmentContainerView instead of fragment in layout XML

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -13,4 +13,5 @@
     <issue id="KotlinPropertyAccess" severity="warning" />
     <issue id="LambdaLast" severity="warning" />
     <issue id="ExtraTranslation" severity="warning" />
+    <issue id="FragmentTagUsage" severity="error" />
 </lint>

--- a/app/src/main/res/layout/fragment_search_text.xml
+++ b/app/src/main/res/layout/fragment_search_text.xml
@@ -31,7 +31,7 @@
         app:layout_constraintTop_toTopOf="@+id/search_bar" />
 
     <!-- Fragment showing search results -->
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/results_frame"
         android:name="androidx.leanback.app.RowsSupportFragment"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -37,7 +37,7 @@
             android:visibility="gone"
             app:use_controller="false" />
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/leanback_fragment"
             android:name="org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment"
             android:layout_width="match_parent"


### PR DESCRIPTION
> FragmentContainerView replaces the <fragment> tag as the preferred way of adding fragments via XML. Unlike the <fragment> tag, FragmentContainerView uses a normal FragmentTransaction under the hood to add the initial fragment, allowing further FragmentTransaction operations on the FragmentContainerView and providing a consistent timing for lifecycle events.  
> 
> More info: https://developer.android.com/reference/androidx/fragment/app/FragmentContainerView.html