### PR TITLE
Use the AddressCandidateHelper of the Kotlin SDK to normalize the inputted server address

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ android {
 dependencies {
 	// Jellyfin
 	implementation("org.jellyfin.apiclient:android:0.7.9")
+	implementation("org.jellyfin.sdk:jellyfin-platform-android:1.0.0-beta.3")
 
 	// Kotlin
 	val kotlinxCoroutinesVersion = "1.4.3"

--- a/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.auth
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.liveData
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import org.jellyfin.androidtv.auth.model.*
 import org.jellyfin.androidtv.util.apiclient.callApi
@@ -15,6 +16,7 @@ import org.jellyfin.apiclient.discovery.DiscoveryServerInfo
 import org.jellyfin.apiclient.interaction.device.IDevice
 import org.jellyfin.apiclient.model.dto.UserDto
 import org.jellyfin.apiclient.model.system.PublicSystemInfo
+import org.jellyfin.sdk.discovery.AddressCandidateHelper
 import timber.log.Timber
 import java.util.*
 
@@ -78,21 +80,43 @@ class ServerRepositoryImpl(
 	override fun addServer(address: String): Flow<ServerAdditionState> = flow {
 		Timber.d("Adding server %s", address)
 
-		emit(ConnectingState)
+		emit(ConnectingState(address))
 
-		// Suppressed because the old apiclient is unreliable
-		@Suppress("TooGenericExceptionCaught")
-		try {
-			val api = jellyfin.createApi(serverAddress = address, device = device)
-			val systemInfo: PublicSystemInfo = callApi { callback ->
-				api.GetPublicSystemInfoAsync(callback)
+		// TODO Use the getRecommendedServer function in the DiscoveryService of the SDK
+		val addressCandidates = AddressCandidateHelper(address).apply {
+			addCommonCandidates()
+			prioritize()
+		}.getCandidates()
+
+		Timber.d("Found ${addressCandidates.size} candidates")
+
+		// Yup we're going to mix the new SDK with the old apiclient for now..
+		for (candidate in addressCandidates) {
+			// Suppressed because the old apiclient is unreliable
+			@Suppress("TooGenericExceptionCaught")
+			try {
+				emit(ConnectingState(candidate))
+				Timber.d("Trying candidate %s", candidate)
+
+				val api = jellyfin.createApi(serverAddress = candidate, device = device)
+				val systemInfo: PublicSystemInfo = callApi { callback ->
+					api.GetPublicSystemInfoAsync(callback)
+				}
+
+				authenticationRepository.saveServer(systemInfo.id.toUUID(), systemInfo.serverName, candidate)
+
+				emit(ConnectedState(systemInfo))
+
+				// Stop looping because we found a working connection
+				break
+			} catch (error: Exception) {
+				emit(UnableToConnectState(error))
+
+				// Wait for 0.3 seconds before attempting the next connection
+				// this is to prevent network flooding and allowing the user to
+				// view the error (although shortly)
+				delay(300)
 			}
-
-			authenticationRepository.saveServer(systemInfo.id.toUUID(), systemInfo.serverName, address)
-
-			emit(ConnectedState(systemInfo))
-		} catch (error: Exception) {
-			emit(UnableToConnectState(error))
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/ServerAdditionState.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/ServerAdditionState.kt
@@ -3,6 +3,6 @@ package org.jellyfin.androidtv.auth.model
 import org.jellyfin.apiclient.model.system.PublicSystemInfo
 
 sealed class ServerAdditionState
-object ConnectingState : ServerAdditionState()
+data class ConnectingState(val address: String) : ServerAdditionState()
 data class UnableToConnectState(val error: Exception) : ServerAdditionState()
 data class ConnectedState(val publicInfo: PublicSystemInfo) : ServerAdditionState()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -12,6 +12,7 @@ import org.jellyfin.androidtv.auth.model.UnableToConnectState
 import org.jellyfin.androidtv.databinding.FragmentAlertAddServerBinding
 import org.jellyfin.androidtv.ui.shared.AlertFragment
 import org.jellyfin.androidtv.ui.shared.KeyboardFocusChangeListener
+import org.jellyfin.androidtv.util.toUUID
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class AddServerAlertFragment : AlertFragment() {
@@ -59,11 +60,9 @@ class AddServerAlertFragment : AlertFragment() {
 
 	override fun onConfirm(): Boolean {
 		if (binding.address.text.isNotBlank()) {
-			loginViewModel.addServer(
-				binding.address.text.toString()
-			).observe(viewLifecycleOwner) { state ->
+			loginViewModel.addServer(binding.address.text.toString()).observe(viewLifecycleOwner) { state ->
 				when (state) {
-					ConnectingState -> binding.error.setText(R.string.server_connecting)
+					is ConnectingState -> binding.error.text = getString(R.string.server_connecting, state.address)
 					is UnableToConnectState -> binding.error.text = getString(R.string.server_connection_failed, state.error.message)
 					is ConnectedState -> onClose()
 				}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -422,7 +422,7 @@
     <string name="lbl_always">Always</string>
     <string name="pref_clock_display_browsing">While browsing</string>
     <string name="pref_clock_display_playback">During playback</string>
-    <string name="server_connecting">Connecting to server...</string>
+    <string name="server_connecting">Connecting to %s</string>
     <string name="server_connection_failed">Unable to connect to server: %s</string>
     <string name="server_field_empty">The address cannot be empty</string>
     <string name="login_authenticating">Authenticating...</string>


### PR DESCRIPTION
**Changes**

- Add the Kotlin SDK as dependency
- Use the AddressCandidateHelper from the SDK to find candidates for the inputted server address and try them one-by-one. The first one that works is chosen. If none of the candidates work we show the error of the latest attempt.

Function-wise this works great, I can now just input "demo.jellyfin.org/stable" and it will automatically add  the protocol. UI-wise it's terrible right now, error reporting wasn't great before but it's garbage now.

The `// TODO` is not something that can be fixed right now - we don't have a `Jellyfin()` instance of the SDK at this moment.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
