### PR TITLE
Use the jvmargs from kotlin sdk to increase memory available to Java process

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Gradle
-org.gradle.jvmargs=-Xmx768m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 
 # Kotlin version
 kotlinVersion=1.4.31


### PR DESCRIPTION
**Changes**

Running the linter in #784 locally didn't work because it ran out of memory. I think it's time to increase it (again). Copied the values from the Kotlin SDK and it works great now (at least for me).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
