### PR TITLE
Fix crash when watching and recording live tv

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -186,7 +186,10 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
         guideAction = new GuideAction(context, this);
         guideAction.setLabels(new String[]{context.getString(R.string.lbl_live_tv_guide)});
         recordAction = new RecordAction(context, this);
-        recordAction.setLabels(new String[]{context.getString(R.string.lbl_record)});
+        recordAction.setLabels(new String[]{
+                context.getString(R.string.lbl_record),
+                context.getString(R.string.lbl_cancel_recording)
+        });
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.java
@@ -17,7 +17,6 @@ public class RecordAction extends CustomAction {
         super(context, customPlaybackTransportControlGlue);
         Drawable recordInactive = ContextCompat.getDrawable(context, R.drawable.ic_record);
         Drawable recordActive = ContextCompat.getDrawable(context, R.drawable.ic_record_red);
-        setIndex(INDEX_INACTIVE);
         setDrawables(new Drawable[]{recordInactive, recordActive});
     }
 }


### PR DESCRIPTION
**Changes**
Fixes a crash due to an index out of bounds when watching a live tv program that is also being recorded. The `setIndex` call was just unnecessary because calling `setDrawables` calls `setIndex(0)` already.

**Issues**
N/A
