### PR TITLE
Fix crash in home when changing theme

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
@@ -12,7 +12,6 @@ import android.widget.ImageView;
 import android.widget.TextClock;
 import android.widget.TextView;
 
-import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.leanback.app.BrowseSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -213,22 +212,20 @@ public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoad
     }
 
     @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onStart() {
+        super.onStart();
 
         // move the badge/title to the left to make way for our clock/user bug
         ImageView badge = (ImageView) getActivity().findViewById(R.id.title_badge);
+        TextView title = (TextView) getActivity().findViewById(R.id.title_text);
         if (badge != null) {
             FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) badge.getLayoutParams();
             lp.rightMargin = Utils.convertDpToPixel(getActivity(), 120);
-            lp.width = Utils.convertDpToPixel(getActivity(), 250);
             badge.setLayoutParams(lp);
         }
-        TextView title = (TextView) getActivity().findViewById(R.id.title_text);
         if (title != null) {
             FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) title.getLayoutParams();
             lp.rightMargin = Utils.convertDpToPixel(getActivity(), 120);
-            lp.width = Utils.convertDpToPixel(getActivity(), 250);
             title.setLayoutParams(lp);
         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -10,6 +10,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.TvApp
@@ -151,6 +152,9 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 
 			// Make sure the rows are empty
 			rows.clear()
+
+			// Check for couroutine cancellation
+			if (!isActive) return@launch
 
 			// Actually add the sections
 			homesections.forEach { section -> addSection(section.value) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyImageCardView.java
@@ -45,12 +45,12 @@ public class MyImageCardView extends BaseCardView {
     protected void onFocusChanged(boolean gainFocus, int direction, @Nullable Rect previouslyFocusedRect) {
         super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
         if (gainFocus) {
-            binding.titleText.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color));
+            binding.title.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color));
             binding.contentText.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color));
             binding.badgeText.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color));
             binding.extraBadge.setAlpha(1.0f);
         } else {
-            binding.titleText.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color_inactive));
+            binding.title.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color_inactive));
             binding.contentText.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color_inactive));
             binding.badgeText.setTextColor(ContextCompat.getColor(getContext(), R.color.lb_basic_card_title_text_color_inactive));
             binding.extraBadge.setAlpha(0.25f);
@@ -95,11 +95,11 @@ public class MyImageCardView extends BaseCardView {
     }
 
     public void setTitleText(CharSequence text) {
-        if (binding.titleText == null) {
+        if (binding.title == null) {
             return;
         }
 
-        binding.titleText.setText(text);
+        binding.title.setText(text);
         setTextMaxLines();
     }
 
@@ -156,12 +156,12 @@ public class MyImageCardView extends BaseCardView {
         binding.overlayText.setLayoutParams(parms);
     }
 
-    public CharSequence getTitleText() {
-        if (binding.titleText == null) {
+    public CharSequence gettitle() {
+        if (binding.title == null) {
             return null;
         }
 
-        return binding.titleText.getText();
+        return binding.title.getText();
     }
 
     public void setContentText(CharSequence text) {
@@ -210,16 +210,16 @@ public class MyImageCardView extends BaseCardView {
     }
 
     private void setTextMaxLines() {
-        if (TextUtils.isEmpty(getTitleText())) {
+        if (TextUtils.isEmpty(gettitle())) {
             binding.contentText.setMaxLines(2);
         } else {
             binding.contentText.setMaxLines(1);
         }
 
         if (TextUtils.isEmpty(getContentText())) {
-            binding.titleText.setMaxLines(2);
+            binding.title.setMaxLines(2);
         } else {
-            binding.titleText.setMaxLines(1);
+            binding.title.setMaxLines(1);
         }
     }
 

--- a/app/src/main/res/layout/image_card_view.xml
+++ b/app/src/main/res/layout/image_card_view.xml
@@ -172,7 +172,7 @@
             android:paddingBottom="@dimen/lb_basic_card_info_padding_bottom">
 
             <TextView
-                android:id="@+id/title_text"
+                android:id="@+id/title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
@@ -206,7 +206,7 @@
                 android:id="@+id/badge_layout"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/title_text"
+                android:layout_below="@id/title"
                 android:layout_alignParentEnd="true"
                 android:layout_centerVertical="true"
                 android:orientation="horizontal">


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fixed a crash in the async setupQueries() function by checking for coroutine cancellation.
- Fixed logo position after changing theme
  - Also removed the width constraint so it will be displayed slightly more to the right
- Rename `title_text` id in image card view to just `title` because `title_text` is used by the leanback logo and caused crashes (lol)

**Issues**
Fixes #812