### PR TITLE
Fix rating not clearing properly

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -339,6 +339,8 @@ public class CardPresenter extends Presenter {
             mCardView.clearBanner();
             mCardView.setUnwatchedCount(-1);
             mCardView.setProgress(0);
+            mCardView.setRating(null);
+            mCardView.setBadgeImage(null);
 
             mCardView.getMainImageView().setImageResource(R.drawable.loading);
         }


### PR DESCRIPTION
When a card is re-used by the presenter it might not set the rating, this would cause the old rating to still show up. This PR fixes it by always clearing the rating.

**Changes**
- Fix rating not clearing properly

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
