### PR TITLE
Fix incorrect placeholder scaling

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -1,7 +1,8 @@
 package org.jellyfin.androidtv.ui.presentation;
 
+import static org.koin.java.KoinJavaComponent.get;
+
 import android.content.res.Resources;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
 import android.view.View;
@@ -39,8 +40,6 @@ import java.util.Date;
 import java.util.HashMap;
 
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
 
 public class CardPresenter extends Presenter {
     private static final double ASPECT_RATIO_BANNER = 5.414;
@@ -360,7 +359,7 @@ public class CardPresenter extends Presenter {
                             Glide.with(mCardView.getContext())
                                 .load(url)
                                 .error(mDefaultCardImage)
-                                .placeholder(bitmap != null ? new BitmapDrawable(mCardView.getResources(), bitmap) : mDefaultCardImage)
+                                .thumbnail(Glide.with(mCardView.getContext()).load(bitmap != null ? bitmap : mDefaultCardImage).centerCrop())
                                 .transition(DrawableTransitionOptions.withCrossFade(200))
                                 .into(mCardView.getMainImageView());
 

--- a/app/src/main/res/layout/view_card_legacy_image.xml
+++ b/app/src/main/res/layout/view_card_legacy_image.xml
@@ -27,7 +27,6 @@
             android:id="@+id/main_image"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:adjustViewBounds="true"
             android:background="@drawable/shape_card_image_background"
             android:contentDescription="@null"
             android:scaleType="centerCrop"


### PR DESCRIPTION
See https://github.com/bumptech/glide/issues/1456 for information about this bug.

**Changes**
- Remove adjustViewBounds from card main image (not used since we set an absolute width/height)
- Use Glide thumbnail instead of placeholder so the images will be properly scaled

**Issues**

Fixes #992
