### PR TITLE
Adjust card and column sizes for vertical grid

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -57,6 +57,16 @@ public class GridFragment extends Fragment {
     protected int MED_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 88);
     protected int LARGE_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 105);
 
+    protected int SMALL_VERTICAL_POSTER = Utils.convertDpToPixel(TvApp.getApplication(), 116);
+    protected int MED_VERTICAL_POSTER = Utils.convertDpToPixel(TvApp.getApplication(), 171);
+    protected int LARGE_VERTICAL_POSTER = Utils.convertDpToPixel(TvApp.getApplication(), 202);
+    protected int SMALL_VERTICAL_THUMB = Utils.convertDpToPixel(TvApp.getApplication(), 116);
+    protected int MED_VERTICAL_THUMB = Utils.convertDpToPixel(TvApp.getApplication(), 155);
+    protected int LARGE_VERTICAL_THUMB = Utils.convertDpToPixel(TvApp.getApplication(), 210);
+    protected int SMALL_VERTICAL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 51);
+    protected int MED_VERTICAL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 77);
+    protected int LARGE_VERTICAL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 118);
+
     /**
      * Sets the grid presenter.
      */

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -130,16 +130,34 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
             // is this bad? Yup it definitely is, we'll fix it when this screen is rewritten
 
             int size;
-            switch (mPosterSizeSetting) {
-                case PosterSize.SMALL:
-                    size = 10;
-                    break;
-                case PosterSize.MED:
+            switch (mImageType) {
+                case ImageType.DEFAULT:
                 default:
-                    size = 6;
+                    if (mCardHeight == SMALL_VERTICAL_POSTER) {
+                        size = 10;
+                    } else if (mCardHeight == MED_VERTICAL_POSTER) {
+                        size = 7;
+                    } else {
+                        size = 6;
+                    }
                     break;
-                case PosterSize.LARGE:
-                    size = 5;
+                case ImageType.THUMB:
+                    if (mCardHeight == SMALL_VERTICAL_THUMB) {
+                        size = 4;
+                    } else if (mCardHeight == MED_VERTICAL_THUMB) {
+                        size = 3;
+                    } else {
+                        size = 2;
+                    }
+                    break;
+                case ImageType.BANNER:
+                    if (mCardHeight == SMALL_VERTICAL_BANNER) {
+                        size = 3;
+                    } else if (mCardHeight == MED_VERTICAL_BANNER) {
+                        size = 2;
+                    } else {
+                        size = 1;
+                    }
                     break;
             }
 
@@ -296,13 +314,24 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
     }
 
     protected int getCardHeight(String heightSetting) {
-        switch (heightSetting) {
-            case PosterSize.MED:
-                return mImageType.equals(ImageType.BANNER) ? MED_BANNER : MED_CARD;
-            case PosterSize.LARGE:
-                return mImageType.equals(ImageType.BANNER) ? LARGE_BANNER : LARGE_CARD;
-            default:
-                return mImageType.equals(ImageType.BANNER) ? SMALL_BANNER : SMALL_CARD;
+        if (getGridPresenter() instanceof VerticalGridPresenter) {
+            switch (heightSetting) {
+                case PosterSize.MED:
+                    return mImageType.equals(ImageType.BANNER) ? MED_VERTICAL_BANNER : mImageType.equals(ImageType.THUMB) ? MED_VERTICAL_THUMB : MED_VERTICAL_POSTER;
+                case PosterSize.LARGE:
+                    return mImageType.equals(ImageType.BANNER) ? LARGE_VERTICAL_BANNER : mImageType.equals(ImageType.THUMB) ? LARGE_VERTICAL_THUMB : LARGE_VERTICAL_POSTER;
+                default:
+                    return mImageType.equals(ImageType.BANNER) ? SMALL_VERTICAL_BANNER : mImageType.equals(ImageType.THUMB) ? SMALL_VERTICAL_THUMB : SMALL_VERTICAL_POSTER;
+            }
+        } else {
+            switch (heightSetting) {
+                case PosterSize.MED:
+                    return mImageType.equals(ImageType.BANNER) ? MED_BANNER : MED_CARD;
+                case PosterSize.LARGE:
+                    return mImageType.equals(ImageType.BANNER) ? LARGE_BANNER : LARGE_CARD;
+                default:
+                    return mImageType.equals(ImageType.BANNER) ? SMALL_BANNER : SMALL_CARD;
+            }
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -107,12 +107,12 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
         if (mImageType == null) mImageType = ImageType.DEFAULT;
         if (mPosterSizeSetting == null) mPosterSizeSetting = PosterSize.AUTO;
 
-        mCardHeight = getCardHeight(mPosterSizeSetting);
-
         if (get(UserPreferences.class).get(UserPreferences.Companion.getGridDirection()) == GridDirection.HORIZONTAL)
             setGridPresenter(new HorizontalGridPresenter());
         else
             setGridPresenter(new VerticalGridPresenter());
+
+        mCardHeight = getCardHeight(mPosterSizeSetting);
 
         setGridSizes();
 


### PR DESCRIPTION
**Changes**
For the vertical grid:
- Adjust column size for thumb and banner views
- Decrease heights of medium posters (175 -> 171 dp) and large posters (210 -> 202 dp) to fit another item in each row
- Setting the image size preference to Default (used to be named Auto) now chooses the correct column size for the image size that gets used
