### PR TITLE
Fix for HDR always being activated

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,7 +90,6 @@
 
         <activity
             android:name=".ui.playback.PlaybackOverlayActivity"
-            android:colorMode="wideColorGamut"
             android:label="PlaybackOverlayActivity"
             android:screenOrientation="landscape" />
 


### PR DESCRIPTION
**Changes**
I think this might be a Shield-specific issue, so I couldn't reproduce it (I don't have a Shield). This seems to have fixed it, though.

Edit: ~~Agh, this breaks Dolby Vision in mkv. Dolby Vision in mp4 still works.~~ I take that back, the file was transcoding instead of direct playing. HDR behavior seems the same on my Sony TV and Chromecast with Google TV.

**Issues**
Fixes #782
