### PR TITLE
Use BaseActivity as parent class for MainActivity

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -1,13 +1,12 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.home.HomeFragment
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 import org.koin.android.ext.android.inject
 
-
-class MainActivity : FragmentActivity() {
+class MainActivity : BaseActivity() {
 	private val backgroundService: BackgroundService by inject<BackgroundService>()
 
 	override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Regression from #743

**Changes**

- Use BaseActivity as parent in MainActivity

**Issues**

Fixes #776
