### PR TITLE
Disable folders views because types are missing in the apiclient

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -813,7 +813,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         notifyRetrieveFinished();
     }
 
-    private static String[] ignoreTypes = new String[]{"books", "games"};
+    private static String[] ignoreTypes = new String[]{"books", "games", "folders"};
     private static List<String> ignoreTypeList = Arrays.asList(ignoreTypes);
 
     private void retrieveViews() {


### PR DESCRIPTION
**Changes**
The necessary types for folders are missing in `BaseItemType` in the current apiclient. This causes the app ui to break due to an exception, so best to disable for now.

**Issues**
N/A
