### PR TITLE
Fix automatic sign out when switching users

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,7 @@ android {
 
 dependencies {
 	// Jellyfin
-	implementation("org.jellyfin.apiclient:android:0.7.7")
+	implementation("org.jellyfin.apiclient:android:0.7.9")
 
 	// Kotlin
 	implementation(kotlin("stdlib"))

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationDevice.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationDevice.kt
@@ -1,0 +1,23 @@
+package org.jellyfin.androidtv.auth
+
+import org.jellyfin.apiclient.interaction.device.IDevice
+import java.security.MessageDigest
+
+/**
+ * Wrapper for [IDevice] that changes the device id to a combination of the original device id
+ * and the username. This is neccasary to prevent the server from trashing other sessions with
+ * the same device id.
+ */
+class AuthenticationDevice(
+	private val parent: IDevice,
+	private val username: String
+) : IDevice {
+	// Hash the deviceId because we can't use special characters as the device id is send
+	// via HTTP headers
+	override val deviceId = MessageDigest.getInstance("SHA-1").run {
+		update("${parent.deviceId}+${username}".toByteArray())
+		digest().joinToString("") { "%02x".format(it) }
+	}
+
+	override val deviceName = parent.deviceName
+}

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
@@ -57,6 +57,7 @@ class AuthenticationRepository(
 	 * @return Whether the user information can be retrieved.
 	 */
 	private suspend fun setActiveSession(user: User, server: Server): Boolean {
+		apiClient.setDevice(AuthenticationDevice(device, user.name))
 		apiClient.SetAuthenticationInfo(user.accessToken, user.id.toString())
 		apiClient.EnableAutomaticNetworking(ServerInfo().apply {
 			id = server.id.toString()

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
@@ -122,7 +122,7 @@ class AuthenticationRepository(
 	) = flow {
 		val result = try {
 			callApi<AuthenticationResult> { callback ->
-				val api = jellyfin.createApi(server.address, device = device)
+				val api = jellyfin.createApi(server.address, device = AuthenticationDevice(device, username))
 				api.AuthenticateUserAsync(username, password, callback)
 			}
 
@@ -153,4 +153,3 @@ class AuthenticationRepository(
 		else emit(RequireSignInState)
 	}
 }
-


### PR DESCRIPTION
**Changes**

The server only allows a single authenticated user per device id. To fix this we need to create an unique device id for each session. The server still needs this device id in all requests so the id is based on app-device id + username.

# Requires (unreleased) version 0.7.8 of apiclient.
See https://github.com/jellyfin/jellyfin-apiclient-java/pull/174

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
