### PR TITLE
Playback fixes for Fire TVs

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -2,10 +2,23 @@ package org.jellyfin.androidtv.util;
 
 import android.os.Build;
 
+import java.util.Arrays;
+
 public class DeviceUtils {
     private static final String FIRE_TV_PREFIX = "AFT";
+    // Fire TV Stick Models
     private static final String FIRE_STICK_MODEL_GEN_1 = "AFTM";
+    private static final String FIRE_STICK_MODEL_GEN_2 = "AFTT";
+    private static final String FIRE_STICK_MODEL_GEN_3 = "AFTSSS";
+    private static final String FIRE_STICK_LITE_MODEL = "AFTSS";
     private static final String FIRE_STICK_4K_MODEL = "AFTMM";
+    // Fire TV Cube Models
+    private static final String FIRE_CUBE_MODEL_GEN_1 = "AFTA";
+    private static final String FIRE_CUBE_MODEL_GEN_2 = "AFTR";
+    // Fire TV (Box) Models
+    private static final String FIRE_TV_MODEL_GEN_1 = "AFTB";
+    private static final String FIRE_TV_MODEL_GEN_2 = "AFTS";
+    private static final String FIRE_TV_MODEL_GEN_3 = "AFTN";
 
     public static boolean isFireTv() {
         return Build.MODEL.startsWith(FIRE_TV_PREFIX);
@@ -17,6 +30,18 @@ public class DeviceUtils {
 
     public static boolean isFireTvStick4k() {
         return Build.MODEL.equals(FIRE_STICK_4K_MODEL);
+    }
+
+    public static boolean has4kVideoSupport() {
+        return !Arrays.asList(
+            // These devices only support a max video resolution of 1080p
+            FIRE_STICK_MODEL_GEN_1,
+            FIRE_STICK_MODEL_GEN_2,
+            FIRE_STICK_MODEL_GEN_3,
+            FIRE_STICK_LITE_MODEL,
+            FIRE_TV_MODEL_GEN_1,
+            FIRE_TV_MODEL_GEN_2
+        ).contains(Build.MODEL);
     }
 
     public static boolean is50() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -5,6 +5,7 @@ import android.os.Build;
 public class DeviceUtils {
     private static final String FIRE_TV_PREFIX = "AFT";
     private static final String FIRE_STICK_MODEL_GEN_1 = "AFTM";
+    private static final String FIRE_STICK_4K_MODEL = "AFTMM";
 
     public static boolean isFireTv() {
         return Build.MODEL.startsWith(FIRE_TV_PREFIX);
@@ -12,6 +13,10 @@ public class DeviceUtils {
 
     public static boolean isFireTvStickGen1() {
         return Build.MODEL.equals(FIRE_STICK_MODEL_GEN_1);
+    }
+
+    public static boolean isFireTvStick4k() {
+        return Build.MODEL.equals(FIRE_STICK_4K_MODEL);
     }
 
     public static boolean is50() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -2,10 +2,7 @@ package org.jellyfin.androidtv.util.profile
 
 import org.jellyfin.androidtv.constant.CodecTypes
 import org.jellyfin.androidtv.constant.ContainerTypes
-import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
-import org.jellyfin.androidtv.util.profile.ProfileHelper.H264_LEVEL_4_1
-import org.jellyfin.androidtv.util.profile.ProfileHelper.H264_LEVEL_5_1
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.util.profile
 
 import org.jellyfin.androidtv.constant.CodecTypes
 import org.jellyfin.androidtv.constant.ContainerTypes
-import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
@@ -15,9 +14,6 @@ import org.jellyfin.apiclient.model.dlna.CodecProfile
 import org.jellyfin.apiclient.model.dlna.CodecType
 import org.jellyfin.apiclient.model.dlna.DirectPlayProfile
 import org.jellyfin.apiclient.model.dlna.DlnaProfileType
-import org.jellyfin.apiclient.model.dlna.ProfileCondition
-import org.jellyfin.apiclient.model.dlna.ProfileConditionType
-import org.jellyfin.apiclient.model.dlna.ProfileConditionValue
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod
 
 class LibVlcProfile(

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -18,8 +18,9 @@ import timber.log.Timber
 
 object ProfileHelper {
 	// H264 codec levels https://en.wikipedia.org/wiki/Advanced_Video_Coding#Levels
-	const val H264_LEVEL_4_1 = "41"
-	const val H264_LEVEL_5_1 = "51"
+	private const val H264_LEVEL_4_1 = "41"
+	private const val H264_LEVEL_5_1 = "51"
+	private const val H264_LEVEL_5_2 = "52"
 
 	private val MediaTest by lazy { MediaCodecCapabilitiesTest() }
 
@@ -69,7 +70,12 @@ object ProfileHelper {
 		ProfileCondition(
 			ProfileConditionType.LessThanEqual,
 			ProfileConditionValue.VideoLevel,
-			if (DeviceUtils.isFireTvStickGen1()) H264_LEVEL_4_1 else H264_LEVEL_5_1
+			when {
+				// https://developer.amazon.com/docs/fire-tv/device-specifications.html
+				DeviceUtils.isFireTvStick4k() -> H264_LEVEL_5_2
+				DeviceUtils.isFireTv() -> H264_LEVEL_4_1
+				else -> H264_LEVEL_5_1
+			}
 		)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -92,6 +92,21 @@ object ProfileHelper {
 		)
 	}
 
+	val max1080pProfileConditions by lazy {
+		arrayOf(
+			ProfileCondition(
+				ProfileConditionType.LessThanEqual,
+				ProfileConditionValue.Width,
+				"1920"
+			),
+			ProfileCondition(
+				ProfileConditionType.LessThanEqual,
+				ProfileConditionValue.Height,
+				"1080"
+			)
+		)
+	}
+
 	val photoDirectPlayProfile by lazy {
 		DirectPlayProfile().apply {
 			type = DlnaProfileType.Photo


### PR DESCRIPTION
**Changes**
* Fixes the supported h264 level for Fire TV devices
* Adds a profile condition for devices that only support 1080p video playback (Requires a server side fix https://github.com/jellyfin/jellyfin/pull/6274 to work in 10.7.x)

Ideally both of these would be covered by properly querying the devices capabilities, but I don't want to dive into that when we want to get a beta release out soon :tm:.

**Issues**
Maybe some playback issues :man_shrugging: 
