### PR TITLE
Add desugaring to support java.time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,10 @@ android {
 		viewBinding = true
 	}
 
+	compileOptions {
+		isCoreLibraryDesugaringEnabled = true
+	}
+
 	lintOptions {
 		isAbortOnError = false
 		sarifReport = true
@@ -124,6 +128,9 @@ dependencies {
 	// Debugging
 	if (getProperty("leakcanary.enable")?.toBoolean() == true)
 		debugImplementation("com.squareup.leakcanary:leakcanary-android:2.6")
+
+	// Compatibility (desugaring)
+	coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 
 	// Testing
 	testImplementation("junit:junit:4.13.1")


### PR DESCRIPTION
**Changes**

Although the library already used desugaring in a previous beta it appears that it doesn't matter unless it is added to the app using it. This PR fixes that by adding the desugaring to the app and allows java.time to be used fixing the crash from @thornbill in #880.

**Issues**

Required for #880 to work on older devices (\<Android 8)
