### PR TITLE
Fix Fire OS focus issues on login

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyboardFocusChangeListener.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyboardFocusChangeListener.kt
@@ -3,9 +3,14 @@ package org.jellyfin.androidtv.ui.shared
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.core.content.getSystemService
+import org.jellyfin.androidtv.util.DeviceUtils
 
 class KeyboardFocusChangeListener : View.OnFocusChangeListener {
 	override fun onFocusChange(view: View, hasFocus: Boolean) {
+		// The Fire OS on-screen keyboard blocks virtually all content on screen,
+		// so require manually opening the keyboard there
+		if (DeviceUtils.isFireTv()) return
+
 		view.context.getSystemService<InputMethodManager>()?.apply {
 			if (!hasFocus) hideSoftInputFromWindow(view.windowToken, 0)
 			else showSoftInput(view, 0)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyboardFocusChangeListener.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyboardFocusChangeListener.kt
@@ -7,13 +7,11 @@ import org.jellyfin.androidtv.util.DeviceUtils
 
 class KeyboardFocusChangeListener : View.OnFocusChangeListener {
 	override fun onFocusChange(view: View, hasFocus: Boolean) {
-		// The Fire OS on-screen keyboard blocks virtually all content on screen,
-		// so require manually opening the keyboard there
-		if (DeviceUtils.isFireTv()) return
-
 		view.context.getSystemService<InputMethodManager>()?.apply {
 			if (!hasFocus) hideSoftInputFromWindow(view.windowToken, 0)
-			else showSoftInput(view, 0)
+			// The Fire OS on-screen keyboard blocks virtually all content on screen,
+			// so require manually opening the keyboard there
+			else if (!DeviceUtils.isFireTv()) showSoftInput(view, 0)
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -42,6 +42,7 @@ class AddServerAlertFragment : AlertFragment() {
 		with(binding.address) {
 			onFocusChangeListener = KeyboardFocusChangeListener()
 			nextFocusForwardId = parentBinding.confirm.id
+			nextFocusDownId = parentBinding.confirm.id
 			imeOptions = EditorInfo.IME_ACTION_DONE
 			setOnEditorActionListener { _, actionId, _ ->
 				if (actionId == EditorInfo.IME_ACTION_DONE) parentBinding.confirm.performClick()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -49,8 +49,9 @@ class AddServerAlertFragment : AlertFragment() {
 					clearFocus()
 					parentBinding.confirm.performClick()
 					return@setOnEditorActionListener true
+				} else {
+					false
 				}
-				else false
 			}
 
 			if (serverAddressArgument != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -45,7 +45,11 @@ class AddServerAlertFragment : AlertFragment() {
 			nextFocusDownId = parentBinding.confirm.id
 			imeOptions = EditorInfo.IME_ACTION_DONE
 			setOnEditorActionListener { _, actionId, _ ->
-				if (actionId == EditorInfo.IME_ACTION_DONE) parentBinding.confirm.performClick()
+				if (actionId == EditorInfo.IME_ACTION_DONE) {
+					clearFocus()
+					parentBinding.confirm.performClick()
+					return@setOnEditorActionListener true
+				}
 				else false
 			}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/AddServerAlertFragment.kt
@@ -48,7 +48,7 @@ class AddServerAlertFragment : AlertFragment() {
 				if (actionId == EditorInfo.IME_ACTION_DONE) {
 					clearFocus()
 					parentBinding.confirm.performClick()
-					return@setOnEditorActionListener true
+					true
 				} else {
 					false
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -64,8 +64,9 @@ class UserLoginAlertFragment : AlertFragment() {
 					clearFocus()
 					parentBinding.confirm.performClick()
 					return@setOnEditorActionListener true
+				} else {
+					false
 				}
-				else false
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -46,6 +46,7 @@ class UserLoginAlertFragment : AlertFragment() {
 			onFocusChangeListener = KeyboardFocusChangeListener()
 
 			if (usernameArgument != null) {
+				isFocusable = false
 				isEnabled = false
 				setText(usernameArgument)
 				binding.password.requestFocus()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -60,7 +60,7 @@ class UserLoginAlertFragment : AlertFragment() {
 			imeOptions = EditorInfo.IME_ACTION_DONE
 			setOnEditorActionListener { _, actionId, _ ->
 				if (actionId == EditorInfo.IME_ACTION_DONE) {
-					binding.password.clearFocus()
+					clearFocus()
 					parentBinding.confirm.performClick()
 					return@setOnEditorActionListener true
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -55,6 +55,7 @@ class UserLoginAlertFragment : AlertFragment() {
 		with(binding.password) {
 			onFocusChangeListener = KeyboardFocusChangeListener()
 			nextFocusForwardId = parentBinding.confirm.id
+			nextFocusDownId = parentBinding.confirm.id
 
 			imeOptions = EditorInfo.IME_ACTION_DONE
 			setOnEditorActionListener { _, actionId, _ ->

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -59,7 +59,11 @@ class UserLoginAlertFragment : AlertFragment() {
 
 			imeOptions = EditorInfo.IME_ACTION_DONE
 			setOnEditorActionListener { _, actionId, _ ->
-				if (actionId == EditorInfo.IME_ACTION_DONE) parentBinding.confirm.performClick()
+				if (actionId == EditorInfo.IME_ACTION_DONE) {
+					binding.password.clearFocus()
+					parentBinding.confirm.performClick()
+					return@setOnEditorActionListener true
+				}
 				else false
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginAlertFragment.kt
@@ -63,7 +63,7 @@ class UserLoginAlertFragment : AlertFragment() {
 				if (actionId == EditorInfo.IME_ACTION_DONE) {
 					clearFocus()
 					parentBinding.confirm.performClick()
-					return@setOnEditorActionListener true
+					true
 				} else {
 					false
 				}


### PR DESCRIPTION
**Changes**
* Prevents the on-screen keyboard from being activated automatically on Fire OS
* Fixes navigating down on alert fragments
* Ensures focus is cleared when confirm is selected
* Fixes username field receiving focus when disabled

**Issues**
N/A
