### PR TITLE
Fix null media url crash

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
@@ -9,6 +9,7 @@ import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.QueryStringDictionary;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dlna.DlnaProfileType;
+import org.jellyfin.apiclient.model.dlna.PlaybackErrorCode;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.mediainfo.LiveStreamRequest;
 import org.jellyfin.apiclient.model.mediainfo.LiveStreamResponse;
@@ -138,6 +139,14 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
             streamInfo.setPlayMethod(PlayMethod.Transcode);
             streamInfo.setContainer(mediaSourceInfo.getTranscodingContainer());
             streamInfo.setMediaUrl(apiClient.GetApiUrl(mediaSourceInfo.getTranscodingUrl()));
+        }
+
+        // A null url will crash the app, make sure to call onError instead
+        if (streamInfo.getMediaUrl() == null) {
+            PlaybackException exception = new PlaybackException();
+            exception.setErrorCode(PlaybackErrorCode.NoCompatibleStream);
+            response.onError(exception);
+            return;
         }
 
         playbackManager.SendResponse(response, streamInfo);


### PR DESCRIPTION
**Changes**
Fixes the app crashing when the media url is null. Specifically addresses an issue where this condition is hit on 10.7.5 when transcoding and remuxing is disabled.

**Issues**
N/A
