### PR TITLE
Fix auto bitrate issues

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/UtilsModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/UtilsModule.kt
@@ -4,5 +4,5 @@ import org.jellyfin.androidtv.util.AutoBitrate
 import org.koin.dsl.module
 
 val utilsModule = module {
-	single { AutoBitrate(get()) }
+	single { AutoBitrate(get(userApiClient)) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -50,9 +50,10 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 
 		/* Playback - General*/
 		/**
-		 * Maximum bitrate in megabit for playback. A value of 0 means "auto".
+		 * Maximum bitrate in megabit for playback. A value of [MAX_BITRATE_AUTO] is used when
+		 * the bitrate should be automatically detected.
 		 */
-		var maxBitrate = Preference.string("pref_max_bitrate", "0")
+		var maxBitrate = Preference.string("pref_max_bitrate", "100")
 
 		/**
 		 * Auto-play next item

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -17,6 +17,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 	sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 ) {
 	companion object {
+		/**
+		 * The value used for automatic detection in [maxBitrate].
+		 */
+		const val MAX_BITRATE_AUTO = "0"
+
 		/* Display */
 		/**
 		 * Select the app theme

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.ui.playback;
 
+import static org.koin.java.KoinJavaComponent.get;
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ComponentName;
@@ -33,7 +35,6 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.util.AutoBitrate;
 import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.RemoteControlReceiver;
 import org.jellyfin.androidtv.util.Utils;
@@ -55,8 +56,6 @@ import java.util.Date;
 import java.util.List;
 
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
 
 public class MediaManager {
     private ItemRowAdapter mCurrentMediaAdapter;
@@ -563,8 +562,8 @@ public class MediaManager {
         AudioOptions options = new AudioOptions();
         options.setDeviceId(apiClient.getDeviceId());
         options.setItemId(item.getId());
-        Long maxBitrate = get(AutoBitrate.class).getBitrate();
-        if (maxBitrate != null) options.setMaxBitrate(maxBitrate.intValue());
+        Integer maxBitrate = Utils.getMaxBitrate();
+        if (maxBitrate != null) options.setMaxBitrate(maxBitrate);
         options.setMediaSources(item.getMediaSources());
         DeviceProfile profile;
         if (DeviceUtils.is60()) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/AutoBitrate.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/AutoBitrate.kt
@@ -1,22 +1,25 @@
 package org.jellyfin.androidtv.util
 
-import org.jellyfin.androidtv.util.apiclient.callApi
-import org.jellyfin.apiclient.interaction.ApiClient
+import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.extensions.detectBitrate
+import org.jellyfin.sdk.api.operations.MediaInfoApi
 import timber.log.Timber
 
 /**
  * Small utility class to store and automatically detect a preferred bitrate.
  */
 class AutoBitrate(
-	private val apiClient: ApiClient
+	private val apiClient: KtorClient
 ) {
+	private val mediaInfoApi = MediaInfoApi(apiClient)
+
 	var bitrate: Long? = null
 		private set
 
 	suspend fun detect() {
-		bitrate = callApi<Long> { apiClient.detectBitrate(it) }
+		val measurement = mediaInfoApi.detectBitrate()
+		bitrate = measurement.bitrate
+
 		Timber.i("Auto bitrate set to: %d", bitrate)
 	}
-
-	fun getOr(default: Long) = bitrate ?: default
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -1,10 +1,10 @@
 package org.jellyfin.androidtv.util;
 
+import static org.koin.java.KoinJavaComponent.get;
+
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.media.AudioManager;
-import android.view.View;
-import android.widget.PopupMenu;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -19,8 +19,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
 
 /**
  * A collection of utility methods, all static.
@@ -143,8 +141,12 @@ public class Utils {
     public static int getMaxBitrate() {
         String maxRate = get(UserPreferences.class).get(UserPreferences.Companion.getMaxBitrate());
         Long autoRate = get(AutoBitrate.class).getBitrate();
+        if (maxRate == UserPreferences.MAX_BITRATE_AUTO && autoRate != null) {
+            return (int) autoRate.longValue();
+        }
+
         float factor = Float.parseFloat(maxRate) * 10;
-        return Math.min(autoRate != null && factor == 0 ? autoRate.intValue() : ((int) factor * 100000), 100000000);
+        return Math.min((int) factor * 100000, 100000000);
     }
 
     public static int getThemeColor(@NonNull Context context, int resourceId) {


### PR DESCRIPTION
**Changes**
- Use `detectBitrate` function from the SDK to calculcate the "auto bitrate"
  - The function gives better results as the old apiclient did but the results are still low because the server API has a low limit making it hard to test the bitrates
- Set default value for max bitrate to 100 (Mbit/s) instead of 0 (auto)
- Use bitrate settings for music playback

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
