### PR TITLE
Add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     labels:
       - ci
       - github-actions
+      - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci
+      - github-actions


### PR DESCRIPTION
**Changes**
- Add Dependabot for GitHub Actions updates
  - Mostly copied from jellyfin-sdk-kotlin (originally added by @h1dden-da3m0n)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
