### PR TITLE
Add flac support to exoplayer profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -87,6 +87,7 @@ class ExoPlayerProfile(
 				CodecTypes.AAC,
 				CodecTypes.MP3,
 				CodecTypes.MPA,
+				CodecTypes.FLAC,
 				CodecTypes.WAV,
 				CodecTypes.WMA,
 				CodecTypes.MP2,


### PR DESCRIPTION
**Changes**
Adds flac direct play support to the ExoPlayer profile. Support is required for API level 27+ but all Amazon Fire devices support it.

**Issues**
Fixes #163 
