### PR TITLE
Use consistent animations for different card views

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
@@ -9,6 +9,7 @@ import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.core.view.updateLayoutParams
 import com.bumptech.glide.Glide
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.ViewCardDefaultBinding
 import kotlin.math.roundToInt
 
@@ -19,9 +20,7 @@ class DefaultCardView @JvmOverloads constructor(
 	defStyleRes: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 	companion object {
-		const val ANIMATION_DURATION = 200L // 200ms
-		const val SCALE_DEFAULT = 1.0f // 100%
-		const val SCALE_FOCUSED = 1.15f // 115%
+		const val ANIMATION_DURATION = 150L // 150ms
 	}
 
 	init {
@@ -71,7 +70,8 @@ class DefaultCardView @JvmOverloads constructor(
 	override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
 		super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
 
-		val scale = if (gainFocus) SCALE_FOCUSED else SCALE_DEFAULT
+		val scaleRes = if (gainFocus) R.fraction.card_scale_focus else R.fraction.card_scale_default
+		val scale = resources.getFraction(scaleRes, 1, 1)
 
 		post {
 			animate().apply {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,13 @@
     <dimen name="overscan_vertical">48dp</dimen>
 
     <dimen name="lb_settings_pane_width">500dp</dimen>
+
+    <fraction name="card_scale_default">100%</fraction>
+    <fraction name="card_scale_focus">115%</fraction>
+
+    <!-- Set leanback card scale values -->
+    <fraction name="lb_focus_zoom_factor_small">@fraction/card_scale_focus</fraction>
+    <fraction name="lb_focus_zoom_factor_xsmall">@fraction/card_scale_focus</fraction>
+    <fraction name="lb_focus_zoom_factor_medium">@fraction/card_scale_focus</fraction>
+    <fraction name="lb_focus_zoom_factor_large">@fraction/card_scale_focus</fraction>
 </resources>


### PR DESCRIPTION
The leanback based cards previously used 114% scaling and the animation is hardcoded to 150ms. The timing of our own DefaultCardView is now also 150ms and the scaling for the leanback cards is now 115%. This makes our own card and the leanback based cards consistent in their animations.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- some code changed
  - xml stuff

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
