### PR TITLE
fix  to check for PAUSED state when running startPauseReportLoop

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1011,7 +1011,7 @@ public class PlaybackController {
                 }
 
                 if (mPlaybackState != PlaybackState.PAUSED) {
-                    // Playback was stopped, don't report progress anymore
+                    // Playback is not paused anymore, stop reporting
                     return;
                 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1010,7 +1010,7 @@ public class PlaybackController {
                     return;
                 }
 
-                if (mPlaybackState != PlaybackState.PLAYING) {
+                if (mPlaybackState != PlaybackState.PAUSED) {
                     // Playback was stopped, don't report progress anymore
                     return;
                 }


### PR DESCRIPTION

**Changes**
This change is to permit startPauseReportLoop to run effectively and avoid a web socket timeout when pausing player. 


**Issues**
Fixes #400 
