### PR TITLE
WIP: Display next up before video ends

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -987,7 +987,9 @@ public class PlaybackController {
             public void run() {
                 if (mPlaybackState == PlaybackState.PLAYING) {
                     long currentTime = isLiveTv ? getTimeShiftedProgress() : mVideoManager.getCurrentPosition();
-
+                    if (hasNextItem() && currentTime >= mVideoManager.getDuration() - 90*1000) {
+                        mFragment.showNextUp(getNextItem().getId());
+                    }
                     ReportingHelper.reportProgress(getCurrentlyPlayingItem(), getCurrentStreamInfo(), currentTime * 10000, false);
                 }
                 if (mPlaybackState != PlaybackState.UNDEFINED && mPlaybackState != PlaybackState.IDLE) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -13,7 +13,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 class NextUpFragment : Fragment() {
 	private val viewModel: NextUpViewModel by sharedViewModel()
 	private lateinit var binding: FragmentNextUpBinding
-	private val backgroundService: BackgroundService by inject()
+	//private val backgroundService: BackgroundService by inject()
 	private var timerStarted = false
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -23,7 +23,7 @@ class NextUpFragment : Fragment() {
 			// No data, keep current
 			if (data == null) return@observe
 
-			backgroundService.setBackground(data.baseItem)
+			//backgroundService.setBackground(data.baseItem)
 
 			binding.logo.setImageBitmap(data.logo)
 			binding.image.setImageBitmap(data.thumbnail)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Displays next up before video ends.

Should not conflict with #850 as of now (05/26/21)

**Todo**

- better time calcs
- block player ui from showing
- test, test and test
- probably some other stuff too

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
