### PR TITLE
Support different SDK flavors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,13 +76,18 @@ val versionTxt by tasks.registering {
 }
 
 dependencies {
-	// Jellyfin
+	// Jellyfin apiclient
 	implementation("com.github.jellyfin.jellyfin-sdk-kotlin:android:v0.7.10")
-	val sdkVersion = when (getProperty("sdk.useSnapshot")?.toBoolean()) {
-		true -> "master-SNAPSHOT"
-		else -> "1.0.0-beta.8"
+	// Jellyfin SDK
+	val sdkVersion = findProperty("sdk.version")?.toString()
+	implementation("org.jellyfin.sdk:jellyfin-platform-android:1.0.0-beta.8") {
+		// Change version if desired
+		when (sdkVersion) {
+			"local" -> version { strictly("latest-SNAPSHOT") }
+			"snapshot" -> version { strictly("master-SNAPSHOT") }
+			"unstable-snapshot" -> version { strictly("openapi-unstable-SNAPSHOT") }
+		}
 	}
-	implementation("org.jellyfin.sdk:jellyfin-platform-android:$sdkVersion")
 
 	// Kotlin
 	val kotlinxCoroutinesVersion = "1.4.3"

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
+import androidx.core.net.toUri
 import androidx.tvprovider.media.tv.*
 import androidx.tvprovider.media.tv.TvContractCompat.WatchNextPrograms
 import androidx.work.CoroutineWorker
@@ -135,10 +136,10 @@ class LeanbackChannelWorker(
 			.orEmpty()
 			.filterNot { it.collectionType in ItemRowAdapter.ignoredCollectionTypes }
 			.map { item ->
-				val imageUri = when (ImageType.PRIMARY) {
-					in item.imageTags -> Uri.parse(imageApi.getItemImageUrl(item.id, ImageType.PRIMARY))
-					else -> Uri.parse(ImageUtils.getResourceUrl(context, R.drawable.tile_land_tv))
-				}
+				val imageUri = if (item.imageTags?.contains(ImageType.PRIMARY) == true)
+					imageApi.getItemImageUrl(item.id, ImageType.PRIMARY).toUri()
+				else
+					ImageUtils.getResourceUrl(context, R.drawable.tile_land_tv).toUri()
 
 				PreviewProgram.Builder()
 					.setChannelId(ContentUris.parseId(channelUri))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,12 +17,19 @@ allprojects {
 	repositories {
 		mavenCentral()
 		google()
-		maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+		// Jellyfin SDK
+		mavenLocal {
 			content {
-				// Only allow SDK snapshots
-				includeVersionByRegex("org\\.jellyfin\\.sdk", ".*", ".*-SNAPSHOT")
+				includeVersionByRegex("org.jellyfin.sdk", ".*", "latest-SNAPSHOT")
 			}
 		}
+		maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+			content {
+				includeVersionByRegex("org.jellyfin.sdk", ".*", "master-SNAPSHOT")
+				includeVersionByRegex("org.jellyfin.sdk", ".*", "openapi-unstable-SNAPSHOT")
+			}
+		}
+		// Jellyfin apiclient
 		maven("https://jitpack.io") {
 			content {
 				// Only allow legacy apiclient

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,12 @@
 # Gradle
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 
-# Jellyfin SDK
-sdk.useSnapshot=false
+# Allow switching between flavors of the Jellyfin SDK. Possible values are:
+# - "default"
+# - "local" (local Maven repository)
+# - "snapshot" (SDK master)
+# - "unstable-snapshot" (SDK with unstable Jellyfin API)
+sdk.version=default
 
 # Kotlin
 kotlin.version=1.5.0


### PR DESCRIPTION

**Changes**
From https://github.com/jellyfin/jellyfin-android/pull/428: This should help with preparing for next server releases, next sdk releases or sdk development.

- Allow using stable/snapshot/unstable-api-snapshot/local versions of SDK
- Bumped SDK to beta 9
  - Fixed nullability issue in LeanbackChannelWorker (was not-null before beta9)

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
