### PR TITLE
Fix crash when seeking in video

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -100,7 +100,13 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     @Override
     protected PlaybackRowPresenter onCreateRowPresenter() {
-        return new PlaybackTransportRowPresenter() {
+        final AbstractDetailsDescriptionPresenter detailsPresenter = new AbstractDetailsDescriptionPresenter() {
+            @Override
+            protected void onBindDescription(ViewHolder vh, Object item) {
+
+            }
+        };
+        PlaybackTransportRowPresenter rowPresenter = new PlaybackTransportRowPresenter() {
             @Override
             protected RowPresenter.ViewHolder createRowViewHolder(ViewGroup parent) {
                 RowPresenter.ViewHolder vh = super.createRowViewHolder(parent);
@@ -149,6 +155,8 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
                 vh.setOnKeyListener(null);
             }
         };
+        rowPresenter.setDescriptionPresenter(detailsPresenter);
+        return rowPresenter;
     }
 
     private void initActions(Context context) {


### PR DESCRIPTION
**Changes**
Fixes a crash when fast-forwarding/rewinding in the player

<details>
<summary>Logs from the crash</summary>

```
2021-07-02 01:15:16.412 4283-4283/org.jellyfin.androidtv.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.jellyfin.androidtv.debug, PID: 4283
    java.lang.NullPointerException: Attempt to read from field 'android.view.View androidx.leanback.widget.Presenter$ViewHolder.view' on a null object reference
        at androidx.leanback.widget.PlaybackTransportRowPresenter$ViewHolder.startSeek(PlaybackTransportRowPresenter.java:386)
        at androidx.leanback.widget.PlaybackTransportRowPresenter$ViewHolder.onBackward(PlaybackTransportRowPresenter.java:253)
        at androidx.leanback.widget.PlaybackTransportRowPresenter$ViewHolder$4.onKey(PlaybackTransportRowPresenter.java:292)
        at android.view.View.dispatchKeyEvent(View.java:12446)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at androidx.leanback.widget.PlaybackTransportRowView.dispatchKeyEvent(PlaybackTransportRowView.java:71)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at androidx.leanback.widget.BaseGridView.dispatchKeyEvent(BaseGridView.java:1081)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1896)
        at com.android.internal.policy.DecorView.superDispatchKeyEvent(DecorView.java:428)
        at com.android.internal.policy.PhoneWindow.superDispatchKeyEvent(PhoneWindow.java:1820)
        at android.app.Activity.dispatchKeyEvent(Activity.java:3360)
        at androidx.core.app.ComponentActivity.superDispatchKeyEvent(ComponentActivity.java:122)
        at androidx.core.view.KeyEventDispatcher.dispatchKeyEvent(KeyEventDispatcher.java:84)
        at androidx.core.app.ComponentActivity.dispatchKeyEvent(ComponentActivity.java:140)
        at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:342)
        at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:5037)
        at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:4905)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4426)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4479)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4445)
        at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4585)
        at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4453)
        at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:4642)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4426)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4479)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4445)
        at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4453)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4426)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4479)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4445)
        at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4618)
        at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:4779)
        at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:2571)
        at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:2081)
        at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:2072)
        at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:2548)
        at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:141)
        at android.os.MessageQueue.nativePollOnce(Native Method)
2021-07-02 01:15:16.412 4283-4283/org.jellyfin.androidtv.debug E/AndroidRuntime:     at android.os.MessageQueue.next(MessageQueue.java:326)
        at android.os.Looper.loop(Looper.java:160)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```
</details>