### PR TITLE
Hide live TV section when unavailable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -106,22 +106,19 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 
 	override fun setupQueries(rowLoader: IRowLoader) {
 		lifecycleScope.launch(Dispatchers.IO) {
+			val currentUser = TvApp.getApplication().currentUser!!
 			// Update the views before creating rows
-			views = callApi<ItemsResult> { apiClient.GetUserViews(TvApp.getApplication().currentUser!!.id, it) }
+			views = callApi<ItemsResult> { apiClient.GetUserViews(currentUser.id, it) }
 
 			// Check for live TV support
-			if (TvApp.getApplication().currentUser!!.policy.enableLiveTvAccess) {
+			if (currentUser.policy.enableLiveTvAccess) {
 				// This is kind of ugly, but it mirrors how web handles the live TV rows on the home screen
 				// If we can retrieve one live TV recommendation, then we should display the rows
 				callApi<ItemsResult> {
 					apiClient.GetRecommendedLiveTvProgramsAsync(
 						RecommendedProgramQuery().apply {
-							userId = TvApp.getApplication().currentUser!!.id
+							userId = currentUser.id
 							enableTotalRecordCount = false
-							fields = arrayOf(
-								ItemFields.ChannelInfo,
-								ItemFields.PrimaryImageAspectRatio
-							)
 							imageTypeLimit = 1
 							isAiring = true
 							limit = 1

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -110,24 +110,6 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 			// Update the views before creating rows
 			views = callApi<ItemsResult> { apiClient.GetUserViews(currentUser.id, it) }
 
-			// Check for live TV support
-			if (currentUser.policy.enableLiveTvAccess) {
-				// This is kind of ugly, but it mirrors how web handles the live TV rows on the home screen
-				// If we can retrieve one live TV recommendation, then we should display the rows
-				callApi<ItemsResult> {
-					apiClient.GetRecommendedLiveTvProgramsAsync(
-						RecommendedProgramQuery().apply {
-							userId = currentUser.id
-							enableTotalRecordCount = false
-							imageTypeLimit = 1
-							isAiring = true
-							limit = 1
-						},
-						it
-					)
-				}.let { includeLiveTvRows = !it.items.isNullOrEmpty() }
-			}
-
 			// Start out with default sections
 			val homesections = DEFAULT_SECTIONS.toMutableMap()
 
@@ -150,6 +132,24 @@ class HomeFragment : StdBrowseFragment(), AudioEventListener {
 				}
 			} catch (exception: Exception) {
 				Timber.e(exception, "Unable to retrieve home sections")
+			}
+
+			// Check for live TV support
+			if (homesections.containsValue(HomeSectionType.LIVE_TV) && currentUser.policy.enableLiveTvAccess) {
+				// This is kind of ugly, but it mirrors how web handles the live TV rows on the home screen
+				// If we can retrieve one live TV recommendation, then we should display the rows
+				callApi<ItemsResult> {
+					apiClient.GetRecommendedLiveTvProgramsAsync(
+						RecommendedProgramQuery().apply {
+							userId = currentUser.id
+							enableTotalRecordCount = false
+							imageTypeLimit = 1
+							isAiring = true
+							limit = 1
+						},
+						it
+					)
+				}.let { includeLiveTvRows = !it.items.isNullOrEmpty() }
 			}
 
 			// Make sure the rows are empty

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -113,7 +113,7 @@ class HomeFragmentHelper(
 	}
 
 	companion object {
-		// Maximum ammount of items loaded for a row
+		// Maximum amount of items loaded for a row
 		private const val ITEM_LIMIT_RESUME = 50
 		private const val ITEM_LIMIT_RECORDINGS = 40
 		private const val ITEM_LIMIT_NEXT_UP = 50


### PR DESCRIPTION
**Changes**
* Hides the Live TV rows from the home screen when unavailable on a server. This mimics the logic in web although it's kind of crappy.

**Issues**
Kind of fixes the issue for #512 while not adding the requested feature
