### PR TITLE
Add episode full name as subtitle while playing TV episode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -7,7 +7,9 @@ import androidx.leanback.app.PlaybackSupportFragment;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
+import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.apiclient.model.dto.BaseItemType;
 
 public class LeanbackOverlayFragment extends PlaybackSupportFragment {
 
@@ -69,6 +71,8 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
         if (currentlyPlayingItem == null) return;
 
         playerGlue.setTitle(currentlyPlayingItem.getName());
+        if (currentlyPlayingItem.getBaseItemType() == BaseItemType.Episode)
+            playerGlue.setSubtitle(BaseItemUtils.getFullName(currentlyPlayingItem));
         playerGlue.invalidatePlaybackControls();
         playerGlue.setSeekEnabled(playerAdapter.canSeek());
         playerGlue.setSeekProvider(playerAdapter.canSeek() ? new CustomSeekProvider(playerAdapter) : null);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Adds the "Series Name S1 E1" text as the subtitle while playing a TV episode. Useful for a quick glimpse at what season and episode you are on without having to back out of your video.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
