### PR TITLE
Disable headers on home screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.java
@@ -38,7 +38,7 @@ public class BrowseFolderFragment extends StdBrowseFragment {
     private Lazy<GsonJsonSerializer> serializer = inject(GsonJsonSerializer.class);
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         mFolder = serializer.getValue().DeserializeFromString(getActivity().getIntent().getStringExtra(Extras.Folder), BaseItemDto.class);
         if (MainTitle == null) MainTitle = mFolder.getName();
         ShowBadge = false;
@@ -60,7 +60,7 @@ public class BrowseFolderFragment extends StdBrowseFragment {
             showViews = false;
         }
 
-        super.onActivityCreated(savedInstanceState);
+        super.onCreate(savedInstanceState);
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CustomViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CustomViewFragment.java
@@ -10,11 +10,11 @@ public class CustomViewFragment extends BrowseFolderFragment {
     protected String includeType;
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         includeType = getActivity().getIntent().getStringExtra(Extras.IncludeType);
         Timber.d("Item type: %s", includeType);
         showViews = false;
 
-        super.onActivityCreated(savedInstanceState);
+        super.onCreate(savedInstanceState);
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2014 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.jellyfin.androidtv.ui.browsing;
 
 import android.content.Intent;
@@ -26,6 +12,7 @@ import android.widget.ImageView;
 import android.widget.TextClock;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.leanback.app.BrowseSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -87,8 +74,8 @@ public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoad
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
         if (getActivity() instanceof BaseActivity) mActivity = (BaseActivity)getActivity();
 
@@ -218,10 +205,16 @@ public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoad
     }
 
     protected void setupUIElements() {
-        if (ShowBadge) setBadgeDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.app_logo_transparent));
+        if (ShowBadge)
+            setBadgeDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.app_logo_transparent));
+
         setTitle(MainTitle); // Badge, when set, takes precedent over title
-        setHeadersState(HEADERS_ENABLED);
-        setHeadersTransitionOnBackEnabled(true);
+        setHeadersState(HEADERS_DISABLED);
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
 
         // move the badge/title to the left to make way for our clock/user bug
         ImageView badge = (ImageView) getActivity().findViewById(R.id.title_badge);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -47,12 +47,12 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 	private val footer by lazy { HomeFragmentFooterRow(requireActivity()) }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
-
 		// Create adapter/presenter and set it to parent
 		mRowsAdapter = ArrayObjectAdapter(PositionableListRowPresenter())
 		mCardPresenter = CardPresenter()
 		adapter = mRowsAdapter
+
+		super.onCreate(savedInstanceState)
 
 		// Get auto bitrate
 		// TODO move to somewhere else (automatically start at app start?)


### PR DESCRIPTION
Finally found out why it didn't work before. The StdBrowseFragment used onActivityCreated because it needs to tweak UI in the activity (lol). Changed it to use the onCreate function for most code (except clock initialization) and now we can disable the headers perfectly fine. I decided to not add a preference to enable/disable the headers because it can't show more than 6 anyway.

**Changes**
- Disable headers on all screens
- Enabling them is not possible when extending StdBrowseFragment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
