### PR TITLE
Fix crash when previous channel id is empty

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -665,7 +665,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     }
 
     public void switchChannel(String id, boolean hideGuide) {
-        if (id == null) return;
+        if (Utils.isEmpty(id)) return;
         if (mPlaybackController.getCurrentlyPlayingItem().getId().equals(id)) {
             // same channel, just dismiss overlay
             if (hideGuide)


### PR DESCRIPTION
**Changes**
Fixes a crash when selecting the "previous channel" button on live tv when there is no previous channel

**Issues**
N/A
