### PR TITLE
Use Jellyfin apiclient from JitPack, remove JCenter repository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ val versionTxt by tasks.registering {
 
 dependencies {
 	// Jellyfin
-	implementation("org.jellyfin.apiclient:android:0.7.9")
+	implementation("com.github.jellyfin.jellyfin-sdk-kotlin:android:v0.7.10")
 	val sdkVersion = when (getProperty("sdk.useSnapshot")?.toBoolean()) {
 		true -> "master-SNAPSHOT"
 		else -> "1.0.0-beta.7"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,12 @@ allprojects {
 				includeVersionByRegex("org\\.jellyfin\\.sdk", ".*", ".*-SNAPSHOT")
 			}
 		}
-		jcenter()
+		maven("https://jitpack.io") {
+			content {
+				// Only allow legacy apiclient
+				includeVersionByRegex("com.github.jellyfin.jellyfin-sdk-kotlin", ".*", "v0.7.10")
+			}
+		}
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ allprojects {
 }
 
 plugins {
-	id("io.gitlab.arturbosch.detekt").version("1.16.0")
+	id("io.gitlab.arturbosch.detekt").version("1.17.1")
 }
 
 // Detekt configuration


### PR DESCRIPTION
In case 0.13 will end up taking over a year this PR makes sure 0.12 will at least be able to support maintenance updates :).

**Changes**

- Removed JCenter repository
- Use apiclient from JitPack (and yes I still don't like JitPack)
- "update" apiclient to 0.7.10
- Update Detekt to 1.17.1 (current version used a JCenter dependency)

**Issues**

Closes #839 
