### PR TITLE
FIX: allow switch audio from paused

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -664,7 +664,7 @@ public class PlaybackController {
     }
 
     public void switchAudioStream(int index) {
-        if (!isPlaying()) return;
+        if (!(isPlaying() || isPaused())) return;
 
         mCurrentOptions.setAudioStreamIndex(index);
         if (mVideoManager.isNativeMode()) {


### PR DESCRIPTION
**Changes**
Allow switching audio track from paused state.
Currently, changing track in the UI when paused is silently ignored.

Tested with libVlc

