### PR TITLE
Initialize workmanager factory after setting the modules

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -50,7 +50,6 @@ class JellyfinApplication : TvApp() {
 		startKoin {
 			androidLogger()
 			androidContext(this@JellyfinApplication)
-			workManagerFactory()
 
 			modules(
 				appModule,
@@ -60,6 +59,10 @@ class JellyfinApplication : TvApp() {
 				preferenceModule,
 				utilsModule
 			)
+
+			// Must be called after setting the modules to prevent a crash because the worker class
+			// definition is not found
+			workManagerFactory()
 		}
 
 		// Setup workers


### PR DESCRIPTION
I looked into the sourcecode of Koin and found out that calling the `workManagerFactory()` function instantly initializes the androidx.workmanager library, in some cases this would try to start the workers but those weren't defined. Changing the order of function calls fixed it for me.

**Changes**
- Fixed crash on startup due too race conditions

**Issues**
https://github.com/jellyfin/jellyfin-androidtv/pull/784#issuecomment-808769226
