### PR TITLE
Fix BackgroundService fragment crash and default background not restoring

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundServiceFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundServiceFragment.kt
@@ -2,25 +2,30 @@ package org.jellyfin.androidtv.data.service
 
 import android.graphics.drawable.Drawable
 import androidx.fragment.app.Fragment
+import org.koin.android.ext.android.inject
+import timber.log.Timber
 
 /**
  * Fragment used to hook into the activity lifecycle and set the background when neccesary.
  */
-internal class BackgroundServiceFragment(
-	private val backgroundService: BackgroundService
-) : Fragment() {
+internal class BackgroundServiceFragment : Fragment() {
+	private val backgroundService by inject<BackgroundService>()
 	private var backgrounds: Array<Drawable>? = null
 
 	override fun onResume() {
 		super.onResume()
 
 		if (backgrounds != null) {
+			Timber.d("Restoring active backgrounds")
+
 			backgroundService.backgrounds.clear()
 			backgroundService.backgrounds.addAll(backgrounds!!)
 			backgroundService.update()
 		}
 
 		activity?.window?.decorView?.apply {
+			Timber.d("Restoring background drawable")
+
 			// We need to force the system to add a new callback
 			// this won't happen if we set the background to the same one
 			// so we set it to null first


### PR DESCRIPTION
**Changes**

- The default background didn't restore properly because a bitmap of the backgroundservice background was saved (whoops)
- The fragment could crash because it didn't have an empty constructor (as is required for fragments)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
