### PR TITLE
Fix discovered server button text colors

### DIFF
--- a/app/src/main/res/layout/item_discovery_server.xml
+++ b/app/src/main/res/layout/item_discovery_server.xml
@@ -8,16 +8,17 @@
     android:layout_marginTop="8dp"
     android:padding="8dp">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/icon"
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:layout_marginEnd="8dp"
+        android:duplicateParentState="true"
         android:src="@drawable/ic_cloud"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:tint="#73FFFFFF" />
+        app:tint="@drawable/button_default_text" />
 
     <TextView
         android:id="@+id/server_name"
@@ -25,6 +26,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
+        android:duplicateParentState="true"
+        android:textColor="@drawable/button_default_text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintStart_toEndOf="@id/icon"
@@ -36,6 +39,8 @@
         style="@style/TextAppearance.AppCompat.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:duplicateParentState="true"
+        android:textColor="@drawable/button_default_text"
         app:layout_constraintStart_toStartOf="@id/server_name"
         app:layout_constraintTop_toBottomOf="@id/server_name"
         tools:text="http://192.168.1.1:8096" />
@@ -45,6 +50,8 @@
         style="@style/TextAppearance.AppCompat.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:duplicateParentState="true"
+        android:textColor="@drawable/button_default_text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/server_name"
         tools:text="Jellyfin 10.7.0" />


### PR DESCRIPTION
**Changes**
Fixes the text color of the discovered server buttons. For some reason I needed to use `AppCompatImageView` for the `app:tint` to actually work. :man_shrugging: 

**Issues**
N/A
