### PR TITLE
Implement auto-login and introduce SessionRepository for managing sessions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -10,6 +10,7 @@ import org.acra.annotation.AcraDialog
 import org.acra.annotation.AcraHttpSender
 import org.acra.annotation.AcraLimiter
 import org.acra.sender.HttpSender
+import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.di.*
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.koin.android.ext.android.get
@@ -42,6 +43,19 @@ class JellyfinApplication : TvApp() {
 	override fun onCreate() {
 		super.onCreate()
 
+		// Enable improved logging for leaking resources
+		// https://wh0.github.io/2020/08/12/closeguard.html
+		if (BuildConfig.DEBUG) {
+			try {
+				Class.forName("dalvik.system.CloseGuard")
+					.getMethod("setEnabled", Boolean::class.javaPrimitiveType)
+					.invoke(null, true)
+			} catch (e: ReflectiveOperationException) {
+				@Suppress("TooGenericExceptionThrown")
+				throw RuntimeException(e)
+			}
+		}
+
 		// Initialize the logging library
 		Timber.plant(DebugTree())
 		Timber.i("Application object created")
@@ -72,17 +86,10 @@ class JellyfinApplication : TvApp() {
 		// Register lifecycle callbacks
 		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)
 
-		// Enable improved logging for leaking resources
-		// https://wh0.github.io/2020/08/12/closeguard.html
-		if (BuildConfig.DEBUG) {
-			try {
-				Class.forName("dalvik.system.CloseGuard")
-					.getMethod("setEnabled", Boolean::class.javaPrimitiveType)
-					.invoke(null, true)
-			} catch (e: ReflectiveOperationException) {
-				@Suppress("TooGenericExceptionThrown")
-				throw RuntimeException(e)
-			}
+		// Restore session
+		get<SessionRepository>().apply {
+			restoreDefaultSession()
+			restoreDefaultSystemSession()
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -5,6 +5,8 @@ import android.app.Application;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
 
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer;
@@ -37,7 +39,7 @@ public class TvApp extends Application {
     public static final int LIVE_TV_SERIES_OPTION_ID = 5000;
 
     private static TvApp app;
-    private UserDto currentUser;
+    private MediatorLiveData<UserDto> currentUser = new MediatorLiveData<UserDto>();
     private BaseItemDto lastPlayedItem;
     private PlaybackController playbackController;
 
@@ -62,16 +64,17 @@ public class TvApp extends Application {
     @Deprecated
     @Nullable
     public UserDto getCurrentUser() {
-        if (currentUser == null) {
-            Timber.e("Called getCurrentUser() but value was null.");
-        }
+        return currentUser.getValue();
+    }
 
+    @Deprecated
+    public LiveData<UserDto> getCurrentUserLiveData() {
         return currentUser;
     }
 
     @Deprecated
     public void setCurrentUser(UserDto currentUser) {
-        this.currentUser = currentUser;
+        this.currentUser.postValue(currentUser);
         TvManager.clearCache();
         this.displayPrefsCache = new HashMap<>();
     }
@@ -121,6 +124,7 @@ public class TvApp extends Application {
 
     @NonNull
     public boolean canManageRecordings() {
+        UserDto currentUser = getCurrentUser();
         return currentUser != null && currentUser.getPolicy().getEnableLiveTvManagement();
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/ApiBinder.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ApiBinder.kt
@@ -1,0 +1,54 @@
+package org.jellyfin.androidtv.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.JellyfinApplication
+import org.jellyfin.androidtv.util.apiclient.callApi
+import org.jellyfin.apiclient.interaction.ApiClient
+import org.jellyfin.apiclient.interaction.device.IDevice
+import org.jellyfin.apiclient.model.apiclient.ServerInfo
+import org.jellyfin.apiclient.model.dto.UserDto
+import timber.log.Timber
+
+class ApiBinder(
+	private val application: JellyfinApplication,
+	private val api: ApiClient,
+	private val device: IDevice,
+	private val authenticationStore: AuthenticationStore,
+) {
+	fun updateSession(session: Session?) {
+		if (session == null) {
+			application.currentUser = null
+			return
+		}
+
+		val server = authenticationStore.getServer(session.serverId)
+		if (server == null) {
+			Timber.e("Could not bind API because server ${session.serverId} was not found in the store.")
+			return
+		}
+
+		api.setDevice(AuthenticationDevice(device, session.userId.toString()))
+		api.SetAuthenticationInfo(session.accessToken, session.userId.toString())
+		api.EnableAutomaticNetworking(ServerInfo().apply {
+			id = session.serverId.toString()
+			name = server.name
+			address = server.address
+			userId = session.userId.toString()
+			accessToken = session.accessToken
+		})
+
+		// Update currentUser DTO
+		GlobalScope.launch(Dispatchers.IO) {
+			val response = try {
+				callApi<UserDto> { callback -> api.GetUserAsync(session.userId.toString(), callback) }
+			} catch (exception: Exception) {
+				Timber.e(exception, "Could not get user information while access token was set")
+				null
+			}
+
+			application.currentUser = response
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
@@ -12,30 +12,39 @@ import org.jellyfin.androidtv.util.toUUID
 import org.jellyfin.apiclient.Jellyfin
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.interaction.device.IDevice
-import org.jellyfin.apiclient.model.apiclient.ServerInfo
 import org.jellyfin.apiclient.model.dto.ImageOptions
-import org.jellyfin.apiclient.model.dto.UserDto
 import org.jellyfin.apiclient.model.entities.ImageType
 import org.jellyfin.apiclient.model.users.AuthenticationResult
 import timber.log.Timber
 import java.util.*
 
-class AuthenticationRepository(
+interface AuthenticationRepository {
+	fun getServers(): List<Server>
+	fun getUsers(server: UUID): List<PrivateUser>?
+	fun saveServer(id: UUID, name: String, address: String)
+	fun authenticateUser(user: User): Flow<LoginState>
+	fun authenticateUser(user: User, server: Server): Flow<LoginState>
+	fun login(server: Server, username: String, password: String = ""): Flow<LoginState>
+	fun getUserImageUrl(server: Server, user: User): String?
+}
+
+class AuthenticationRepositoryImpl(
 	private val application: JellyfinApplication,
 	private val jellyfin: Jellyfin,
 	private val api: ApiClient,
+	private val sessionRepository: SessionRepository,
 	private val device: IDevice,
 	private val accountManagerHelper: AccountManagerHelper,
 	private val authenticationStore: AuthenticationStore,
-) {
+) : AuthenticationRepository {
 	private val serverComparator = compareByDescending<Server> { it.dateLastAccessed }.thenBy { it.name }
-	private val userComparator = compareByDescending<PrivateUser> {it.lastUsed }.thenBy { it.name }
+	private val userComparator = compareByDescending<PrivateUser> { it.lastUsed }.thenBy { it.name }
 
-	fun getServers() = authenticationStore.getServers().map { (id, info) ->
+	override fun getServers() = authenticationStore.getServers().map { (id, info) ->
 		Server(id, info.name, info.address, Date(info.lastUsed))
 	}.sortedWith(serverComparator)
 
-	fun getUsers(server: UUID): List<PrivateUser>? =
+	override fun getUsers(server: UUID): List<PrivateUser>? =
 		authenticationStore.getUsers(server)?.mapNotNull { (userId, userInfo) ->
 			accountManagerHelper.getAccount(userId).let { authInfo ->
 				PrivateUser(
@@ -49,7 +58,7 @@ class AuthenticationRepository(
 			}
 		}?.sortedWith(userComparator)
 
-	fun saveServer(id: UUID, name: String, address: String) {
+	override fun saveServer(id: UUID, name: String, address: String) {
 		val current = authenticationStore.getServer(id)
 
 		if (current != null)
@@ -64,7 +73,7 @@ class AuthenticationRepository(
 	 *
 	 * @return Whether the user information can be retrieved.
 	 */
-	private suspend fun setActiveSession(user: User, server: Server): Boolean {
+	private suspend fun setActiveSession(user: User, server: Server) {
 		// Update last use in store
 		authenticationStore.getServer(server.id)?.let { storedServer ->
 			authenticationStore.putServer(server.id, storedServer.copy(lastUsed = Date().time))
@@ -74,34 +83,11 @@ class AuthenticationRepository(
 			authenticationStore.putUser(server.id, user.id, storedUser.copy(lastUsed = Date().time))
 		}
 
-		// Set user in apiclient
-		api.setDevice(AuthenticationDevice(device, user.name))
-		api.SetAuthenticationInfo(user.accessToken, user.id.toString())
-		api.EnableAutomaticNetworking(ServerInfo().apply {
-			id = server.id.toString()
-			name = server.name
-			address = server.address
-			userId = user.id.toString()
-			accessToken = user.accessToken
-		})
-
-		// Suppressed because the old apiclient is unreliable
-		@Suppress("TooGenericExceptionCaught")
-		try {
-			val userDto = callApi<UserDto?> { callback -> api.GetUserAsync(user.id.toString(), callback) }
-			if (userDto != null) {
-				application.currentUser = userDto
-				return true
-			}
-		} catch (err: Exception) {
-			Timber.e(err, "Could not get user information while access token was set")
-		}
-
-		return false
+		sessionRepository.switchCurrentSession(user.id)
 	}
 
 	@OptIn(ExperimentalCoroutinesApi::class)
-	fun authenticateUser(user: User): Flow<LoginState> = flow {
+	override fun authenticateUser(user: User): Flow<LoginState> = flow {
 		Timber.d("Authenticating serverless user %s", user)
 		emit(AuthenticatingState)
 
@@ -114,7 +100,7 @@ class AuthenticationRepository(
 	}
 
 	@OptIn(ExperimentalCoroutinesApi::class)
-	fun authenticateUser(user: User, server: Server): Flow<LoginState> = flow {
+	override fun authenticateUser(user: User, server: Server): Flow<LoginState> = flow {
 		Timber.d("Authenticating user %s", user)
 		emit(AuthenticatingState)
 
@@ -122,9 +108,8 @@ class AuthenticationRepository(
 		when {
 			// Access token found, proceed with sign in
 			account?.accessToken != null -> {
-				val authenticated = setActiveSession(user, server)
-				if (authenticated) emit(AuthenticatedState)
-				else emit(RequireSignInState)
+				setActiveSession(user, server)
+				emit(AuthenticatedState)
 			}
 			// User is known to not require a password, try a sign in
 			!user.requirePassword -> emitAll(login(server, user.name))
@@ -134,11 +119,7 @@ class AuthenticationRepository(
 	}
 
 	@OptIn(ExperimentalCoroutinesApi::class)
-	fun login(
-		server: Server,
-		username: String,
-		password: String = ""
-	) = flow {
+	override fun login(server: Server, username: String, password: String) = flow {
 		val result = try {
 			callApi<AuthenticationResult> { callback ->
 				val api = jellyfin.createApi(server.address, device = AuthenticationDevice(device, username))
@@ -175,12 +156,11 @@ class AuthenticationRepository(
 			imageTag = result.user.primaryImageTag,
 			lastUsed = Date().time,
 		)
-		val authenticated = setActiveSession(user, server)
-		if (authenticated) emit(AuthenticatedState)
-		else emit(RequireSignInState)
+		setActiveSession(user, server)
+		emit(AuthenticatedState)
 	}
 
-	fun getUserImageUrl(server: Server, user: User): String? {
+	override fun getUserImageUrl(server: Server, user: User): String? {
 		val apiClient = jellyfin.createApi(serverAddress = server.address, device = device)
 		return apiClient.GetUserImageUrl(user.id.toString(), ImageOptions().apply {
 			tag = user.imageTag

--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -18,8 +18,8 @@ data class Session(
 )
 
 interface SessionRepository {
-	val currentSession: LiveData<Session>
-	val currentSystemSession: LiveData<Session>
+	val currentSession: LiveData<Session?>
+	val currentSystemSession: LiveData<Session?>
 
 	fun restoreDefaultSession()
 	fun restoreDefaultSystemSession()
@@ -33,11 +33,11 @@ class SessionRepositoryImpl(
 	private val accountManagerHelper: AccountManagerHelper,
 	private val apiBinder: ApiBinder,
 ) : SessionRepository {
-	private val _currentSession = MutableLiveData<Session>()
-	override val currentSession: LiveData<Session> get() = _currentSession
+	private val _currentSession = MutableLiveData<Session?>()
+	override val currentSession: LiveData<Session?> get() = _currentSession
 
-	private val _currentSystemSession = MutableLiveData<Session>()
-	override val currentSystemSession: LiveData<Session> get() = _currentSystemSession
+	private val _currentSystemSession = MutableLiveData<Session?>()
+	override val currentSystemSession: LiveData<Session?> get() = _currentSystemSession
 
 	override fun restoreDefaultSession() {
 		val behavior = authenticationPreferences[AuthenticationPreferences.autoLoginUserBehavior]

--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -1,0 +1,114 @@
+package org.jellyfin.androidtv.auth
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.preference.AuthenticationPreferences
+import org.jellyfin.androidtv.preference.constant.UserSelectBehavior.*
+import org.jellyfin.androidtv.util.toUUIDOrNull
+import timber.log.Timber
+import java.util.*
+
+data class Session(
+	val userId: UUID,
+	val serverId: UUID,
+	val accessToken: String
+)
+
+interface SessionRepository {
+	val currentSession: LiveData<Session>
+	val currentSystemSession: LiveData<Session>
+
+	fun restoreDefaultSession()
+	fun restoreDefaultSystemSession()
+
+	fun switchCurrentSession(userId: UUID)
+	fun destroyCurrentSession()
+}
+
+class SessionRepositoryImpl(
+	private val authenticationPreferences: AuthenticationPreferences,
+	private val accountManagerHelper: AccountManagerHelper,
+	private val apiBinder: ApiBinder,
+) : SessionRepository {
+	private val _currentSession = MutableLiveData<Session>()
+	override val currentSession: LiveData<Session> get() = _currentSession
+
+	private val _currentSystemSession = MutableLiveData<Session>()
+	override val currentSystemSession: LiveData<Session> get() = _currentSystemSession
+
+	override fun restoreDefaultSession() {
+		val behavior = authenticationPreferences[AuthenticationPreferences.autoLoginUserBehavior]
+		val userId = authenticationPreferences[AuthenticationPreferences.autoLoginUserId].toUUIDOrNull()
+
+		when (behavior) {
+			DISABLED -> setCurrentSessionSync(null, false)
+			LAST_USER -> setCurrentSessionSync(createLastUserSession(), false)
+			SPECIFIC_USER -> setCurrentSessionSync(createUserSession(userId), false)
+		}
+	}
+
+	override fun restoreDefaultSystemSession() {
+		val behavior = authenticationPreferences[AuthenticationPreferences.systemUserBehavior]
+		val userId = authenticationPreferences[AuthenticationPreferences.systemUserId].toUUIDOrNull()
+
+		when (behavior) {
+			DISABLED -> _currentSystemSession.postValue(null)
+			LAST_USER -> _currentSystemSession.postValue(createLastUserSession())
+			SPECIFIC_USER -> _currentSystemSession.postValue(createUserSession(userId))
+		}
+	}
+
+	override fun switchCurrentSession(userId: UUID) {
+		val session = createUserSession(userId)
+		if (session == null) {
+			Timber.d("switchCurrentSession was unable to succeed")
+			return
+		}
+
+		setCurrentSession(session, true)
+	}
+
+	override fun destroyCurrentSession() {
+		setCurrentSession(null, false)
+	}
+
+	private fun setCurrentSessionSync(session: Session?, includeSystemUser: Boolean) = runBlocking {
+		withContext(Dispatchers.IO) {
+			setCurrentSession(session, includeSystemUser)
+		}
+	}
+
+	private fun setCurrentSession(session: Session?, includeSystemUser: Boolean) {
+		if (session != null) authenticationPreferences[AuthenticationPreferences.lastUserId] = session.userId.toString()
+
+		val systemUserBehavior = authenticationPreferences[AuthenticationPreferences.systemUserBehavior]
+		if (includeSystemUser && systemUserBehavior == LAST_USER) _currentSystemSession.postValue(session)
+
+		// Update API details
+		apiBinder.updateSession(session)
+
+		// Actually set the session
+		_currentSession.postValue(session)
+	}
+
+	private fun createLastUserSession(): Session? {
+		val lastUserId = authenticationPreferences[AuthenticationPreferences.lastUserId].toUUIDOrNull()
+		return createUserSession(lastUserId)
+	}
+
+	private fun createUserSession(userId: UUID?): Session? {
+		if (userId == null) return null
+
+		val account = accountManagerHelper.getAccount(userId)
+		if (account == null || account.accessToken == null) return null
+
+		return Session(
+			userId = account.id,
+			serverId = account.server,
+			accessToken = account.accessToken
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -2,10 +2,7 @@ package org.jellyfin.androidtv.di
 
 import androidx.core.content.getSystemService
 import org.jellyfin.androidtv.JellyfinApplication
-import org.jellyfin.androidtv.auth.AccountManagerHelper
-import org.jellyfin.androidtv.auth.AuthenticationRepository
-import org.jellyfin.androidtv.auth.AuthenticationStore
-import org.jellyfin.androidtv.auth.LegacyAccountMigration
+import org.jellyfin.androidtv.auth.*
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
@@ -13,6 +10,8 @@ import org.koin.dsl.module
 val authModule = module {
 	single { AuthenticationStore(androidContext()) }
 	single { AccountManagerHelper(androidContext().getSystemService()!!) }
-	single { AuthenticationRepository(androidApplication() as JellyfinApplication, get(), get(), get(), get(), get()) }
+	single<AuthenticationRepository> { AuthenticationRepositoryImpl(androidApplication() as JellyfinApplication, get(), get(), get(), get(), get(), get()) }
+	single<SessionRepository> { SessionRepositoryImpl(get(), get(), get()) }
 	single { LegacyAccountMigration(androidContext(), get(), get()) }
+	single { ApiBinder(androidApplication() as JellyfinApplication, get(), get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
@@ -12,5 +12,10 @@ class AuthenticationPreferences(context: Context) : SharedPreferenceStore(
 
 		val systemUserBehavior = Preference.enum<UserSelectBehavior>("system_user_behavior", UserSelectBehavior.LAST_USER)
 		val systemUserId = Preference.string("system_user_id", "")
+
+		/**
+		 * Do not set directly, use [SessionRepository] instead.
+		 */
+		val lastUserId = Preference.string("last_user_id", "")
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -44,7 +44,7 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 	// Special rows
 	private val nowPlaying by lazy { HomeFragmentNowPlayingRow(requireActivity(), mediaManager) }
 	private val liveTVRow by lazy { HomeFragmentLiveTVRow(requireActivity(), get()) }
-	private val footer by lazy { HomeFragmentFooterRow(requireActivity()) }
+	private val footer by lazy { HomeFragmentFooterRow(requireActivity(), get()) }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		// Create adapter/presenter and set it to parent

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentFooterRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentFooterRow.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import androidx.leanback.widget.*
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.TvApp
+import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.ui.GridButton
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
@@ -12,7 +12,8 @@ import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 
 class HomeFragmentFooterRow(
-	private val activity: Activity
+	private val activity: Activity,
+	private val sessionRepository: SessionRepository,
 ) : HomeFragmentRow, OnItemViewClickedListener {
 	override fun addToRowsAdapter(cardPresenter: CardPresenter, rowsAdapter: ArrayObjectAdapter) {
 		val header = HeaderItem(rowsAdapter.size().toLong(), activity.getString(R.string.lbl_settings))
@@ -34,8 +35,7 @@ class HomeFragmentFooterRow(
 
 		when (item.id) {
 			BUTTON_LOGOUT -> {
-				// Unset the current user
-				TvApp.getApplication().currentUser = null
+				sessionRepository.destroyCurrentSession()
 
 				// Open login activity
 				val selectUserIntent = Intent(activity, StartupActivity::class.java)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/ServerFragment.kt
@@ -48,8 +48,7 @@ class ServerFragment : RowsSupportFragment() {
 						// TODO show error
 					}
 					AuthenticatedState -> {
-						// TODO use view model and observe in activity or something similar
-						(requireActivity() as StartupActivity).openNextActivity()
+						// Ignore
 					}
 				}
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -69,11 +69,15 @@ class StartupActivity : FragmentActivity() {
 		var isLoaded = false
 		sessionRepository.currentSession.observe(this) { session ->
 			if (session != null) {
+				Timber.i("Found a session in the session repository, waiting for the currentUser in the application class.")
+
 				supportFragmentManager.beginTransaction()
 					.replace(R.id.content_view, SplashFragment())
 					.commit()
 
 				application?.currentUserLiveData?.observe(this) { currentUser ->
+					Timber.i("CurrentUser changed to ${currentUser?.id} while waiting for startup.")
+
 					if (currentUser != null) openNextActivity()
 				}
 			} else if (isLoaded == false) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -92,9 +92,6 @@ class UserLoginAlertFragment(
 						}
 						AuthenticatedState -> {
 							onClose()
-
-							// TODO use view model and observe in activity
-							(requireActivity() as StartupActivity).openNextActivity()
 						}
 					}
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.util.apiclient
 
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.apiclient.interaction.ApiClient
+import org.jellyfin.apiclient.interaction.EmptyResponse
 import org.jellyfin.apiclient.interaction.Response
 import org.jellyfin.apiclient.model.dto.BaseItemDto
 import org.jellyfin.apiclient.model.dto.UserDto
@@ -55,6 +56,13 @@ suspend fun ApiClient.getItem(id: String): BaseItemDto? = suspendCoroutine { con
 suspend fun <T : Any?> callApi(init: (callback: Response<T>) -> Unit): T = suspendCoroutine { continuation ->
 	init(object : Response<T>() {
 		override fun onResponse(response: T) = continuation.resumeWith(Result.success(response))
+		override fun onError(exception: Exception) = continuation.resumeWith(Result.failure(exception))
+	})
+}
+
+suspend fun callApiEmpty(init: (callback: EmptyResponse) -> Unit): Unit = suspendCoroutine { continuation ->
+	init(object : EmptyResponse() {
+		override fun onResponse() = continuation.resumeWith(Result.success(Unit))
 		override fun onError(exception: Exception) = continuation.resumeWith(Result.failure(exception))
 	})
 }


### PR DESCRIPTION
**Changes**
This PR introduces the "SessionRepository" that manages the current session in the app. It contains two methods to restore the session based on the authentication preferences, these methods are called on application start.
When the session changes it uses a new class "ApiBinder" to configure the apiclient instance. I had to implement a hack to set the "currentUser" in the Application class (couldn't think of a better way unfortunatetely).

The StartupActivity now observes the current session, if a session is found it will wait for the currentUser to be assigned too and switch to the next activity. The splash screen is used to indicate something is happening. If the session is restored on start the startup activity will skip showing the user screen.

The sign out button on the home screen uses the destroyCurrentSession function which also unsets the currentuser.

**Issues**
Part of #612 
