### PR TITLE
Move linting and testing to GitHub actions

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -17,40 +17,6 @@ pr:
     - '*'
 
 jobs:
-- job: Lint
-  displayName: 'Lint'
-
-  pool:
-    vmImage: 'ubuntu-latest'
-
-  steps:
-  - task: Gradle@2
-    displayName: 'Run Lint'
-    inputs:
-      gradleWrapperFile: 'gradlew'
-      tasks: 'lint'
-      publishJUnitResults: false
-      testResultsFiles: '**/TEST-*.xml'
-      javaHomeOption: 'JDKVersion'
-      sonarQubeRunAnalysis: false
-
-- job: Test
-  displayName: 'Test'
-
-  pool:
-    vmImage: 'ubuntu-latest'
-
-  steps:
-  - task: Gradle@2
-    displayName: 'Run Tests'
-    inputs:
-      gradleWrapperFile: 'gradlew'
-      tasks: 'test'
-      publishJUnitResults: true
-      testResultsFiles: '**/TEST-*.xml'
-      javaHomeOption: 'JDKVersion'
-      sonarQubeRunAnalysis: false
-
 - job: Build
   displayName: 'Build'
 

--- a/.github/workflows/app-lint.yaml
+++ b/.github/workflows/app-lint.yaml
@@ -1,0 +1,36 @@
+name: App Lint
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Setup Gradle cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run detekt task
+        run: ./gradlew --build-cache --no-daemon --info detekt
+      - name: Upload SARIF files
+        uses: github/codeql-action/upload-sarif@v1
+        if: ${{ always() }}
+        with:
+          sarif_file: .

--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -1,0 +1,31 @@
+name: App Test
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Setup Gradle cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run test task
+        run: ./gradlew --build-cache --no-daemon --info test

--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -1,16 +1,17 @@
-name: Merge conflict label
+name: Merge conflict labeler
 
 on:
-  schedule:
-    - cron: '0 4 * * *'
   push:
+  pull_request_target:
+    types:
+      - synchronize
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'jellyfin/jellyfin-androidtv'
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@v2.0
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
-          CONFLICT_LABEL_NAME: merge conflict
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          dirtyLabel: merge conflict
+          repoToken: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -13,4 +13,4 @@ jobs:
       - uses: mschilde/auto-label-merge-conflicts@v2.0
         with:
           CONFLICT_LABEL_NAME: merge conflict
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,5 +33,10 @@ subprojects {
 		buildUponDefaultConfig = true
 		ignoreFailures = true
 		config = files("$rootDir/detekt.yml")
+		basePath = rootDir.absolutePath
+
+		reports {
+			sarif.enabled = true
+		}
 	}
 }


### PR DESCRIPTION
**Changes**
- Add new test action to run `gradlew test`
  - Copied from the Kotlin SDK
- Add new lint action to run `gradlew detekt` and upload the sarif file
  - Copied from the Kotlin SDK
  - This will start showing linter issues in pull requests, we need to finetune the for this linter config later
  - Temporarily removed Android linting (SARIF support is added in the next Android Gradle build tools version so we'll wait a bit for that)
- Remove test and lint jobs from Azure CI
- Use `GH_TOKEN` so CI actions run as the bot. ~~**SECRET NEEDS TO BE ADDED TO THE REPOSITORY FOR THIS TO WORK**~~
- Rename .yml to .yaml for merge conflict labeler
- Replace `mschilde/auto-label-merge-conflicts` (unmaintained) with `eps1lon/actions-label-merge-conflict`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
