### PR TITLE
ISSUE_TEMPLATE/config.yml: fix URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Jellyfin documentation
-    url:  https://jellyfin.org/docs/getting-help.html
+    url:  https://jellyfin.org/docs/general/getting-help.html
     about: Our documentation contains lots of help for common issues


### PR DESCRIPTION
Fix the "Getting help" URL in ISSUE_TEMPLATE/config.yml.

Signed-off-by: Jeff Squyres <jeff@squyres.com>

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

Trivial URL fix in the `.github/ISSUE_TEMPLATE/config.yml` file so that the "Jellyfin documentation" link on https://github.com/jellyfin/jellyfin-androidtv/issues/new/choose is correct (I'm guessing that the old URL is just stale / has changed...?).

I do not think that this trivial change is worth adding me to CONTRIBUTORS.md.  😄 

**Issues**

NA.