### PR TITLE
Fix legacy credential migration not working as expected

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
@@ -68,7 +68,7 @@ class ServerRepositoryImpl(
 		val now = Date().time
 
 		// Only update every 10 minutes
-		if (now - serverInfo.lastRefreshed < 600000) return false
+		if (now - serverInfo.lastRefreshed < 600000 && serverInfo.version != null) return false
 
 		return try {
 			val client = jellyfin.createApi(server.address)

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -16,6 +16,6 @@ val authModule = module {
 	single<SessionRepository> {
 		SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient))
 	}
-	single { LegacyAccountMigration(androidContext(), get(), get()) }
+	single { LegacyAccountMigration(androidContext(), get(), get(), get()) }
 	single { ApiBinder(androidApplication() as JellyfinApplication, get(), get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
@@ -55,9 +55,15 @@ class SystemPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		val liveTvGuideFilterSports = Preference.boolean("guide_filter_sports", false)
 
+		// Other persistent variables
 		/**
 		 * Chosen player for play with button. Changes every time user chooses a player with "play with" button.
 		 */
 		var chosenPlayer = Preference.enum("chosen_player", PreferredVideoPlayer.VLC)
+
+		/**
+		 * Stores whether the legacy credentials (0.11<=) where migrated to the new format (0.12>=)
+		 */
+		var legacyCredentialsMigrated = Preference.boolean("legacy_credentials_migrated", false)
 	}
 }


### PR DESCRIPTION
The 0.11.5 -> 0.12.0 migration contained a few issues that I noticed when updating my stable version of the app. This PR fixes those issues. I tested it locally in an emulator by removing the app + app data, install 0.11, sign in and then update to this branch.

**Changes**
- Migration
  - Read access token from serverinfo (who invented this scheme lol) - fallback to the old approach as I'm not sure why we did it that way
  - Add server version
  - Only run once (prevents server being re-added if the user manually removes it)
- Curent beta users fix
  - Refresh server info when version is null, even if the timer says we shouldn't

**Issues**

Fixes #1030 