### PR TITLE
Remove audio behavior warning

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
@@ -13,12 +13,6 @@ class SystemPreferences(context: Context) : SharedPreferenceStore(
 	sharedPreferences = context.getSharedPreferences("systemprefs", Context.MODE_PRIVATE)
 ) {
 	companion object {
-		// Warnings
-		/**
-		 * Used to track if the warning for the `pref_audio_option` has been shown.
-		 */
-		val audioWarned = Preference.boolean("syspref_audio_warned", false)
-
 		// Live TV - Channel history
 		/**
 		 * Stores the channel that was active before leaving the app
@@ -62,9 +56,8 @@ class SystemPreferences(context: Context) : SharedPreferenceStore(
 		val liveTvGuideFilterSports = Preference.boolean("guide_filter_sports", false)
 
 		/**
-		 * chosen player for play with button - changes every time user chooses a player with "play with" button
+		 * Chosen player for play with button. Changes every time user chooses a player with "play with" button.
 		 */
-
 		var chosenPlayer = Preference.enum("chosen_player", PreferredVideoPlayer.VLC)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.home
 
-import android.app.AlertDialog
 import android.os.Bundle
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.Presenter
@@ -13,13 +12,9 @@ import androidx.work.WorkManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.constant.HomeSectionType
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
-import org.jellyfin.androidtv.preference.SystemPreferences
-import org.jellyfin.androidtv.preference.UserPreferences
-import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.androidtv.ui.browsing.IRowLoader
 import org.jellyfin.androidtv.ui.browsing.StdBrowseFragment
@@ -63,21 +58,6 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 		// TODO move to somewhere else (automatically start at app start?)
 		lifecycleScope.launch(Dispatchers.IO) {
 			get<AutoBitrate>().detect()
-		}
-
-		//First time audio message
-		// TODO move to somewhere else (remove entirely?)
-		if (!get<SystemPreferences>()[SystemPreferences.audioWarned]) {
-			get<SystemPreferences>()[SystemPreferences.audioWarned] = true
-			AlertDialog.Builder(requireContext())
-				.setTitle(getString(R.string.lbl_audio_capabilitites))
-				.setMessage(getString(R.string.msg_audio_warning))
-				.setPositiveButton(getString(R.string.btn_got_it), null)
-				.setNegativeButton(getString(R.string.btn_set_compatible_audio)) { _, _ ->
-					get<UserPreferences>()[UserPreferences.audioBehaviour] = AudioBehavior.DOWNMIX_TO_STEREO
-				}
-				.setCancelable(false)
-				.show()
 		}
 
 		// Subscribe to Audio messages

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,13 +246,10 @@
     <string name="lbl_zoom">Zoom</string>
     <string name="lbl_horizontal_stretch">Horizontal Stretch</string>
     <string name="lbl_vertical_stretch">Vertical Stretch</string>
-    <string name="lbl_audio_capabilitites">Audio Capabilities</string>
     <string name="lbl_audio_track">Select audio track</string>
     <string name="lbl_subtitle_track">Select subtitle track</string>
-    <string name="msg_audio_warning">This app has the ability to direct stream certain multi-channel audio formats. If your hardware does not support these formats, you may hear no sound when playing certain items. This can be fixed by changing the audio mode to \'downmix\' in the settings.</string>
     <string name="msg_external_path">This feature will only work if you have properly set up your library on the server with network paths or path substitution and the client you are using can directly access these locations over the network.</string>
     <string name="btn_got_it">Got it</string>
-    <string name="btn_set_compatible_audio">Set downmix now</string>
     <string name="lbl_current_queue">Current Queue</string>
     <string name="desc_current_video_queue">Video items currently queued for playback</string>
     <string name="lbl_clear_queue">Clear Queue</string>


### PR DESCRIPTION
**Changes**
Removed the warning to enable audio downmixing in the home screen. It only appeared once for new installs. In the future we should auto-detect capabilities (with the playback rewrite) so users don't need to do anything, for now going to the preferences and changing the behavior enum is the way to go.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
