### PR TITLE
Move worker initialization and auto bitrate test to after session is created

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -6,16 +6,12 @@ import androidx.leanback.widget.Presenter
 import androidx.leanback.widget.Row
 import androidx.leanback.widget.RowPresenter
 import androidx.lifecycle.lifecycleScope
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.constant.HomeSectionType
-import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.androidtv.ui.browsing.IRowLoader
 import org.jellyfin.androidtv.ui.browsing.StdBrowseFragment
@@ -23,7 +19,6 @@ import org.jellyfin.androidtv.ui.playback.AudioEventListener
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter
-import org.jellyfin.androidtv.util.AutoBitrate
 import org.jellyfin.androidtv.util.apiclient.callApi
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.model.entities.DisplayPreferences
@@ -55,27 +50,12 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 
 		super.onCreate(savedInstanceState)
 
-		// Get auto bitrate
-		// TODO move to somewhere else (automatically start at app start?)
-		lifecycleScope.launch(Dispatchers.IO) {
-			get<AutoBitrate>().detect()
-		}
-
 		// Subscribe to Audio messages
 		mediaManager.addAudioEventListener(this)
 	}
 
 	override fun onResume() {
 		super.onResume()
-
-		// Update leanback channels
-		// TODO Move this (on app start?)
-		val channelUpdateRequest = OneTimeWorkRequest.from(LeanbackChannelWorker::class.java)
-		get<WorkManager>().enqueueUniqueWork(
-			LeanbackChannelWorker.SINGLE_UPDATE_REQUEST_NAME,
-			ExistingWorkPolicy.REPLACE,
-			channelUpdateRequest
-		)
 
 		// Update audio queue
 		Timber.i("Updating audio queue in HomeFragment (onResume)")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.replace
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.jellyfin.androidtv.JellyfinApplication
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.auth.ServerRepository
@@ -96,6 +97,9 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 	private suspend fun openNextActivity() {
 		val itemId = intent.getStringExtra(EXTRA_ITEM_ID)
 		val itemIsUserView = intent.getBooleanExtra(EXTRA_ITEM_IS_USER_VIEW, false)
+
+		// Start session
+		(application as? JellyfinApplication)?.onSessionStart()
 
 		if (itemId != null) {
 			if (itemIsUserView) {


### PR DESCRIPTION
**Changes**

The app crashed on start because the WorkManager was not initialized in the applications onCreate function. This might have caused the Koin issues before,....
Move worker initialization and auto bitrate test to after session is created.

I also moved the autobitrate thingy, it takes around 250ms for me. But when I look at the references it looks like it isn't even used. the only reference that uses it is here:

https://github.com/jellyfin/jellyfin-androidtv/blob/71e52b1bb25fa3c57daddca9bc73ce817fab2d44/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java#L566-L567

I'm considering removing the autobitrate stuff for now, it didn't seem to work anyway.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
