### PR TITLE
Ignore strings related linter issues

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <lint>
+    <issue id="BinaryOperationInTimber" severity="error" />
     <issue id="ConvertToWebp" severity="warning" />
+    <issue id="DuplicateStrings" severity="ignore" />
     <issue id="EasterEgg" severity="fatal" />
+    <issue id="ExtraTranslation" severity="warning" />
+    <issue id="FragmentTagUsage" severity="error" />
+    <issue id="GradleDependency" severity="ignore" />
+    <issue id="KotlinPropertyAccess" severity="warning" />
+    <issue id="LambdaLast" severity="warning" />
+    <issue id="LogNotTimber" severity="error" />
     <issue id="MangledCRLF" severity="warning" />
     <issue id="NegativeMargin" severity="warning" />
     <issue id="NoHardKeywords" severity="warning" />
     <issue id="Registered" severity="warning" />
     <issue id="RequiredSize" severity="error" />
+    <issue id="Typos" severity="ignore" />
     <issue id="UnknownNullness" severity="informational" />
     <issue id="UnusedIds" severity="ignore" />
-    <issue id="KotlinPropertyAccess" severity="warning" />
-    <issue id="LambdaLast" severity="warning" />
-    <issue id="ExtraTranslation" severity="warning" />
-    <issue id="LogNotTimber" severity="error" />
-    <issue id="BinaryOperationInTimber" severity="error" />
-    <issue id="FragmentTagUsage" severity="error" />
-    <issue id="GradleDependency" severity="ignore" />
-    <issue id="DuplicateStrings" severity="ignore" />
-    <issue id="Typos" severity="ignore" />
 </lint>

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <lint>
     <issue id="ConvertToWebp" severity="warning" />
-    <issue id="DuplicateStrings" severity="warning" />
     <issue id="EasterEgg" severity="fatal" />
     <issue id="MangledCRLF" severity="warning" />
     <issue id="NegativeMargin" severity="warning" />
@@ -17,4 +16,5 @@
     <issue id="BinaryOperationInTimber" severity="error" />
     <issue id="FragmentTagUsage" severity="error" />
     <issue id="GradleDependency" severity="ignore" />
+    <issue id="DuplicateStrings" severity="ignore" />
 </lint>

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -17,4 +17,5 @@
     <issue id="FragmentTagUsage" severity="error" />
     <issue id="GradleDependency" severity="ignore" />
     <issue id="DuplicateStrings" severity="ignore" />
+    <issue id="Typos" severity="ignore" />
 </lint>


### PR DESCRIPTION
**Changes**
- Added Typos and DuplicateStrings to ignore list. Both are caused by translations which often are correct. Weblate does a bit of linting on it's own and translators don't look at our issue list.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
