### PR TITLE
Cancel loading backgrounds on clear

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -175,6 +175,8 @@ class BackgroundService(
 	}
 
 	fun clearBackgrounds() {
+		loadBackgroundsJob?.cancel()
+
 		if (backgrounds.isEmpty()) return
 
 		backgrounds.clear()


### PR DESCRIPTION
**Changes**
Fixed a race condition where backgrounds would appear for items with no backgrounds if the previous backgrounds were still loading.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
