### PR TITLE
Change default step value in NumberSpinner

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/NumberSpinner.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NumberSpinner.java
@@ -11,7 +11,7 @@ import org.jellyfin.androidtv.R;
 
 public class NumberSpinner extends FrameLayout {
     long mValue = 0;
-    long mIncrement = 100;
+    long mIncrement = 10;
     TextView mTextValue;
     ValueChangedListener<Long> mValueChangedListener;
 


### PR DESCRIPTION
**Changes**
This class is only used for the audio delay popup and 100ms steps seem too large. In the app settings we allow for 1ms steps, so maybe we should just use 1 here also? Either way 100 was far too large.

**Issues**
N/A
