### PR TITLE
Add link to system subtitle settings in playback preferences

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -2,6 +2,8 @@ package org.jellyfin.androidtv.ui.preference.category
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.content.Intent
+import android.provider.Settings
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AudioBehavior
@@ -95,6 +97,13 @@ fun OptionsScreen.playbackCategory(
 		setTitle(R.string.lbl_audio_output)
 		bind(userPreferences, UserPreferences.audioBehaviour)
 		depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL && !DeviceUtils.isFireTv() && DeviceUtils.is50() }
+	}
+
+	link {
+		title = context.getString(R.string.settings_captions)
+		content = context.getString(R.string.settings_captions_description)
+		intent = Intent(Settings.ACTION_CAPTIONING_SETTINGS)
+		depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL && intent!!.resolveActivity(context.packageManager) != null }
 	}
 
 	checkbox {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsLink.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsLink.kt
@@ -1,10 +1,10 @@
 package org.jellyfin.androidtv.ui.preference.dsl
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.core.os.bundleOf
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import java.util.*
@@ -20,6 +20,7 @@ class OptionsLink(
 	var icon: Int? = null
 	var content: String? = null
 	var fragment: KClass<out OptionsFragment>? = null
+	var intent: Intent? = null
 	var extras: Bundle? = null
 
 	inline fun <reified T : OptionsFragment> withFragment(extraBundle: Bundle? = null) {
@@ -40,6 +41,7 @@ class OptionsLink(
 			it.isPersistent = false
 			it.key = UUID.randomUUID().toString()
 			it.fragment = fragment?.qualifiedName
+			it.intent = intent
 			extras?.let { extras -> it.extras.putAll(extras)}
 			category.addPreference(it)
 			it.isEnabled = dependencyCheckFun() && enabled

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,4 +474,6 @@
     <string name="user_picker_last_user_title">Most recently used</string>
     <string name="user_picker_last_user_summary">Use the last active user</string>
     <string name="lbl_switch_user">Switch user</string>
+    <string name="settings_captions">Captions</string>
+    <string name="settings_captions_description">Subtitle preferences for your device</string>
 </resources>


### PR DESCRIPTION
**Changes**

In emulator/Android TV looks like this:

![image](https://user-images.githubusercontent.com/2305178/115196298-0b78e680-a0f0-11eb-864a-dcdfc62c5002.png)

![image](https://user-images.githubusercontent.com/2305178/115196329-13388b00-a0f0-11eb-871d-db0ef2cfcf2b.png)

AFAIK ExoPlayer uses the chosen style.

Link is disabled when setting not supported by device.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
