### PR TITLE
Remove activity labels

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,12 +66,10 @@
 
         <activity
             android:name=".ui.browsing.MainActivity"
-            android:label="@string/app_name"
             android:logo="@drawable/app_logo"
             android:screenOrientation="landscape" />
         <activity
             android:name=".ui.startup.StartupActivity"
-            android:label="@string/app_name"
             android:logo="@drawable/app_logo"
             android:noHistory="true"
             android:screenOrientation="landscape"
@@ -90,7 +88,6 @@
 
         <activity
             android:name=".ui.playback.PlaybackOverlayActivity"
-            android:label="PlaybackOverlayActivity"
             android:screenOrientation="landscape" />
 
         <activity
@@ -169,7 +166,6 @@
 
         <activity
             android:name=".ui.itemdetail.ExpandedTextActivity"
-            android:label="@string/title_activity_expanded_text"
             android:screenOrientation="landscape" />
 
         <activity


### PR DESCRIPTION
**Changes**
Removed labels for activities in the manifest. According to the Android documentation the app name will be used if it's not set.
https://developer.android.com/guide/topics/manifest/activity-element#label

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
