### PR TITLE
Rewrite login alerts

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
@@ -4,21 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.CallSuper
 import androidx.annotation.StringRes
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import org.jellyfin.androidtv.databinding.FragmentAlertDialogBinding
 
 @Suppress("LongParameterList")
 abstract class AlertFragment(
 	@StringRes protected var title: Int? = null,
-	@StringRes protected var description: Int? = null,
 	@StringRes protected var confirmButtonText: Int? = null,
 	@StringRes protected var cancelButtonText: Int? = null,
 ) : Fragment() {
 	private lateinit var binding: FragmentAlertDialogBinding
 	protected val parentBinding get() = binding
 
+	@CallSuper
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		binding = FragmentAlertDialogBinding.inflate(inflater, container, false)
 		onCreateChildView(inflater, binding.content)?.let { childView ->
@@ -27,13 +27,11 @@ abstract class AlertFragment(
 		return binding.root
 	}
 
+	@CallSuper
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 		super.onViewCreated(view, savedInstanceState)
 
 		title?.let { binding.title.setText(it) }
-
-		if (description == null) binding.description.isVisible = false
-		else description?.let { binding.description.setText(it) }
 
 		with(binding.confirm) {
 			confirmButtonText?.let { setText(it) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
@@ -9,12 +9,10 @@ import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import org.jellyfin.androidtv.databinding.FragmentAlertDialogBinding
 
-@Suppress("LongParameterList")
-abstract class AlertFragment(
-	@StringRes protected var title: Int? = null,
-	@StringRes protected var confirmButtonText: Int? = null,
-	@StringRes protected var cancelButtonText: Int? = null,
-) : Fragment() {
+abstract class AlertFragment : Fragment() {
+	@StringRes
+	protected var title: Int? = null
+
 	private lateinit var binding: FragmentAlertDialogBinding
 	protected val parentBinding get() = binding
 
@@ -34,19 +32,14 @@ abstract class AlertFragment(
 		title?.let { binding.title.setText(it) }
 
 		with(binding.confirm) {
-			confirmButtonText?.let { setText(it) }
-
 			requestFocus()
 			setOnClickListener {
 				if (onConfirm()) onClose()
 			}
 		}
 
-		with(binding.cancel) {
-			cancelButtonText?.let { setText(it) }
-			setOnClickListener {
-				if (onCancel()) onClose()
-			}
+		binding.cancel.setOnClickListener {
+			if (onCancel()) onClose()
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AlertFragment.kt
@@ -4,50 +4,57 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.databinding.FragmentAlertDialogBinding
 
 @Suppress("LongParameterList")
-open class AlertFragment(
-	@StringRes private val title: Int,
-	@StringRes private val description: Int? = null,
-	@StringRes private val confirmButtonText: Int? = null,
-	private val onConfirmCallback: () -> Unit = {},
-	@StringRes private val cancelButtonText: Int? = null,
-	private val onCancelCallback: () -> Unit = {},
-	private val onClose: () -> Unit = {}
-) : Fragment(R.layout.fragment_alert_dialog) {
+abstract class AlertFragment(
+	@StringRes protected var title: Int? = null,
+	@StringRes protected var description: Int? = null,
+	@StringRes protected var confirmButtonText: Int? = null,
+	@StringRes protected var cancelButtonText: Int? = null,
+) : Fragment() {
+	private lateinit var binding: FragmentAlertDialogBinding
+	protected val parentBinding get() = binding
+
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		val view = super.onCreateView(inflater, container, savedInstanceState)!!
-
-		val titleView = view.findViewById<TextView>(R.id.title)
-		titleView.setText(title)
-
-		val descriptionView = view.findViewById<TextView>(R.id.description)
-		if (description != null) {
-			descriptionView.setText(description)
-		} else {
-			descriptionView.visibility = View.GONE
+		binding = FragmentAlertDialogBinding.inflate(inflater, container, false)
+		onCreateChildView(inflater, binding.content)?.let { childView ->
+			binding.content.addView(childView)
 		}
-
-		val confirmButton = view.findViewById<Button>(R.id.confirm)
-		if (confirmButtonText != null) confirmButton.setText(confirmButtonText)
-		confirmButton.requestFocus()
-		confirmButton.setOnClickListener {
-			onConfirmCallback()
-			onClose()
-		}
-
-		val cancelButton = view.findViewById<Button>(R.id.cancel)
-		if (cancelButtonText != null) cancelButton.setText(cancelButtonText)
-		cancelButton.setOnClickListener {
-			onCancelCallback()
-			onClose()
-		}
-
-		return view
+		return binding.root
 	}
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+		super.onViewCreated(view, savedInstanceState)
+
+		title?.let { binding.title.setText(it) }
+
+		if (description == null) binding.description.isVisible = false
+		else description?.let { binding.description.setText(it) }
+
+		with(binding.confirm) {
+			confirmButtonText?.let { setText(it) }
+
+			requestFocus()
+			setOnClickListener {
+				if (onConfirm()) onClose()
+			}
+		}
+
+		with(binding.cancel) {
+			cancelButtonText?.let { setText(it) }
+			setOnClickListener {
+				if (onCancel()) onClose()
+			}
+		}
+	}
+
+	abstract fun onCreateChildView(inflater: LayoutInflater, contentContainer: ViewGroup): View?
+
+	open fun onConfirm(): Boolean = true
+	open fun onCancel(): Boolean = true
+	open fun onClose() = parentFragmentManager.popBackStack()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyboardFocusChangeListener.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyboardFocusChangeListener.kt
@@ -1,14 +1,14 @@
 package org.jellyfin.androidtv.ui.shared
 
-import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.core.content.getSystemService
 
 class KeyboardFocusChangeListener : View.OnFocusChangeListener {
-	override fun onFocusChange(v : View, hasFocus : Boolean) {
-		(v.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).apply {
-			if (!hasFocus) hideSoftInputFromWindow(v.windowToken, 0)
-			else showSoftInput(v, 0)
+	override fun onFocusChange(view: View, hasFocus: Boolean) {
+		view.context.getSystemService<InputMethodManager>()?.apply {
+			if (!hasFocus) hideSoftInputFromWindow(view.windowToken, 0)
+			else showSoftInput(view, 0)
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -1,93 +1,77 @@
 package org.jellyfin.androidtv.ui.startup
 
 import android.os.Bundle
-import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
-import android.widget.Button
-import android.widget.EditText
-import android.widget.LinearLayout
-import android.widget.TextView
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.model.ConnectedState
 import org.jellyfin.androidtv.auth.model.ConnectingState
 import org.jellyfin.androidtv.auth.model.UnableToConnectState
+import org.jellyfin.androidtv.databinding.FragmentAlertAddServerBinding
 import org.jellyfin.androidtv.ui.shared.AlertFragment
 import org.jellyfin.androidtv.ui.shared.KeyboardFocusChangeListener
-import org.jellyfin.androidtv.util.toUUID
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
-import java.util.*
 
-class AddServerAlertFragment(
-	private val onServerAdded: (serverId: UUID) -> Unit = {},
-) : AlertFragment(
-	title = R.string.lbl_enter_server_address,
-	description = R.string.lbl_valid_server_address,
-) {
+class AddServerAlertFragment : AlertFragment() {
 	companion object {
 		const val ARG_SERVER_ADDRESS = "server_address"
 	}
 
 	private val loginViewModel: LoginViewModel by sharedViewModel()
+	private lateinit var binding: FragmentAlertAddServerBinding
 
-	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		val view = super.onCreateView(inflater, container, savedInstanceState)!!
+	private val serverAddressArgument get() = arguments?.getString(ARG_SERVER_ADDRESS)?.ifBlank { null }
 
-		val confirm = view.findViewById<Button>(R.id.confirm)
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
 
-		// Build the url field
-		val address = EditText(requireContext())
-		address.hint = requireActivity().getString(R.string.lbl_ip_hint)
-		address.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI
-		address.isSingleLine = true
-		address.onFocusChangeListener = KeyboardFocusChangeListener()
-		address.nextFocusDownId = R.id.confirm
-		address.imeOptions = EditorInfo.IME_ACTION_DONE
-		address.requestFocus()
-		address.setOnEditorActionListener { _, actionId, _ ->
-			if (actionId == EditorInfo.IME_ACTION_DONE)
-				confirm.performClick()
-			else
-				false
-		}
-
-		// Add the url field to the content view
-		view.findViewById<LinearLayout>(R.id.content).addView(address)
-
-		// Build the error text field
-		val errorText = TextView(requireContext())
-		view.findViewById<LinearLayout>(R.id.content).addView(errorText)
-
-		// Override the default confirm button click listener to return the address field text
-		confirm.setOnClickListener {
-			if (address.text.isNotBlank()) {
-				loginViewModel.addServer(address.text.toString()).observe(viewLifecycleOwner) { state ->
-					when (state) {
-						ConnectingState -> errorText.text = getString(R.string.server_connecting)
-						is UnableToConnectState -> errorText.text = getString(R.string.server_connection_failed, state.error.message)
-						is ConnectedState -> {
-							onServerAdded(state.publicInfo.id.toUUID())
-							onClose()
-						}
-					}
-				}
-			} else {
-				errorText.text = getString(R.string.server_field_empty)
-			}
-		}
-
-		arguments?.getString(ARG_SERVER_ADDRESS)?.let { serverAddress ->
-			address.setText(serverAddress)
-			address.isEnabled = false
-			confirm.callOnClick()
-		}
-
-		return view
+		title = R.string.lbl_enter_server_address
 	}
 
 	override fun onCreateChildView(inflater: LayoutInflater, contentContainer: ViewGroup): View? {
-		TODO("Not yet implemented")
+		binding = FragmentAlertAddServerBinding.inflate(inflater, contentContainer, false)
+		return binding.root
+	}
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+		super.onViewCreated(view, savedInstanceState)
+
+		with(binding.address) {
+			onFocusChangeListener = KeyboardFocusChangeListener()
+			nextFocusForwardId = parentBinding.confirm.id
+			imeOptions = EditorInfo.IME_ACTION_DONE
+			setOnEditorActionListener { _, actionId, _ ->
+				if (actionId == EditorInfo.IME_ACTION_DONE) parentBinding.confirm.performClick()
+				else false
+			}
+
+			if (serverAddressArgument != null) {
+				setText(serverAddressArgument)
+				isEnabled = false
+				parentBinding.confirm.performClick()
+			} else {
+				requestFocus()
+			}
+		}
+	}
+
+	override fun onConfirm(): Boolean {
+		if (binding.address.text.isNotBlank()) {
+			loginViewModel.addServer(
+				binding.address.text.toString()
+			).observe(viewLifecycleOwner) { state ->
+				when (state) {
+					ConnectingState -> binding.error.setText(R.string.server_connecting)
+					is UnableToConnectState -> binding.error.text = getString(R.string.server_connection_failed, state.error.message)
+					is ConnectedState -> onClose()
+				}
+			}
+		} else {
+			binding.error.setText(R.string.server_field_empty)
+		}
+
+		return false
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -22,13 +22,9 @@ import java.util.*
 
 class AddServerAlertFragment(
 	private val onServerAdded: (serverId: UUID) -> Unit = {},
-	private val onCancelCallback: () -> Unit = {},
-	private val onClose: () -> Unit = {}
 ) : AlertFragment(
 	title = R.string.lbl_enter_server_address,
 	description = R.string.lbl_valid_server_address,
-	onCancelCallback = onCancelCallback,
-	onClose = onClose
 ) {
 	companion object {
 		const val ARG_SERVER_ADDRESS = "server_address"
@@ -89,5 +85,9 @@ class AddServerAlertFragment(
 		}
 
 		return view
+	}
+
+	override fun onCreateChildView(inflater: LayoutInflater, contentContainer: ViewGroup): View? {
+		TODO("Not yet implemented")
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerScreenFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerScreenFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.replace
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.flow.collect
@@ -29,13 +30,12 @@ class AddServerScreenFragment : Fragment() {
 			requireActivity()
 				.supportFragmentManager
 				.beginTransaction()
-				.replace(
+				.replace<AddServerAlertFragment>(
 					R.id.content_view,
-					AddServerAlertFragment().apply {
-						arguments = bundleOf(
-							AddServerAlertFragment.ARG_SERVER_ADDRESS to server.address
-						)
-					}
+					null,
+					bundleOf(
+						AddServerAlertFragment.ARG_SERVER_ADDRESS to server.address
+					)
 				)
 				.addToBackStack(null)
 				.commit()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerScreenFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerScreenFragment.kt
@@ -31,9 +31,7 @@ class AddServerScreenFragment : Fragment() {
 				.beginTransaction()
 				.replace(
 					R.id.content_view,
-					AddServerAlertFragment(onClose = {
-						requireActivity().supportFragmentManager.popBackStack()
-					}).apply {
+					AddServerAlertFragment().apply {
 						arguments = bundleOf(
 							AddServerAlertFragment.ARG_SERVER_ADDRESS to server.address
 						)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/ServerFragment.kt
@@ -3,7 +3,8 @@ package org.jellyfin.androidtv.ui.startup
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.DrawableRes
-import androidx.fragment.app.Fragment
+import androidx.core.os.bundleOf
+import androidx.fragment.app.replace
 import androidx.leanback.app.RowsSupportFragment
 import androidx.leanback.widget.HeaderItem
 import androidx.leanback.widget.ListRow
@@ -39,10 +40,7 @@ class ServerFragment : RowsSupportFragment() {
 					}
 					RequireSignInState -> {
 						// Open login fragment
-						navigate(UserLoginAlertFragment(
-							server = item.server,
-							user = item.user,
-						))
+						showLoginFragment(item.server, item.user)
 					}
 					ServerUnavailableState -> {
 						// TODO show error
@@ -54,9 +52,7 @@ class ServerFragment : RowsSupportFragment() {
 			}
 		} else if (item is AddUserGridButton) {
 			// Open login fragment
-			navigate(UserLoginAlertFragment(
-				server = item.server
-			))
+			showLoginFragment(item.server)
 		}
 	}
 
@@ -125,11 +121,14 @@ class ServerFragment : RowsSupportFragment() {
 		requireView().requestFocus()
 	}
 
-	private fun navigate(fragment: Fragment) {
+	private fun showLoginFragment(server: Server, user: User? = null) {
 		requireActivity()
 			.supportFragmentManager
 			.beginTransaction()
-			.replace(R.id.content_view, fragment)
+			.replace<UserLoginAlertFragment>(R.id.content_view, null, bundleOf(
+				UserLoginAlertFragment.ARG_SERVER_ID to server.id.toString(),
+				UserLoginAlertFragment.ARG_USERNAME to user?.name
+			))
 			.addToBackStack(null)
 			.commit()
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -141,9 +141,7 @@ class StartupActivity : FragmentActivity() {
 	fun addServer() {
 		supportFragmentManager.beginTransaction()
 			.addToBackStack(null)
-			.replace(R.id.content_view, AddServerAlertFragment(
-				onClose = { supportFragmentManager.popBackStack() }
-			))
+			.replace(R.id.content_view, AddServerAlertFragment())
 			.commit()
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -23,6 +23,7 @@ import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.interaction.Response
 import org.jellyfin.apiclient.model.dto.BaseItemDto
 import org.koin.android.ext.android.inject
+import org.koin.androidx.fragment.android.replace
 import timber.log.Timber
 
 class StartupActivity : FragmentActivity() {
@@ -141,7 +142,7 @@ class StartupActivity : FragmentActivity() {
 	fun addServer() {
 		supportFragmentManager.beginTransaction()
 			.addToBackStack(null)
-			.replace(R.id.content_view, AddServerAlertFragment())
+			.replace<AddServerAlertFragment>(R.id.content_view)
 			.commit()
 	}
 

--- a/app/src/main/res/layout/fragment_alert_add_server.xml
+++ b/app/src/main/res/layout/fragment_alert_add_server.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:text="@string/lbl_valid_server_address"/>
+
+    <EditText
+        android:id="@+id/address"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints="username"
+        android:hint="@string/lbl_ip_hint"
+        android:inputType="textUri" />
+
+    <TextView
+        android:id="@+id/error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_alert_dialog.xml
+++ b/app/src/main/res/layout/fragment_alert_dialog.xml
@@ -25,7 +25,7 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="Alert Title" />
 
-        <LinearLayout
+        <FrameLayout
             android:id="@+id/content"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -36,6 +36,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title">
 
+            <!-- TODO remove description -->
             <TextView
                 android:id="@+id/description"
                 android:layout_width="wrap_content"
@@ -43,7 +44,7 @@
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 tools:text="This is the description of the alert." />
 
-        </LinearLayout>
+        </FrameLayout>
 
         <LinearLayout
             android:id="@+id/actions"

--- a/app/src/main/res/layout/fragment_alert_dialog.xml
+++ b/app/src/main/res/layout/fragment_alert_dialog.xml
@@ -34,17 +34,7 @@
             app:layout_constraintBottom_toTopOf="@id/actions"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title">
-
-            <!-- TODO remove description -->
-            <TextView
-                android:id="@+id/description"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                tools:text="This is the description of the alert." />
-
-        </FrameLayout>
+            app:layout_constraintTop_toBottomOf="@id/title" />
 
         <LinearLayout
             android:id="@+id/actions"

--- a/app/src/main/res/layout/fragment_alert_user_login.xml
+++ b/app/src/main/res/layout/fragment_alert_user_login.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="360dp"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/username"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints="username"
+        android:hint="@string/lbl_enter_user_name"
+        android:inputType="text" />
+
+    <EditText
+        android:id="@+id/password"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints="password"
+        android:fontFamily="sans-serif"
+        android:hint="@string/lbl_enter_user_pw"
+        android:inputType="textPassword" />
+
+    <TextView
+        android:id="@+id/error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>


### PR DESCRIPTION
**Changes**

- Alerts don't use the constructor anymore, now Android can correctly resume the fragments
- Alerts now use view binding for type safe layouts
- (child-)Alerts now use XML layouts
- AlertFragment is now easier to extend and work with
- Fixed the "next focus" not going to the confirm button correctly

**Issues**

I think there was one but I can't find it...