### PR TITLE
Fix height of first episode of next up row in the main item details page

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -635,7 +635,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                ItemRowAdapter nextUpAdapter = new ItemRowAdapter(nextUpQuery, false, new CardPresenter(), adapter);
+                ItemRowAdapter nextUpAdapter = new ItemRowAdapter(nextUpQuery, false, new CardPresenter(true, 260), adapter);
                 addItemRow(adapter, nextUpAdapter, 0, TvApp.getApplication().getString(R.string.lbl_next_up));
 
                 SeasonQuery seasons = new SeasonQuery();


### PR DESCRIPTION
**Changes**
Sets the height of the first episode of the next up row of the main item details page to 260 to match the rest of the episodes in the row.

**Issues**
The first episode was 300 while the rest were 260, causing the episode to appear larger and the row height to change as the episode was scrolled off screen.