### PR TITLE
Sign release files using apksigner instead of Gradle and include debug files in release

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -19,17 +19,23 @@ jobs:
           java-version: 11
       - name: Set JELLYFIN_VERSION
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
-      - name: Assemble release APK
-        env:
-          KEYSTORE: ${{ secrets.KEYSTORE }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew --no-daemon --info assembleRelease versionTxt
+      - name: Assemble release files
+        run: ./gradlew --no-daemon --info assemble versionTxt
+      - name: Sign proprietary APK
+        id: sign
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.KEYSTORE }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
       - name: Prepare release archive
         run: |
           mkdir -p build/jellyfin-publish
-          mv app/build/outputs/apk/*/*.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/jellyfin-androidtv-*-debug.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/jellyfin-androidtv-*-release-unsigned.apk build/jellyfin-publish/
+          mv ${{ steps.sign.outputs.signedReleaseFile }} build/jellyfin-publish/jellyfin-androidtv-v${{ env.JELLYFIN_VERSION }}-release.apk
           mv app/build/version.txt build/jellyfin-publish/
       - name: Upload release archive to GitHub release
         uses: alexellis/upload-assets@0.3.0


### PR DESCRIPTION
**Changes**

- Updated publish workflow to use apksigner instead of Gradle
  - This change was originally made in the mobile app repo to fix F-Droid compatibility
- Add unsigned release files to build output
- Add debug files to build output
- Changes originally made by @h1dden-da3m0n 

**Related pull requests**

jellyfin/jellyfin-android#446
jellyfin/jellyfin-android#448
jellyfin/jellyfin-android#449

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
