### PR TITLE
Move build CI to GitHub Actions

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -11,11 +11,6 @@ trigger:
     include:
     - '*'
 
-pr:
-  branches:
-    include:
-    - '*'
-
 jobs:
 - job: Build
   displayName: 'Build'
@@ -27,16 +22,6 @@ jobs:
   - script: 'echo "##vso[task.setvariable variable=JELLYFIN_VERSION]$(git describe --tags)"'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     displayName: 'Set Version Variable'
-
-  - task: Gradle@2
-    displayName: 'Build Debug'
-    inputs:
-      gradleWrapperFile: 'gradlew'
-      tasks: 'assembleDebug'
-      publishJUnitResults: false
-      testResultsFiles: '**/TEST-*.xml'
-      javaHomeOption: 'JDKVersion'
-      sonarQubeRunAnalysis: false
 
   - task: Gradle@2
     displayName: 'Build Release'

--- a/.github/workflows/app-build.yaml
+++ b/.github/workflows/app-build.yaml
@@ -1,14 +1,13 @@
-name: App Lint
+name: App Build
 
 on:
   push:
     branches:
       - master
-      - release-*
   pull_request:
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -27,10 +26,12 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Run detekt and lint task
-        run: ./gradlew --build-cache --no-daemon --info detekt lint
-      - name: Upload SARIF files
-        uses: github/codeql-action/upload-sarif@v1
-        if: ${{ always() }}
+      - name: Assemble debug APKs
+        run: ./gradlew --build-cache --no-daemon --info assembleDebug
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
-          sarif_file: .
+          name: build-artifacts
+          retention-days: 14
+          if-no-files-found: error
+          path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: adopt
           java-version: 11
       - name: Setup Gradle cache
         uses: actions/cache@v2.1.5


### PR DESCRIPTION
Azure still used for releases only (not triggered on pull requests anymore)

**Changes**

Based on the work of @h1dden-da3m0n in the mobile app repository this introduces a new "app-build" workflow that builds the app for pull requests and the master branch The apk can be easily downloaded from GitHub instead of going to Azure.

The Azure CI is still used for publishing an building the release APK on master/release branches. I'm planning to replace that one with a GitHub workflow before 0.12 as well.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
