### PR TITLE
Remove padding from end of toolbar content when clock is hidden

### DIFF
--- a/app/src/main/res/layout/view_toolbar.xml
+++ b/app/src/main/res/layout/view_toolbar.xml
@@ -36,9 +36,9 @@
         android:gravity="bottom"
         android:orientation="horizontal"
         android:paddingStart="24dp"
-        android:paddingEnd="24dp"
         app:layout_constraintEnd_toStartOf="@id/toolbar_end"
-        app:layout_constraintStart_toEndOf="@id/toolbar_start" />
+        app:layout_constraintStart_toEndOf="@id/toolbar_start"
+        tools:ignore="RtlSymmetry" />
 
     <LinearLayout
         android:id="@+id/toolbar_end"
@@ -60,8 +60,10 @@
             android:fontFamily="sans-serif-light"
             android:format12Hour="h:mm"
             android:format24Hour="k:mm"
+            android:paddingStart="24dp"
             android:textSize="20sp"
-            tools:text="13:37" />
+            tools:text="13:37"
+            tools:ignore="RtlSymmetry" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Changes**

- Removes padding from the end of the toolbar content if the clock is hidden

Really liking the toolbar :)

**Screenshots**
<details open>
<summary>Before (no clock)</summary>

![before-no-clock](https://user-images.githubusercontent.com/46704654/121787994-aee9f300-cb97-11eb-9958-a556e45f6154.png)
</details>

<details open>
<summary>After (no clock)</summary>

![after-no-clock](https://user-images.githubusercontent.com/46704654/121787999-b6110100-cb97-11eb-9a94-3bc4471b9698.png)
</details>

<details open>
<summary>Before (with clock)</summary>

![before-clock](https://user-images.githubusercontent.com/46704654/121788001-bd380f00-cb97-11eb-86e5-364bd5c4db96.png)
</details>

<details open>
<summary>After (with clock)</summary>

![after-clock](https://user-images.githubusercontent.com/46704654/121788003-c32df000-cb97-11eb-9e60-81c8619b8c1b.png)
</details>

(Before/after with the clock are the same)