### PR TITLE
Add Gradle property to use SDK snapshot version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
 	implementation("org.jellyfin.apiclient:android:0.7.9")
 	val sdkVersion = when (getProperty("sdk.useSnapshot")?.toBoolean()) {
 		true -> "latest-SNAPSHOT"
-		else -> "1.0.0-beta.6"
+		else -> "1.0.0-beta.7"
 	}
 	implementation("org.jellyfin.sdk:jellyfin-platform-android:$sdkVersion")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,11 @@ android {
 dependencies {
 	// Jellyfin
 	implementation("org.jellyfin.apiclient:android:0.7.9")
-	implementation("org.jellyfin.sdk:jellyfin-platform-android:1.0.0-beta.6")
+	val sdkVersion = when (getProperty("sdk.useSnapshot")?.toBoolean()) {
+		true -> "latest-SNAPSHOT"
+		else -> "1.0.0-beta.6"
+	}
+	implementation("org.jellyfin.sdk:jellyfin-platform-android:$sdkVersion")
 
 	// Kotlin
 	val kotlinxCoroutinesVersion = "1.4.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
 	}
 
 	dependencies {
-		val kotlinVersion: String by project
-		classpath("com.android.tools.build:gradle:4.2.0")
+		val kotlinVersion = getProperty("kotlin.version")
+		classpath("com.android.tools.build:gradle:4.2.1")
 		classpath(kotlin("gradle-plugin", kotlinVersion))
 		classpath(kotlin("serialization", kotlinVersion))
 	}
@@ -17,6 +17,12 @@ allprojects {
 	repositories {
 		mavenCentral()
 		google()
+		maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+			content {
+				// Only allow SDK snapshots
+				includeVersionByRegex("org\\.jellyfin\\.sdk", ".*", "latest-SNAPSHOT")
+			}
+		}
 		jcenter()
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,11 @@
 # Gradle
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 
-# Kotlin version
-kotlinVersion=1.5.0
+# Jellyfin SDK
+sdk.useSnapshot=false
 
-# Kotlin compiler
+# Kotlin
+kotlin.version=1.5.0
 kotlin.incremental=true
 
 # Android


### PR DESCRIPTION
**Changes**

Adds a new property to `gradle.properties` called `sdk.useSnapshot`. When set to `true` it will use the `latest-SNAPSHOT` version of the SDK (which is the master branch). This is useful when making changes for a next release or testing stuff. 
I've also renamed `kotlinVersion` to `kotlin.version` and updated the gradle build tools.

edit: This PR also updates the SDK version to 1.0.0-beta.7

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->