### PR TITLE
Add developer preferences screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/general.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/general.kt
@@ -4,7 +4,6 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AppTheme
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
-import org.jellyfin.androidtv.preference.constant.GridDirection
 import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsScreen
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
@@ -31,11 +30,6 @@ fun OptionsScreen.generalCategory(
 		bind(userPreferences, UserPreferences.premieresEnabled)
 	}
 
-	enum<GridDirection> {
-		setTitle(R.string.grid_direction)
-		bind(userPreferences, UserPreferences.gridDirection)
-	}
-
 	enum<ClockBehavior> {
 		setTitle(R.string.pref_clock_display)
 		bind(userPreferences, UserPreferences.clockBehavior)
@@ -50,11 +44,5 @@ fun OptionsScreen.generalCategory(
 		setTitle(R.string.lbl_enable_seasonal_themes)
 		setContent(R.string.desc_seasonal_themes)
 		bind(userPreferences, UserPreferences.seasonalGreetingsEnabled)
-	}
-
-	checkbox {
-		setTitle(R.string.lbl_enable_debug)
-		setContent(R.string.desc_debug)
-		bind(userPreferences, UserPreferences.debuggingEnabled)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -1,0 +1,36 @@
+package org.jellyfin.androidtv.ui.preference.screen
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.GridDirection
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.checkbox
+import org.jellyfin.androidtv.ui.preference.dsl.enum
+import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.koin.android.ext.android.inject
+
+class DeveloperPreferencesScreen : OptionsFragment() {
+	private val userPreferences: UserPreferences by inject()
+
+	override val screen by optionsScreen {
+		setTitle(R.string.pref_developer_link)
+
+		category {
+			// Legacy debug flag
+			// Not in use by much components anymore
+			checkbox {
+				setTitle(R.string.lbl_enable_debug)
+				setContent(R.string.desc_debug)
+				bind(userPreferences, UserPreferences.debuggingEnabled)
+			}
+
+			// Changing the grid direction is experimental as the vertical
+			// direction doesn't calculate image sizes properly resulting
+			// in a weird layout in some cases.
+			enum<GridDirection> {
+				setTitle(R.string.grid_direction)
+				bind(userPreferences, UserPreferences.gridDirection)
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/UserPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/UserPreferencesScreen.kt
@@ -24,6 +24,14 @@ class UserPreferencesScreen : OptionsFragment() {
 		liveTvCategory(userPreferences)
 		shortcutsCategory(userPreferences)
 		crashReportingCategory(userPreferences)
+
+		link {
+			setTitle(R.string.pref_developer_link)
+			setContent(R.string.pref_developer_link_description)
+			icon = R.drawable.ic_flask
+			withFragment<DeveloperPreferencesScreen>()
+		}
+
 		aboutCategory()
 	}
 }

--- a/app/src/main/res/drawable/ic_flask.xml
+++ b/app/src/main/res/drawable/ic_flask.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.8,18.4L14,10.67V6.5l1.35,-1.69C15.61,4.48 15.38,4 14.96,4H9.04C8.62,4 8.39,4.48 8.65,4.81L10,6.5v4.17L4.2,18.4C3.71,19.06 4.18,20 5,20h14C19.82,20 20.29,19.06 19.8,18.4z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,4 +430,6 @@
     <string name="login_server_unavailable">Unable to connect to server</string>
     <string name="login_username_field_empty">Username cannot be empty</string>
     <string name="pref_authentication_link">Authentication options</string>
+    <string name="pref_developer_link">Developer options</string>
+    <string name="pref_developer_link_description">Advanced and experimental features</string>
 </resources>


### PR DESCRIPTION
_Finishing old branches_

**Changes**
Adds a new preferences screen, linked to from the default preferences screen for "developer options". It contains 2 (moved) preferences for now:
- Debug flag
  Used in some cases to enable extra information in views
- Grid direction
  I added this a while back for 0.12 but I don't consider it a proper fix as it contains quite some bugs, moving it to the dev options will mark it as "experimental".

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
