### PR TITLE
Use Maven Central as primary dependency repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,9 @@ buildscript {
 allprojects {
 	// Dependencies
 	repositories {
-		jcenter()
+		mavenCentral()
 		google()
+		jcenter()
 	}
 }
 


### PR DESCRIPTION
**Changes**
- Add `mavenCentral()` as repository
- Move `jcenter()` to the bottom of the repository list

**Notes**

I checked which dependencies we use are not available when jcenter is removed:

- **Koin** 2.x branch is not on Maven Central, 3.x is, it's not a drop-in replacement though and requires some work
- **Jellyfin Apiclient** is not on Maven Central, Kotlin SDK is, so it needs migration
- **Amazon ExoPlayer** port is not on Maven Central, developers have been ignoring issues for months now. Not likely to see updates. We might need to remove it and start using the official ExoPlayer again.
- **LibVLC** is not on Maven Central, developers acknowledge this as an "important" issue but have not moved yet
- ~~**Android Flexbox** is not on Maven Central, developers acknowledge this and are planning on publishing to Maven Central or Google Maven but have not  yet done it. We barely use it so we can probably remove it with minimal effort.~~ #792


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
