### PR TITLE
Cancel setCurrentSession call if the UserDto cannot be retrieved

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -87,11 +87,10 @@ class SessionRepositoryImpl(
 		val systemUserBehavior = authenticationPreferences[AuthenticationPreferences.systemUserBehavior]
 		if (includeSystemUser && systemUserBehavior == LAST_USER) _currentSystemSession.postValue(session)
 
-		// Update API details
-		apiBinder.updateSession(session)
-
-		// Actually set the session
-		_currentSession.postValue(session)
+		// Update session after binding the apiclient settings
+		apiBinder.updateSession(session) { success ->
+			if (success) _currentSession.postValue(session)
+		}
 	}
 
 	private fun createLastUserSession(): Session? {


### PR DESCRIPTION
**Changes**
- Fix infinite loading issue when the apiBinder fails to set the currentUser property in TvApp.

It's kind of a hack until we fully migrate to the Kotlin SDK and remove the currentUser property entirely.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- https://github.com/jellyfin/jellyfin-androidtv/pull/784#issuecomment-813879511