### PR TITLE
Change exception type for background service crash

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -19,7 +19,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.add
 import androidx.window.WindowManager
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.GlideException
 import kotlinx.coroutines.*
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -29,6 +28,7 @@ import org.jellyfin.apiclient.model.dto.ImageOptions
 import org.jellyfin.apiclient.model.entities.ImageType
 import org.jellyfin.apiclient.model.search.SearchHint
 import timber.log.Timber
+import java.util.concurrent.ExecutionException
 
 class BackgroundService(
 	private val context: Context,
@@ -182,7 +182,7 @@ class BackgroundService(
 					async {
 						try {
 							future.get()
-						} catch (ex: GlideException) {
+						} catch (ex: ExecutionException) {
 							Timber.e(ex, "There was an error fetching the background image.")
 							null
 						}


### PR DESCRIPTION
**Changes**
I found a movie with a backdrop that always causes the crash, so testing for it became very easy. This seems to have finally fixed it.

**Issues**
#752

Logs for reference:
<details><summary>Before: GlideException</summary>

```
2021-04-06 16:02:56.647 5034-5314/org.jellyfin.androidtv.debug E/ACRA: ACRA caught a ExecutionException for org.jellyfin.androidtv.debug
    java.util.concurrent.ExecutionException: com.bumptech.glide.load.engine.GlideException: Failed to load resource
    There was 1 root cause:
    com.bumptech.glide.load.HttpException(Failed to connect or obtain data, status code: 404)
     call GlideException#logRootCauses(String) for more detail
        at com.bumptech.glide.request.RequestFutureTarget.doGet(RequestFutureTarget.java:217)
        at com.bumptech.glide.request.RequestFutureTarget.get(RequestFutureTarget.java:130)
        at org.jellyfin.androidtv.data.service.BackgroundService$loadBackgrounds$1$backdropDrawables$2$1.invokeSuspend(BackgroundService.kt:184)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
     Caused by: com.bumptech.glide.load.engine.GlideException: Failed to load resource
    There was 1 root cause:
    com.bumptech.glide.load.HttpException(Failed to connect or obtain data, status code: 404)
     call GlideException#logRootCauses(String) for more detail
```
</details>
<details>
<summary>After: ExecutionException</summary>

```
2021-04-06 16:14:29.210 5577-5727/org.jellyfin.androidtv.debug E/BackgroundService$loadBackgrounds$1$backdropDrawables: There was an error fetching the background image.
    java.util.concurrent.ExecutionException: com.bumptech.glide.load.engine.GlideException: Failed to load resource
    There was 1 root cause:
    com.bumptech.glide.load.HttpException(Failed to connect or obtain data, status code: 404)
     call GlideException#logRootCauses(String) for more detail
        at com.bumptech.glide.request.RequestFutureTarget.doGet(RequestFutureTarget.java:217)
        at com.bumptech.glide.request.RequestFutureTarget.get(RequestFutureTarget.java:130)
        at org.jellyfin.androidtv.data.service.BackgroundService$loadBackgrounds$1$backdropDrawables$2$1.invokeSuspend(BackgroundService.kt:184)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
     Caused by: com.bumptech.glide.load.engine.GlideException: Failed to load resource
    There was 1 root cause:
    com.bumptech.glide.load.HttpException(Failed to connect or obtain data, status code: 404)
     call GlideException#logRootCauses(String) for more detail
```

</details>