### PR TITLE
Allow themes to change rounding values/indicator shape, add Muted Purple theme

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/AppTheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/AppTheme.kt
@@ -19,7 +19,7 @@ enum class AppTheme {
 	/**
 	 * A theme with a more muted accent color, inspired by CTalvio's Monochromic CSS theme for Jellyfin Web
 	 */
-	@EnumDisplayOptions(R.string.pref_theme_muted)
+	@EnumDisplayOptions(R.string.pref_theme_muted_purple)
 	MUTED_PURPLE,
 
 	/**

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/AppTheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/AppTheme.kt
@@ -17,6 +17,12 @@ enum class AppTheme {
 	EMERALD,
 
 	/**
+	 * A theme with a more muted accent color, inspired by CTalvio's Monochromic CSS theme for Jellyfin Web
+	 */
+	@EnumDisplayOptions(R.string.pref_theme_muted)
+	MUTED_PURPLE,
+
+	/**
 	 * Theme inspired by Win 3.1's "hot dog stand"
 	 */
 	@EnumDisplayOptions(hidden = true)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/ThemeManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/ThemeManager.kt
@@ -30,6 +30,7 @@ object ThemeManager {
 		return when (appTheme) {
 			AppTheme.DARK -> R.style.Theme_Jellyfin
 			AppTheme.EMERALD -> R.style.Theme_Jellyfin_Emerald
+			AppTheme.MUTED_PURPLE -> R.style.Theme_Jellyfin_MutedPurple
 			AppTheme.HOT_DOG_STAND -> R.style.Theme_Jellyfin_HotDogStand
 		}
 	}

--- a/app/src/main/res/drawable/btn_focus.xml
+++ b/app/src/main/res/drawable/btn_focus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners android:radius="2dp" />
+    <corners android:radius="?attr/buttonRounding" />
     <solid android:color="?android:attr/colorAccent" />
 </shape>

--- a/app/src/main/res/drawable/btn_non_focus.xml
+++ b/app/src/main/res/drawable/btn_non_focus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners android:radius="2dp" />
+    <corners android:radius="?attr/buttonRounding" />
     <solid android:color="?android:attr/colorButtonNormal" />
 </shape>

--- a/app/src/main/res/drawable/square_accent.xml
+++ b/app/src/main/res/drawable/square_accent.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
+    <solid android:color="?android:attr/colorAccent" />
     <corners android:radius="?attr/cardRounding" />
 </shape>

--- a/app/src/main/res/layout/image_card_view.xml
+++ b/app/src/main/res/layout/image_card_view.xml
@@ -77,7 +77,7 @@
                 android:id="@+id/watched"
                 android:layout_width="20dp"
                 android:layout_height="20dp"
-                android:src="@drawable/circle_accent" />
+                android:src="?attr/accentShape" />
 
             <TextView
                 android:id="@+id/unwatchedCount"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -13,5 +13,9 @@
         <attr name="popupWindowBackground" format="reference|color" />
         <!-- CardView Attributes -->
         <attr name="cardViewBackground" format="reference|color" />
+        <!-- Theme Attributes -->
+        <attr name="cardRounding" format="dimension" />
+        <attr name="buttonRounding" format="dimension" />
+        <attr name="accentShape" format="reference" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,4 +474,5 @@
     <string name="user_picker_last_user_title">Most recently used</string>
     <string name="user_picker_last_user_summary">Use the last active user</string>
     <string name="lbl_switch_user">Switch user</string>
+    <string name="pref_theme_muted">Muted Purple</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,5 +474,5 @@
     <string name="user_picker_last_user_title">Most recently used</string>
     <string name="user_picker_last_user_summary">Use the last active user</string>
     <string name="lbl_switch_user">Switch user</string>
-    <string name="pref_theme_muted">Muted Purple</string>
+    <string name="pref_theme_muted_purple">Muted Purple</string>
 </resources>

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -33,6 +33,16 @@
 
         <item name="preferenceTheme">@style/PreferenceThemeOverlayLeanback</item>
 
+        <!-- Rounding Values -->
+        <item name="cardRounding">4dp</item>
+        <item name="buttonRounding">4dp</item>
+
+        <!-- Watched Indicator Shape -->
+        <item name="accentShape">@drawable/circle_accent</item>
+
+        <!-- Dim level of non-focus grid items -->
+        <item name="overlayDimDimmedLevel">30%</item>
+
         <!-- Tile colors -->
         <item name="tile_settings_bg">#359AB8</item>
         <item name="tile_edit_bg">#4b41ae</item>

--- a/app/src/main/res/values/theme_mutedpurple.xml
+++ b/app/src/main/res/values/theme_mutedpurple.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <color name="theme_muted_purple_accent">#627EC8</color>
+    <color name="light_grey_transparent">#2EAAAAAA</color>
+
+    <style name="Theme.Jellyfin.MutedPurple" parent="Theme.Jellyfin">
+        <!-- Colors -->
+        <item name="android:colorAccent">@color/theme_muted_purple_accent</item>
+        <item name="defaultSearchColor">@color/theme_muted_purple_accent</item>
+        <item name="progressPrimary">@color/theme_muted_purple_accent</item>
+        <item name="android:colorButtonNormal">@color/light_grey_transparent</item>
+
+        <!-- Rounding Values -->
+        <item name="cardRounding">5dp</item>
+        <item name="buttonRounding">7dp</item>
+
+        <!-- Watched Indicator Shape -->
+        <item name="accentShape">@drawable/square_accent</item>
+    </style>
+</resources>


### PR DESCRIPTION
**Changes**

- Allows themes to change the indicator shape and the rounding values for cards/buttons
- Adds a Muted Purple theme that uses an accent color from the inner triangle of the Jellyfin logo, translucent buttons, and a rounded square watched indicator
- Increases the rounding value for btn_focus and btn_non_focus from 2dp to 4dp (default theme)
- Raises the brightness of the non-focus grid items (all themes)