### PR TITLE
Fix EnhancedBrowseFragment crash

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class BrowseRecordingsActivity : FragmentActivity() {
+class BrowseRecordingsActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class BrowseScheduleActivity : FragmentActivity() {
+class BrowseScheduleActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class CollectionActivity : FragmentActivity() {
+class CollectionActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -14,6 +14,7 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
 import androidx.leanback.widget.ClassPresenterSelector;
@@ -65,7 +66,7 @@ import static org.koin.java.KoinJavaComponent.get;
 import static org.koin.java.KoinJavaComponent.inject;
 
 public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
-    BaseActivity mActivity;
+    FragmentActivity mActivity;
 
     TextView mTitle;
     LinearLayout mInfoRow;
@@ -120,7 +121,7 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
 
         View root = inflater.inflate(R.layout.enhanced_detail_browse, container, false);
 
-        mActivity = (BaseActivity) getActivity();
+        mActivity = getActivity();
 
         mTitle = (TextView) root.findViewById(R.id.title);
         mTitle.setShadowLayer(5, 5, 5, Color.BLACK);
@@ -347,15 +348,15 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
 
         mRowsFragment.setOnItemViewSelectedListener(mSelectedListener);
         mSelectedListener.registerListener(new ItemViewSelectedListener());
-        if (mActivity != null) {
-            mActivity.registerKeyListener(new IKeyListener() {
+        if (mActivity != null && mActivity instanceof BaseActivity) {
+            ((BaseActivity) mActivity).registerKeyListener(new IKeyListener() {
                 @Override
                 public boolean onKeyUp(int key, KeyEvent event) {
-                    return KeyProcessor.HandleKey(key, mCurrentItem, mActivity);
+                    return KeyProcessor.HandleKey(key, mCurrentItem, ((BaseActivity) mActivity));
                 }
             });
 
-            mActivity.registerMessageListener(new IMessageListener() {
+            ((BaseActivity) mActivity).registerMessageListener(new IMessageListener() {
                 @Override
                 public void onMessageReceived(CustomMessage message) {
                     switch (message) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -66,11 +66,11 @@ import static org.koin.java.KoinJavaComponent.get;
 import static org.koin.java.KoinJavaComponent.inject;
 
 public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
-    FragmentActivity mActivity;
+    protected FragmentActivity mActivity;
 
-    TextView mTitle;
-    LinearLayout mInfoRow;
-    TextView mSummary;
+    protected TextView mTitle;
+    private LinearLayout mInfoRow;
+    private TextView mSummary;
 
     protected static final int BY_LETTER = 0;
     protected static final int GENRES = 1;
@@ -91,13 +91,13 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
 
     protected BaseRowItem favSongsRowItem;
 
-    RowsSupportFragment mRowsFragment;
+    protected RowsSupportFragment mRowsFragment;
     protected CompositeClickedListener mClickedListener = new CompositeClickedListener();
     protected CompositeSelectedListener mSelectedListener = new CompositeSelectedListener();
     protected ArrayObjectAdapter mRowsAdapter;
     private final Handler mHandler = new Handler();
     protected ArrayList<BrowseRowDef> mRows = new ArrayList<>();
-    CardPresenter mCardPresenter;
+    protected CardPresenter mCardPresenter;
     protected BaseRowItem mCurrentItem;
     protected ListRow mCurrentRow;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class GenericFolderActivity : FragmentActivity() {
+class GenericFolderActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class SuggestedMoviesActivity : FragmentActivity() {
+class SuggestedMoviesActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/UserViewActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/UserViewActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class UserViewActivity : FragmentActivity() {
+class UserViewActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 


### PR DESCRIPTION
The fragment uses the messaging trash in BaseActivity.

**Changes**
- Add check in EnhancedBrowseFragment if the parent activity is a BaseActivity
- Use BaseActivity for all activities (indirectly) using the EnhancedBrowseFragment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
