### PR TITLE
Add skip button to next up screen when shuffling

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -957,6 +957,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                     TextUnderButton shuffle = new TextUnderButton(this, R.drawable.ic_shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
+                            mediaManager.getValue().setVideoQueueShuffled(true);
                             play(mBaseItem, 0, true);
                         }
                     });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -550,6 +550,7 @@ public class ItemListActivity extends FragmentActivity {
                     @Override
                     public void onClick(View v) {
                         if (mItems.size() > 0) {
+                            mediaManager.getValue().setVideoQueueShuffled(true);
                             if (mBaseItem.getId().equals(VIDEO_QUEUE)
                                     || mBaseItem.getId().equals(FAV_SONGS)
                                     || mBaseItem.getBaseItemType() == BaseItemType.Playlist

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -722,6 +722,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         super.onDestroy();
         if (mPlaybackController != null && mPlaybackController.hasFragment()) {
             mPlaybackController.removePreviousQueueItems();
+            mediaManager.getValue().setVideoQueueShuffled(false);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -120,6 +120,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
                                 } else {
                                     mItemsToPlay.remove(0);
                                 }
+                                mediaManager.getValue().setVideoQueueShuffled(false);
                                 finish();
                             }
                         })
@@ -134,6 +135,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
                 playNext();
             } else {
                 mItemsToPlay.remove(0);
+                mediaManager.getValue().setVideoQueueShuffled(false);
                 finish();
             }
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -78,6 +78,7 @@ public class MediaManager {
     private boolean audioInitialized;
     private boolean nativeMode = false;
     private boolean videoQueueModified = false;
+    private boolean videoQueueShuffled = false;
 
     private List<AudioEventListener> mAudioEventListeners = new ArrayList<>();
 
@@ -819,5 +820,13 @@ public class MediaManager {
     public void clearVideoQueue() {
         mCurrentVideoQueue = new ArrayList<>();
         videoQueueModified = false;
+    }
+
+    public boolean isVideoQueueShuffled() {
+        return videoQueueShuffled;
+    }
+
+    public void setVideoQueueShuffled(boolean videoQueueShuffled) {
+        this.videoQueueShuffled = videoQueueShuffled;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -7,12 +7,15 @@ import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.ProgressBar
+import android.widget.Space
 import androidx.appcompat.widget.AppCompatButton
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.koin.core.component.KoinApiExtension
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
+import org.koin.core.component.inject
 
 @KoinApiExtension
 class NextUpButtons(
@@ -23,6 +26,7 @@ class NextUpButtons(
 ) : FrameLayout(context, attrs, defStyleAttr, defStyle), KoinComponent {
 	constructor(context: Context, attrs: AttributeSet) : this(context, attrs, 0, 0)
 
+	private val mediaManager: MediaManager by inject()
 	private var countdownTimer: CountDownTimer? = null
 	private val view = View.inflate(context, R.layout.fragment_next_up_buttons, null)
 
@@ -34,6 +38,12 @@ class NextUpButtons(
 
 			// Add initial focus
 			requestFocus()
+		}
+
+		// Show skip button if episodes are shuffled
+		if (mediaManager.isVideoQueueShuffled && mediaManager.currentVideoQueue.size > 1) {
+			view.findViewById<Button>(R.id.fragment_next_up_buttons_skip).visibility = VISIBLE
+			view.findViewById<Space>(R.id.fragment_next_up_buttons_skip_space).visibility = VISIBLE
 		}
 	}
 
@@ -71,6 +81,13 @@ class NextUpButtons(
 
 	fun setPlayNextListener(listener: (() -> Unit)?) {
 		val button = view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next)
+
+		if (listener == null) button.setOnClickListener(null)
+		else button.setOnClickListener { listener() }
+	}
+
+	fun setSkipListener(listener: () -> Unit) {
+		val button = view.findViewById<Button>(R.id.fragment_next_up_buttons_skip)
 
 		if (listener == null) button.setOnClickListener(null)
 		else button.setOnClickListener { listener() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -34,6 +34,7 @@ class NextUpFragment : Fragment() {
 
 		binding.fragmentNextUpButtons.apply {
 			setPlayNextListener(viewModel::playNext)
+			setSkipListener(viewModel::skip)
 			setCancelListener(viewModel::close)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpState.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpState.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.playback.nextup
 enum class NextUpState {
 	INITIALIZED,
 	PLAY_NEXT,
+	SKIP,
 	CLOSE,
 	NO_DATA
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpViewModel.kt
@@ -41,6 +41,10 @@ class NextUpViewModel(
 		_state.postValue(NextUpState.PLAY_NEXT)
 	}
 
+	fun skip() {
+		_state.postValue(NextUpState.SKIP)
+	}
+
 	fun close() {
 		_state.postValue(NextUpState.CLOSE)
 	}

--- a/app/src/main/res/layout/fragment_next_up_buttons.xml
+++ b/app/src/main/res/layout/fragment_next_up_buttons.xml
@@ -17,6 +17,21 @@
         android:layout_width="8dp"
         android:layout_height="0dp" />
 
+    <Button
+        android:id="@+id/fragment_next_up_buttons_skip"
+        style="@style/Button.Default"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:elevation="0dp"
+        android:text="@string/lbl_skip"
+        android:visibility="gone" />
+
+    <Space
+        android:id="@+id/fragment_next_up_buttons_skip_space"
+        android:layout_width="8dp"
+        android:layout_height="0dp"
+        android:visibility="gone" />
+
     <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,4 +411,5 @@
     <string name="pref_theme_muted_purple">Muted Purple</string>
     <string name="no_network_permissions">Jellyfin requires network permissions to function</string>
     <string name="press_to_close">Press to close</string>
+    <string name="lbl_skip">Skip</string>
 </resources>


### PR DESCRIPTION
**Changes**

- Adds a button to the next up screen when shuffling to skip the queued item

I wasn't sure if there'd be any interest in skipping an item when playing in sequential order, so I didn't want to add an extra click to get to the "cancel" button in that case. The restriction can be removed if there's interest in always showing it, though.