### PR TITLE
Don't close the video player when activity is paused

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -727,7 +727,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Override
     public void onPause() {
         super.onPause();
-        mPlaybackController.stop();
+        mPlaybackController.pause();
 
         // in case we come back
         setPlayPauseActionState(0);
@@ -735,7 +735,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         // give back audio focus
         mAudioManager.abandonAudioFocus(mAudioFocusChanged);
         Timber.d("Fragment pausing. IsFinishing: %b", mActivity.isFinishing());
-        if (!mActivity.isFinishing()) mActivity.finish(); // user hit "home" we want to back out
     }
 
     public void show() {


### PR DESCRIPTION
**Changes**

Noticed an issue where the video player would close if the activity was paused on my shield. This could happen when you opened system settings (even quick settings that show on top). Apparently this was done because someone assumed a pause means the user hit the home button!?

```java
if (!mActivity.isFinishing()) mActivity.finish(); // user hit "home" we want to back out
```

In my quick testing this change did not cause any issues since the onResume function is properly-ish implemented.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
