### PR TITLE
Add an option to hide ratings on cards/item details

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/RatingType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/RatingType.kt
@@ -14,5 +14,11 @@ enum class RatingType {
 	 * Sets the default rating type to stars.
 	 */
 	@EnumDisplayOptions(R.string.lbl_stars)
-	RATING_STARS
+	RATING_STARS,
+
+	/**
+	 * Sets the default rating type to hidden.
+	 */
+	@EnumDisplayOptions(R.string.lbl_hidden)
+	RATING_HIDDEN
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -12,6 +12,8 @@ import androidx.annotation.NonNull;
 import com.google.android.flexbox.FlexboxLayout;
 
 import org.jellyfin.androidtv.R;
+import org.jellyfin.androidtv.preference.UserPreferences;
+import org.jellyfin.androidtv.preference.constant.RatingType;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.androidtv.util.apiclient.StreamHelper;
@@ -23,6 +25,8 @@ import org.jellyfin.apiclient.model.entities.SeriesStatus;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+
+import static org.koin.java.KoinJavaComponent.get;
 
 public class InfoLayoutHelper {
 
@@ -50,7 +54,10 @@ public class InfoLayoutHelper {
     }
 
     public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
-        addCriticInfo(activity, item, layout);
+        RatingType ratingType = get(UserPreferences.class).get(UserPreferences.Companion.getDefaultRatingType());
+        if (ratingType != RatingType.RATING_HIDDEN) {
+            addCriticInfo(activity, item, layout);
+        }
         switch (item.getBaseItemType()) {
             case Episode:
                 addSeasonEpisode(activity, item, layout);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -453,4 +453,5 @@
     <string name="image_size_large">Large</string>
     <string name="pref_developer_link">Developer options</string>
     <string name="pref_developer_link_description">Advanced and experimental features</string>
+    <string name="lbl_hidden">Hidden</string>
 </resources>


### PR DESCRIPTION
**Changes**

- Adds an option to hide the Rotten Tomatoes/IMDb ratings on the home screen cards and the item details page.
