### PR TITLE
Disable AC3 for Fire Stick Gen 1 devices

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -198,5 +198,10 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		migration(toVersion = 4) {
 			putInt("libvlc_audio_delay", it.getLong("libvlc_audio_delay", 0).toInt())
 		}
+
+		// Disable AC3 (Dolby Digital) on Fire Stick Gen 1 devices
+		migration(toVersion = 5) {
+			if (DeviceUtils.isFireTvStickGen1()) putBoolean("pref_bitstream_ac3", false)
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -5,6 +5,7 @@ import android.view.KeyEvent
 import androidx.preference.PreferenceManager
 import org.acra.ACRA
 import org.jellyfin.androidtv.preference.constant.*
+import org.jellyfin.androidtv.util.DeviceUtils
 
 /**
  * User preferences are configurable by the user and change behavior of the application.
@@ -104,7 +105,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Enable AC3
 		 */
-		var ac3Enabled = Preference.boolean("pref_bitstream_ac3", true)
+		var ac3Enabled = Preference.boolean("pref_bitstream_ac3", !DeviceUtils.isFireTvStickGen1())
 
 		/**
 		 * Default audio delay in milliseconds for libVLC

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -509,7 +509,7 @@ public class PlaybackController {
                                                 internalResponse.getMediaSource().getDefaultAudioStream() == null ||
                                                 (!internalResponse.getMediaSource().getDefaultAudioStream().getCodec().equals("dca") &&
                                                         !internalResponse.getMediaSource().getDefaultAudioStream().getCodec().equals("dts"))) &&
-                                        (!DeviceUtils.isFireTvStick() ||
+                                        (!DeviceUtils.isFireTvStickGen1() ||
                                                 (vlcResponse.getMediaSource().getVideoStream() != null && vlcResponse.getMediaSource().getVideoStream().getWidth() < 1000));
                             } else if (preferredVideoPlayer == PreferredVideoPlayer.CHOOSE) {
                                 PreferredVideoPlayer preferredVideoPlayerByPlayWith = systemPreferences.getValue().get(SystemPreferences.Companion.getChosenPlayer());

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -4,14 +4,14 @@ import android.os.Build;
 
 public class DeviceUtils {
     private static final String FIRE_TV_PREFIX = "AFT";
-    private static final String FIRE_STICK_MODEL = "AFTM";
+    private static final String FIRE_STICK_MODEL_GEN_1 = "AFTM";
 
     public static boolean isFireTv() {
         return Build.MODEL.startsWith(FIRE_TV_PREFIX);
     }
 
-    public static boolean isFireTvStick() {
-        return Build.MODEL.equals(FIRE_STICK_MODEL);
+    public static boolean isFireTvStickGen1() {
+        return Build.MODEL.equals(FIRE_STICK_MODEL_GEN_1);
     }
 
     public static boolean is50() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ProfileHelper.java
@@ -230,7 +230,7 @@ public class ProfileHelper {
         h264MainProfile.setConditions(new ProfileCondition[]
                 {
                         new ProfileCondition(ProfileConditionType.EqualsAny, ProfileConditionValue.VideoProfile, "high|main|baseline|constrained baseline"),
-                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.VideoLevel, DeviceUtils.isFireTvStick() ? "41" : "51"),
+                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.VideoLevel, DeviceUtils.isFireTvStickGen1() ? "41" : "51"),
                         new ProfileCondition(ProfileConditionType.GreaterThanEqual, ProfileConditionValue.RefFrames, "2"),
                 });
 
@@ -344,7 +344,7 @@ public class ProfileHelper {
         videoCodecProfile.setConditions(new ProfileCondition[]
                 {
                         new ProfileCondition(ProfileConditionType.EqualsAny, ProfileConditionValue.VideoProfile, "high|main|baseline|constrained baseline"),
-                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.VideoLevel, DeviceUtils.isFireTvStick()? "41" : "51")
+                        new ProfileCondition(ProfileConditionType.LessThanEqual, ProfileConditionValue.VideoLevel, DeviceUtils.isFireTvStickGen1()? "41" : "51")
                 });
 
         CodecProfile refFramesProfile = new CodecProfile();


### PR DESCRIPTION
**Changes**
* Disables support for AC3 for Fire Stick Gen 1 devices as a follow up to #843

**Issues**
N/A
