### PR TITLE
Fix crash when genres in baseitem is null

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -504,7 +504,9 @@ public class ItemListActivity extends FragmentActivity {
     }
 
     private void addGenres(TextView textView) {
-        textView.setText(TextUtils.join(" / ", mBaseItem.getGenres()));
+        ArrayList<String> genres = mBaseItem.getGenres();
+        if (genres != null) textView.setText(TextUtils.join(" / ", genres));
+        else textView.setText(null);
     }
 
     private void play(List<BaseItemDto> items) {


### PR DESCRIPTION
**Changes**

Big brain in this part of the code caused a crash because genres is null but we didn't check for it in the addGenres function.

https://github.com/jellyfin/jellyfin-androidtv/blob/29c671164b036e51da55602b173abcb4bc5377a4/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java#L336-L367

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
