### PR TITLE
Fix long single-line title pushing item details text up

### DIFF
--- a/app/src/main/res/layout/new_details_overview_row.xml
+++ b/app/src/main/res/layout/new_details_overview_row.xml
@@ -83,9 +83,9 @@
             android:text="Main Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:gravity="bottom"
             android:id="@+id/fdTitle"
-            android:layout_alignParentTop="true"
-            android:layout_marginTop="85sp"
+            android:layout_above="@id/fdMainInfoRow"
             android:textSize="32sp"
             android:maxLines="2"
             android:ellipsize="end"
@@ -99,7 +99,7 @@
             android:layout_height="20sp"
             android:id="@+id/fdMainInfoRow"
             android:dividerPadding="4sp"
-            android:layout_below="@+id/fdTitle"
+            android:layout_above="@+id/fdGenreRow"
             android:layout_alignStart="@+id/fdTitle"
             />
 
@@ -107,7 +107,7 @@
             android:id="@+id/fdGenreRow"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/fdMainInfoRow"
+            android:layout_above="@+id/fdSummaryText"
             android:layout_alignStart="@+id/fdMainInfoRow"
             android:minHeight="22sp" />
 
@@ -120,9 +120,9 @@
             android:textSize="16sp"
             android:maxLines="6"
             android:ellipsize="end"
-            android:layout_below="@id/fdGenreRow"
+            android:layout_above="@id/fdButtonRow"
             android:layout_alignStart="@id/fdTitle"
-            android:layout_height="130dp"
+            android:layout_height="135dp"
             android:fontFamily="sans-serif-light" />
 
         <LinearLayout


### PR DESCRIPTION
**Changes**
Fixes an issue with titles that were long enough to reach the end of the first line but not long enough to extend onto a second line. The title/main info row/genre row/summary would get pushed up as if it were trying to accommodate a two-line title even though the title is only one line. Examples of titles that caused this issue: 

> Marvel's Agents of S.H.I.E.L.D.
> Revenge, Getting Rich, Aching

- This PR should have no effect on the layout for items with a title that takes up only 1 line (aside from fixing this issue)
- For titles that extend onto a second line, the main info row/genre row/summary are now 5dp higher—these positions now match their respective positions when the title is only one line

Screenshots:
<details>
<summary> Bug </summary>

![aos-before](https://user-images.githubusercontent.com/46704654/120884213-ab5ed680-c5af-11eb-8576-5d2737f03f84.png)
</details>

<details>
<summary> Single-line title </summary>

Before/after screenshots are the exact same
![goodomens-before](https://user-images.githubusercontent.com/46704654/120884733-e282b700-c5b2-11eb-94b9-bd4d64e40d62.png)

</details>

<details>
<summary> Two-line title (before) </summary>

![animaniacs-before](https://user-images.githubusercontent.com/46704654/120884279-4788dd80-c5b0-11eb-99b0-4576dd601f30.png)
</details>

<details>
<summary> Two-line title (after) </summary>

![animaniacs-after](https://user-images.githubusercontent.com/46704654/120884388-f0373d00-c5b0-11eb-8211-ec794f6542a0.png)
</details>