### PR TITLE
Enable static height on most home rows

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.ui.browsing;
 import org.jellyfin.androidtv.constant.ChangeTriggerType;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.querying.ViewQuery;
-
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery;
 import org.jellyfin.apiclient.model.livetv.RecordingGroupQuery;
@@ -112,6 +111,7 @@ public class BrowseRowDef {
         headerText = header;
         this.latestItemsQuery = query;
         this.queryType = QueryType.LatestItems;
+        this.staticHeight = true;
         this.changeTriggers = changeTriggers;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -43,7 +43,7 @@ class HomeFragmentHelper(
 			sortOrder = org.jellyfin.apiclient.model.entities.SortOrder.Descending
 		}
 
-		return HomeFragmentBrowseRowDefRow(BrowseRowDef(title, query, 0, arrayOf(ChangeTriggerType.VideoQueueChange, ChangeTriggerType.TvPlayback, ChangeTriggerType.MoviePlayback)))
+		return HomeFragmentBrowseRowDefRow(BrowseRowDef(title, query, 0, false, true, arrayOf(ChangeTriggerType.VideoQueueChange, ChangeTriggerType.TvPlayback, ChangeTriggerType.MoviePlayback)))
 	}
 
 	fun loadResumeVideo(): HomeFragmentRow {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -234,6 +234,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         mLatestQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
         queryType = QueryType.LatestItems;
         this.preferParentThumb = preferParentThumb;
+        staticHeight = true;
         add(new BaseRowItem(new GridButton(0, TvApp.getApplication().getString(R.string.lbl_loading_elipses), R.drawable.loading, null)));
     }
 


### PR DESCRIPTION
**Changes**
Set the staticHeight option to `true` for the latest & resume rows used in the home screen. This will make all images in the cards use the same height. Old behavior was especially noticeable when a series poster and episode thumbnail were shown next to each other and in image libraries using different sized images.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
