### PR TITLE
Add backoff setting for leanback channel worker

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -1,10 +1,7 @@
 package org.jellyfin.androidtv
 
 import android.content.Context
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
-import androidx.work.await
+import androidx.work.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.acra.ACRA
@@ -27,6 +24,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import timber.log.Timber
 import timber.log.Timber.DebugTree
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @AcraCore(
@@ -106,7 +104,9 @@ class JellyfinApplication : TvApp() {
 		workManager.enqueueUniquePeriodicWork(
 			LeanbackChannelWorker.PERIODIC_UPDATE_REQUEST_NAME,
 			ExistingPeriodicWorkPolicy.REPLACE,
-			PeriodicWorkRequestBuilder<LeanbackChannelWorker>(1, TimeUnit.HOURS).build()
+			PeriodicWorkRequestBuilder<LeanbackChannelWorker>(1, TimeUnit.HOURS)
+				.setBackoffCriteria(BackoffPolicy.LINEAR, Duration.ofMinutes(10))
+				.build()
 		).await()
 
 		// Detect auto bitrate

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -24,7 +24,6 @@ import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import timber.log.Timber
 import timber.log.Timber.DebugTree
-import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @AcraCore(
@@ -105,7 +104,7 @@ class JellyfinApplication : TvApp() {
 			LeanbackChannelWorker.PERIODIC_UPDATE_REQUEST_NAME,
 			ExistingPeriodicWorkPolicy.REPLACE,
 			PeriodicWorkRequestBuilder<LeanbackChannelWorker>(1, TimeUnit.HOURS)
-				.setBackoffCriteria(BackoffPolicy.LINEAR, Duration.ofMinutes(10))
+				.setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
 				.build()
 		).await()
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Add a linear backoff criteria that will retry every 10 minutes. This will retry faster when a user is not signed in when the worker is run and needs to retry. And prevents the worker from not running because the server was offline for a while (default was exponential).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
