### PR TITLE
FIX: [vlc] "setAudioOutput" disables passthrough

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -234,7 +234,6 @@ public class MediaManager {
 
                 mVlcPlayer = new org.videolan.libvlc.MediaPlayer(mLibVLC);
                 if(!Utils.downMixAudio()) {
-                    mVlcPlayer.setAudioOutput("android_audiotrack");
                     mVlcPlayer.setAudioDigitalOutputEnabled(true);
                 } else {
                     mVlcPlayer.setAudioOutput("opensles_android");

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -422,9 +422,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     private void setVlcAudioOptions() {
-
         if(!Utils.downMixAudio()) {
-            mVlcPlayer.setAudioOutput("android_audiotrack");
             mVlcPlayer.setAudioDigitalOutputEnabled(true);
         } else {
             setCompatibleAudio();


### PR DESCRIPTION
Fix VLC player passthrough

**Changes**
As per the vlc javadoc, using `setAudioOutput`  "disable the encoding detection", and that seems to intefere with PT.
As  `android_audiotrack` is the default value (and I don't think you can switch the output during a playback), plainly removing the lines fixes the issue.

**Issues**
Fixes #786 
