### PR TITLE
Show server not supported error in user login alert and replace ServerVersion.asText() with ServerVersion.toString()

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -22,7 +22,6 @@ import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.card.DefaultCardView
 import org.jellyfin.androidtv.ui.startup.LoginViewModel
 import org.jellyfin.androidtv.util.ListAdapter
-import org.jellyfin.androidtv.util.sdk.asText
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
@@ -62,7 +61,7 @@ class ServerFragment : Fragment() {
 					ServerUnavailableState -> Toast.makeText(context, R.string.server_connection_failed, Toast.LENGTH_LONG).show()
 					is ServerVersionNotSupported -> Toast.makeText(
 						context,
-						getString(R.string.server_unsupported, state.server.version, ServerRepository.minimumServerVersion.asText()),
+						getString(R.string.server_unsupported, state.server.version, ServerRepository.minimumServerVersion.toString()),
 						Toast.LENGTH_LONG
 					).show()
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginAlertFragment.kt
@@ -6,10 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.auth.model.AuthenticatedState
-import org.jellyfin.androidtv.auth.model.AuthenticatingState
-import org.jellyfin.androidtv.auth.model.RequireSignInState
-import org.jellyfin.androidtv.auth.model.ServerUnavailableState
+import org.jellyfin.androidtv.auth.ServerRepository
+import org.jellyfin.androidtv.auth.model.*
 import org.jellyfin.androidtv.databinding.FragmentAlertUserLoginBinding
 import org.jellyfin.androidtv.ui.shared.AlertFragment
 import org.jellyfin.androidtv.ui.shared.KeyboardFocusChangeListener
@@ -87,6 +85,11 @@ class UserLoginAlertFragment : AlertFragment() {
 				binding.password.text.toString()
 			).observe(viewLifecycleOwner) { state ->
 				when (state) {
+					is ServerVersionNotSupported -> binding.error.setText(getString(
+						R.string.server_unsupported,
+						state.server.version,
+						ServerRepository.minimumServerVersion.toString()
+					))
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)
 					RequireSignInState -> binding.error.setText(R.string.login_invalid_credentials)
 					ServerUnavailableState -> binding.error.setText(R.string.login_server_unavailable)

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/ModelExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/ModelExtensions.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.util.sdk
 
 import org.jellyfin.androidtv.auth.model.PublicUser
 import org.jellyfin.androidtv.auth.model.Server
-import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.ServerDiscoveryInfo
 import org.jellyfin.sdk.model.api.UserDto
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
@@ -24,14 +23,4 @@ fun UserDto.toPublicUser(): PublicUser? {
 		requirePassword = hasPassword,
 		imageTag = primaryImageTag
 	)
-}
-
-@Deprecated(
-	"Moved to SDK. See https://github.com/jellyfin/jellyfin-sdk-kotlin/pull/269",
-	ReplaceWith("toString()"),
-	DeprecationLevel.WARNING
-)
-fun ServerVersion.asText(): String = buildString {
-	append(major, '.', minor, '.', patch)
-	if (build != null) append('.', build)
 }


### PR DESCRIPTION
**Changes**
- Show server not supported error in user login alert 
  - Forgot this earlier when adding the new LoginState
- replace ServerVersion.asText() with ServerVersion.toString()
   - Copied that function to the SDK in beta8

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
