### PR TITLE
Fix broken layout on grid pages

### DIFF
--- a/app/src/main/res/layout/clock_user_bug.xml
+++ b/app/src/main/res/layout/clock_user_bug.xml
@@ -2,9 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentTop="true"
-    android:layout_alignParentEnd="true">
+    android:layout_height="wrap_content">
 
         <TextClock
             android:id="@+id/clock"


### PR DESCRIPTION
**Changes**
Fixes an issue introduced in https://github.com/jellyfin/jellyfin-androidtv/pull/920 where the clock view filled the entire width of the screen causing all the other header content to be drawn offscreen.

**Issues**
N/A
