### PR TITLE
Add SDK ApiClient and migrate LeanbackChannelWorker

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -21,9 +21,13 @@ import org.jellyfin.sdk.model.ClientInfo
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.jellyfin.apiclient.Jellyfin as JellyfinApiClient
 import org.jellyfin.sdk.Jellyfin as JellyfinSdk
+
+val userApiClient = named("userApiClient")
+val systemApiClient = named("systemApiClient")
 
 val appModule = module {
 	// New SDK
@@ -35,6 +39,16 @@ val appModule = module {
 			// Add client info
 			clientInfo = ClientInfo("Android TV", BuildConfig.VERSION_NAME)
 		}
+	}
+
+	single(userApiClient) {
+		// Create an empty API instance, the actual values are set by the SessionRepository
+		get<JellyfinSdk>().createApi()
+	}
+
+	single(systemApiClient) {
+		// Create an empty API instance, the actual values are set by the SessionRepository
+		get<JellyfinSdk>().createApi()
 	}
 
 	// Old apiclient

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -11,7 +11,7 @@ val authModule = module {
 	single { AuthenticationStore(androidContext()) }
 	single { AccountManagerHelper(androidContext().getSystemService()!!) }
 	single<AuthenticationRepository> { AuthenticationRepositoryImpl(get(), get(), get(), get(), get()) }
-	single<SessionRepository> { SessionRepositoryImpl(get(), get(), get()) }
+	single<SessionRepository> { SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient)) }
 	single { LegacyAccountMigration(androidContext(), get(), get()) }
 	single { ApiBinder(androidApplication() as JellyfinApplication, get(), get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -11,7 +11,9 @@ val authModule = module {
 	single { AuthenticationStore(androidContext()) }
 	single { AccountManagerHelper(androidContext().getSystemService()!!) }
 	single<AuthenticationRepository> { AuthenticationRepositoryImpl(get(), get(), get(), get(), get()) }
-	single<SessionRepository> { SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient)) }
+	single<SessionRepository> {
+		SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient))
+	}
 	single { LegacyAccountMigration(androidContext(), get(), get()) }
 	single { ApiBinder(androidApplication() as JellyfinApplication, get(), get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/ApiClientExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/ApiClientExtensions.kt
@@ -1,0 +1,10 @@
+package org.jellyfin.androidtv.util.sdk
+
+import org.jellyfin.sdk.api.client.ApiClient
+
+
+/**
+ * Check if both the [baseUrl] and [accessToken] are not null.
+ */
+val ApiClient.isUsable
+	get() = baseUrl != null && accessToken != null


### PR DESCRIPTION
**Changes**

- Add KtorClient instances for user and system and apply sessions in SessionRepository
  - This allows the use of the new SDK while keeping the old apiclient working
- Migrate LeanbackChannelWorker to SDK with the system user

Because of an issue in the current SDK beta the `date created` field is not returned from the server. This causes the order of the "next up" row to be incorrect. It's already fixed with jellyfin/jellyfin-sdk-kotlin#262 and confirmed working when using the snapshot release (#913). We can either wait for the SDK developers to release a new beta or just merge this now. The version will definitely be bumped before releasing anyway (SDK will promote to non-beta).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
