### PR TITLE
Always round up in runtime calculation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -761,7 +761,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     private String getRunTime() {
         Long runtime = Utils.getSafeValue(mBaseItem.getRunTimeTicks(), mBaseItem.getOriginalRunTimeTicks());
-        return runtime != null && runtime > 0 ? runtime / 600000000 + getString(R.string.lbl_min) : "";
+        return runtime != null && runtime > 0 ? (int) Math.ceil((double) runtime / 600000000) + getString(R.string.lbl_min) : "";
     }
 
     private String getEndTime() {


### PR DESCRIPTION
**Changes**

I'm watching a show where each episode is around 1 minute and 50 seconds. The details page said rounded it down to "1 min". It makes more sense to always round up.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
