### PR TITLE
Use HtmlCompat in TextUtils String.toHtmlSpanned function

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
@@ -1,17 +1,13 @@
 package org.jellyfin.androidtv.util
 
-import android.os.Build
-import android.text.Html
 import android.text.Spanned
+import androidx.core.text.HtmlCompat
 import java.util.*
 
-fun String.toHtmlSpanned(): Spanned {
-	@Suppress("DEPRECATION")
-	return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-		Html.fromHtml(this, Html.FROM_HTML_MODE_COMPACT)
-	else
-		Html.fromHtml(this)
-}
+/**
+ * Convert string with HTML to a [Spanned]. Uses the [FROM_HTML_MODE_COMPACT] flag.
+ */
+fun String.toHtmlSpanned(): Spanned = HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)
 
 private val UUID_REGEX = "^([a-z\\d]{8})([a-z\\d]{4})(4[a-z\\d]{3})([a-z\\d]{4})([a-z\\d]{12})\$".toRegex()
 


### PR DESCRIPTION
**Changes**
- Use HtmlCompat in TextUtils String.toHtmlSpanned function.
- Added comment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
