### PR TITLE
Update Koin to 2.2.3 and remove temporary logging change to prevent crashes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
 	implementation("androidx.viewpager:viewpager:1.0.0")
 
 	// Dependency Injection
-	val koinVersion = "2.2.2"
+	val koinVersion = "2.2.3"
 	implementation("io.insert-koin:koin-android:$koinVersion")
 	implementation("io.insert-koin:koin-androidx-viewmodel:$koinVersion")
 	implementation("io.insert-koin:koin-androidx-fragment:$koinVersion")

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -21,10 +21,8 @@ import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
-import org.koin.android.ext.koin.androidLogger
 import org.koin.core.KoinExperimentalAPI
 import org.koin.core.context.startKoin
-import org.koin.core.logger.Level
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.util.concurrent.TimeUnit
@@ -67,9 +65,6 @@ class JellyfinApplication : TvApp() {
 
 		// Dependency Injection
 		startKoin {
-			// FIXME: Log level is required to work around this issue in Koin temporarily
-			// https://github.com/InsertKoinIO/koin/issues/1076
-			androidLogger(Level.ERROR)
 			androidContext(this@JellyfinApplication)
 
 			modules(


### PR DESCRIPTION
New Koin version now supports Kotlin 1.5

**Changes**

Update Koin to 2.2.3 and remove temporary logging change to prevent crashes

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
