### PR TITLE
Remove transparency from card badges

### DIFF
--- a/app/src/main/res/layout/image_card_view.xml
+++ b/app/src/main/res/layout/image_card_view.xml
@@ -216,7 +216,6 @@
                     android:layout_width="@dimen/lb_basic_card_info_badge_size"
                     android:layout_height="@dimen/lb_basic_card_info_badge_size"
                     android:layout_marginStart="10dp"
-                    android:alpha="0.25"
                     android:contentDescription="@null"
                     android:scaleType="fitCenter"
                     android:visibility="gone" />


### PR DESCRIPTION
**Changes**
Removes the transparency applied to rating badges on cards.

This was added in the card redesign in https://github.com/jellyfin/jellyfin-androidtv/pull/585, but I think we should revisit some of the transparency changes made there. This one in particular is rather hard to see currently being only 25% opaque.

**Issues**
N/A
