### PR TITLE
Use sp unit instead of dp for font size in horizontal_grid_browse.xml

### DIFF
--- a/app/src/main/res/layout/horizontal_grid_browse.xml
+++ b/app/src/main/res/layout/horizontal_grid_browse.xml
@@ -79,7 +79,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/statusText"
-        android:textSize="12dp"
+        android:textSize="12sp"
         android:alpha=".6"
         android:layout_alignLeft="@+id/title"
         android:layout_alignBottom="@+id/counter"


### PR DESCRIPTION
> When setting text sizes, you should normally use sp, or "scale-independent pixels". This is like the dp unit, but it is also scaled by the user's font size preference. It is recommend you use this unit when specifying font sizes, so they will be adjusted for both the screen density and the user's preference.
