### PR TITLE
Always cancel existing workers before recreating

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,7 +102,6 @@ dependencies {
 	implementation("io.insert-koin:koin-android:$koinVersion")
 	implementation("io.insert-koin:koin-androidx-viewmodel:$koinVersion")
 	implementation("io.insert-koin:koin-androidx-fragment:$koinVersion")
-	implementation("io.insert-koin:koin-androidx-workmanager:$koinVersion")
 
 	// GSON
 	implementation("com.google.code.gson:gson:2.8.6")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -172,10 +172,5 @@
             android:name=".ui.playback.nextup.NextUpActivity"
             android:noHistory="true"
             android:screenOrientation="landscape" />
-
-        <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
-            tools:node="remove" />
     </application>
 </manifest>

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import androidx.work.await
+import kotlinx.coroutines.runBlocking
 import org.acra.ACRA
 import org.acra.annotation.AcraCore
 import org.acra.annotation.AcraDialog
@@ -15,9 +17,9 @@ import org.jellyfin.androidtv.di.*
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
+import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
-import org.koin.androidx.workmanager.koin.workManagerFactory
 import org.koin.core.KoinExperimentalAPI
 import org.koin.core.context.startKoin
 import timber.log.Timber
@@ -73,18 +75,22 @@ class JellyfinApplication : TvApp() {
 				preferenceModule,
 				utilsModule
 			)
-
-			// Must be called after setting the modules to prevent a crash because the worker class
-			// definition is not found
-			workManagerFactory()
 		}
 
-		// Setup workers
-		get<WorkManager>().enqueueUniquePeriodicWork(
-			LeanbackChannelWorker.PERIODIC_UPDATE_REQUEST_NAME,
-			ExistingPeriodicWorkPolicy.REPLACE,
-			PeriodicWorkRequestBuilder<LeanbackChannelWorker>(1, TimeUnit.HOURS).build()
-		)
+		// Setup background workers
+		runBlocking {
+			val workManager by inject<WorkManager>()
+
+			// Cancel all workers
+			workManager.cancelAllWork().await()
+
+			// Recreate periodic workers
+			workManager.enqueueUniquePeriodicWork(
+				LeanbackChannelWorker.PERIODIC_UPDATE_REQUEST_NAME,
+				ExistingPeriodicWorkPolicy.REPLACE,
+				PeriodicWorkRequestBuilder<LeanbackChannelWorker>(1, TimeUnit.HOURS).build()
+			).await()
+		}
 
 		// Register lifecycle callbacks
 		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -7,7 +7,6 @@ import org.jellyfin.androidtv.auth.ServerRepositoryImpl
 import org.jellyfin.androidtv.data.eventhandling.TvApiEventListener
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.androidtv.data.service.BackgroundService
-import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
 import org.jellyfin.androidtv.ui.startup.LoginViewModel
@@ -21,7 +20,6 @@ import org.jellyfin.apiclient.serialization.GsonJsonSerializer
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
-import org.koin.androidx.workmanager.dsl.worker
 import org.koin.dsl.module
 
 val appModule = module {
@@ -50,9 +48,7 @@ val appModule = module {
 
 	single { DataRefreshService() }
 
-	worker { LeanbackChannelWorker(get(), get(), get()) }
-
-	single { WorkManager.getInstance(androidContext()) }
+	factory { WorkManager.getInstance(androidContext()) }
 
 	single<ServerRepository> { ServerRepositoryImpl(get(), get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -29,18 +29,20 @@ import org.jellyfin.apiclient.model.entities.ImageType
 import org.jellyfin.apiclient.model.querying.ItemFields
 import org.jellyfin.apiclient.model.querying.ItemsResult
 import org.jellyfin.apiclient.model.querying.NextUpQuery
-import org.koin.java.KoinJavaComponent.inject
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Manages channels on the android tv home screen
  *
  * More info: https://developer.android.com/training/tv/discovery/recommendations-channel
  */
+@KoinApiExtension
 class LeanbackChannelWorker(
 	private val context: Context,
-	val workerParams: WorkerParameters,
-	private val apiClient: ApiClient
-) : CoroutineWorker(context, workerParams) {
+	workerParams: WorkerParameters,
+) : CoroutineWorker(context, workerParams), KoinComponent {
 	companion object {
 		/**
 		 * Amount of ticks found in a millisecond, used for calculation
@@ -51,7 +53,8 @@ class LeanbackChannelWorker(
 		const val PERIODIC_UPDATE_REQUEST_NAME = "LeanbackChannelPeriodicUpdateRequest"
 	}
 
-	private val userPreferences by inject(UserPreferences::class.java)
+	private val apiClient by inject<ApiClient>()
+	private val userPreferences by inject<UserPreferences>()
 
 	/**
 	 * Check if the app can use Leanback features and is API level 26 or higher

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -70,7 +70,7 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 
 		// Update leanback channels
 		// TODO Move this (on app start?)
-		val channelUpdateRequest = OneTimeWorkRequest.Builder(LeanbackChannelWorker::class.java).build()
+		val channelUpdateRequest = OneTimeWorkRequest.from(LeanbackChannelWorker::class.java)
 		get<WorkManager>().enqueueUniqueWork(
 			LeanbackChannelWorker.SINGLE_UPDATE_REQUEST_NAME,
 			ExistingWorkPolicy.REPLACE,


### PR DESCRIPTION
I can't reproduce the issue that crashes the application anymore after these tweaks

Issue before:
```
java.lang.Error: org.koin.core.error.InstanceCreationException: Could not create instance for [Factory:'org.jellyfin.androidtv.integration.LeanbackChannelWorker',qualifier:q:'org.jellyfin.androidtv.integration.LeanbackChannelWorker',binds:androidx.work.ListenableWorker]
```
**Changes**

- Always cancel existing workers
  - If we add new ones/change existing ones in the future this prevents duplicate or deprecated runners to run
- Await the results of  the cancellation/creation
  - It should never fail but this makes sure that if it does the exception it thrown to the main thread

Most of it is inspired from a Koin sample here:
https://github.com/InsertKoinIO/koin/blob/68b2e9eaf3ad465f0ebb8f1e6b7cd96541052637/examples/androidx-samples/src/main/java/org/koin/sample/androidx/MainApplication.kt

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
