### PR TITLE
Disable GradleDependency lint check

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -16,4 +16,5 @@
     <issue id="LogNotTimber" severity="error" />
     <issue id="BinaryOperationInTimber" severity="error" />
     <issue id="FragmentTagUsage" severity="error" />
+    <issue id="GradleDependency" severity="ignore" />
 </lint>


### PR DESCRIPTION
**Changes**

Update notifications are not meant to be linter rules, it's annoying that these show up on PR's too.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
