### PR TITLE
Simplify IPositionablePresenter structure (removed interface)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -27,7 +27,7 @@ import org.jellyfin.androidtv.ui.GridFragment;
 import org.jellyfin.androidtv.ui.browsing.EnhancedBrowseFragment;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
-import org.jellyfin.androidtv.ui.presentation.IPositionablePresenter;
+import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.TextItemPresenter;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -451,7 +451,10 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
     }
 
     public void setPosition(int pos) {
-        ((IPositionablePresenter) (getParent().getPresenter(this))).setPosition(pos);
+        Presenter presenter = getParent().getPresenter(this);
+        if (presenter instanceof PositionableListRowPresenter) {
+            ((PositionableListRowPresenter) presenter).setPosition(pos);
+        }
     }
 
     public @Nullable String getStartLetter() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/IPositionablePresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/IPositionablePresenter.java
@@ -1,5 +1,0 @@
-package org.jellyfin.androidtv.ui.presentation;
-
-public interface IPositionablePresenter {
-    public void setPosition(int position);
-}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.java
@@ -1,23 +1,15 @@
 package org.jellyfin.androidtv.ui.presentation;
 
-import android.graphics.drawable.Drawable;
-
 import androidx.leanback.widget.ListRowPresenter;
 import androidx.leanback.widget.RowPresenter;
 
 import timber.log.Timber;
 
-public class PositionableListRowPresenter extends CustomListRowPresenter implements IPositionablePresenter {
-
+public class PositionableListRowPresenter extends CustomListRowPresenter {
     private ListRowPresenter.ViewHolder viewHolder;
 
     public PositionableListRowPresenter() {
         super();
-        setShadowEnabled(false);
-    }
-
-    public PositionableListRowPresenter(Drawable background, Integer padding) {
-        super(background, padding);
         setShadowEnabled(false);
     }
 
@@ -45,7 +37,8 @@ public class PositionableListRowPresenter extends CustomListRowPresenter impleme
 
     public void setPosition(int ndx) {
         Timber.d("Setting position to: %d", ndx);
-        if (viewHolder != null && viewHolder.getGridView() != null) viewHolder.getGridView().setSelectedPosition(ndx);
+        if (viewHolder != null && viewHolder.getGridView() != null)
+            viewHolder.getGridView().setSelectedPosition(ndx);
     }
 
     public int getPosition() {


### PR DESCRIPTION
**Changes**

Interface was only used by one class and one usage, simplified it to use the class directly. Additionally added a check before casting and removed an unused constructor.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
