### PR TITLE
Update README to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">Jellyfin Android TV</h1>
-<h3 align="center">Part of the <a href="https://jellyfin.media">Jellyfin Project</a></h3>
+<h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
 ---
 
@@ -12,8 +12,8 @@
 <a href="https://github.com/jellyfin/jellyfin-androidtv/releases">
 <img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-androidtv.svg"/>
 </a>
-<a href="https://translate.jellyfin.org/projects/jellyfin/jellyfin-androidtv/?utm_source=widget">
-<img src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-androidtv/svg-badge.svg" alt="Translation status" />
+<a href="https://translate.jellyfin.org/projects/jellyfin/jellyfin-androidtv/">
+<img alt="Translation Status" src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-androidtv/svg-badge.svg"/>
 </a>
 <br/>
 <a href="https://opencollective.com/jellyfin">
@@ -30,18 +30,57 @@
 </a>
 <br/>
 <a href="https://play.google.com/store/apps/details?id=org.jellyfin.androidtv">
-<img width="200" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play"/>
+<img width="153" alt="Jellyfin on Google Play" src="https://jellyfin.org/images/store-icons/google-play.png"/>
 </a>
-<br/>
 <a href="https://www.amazon.com/gp/aw/d/B07TX7Z725">
-<img width="170" src="https://images-na.ssl-images-amazon.com/images/G/01/mobile-apps/devportal2/res/images/amazon-appstore-badge-english-black.png" alt="Available at Amazon Appstore"/>
+<img width="153" alt="Jellyfin on Amazon Appstore" src="https://jellyfin.org/images/store-icons/amazon.png"/>
 </a>
 <br/>
 <a href="https://repo.jellyfin.org/releases/client/androidtv/">Download archive</a>
 </p>
 
-Jellyfin Android TV is a Jellyfin client for Android TV, Nvidia Shield, and Amazon Fire TV devices. We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start. Translations can be improved very easily from our <a href="https://translate.jellyfin.org/projects/jellyfin/jellyfin-androidtv">Weblate</a> instance. Look through the following graphic to see if your native language could use some work!
+Jellyfin Android TV is a Jellyfin client for Android TV, Nvidia Shield, and Amazon Fire TV devices.
+We welcome all contributions and pull requests! If you have a larger feature in mind please open an
+issue so we can discuss the implementation before you start. 
 
-<a href="https://translate.jellyfin.org/engage/jellyfin/?utm_source=widget">
-<img src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-androidtv/multi-auto.svg" alt="Detailed Translation Status"/>
+## Translating
+
+Translations can be improved very easily from our
+[Weblate](https://translate.jellyfin.org/projects/jellyfin/jellyfin-androidtv) instance.
+Look through the following graphic to see if your native language could use some work!
+
+<a href="https://translate.jellyfin.org/engage/jellyfin/">
+<img alt="Detailed Translation Status" src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-androidtv/multi-auto.svg"/>
 </a>
+
+## Build Process
+
+### Dependencies
+
+- Android Studio
+
+### Build
+
+1. Clone or download this repository
+
+   ```sh
+   git clone https://github.com/jellyfin/jellyfin-androidtv.git
+   cd jellyfin-androidtv
+   ```
+
+2. Open the project in Android Studio and run it from there or build an APK directly through Gradle:
+
+   ```sh
+   ./gradlew assembleDebug
+   ```
+   
+   Add the Android SDK to you PATH environment variable or create the ANDROID_SDK_ROOT variable for
+   this to work.
+
+### Deploy to device/emulator
+
+   ```sh
+   ./gradlew installDebug
+   ```
+
+*You can also replace the "Debug" with "Release" to get an optimized release binary.*


### PR DESCRIPTION
**Changes**

Update the README to be more like the jellyfin-android readme.

- Removed `utm_source` parameters from urls
- `alt` before `src`
- Update jellyfin.media to jellyfin.org
- Build process (copied from jf-android)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
