### PR TITLE
Hide cardview overlay by default

### DIFF
--- a/app/src/main/res/layout/image_card_view.xml
+++ b/app/src/main/res/layout/image_card_view.xml
@@ -115,7 +115,9 @@
             android:layout_alignBottom="@id/main_image"
             android:background="@color/black_transparent_light"
             android:gravity="center_vertical"
-            android:padding="4dp">
+            android:padding="4dp"
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <ImageView
                 android:id="@+id/icon"


### PR DESCRIPTION
**Changes**
Hide the overlay in cardviews by default, this was previously done in MyImageCard.java but accidentally removed in #744. This PR adds the default visibility back but using the XML (how it should be done).

**Issues**
- https://github.com/jellyfin/jellyfin-androidtv/pull/744#issuecomment-787712008
