### PR TITLE
Remove libvlc RefFrames restriction

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -97,12 +97,7 @@ class LibVlcProfile(
 				codec = CodecTypes.H264
 				conditions = arrayOf(
 					h264VideoProfileCondition,
-					h264VideoLevelProfileCondition,
-					ProfileCondition(
-						ProfileConditionType.GreaterThanEqual,
-						ProfileConditionValue.RefFrames,
-						"2"
-					)
+					h264VideoLevelProfileCondition
 				)
 			},
 			// Audio channel profile


### PR DESCRIPTION
**Changes**
There is a limitation hardcoded in jellyfin-androidtv that prevents
direct playing a h264 file with libvlc if it has a number of reference
frames == 1.

This limitation was added 5 years ago (da38c02) and causes files to
be transcoded. But since then, libvlc seems to support files with
reference frames < 2.

Thus, this commit removes that limitation, as from my tests
jellyfin-androidtv directs streams and plays those files without any
issue when libvlc is selected.

**Issues**
Fixes #958
