### PR TITLE
Update Kotlin and Gradle plugin to latest version and add Android linter to linting workflow

### DIFF
--- a/.github/workflows/app-lint.yaml
+++ b/.github/workflows/app-lint.yaml
@@ -27,8 +27,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Run detekt task
-        run: ./gradlew --build-cache --no-daemon --info detekt
+      - name: Run detekt and lint task
+        run: ./gradlew --build-cache --no-daemon --info detekt lint
       - name: Upload SARIF files
         uses: github/codeql-action/upload-sarif@v1
         if: ${{ always() }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,14 +21,9 @@ android {
 		viewBinding = true
 	}
 
-	compileOptions {
-		// Use Java 1.8 features
-		sourceCompatibility = JavaVersion.VERSION_1_8
-		targetCompatibility = JavaVersion.VERSION_1_8
-	}
-
-	kotlinOptions {
-		jvmTarget = compileOptions.targetCompatibility.toString()
+	lintOptions {
+		isAbortOnError = false
+		sarifReport = true
 	}
 
 	buildTypes {

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -16,4 +16,7 @@
     <issue id="LogNotTimber" severity="error" />
     <issue id="BinaryOperationInTimber" severity="error" />
     <issue id="FragmentTagUsage" severity="error" />
+
+    <!-- Broken in Sarif output -->
+    <issue id="LocaleFolder" severity="ignore" />
 </lint>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
 	dependencies {
 		val kotlinVersion: String by project
-		classpath("com.android.tools.build:gradle:4.1.3")
+		classpath("com.android.tools.build:gradle:4.2.0")
 		classpath(kotlin("gradle-plugin", kotlinVersion))
 		classpath(kotlin("serialization", kotlinVersion))
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 
 # Kotlin version
-kotlinVersion=1.4.31
+kotlinVersion=1.5.0
 
 # Kotlin compiler
 kotlin.incremental=true


### PR DESCRIPTION
**Changes**

- Kotlin 1.5
- Android Gradle plugin 4.2
- Enabled SARIF reports for Android linter
- Updated lint workflow to run the Android linter
- Remove Java 8 target options (is now the default)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
