### PR TITLE
Update ExoPlayer to 2.14.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,7 +108,7 @@ dependencies {
 	implementation("com.google.code.gson:gson:2.8.6")
 
 	// Media players
-	implementation("com.amazon.android:exoplayer:2.11.3")
+	implementation("com.google.android.exoplayer:exoplayer:2.14.0")
 	implementation("org.videolan.android:libvlc-all:3.3.14")
 
 	// Image utility


### PR DESCRIPTION
**Changes**

- Update ExoPlayer to 2.14.0 (was 2.11.3)
- Switch from Amazon fork to official Google version

  Amazon doesn't maintain their fork anymore and I'm not a fan of using an outdated version. There's lots of complains on Reddit about it too, some users even manually replace the dependency and build their own version of the app. Moving away from the fork should not impact too many users, afaik the patches in the fork are mostly for older generations of Fire OS devices. Those users should update their device or force LibVLC as videoplayer.

**Issues**

Part of #839
