### PR TITLE
Update background filter transparency

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -50,5 +50,5 @@
     <!-- Card Background Color -->
     <color name="lb_basic_card_info_bg_color">@color/grey</color>
 
-    <color name="background_filter">#8B000000</color>
+    <color name="background_filter">#CC101010</color>
 </resources>


### PR DESCRIPTION
**Changes**
Changes the background filter to match the default background color with an opacity of 80% based on the discussion in: https://github.com/jellyfin/jellyfin-androidtv/discussions/982.

**Issues**
N/A
