### PR TITLE
Replace item details end time when clock is hidden and add an option to hide the chapters row

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -167,6 +167,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Enable series thumbnails in home screen rows
 		 */
 		var seriesThumbnailsEnabled = Preference.boolean("pref_enable_series_thumbnails", true)
+
+		/**
+		 * Display the chapters row on movie and episode screens
+		 */
+		var chaptersRowEnabled = Preference.boolean("pref_enable_chapters_row", true)
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -43,6 +43,7 @@ import org.jellyfin.androidtv.data.querying.TrailersQuery;
 import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.preference.SystemPreferences;
 import org.jellyfin.androidtv.preference.UserPreferences;
+import org.jellyfin.androidtv.preference.constant.ClockBehavior;
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer;
 import org.jellyfin.androidtv.ui.IRecordingIndicatorView;
 import org.jellyfin.androidtv.ui.RecordPopup;
@@ -434,7 +435,13 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
                     if ((item.getRunTimeTicks() != null && item.getRunTimeTicks() > 0) || item.getOriginalRunTimeTicks() != null) {
                         mDetailsOverviewRow.setInfoItem2(new InfoItem(getString(R.string.lbl_runs), getRunTime()));
-                        mDetailsOverviewRow.setInfoItem3(new InfoItem(getString(R.string.lbl_ends), getEndTime()));
+
+                        ClockBehavior clockBehavior = userPreferences.getValue().get(UserPreferences.Companion.getClockBehavior());
+                        if (clockBehavior == ClockBehavior.ALWAYS || clockBehavior == ClockBehavior.IN_MENUS) {
+                            mDetailsOverviewRow.setInfoItem3(new InfoItem(getString(R.string.lbl_ends), getEndTime()));
+                        } else {
+                            mDetailsOverviewRow.setInfoItem3(new InfoItem());
+                        }
                     } else {
                         mDetailsOverviewRow.setInfoItem2(new InfoItem());
                         mDetailsOverviewRow.setInfoItem3(new InfoItem());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -225,7 +225,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     protected void onResume() {
         super.onResume();
 
-        startClock();
+        ClockBehavior clockBehavior = userPreferences.getValue().get(UserPreferences.Companion.getClockBehavior());
+        if (clockBehavior == ClockBehavior.ALWAYS || clockBehavior == ClockBehavior.IN_MENUS) {
+            startClock();
+        }
 
         //Update information that may have changed - delay slightly to allow changes to take on the server
         if (dataRefreshService.getValue().getLastPlayback() > mLastUpdated.getTimeInMillis() && mBaseItem.getBaseItemType() != BaseItemType.MusicArtist) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -530,7 +530,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     protected void addAdditionalRows(ArrayObjectAdapter adapter) {
         Timber.d("Item type: %s", mBaseItem.getBaseItemType().toString());
-        boolean chaptersRowEnabled;
+        boolean chaptersRowEnabled = userPreferences.getValue().get(UserPreferences.Companion.getChaptersRowEnabled());
         switch (mBaseItem.getBaseItemType()) {
             case Movie:
 
@@ -551,7 +551,6 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 }
 
                 //Chapters
-                chaptersRowEnabled = userPreferences.getValue().get(UserPreferences.Companion.getChaptersRowEnabled());
                 if (chaptersRowEnabled && mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
                     List<ChapterItemInfo> chapters = BaseItemUtils.buildChapterItems(mBaseItem);
                     ItemRowAdapter chapterAdapter = new ItemRowAdapter(chapters, new CardPresenter(true, 240), adapter);
@@ -713,7 +712,6 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 }
 
                 //Chapters
-                chaptersRowEnabled = userPreferences.getValue().get(UserPreferences.Companion.getChaptersRowEnabled());
                 if (chaptersRowEnabled && mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
                     List<ChapterItemInfo> chapters = BaseItemUtils.buildChapterItems(mBaseItem);
                     ItemRowAdapter chapterAdapter = new ItemRowAdapter(chapters, new CardPresenter(true, 240), adapter);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -523,6 +523,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     protected void addAdditionalRows(ArrayObjectAdapter adapter) {
         Timber.d("Item type: %s", mBaseItem.getBaseItemType().toString());
+        boolean chaptersRowEnabled;
         switch (mBaseItem.getBaseItemType()) {
             case Movie:
 
@@ -543,7 +544,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 }
 
                 //Chapters
-                if (mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
+                chaptersRowEnabled = userPreferences.getValue().get(UserPreferences.Companion.getChaptersRowEnabled());
+                if (chaptersRowEnabled && mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
                     List<ChapterItemInfo> chapters = BaseItemUtils.buildChapterItems(mBaseItem);
                     ItemRowAdapter chapterAdapter = new ItemRowAdapter(chapters, new CardPresenter(true, 240), adapter);
                     addItemRow(adapter, chapterAdapter, 1, getString(R.string.lbl_chapters));
@@ -704,7 +706,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 }
 
                 //Chapters
-                if (mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
+                chaptersRowEnabled = userPreferences.getValue().get(UserPreferences.Companion.getChaptersRowEnabled());
+                if (chaptersRowEnabled && mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
                     List<ChapterItemInfo> chapters = BaseItemUtils.buildChapterItems(mBaseItem);
                     ItemRowAdapter chapterAdapter = new ItemRowAdapter(chapters, new CardPresenter(true, 240), adapter);
                     addItemRow(adapter, chapterAdapter, 1, getString(R.string.lbl_chapters));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -74,6 +74,7 @@ import org.jellyfin.apiclient.model.dto.BaseItemPerson;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
+import org.jellyfin.apiclient.model.dto.StudioDto;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.entities.MediaStream;
@@ -437,13 +438,26 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                     mDetailsOverviewRow.setInfoItem1(firstRow);
 
                     if ((item.getRunTimeTicks() != null && item.getRunTimeTicks() > 0) || item.getOriginalRunTimeTicks() != null) {
-                        mDetailsOverviewRow.setInfoItem2(new InfoItem(getString(R.string.lbl_runs), getRunTime()));
-
                         ClockBehavior clockBehavior = userPreferences.getValue().get(UserPreferences.Companion.getClockBehavior());
                         if (clockBehavior == ClockBehavior.ALWAYS || clockBehavior == ClockBehavior.IN_MENUS) {
+                            mDetailsOverviewRow.setInfoItem2(new InfoItem(getString(R.string.lbl_runs), getRunTime()));
                             mDetailsOverviewRow.setInfoItem3(new InfoItem(getString(R.string.lbl_ends), getEndTime()));
                         } else {
-                            mDetailsOverviewRow.setInfoItem3(new InfoItem());
+                            InfoItem secondRow;
+                            if (item.getBaseItemType() == BaseItemType.Series) {
+                                StudioDto[] itemStudios = item.getStudios();
+                                StudioDto network = itemStudios.length > 0 ? itemStudios[0] : null;
+                                secondRow = new InfoItem(
+                                        getString(R.string.lbl_network),
+                                        network != null ? network.getName() : getString(R.string.lbl_bracket_unknown));
+                            } else {
+                                BaseItemPerson writer = BaseItemUtils.getFirstPerson(item, PersonType.Writer);
+                                secondRow = new InfoItem(
+                                        getString(R.string.lbl_written_by),
+                                        writer != null ? writer.getName() : getString(R.string.lbl_bracket_unknown));
+                            }
+                            mDetailsOverviewRow.setInfoItem2(secondRow);
+                            mDetailsOverviewRow.setInfoItem3(new InfoItem(getString(R.string.lbl_runs), getRunTime()));
                         }
                     } else {
                         mDetailsOverviewRow.setInfoItem2(new InfoItem());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/general.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/general.kt
@@ -53,6 +53,12 @@ fun OptionsScreen.generalCategory(
 	}
 
 	checkbox {
+		setTitle(R.string.lbl_show_chapters_row)
+		setContent(R.string.lbl_show_chapters_row_description)
+		bind(userPreferences, UserPreferences.chaptersRowEnabled)
+	}
+
+	checkbox {
 		setTitle(R.string.lbl_enable_seasonal_themes)
 		setContent(R.string.desc_seasonal_themes)
 		bind(userPreferences, UserPreferences.seasonalGreetingsEnabled)

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.preference.UserPreferences;
+import org.jellyfin.androidtv.preference.constant.ClockBehavior;
 import org.jellyfin.androidtv.preference.constant.RatingType;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
@@ -205,6 +206,10 @@ public class InfoLayoutHelper {
     }
 
     private static void addRuntime(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeEndtime) {
+        ClockBehavior clockBehavior = get(UserPreferences.class).get(UserPreferences.Companion.getClockBehavior());
+        if (clockBehavior != ClockBehavior.ALWAYS && clockBehavior != ClockBehavior.IN_MENUS) {
+            includeEndtime = false;
+        }
         Long runtime = Utils.getSafeValue(item.getRunTimeTicks(), item.getOriginalRunTimeTicks());
         if (runtime != null && runtime > 0) {
             long endTime = includeEndtime ? System.currentTimeMillis() + runtime / 10000 - (item.getUserData() != null && item.getCanResume() ? item.getUserData().getPlaybackPositionTicks()/10000 : 0) : 0;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,4 +474,6 @@
     <string name="user_picker_last_user_title">Most recently used</string>
     <string name="user_picker_last_user_summary">Use the last active user</string>
     <string name="lbl_switch_user">Switch user</string>
+    <string name="lbl_show_chapters_row">Show chapters row</string>
+    <string name="lbl_show_chapters_row_description">"Display the video's chapters on the item screen"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,4 +476,6 @@
     <string name="lbl_switch_user">Switch user</string>
     <string name="lbl_show_chapters_row">Show video chapters</string>
     <string name="lbl_show_chapters_row_description">Display the video\'s chapters on the item details</string>
+    <string name="lbl_written_by">Written By</string>
+    <string name="lbl_network">Network</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,6 +474,6 @@
     <string name="user_picker_last_user_title">Most recently used</string>
     <string name="user_picker_last_user_summary">Use the last active user</string>
     <string name="lbl_switch_user">Switch user</string>
-    <string name="lbl_show_chapters_row">Show chapters row</string>
-    <string name="lbl_show_chapters_row_description">"Display the video's chapters on the item screen"</string>
+    <string name="lbl_show_chapters_row">Show video chapters</string>
+    <string name="lbl_show_chapters_row_description">Display the video\'s chapters on the item details</string>
 </resources>


### PR DESCRIPTION
**Changes**

- Adds an option to hide the chapters row on the item details screen. Since I don't extract chapter images and I never use the row, it just ends up being a rather unattractive row of teal.
- Replaces the "Ends" time with the episode/movie writer or series network if the clock is hidden on the screen