### PR TITLE
Update ACRA to 5.8.x

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import androidx.work.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.acra.ACRA
-import org.acra.annotation.AcraCore
-import org.acra.annotation.AcraDialog
-import org.acra.annotation.AcraHttpSender
-import org.acra.annotation.AcraLimiter
+import org.acra.config.dialog
+import org.acra.config.httpSender
+import org.acra.config.limiter
+import org.acra.data.StringFormat
+import org.acra.ktx.initAcra
 import org.acra.sender.HttpSender
 import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.di.*
@@ -24,19 +24,6 @@ import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.util.concurrent.TimeUnit
 
-@AcraCore(
-	buildConfigClass = BuildConfig::class
-)
-@AcraHttpSender(
-	uri = "https://collector.tracepot.com/a2eda9d9",
-	httpMethod = HttpSender.Method.POST
-)
-@AcraDialog(
-	resTitle = R.string.acra_dialog_title,
-	resText = R.string.acra_dialog_text,
-	resTheme = R.style.Theme_Jellyfin
-)
-@AcraLimiter
 @Suppress("unused")
 class JellyfinApplication : TvApp() {
 	@OptIn(KoinExperimentalAPI::class)
@@ -112,6 +99,22 @@ class JellyfinApplication : TvApp() {
 	override fun attachBaseContext(base: Context?) {
 		super.attachBaseContext(base)
 
-		ACRA.init(this)
+		initAcra {
+			buildConfigClass = BuildConfig::class.java
+			reportFormat = StringFormat.JSON
+
+			httpSender {
+				uri = "https://collector.tracepot.com/a2eda9d9"
+				httpMethod = HttpSender.Method.POST
+			}
+
+			dialog {
+				withResTitle(R.string.acra_dialog_title)
+				withResText(R.string.acra_dialog_text)
+				withResTheme(R.style.Theme_Jellyfin)
+			}
+
+			limiter {}
+		}
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ androidx-leanback = "1.1.0-beta01"
 androidx-lifecycle = "2.3.1"
 koin = "2.2.3"
 glide = "4.12.0"
-acra = "5.7.0"
+acra = "5.8.4"
 
 [libraries]
 # Jellyfin apiclient


### PR DESCRIPTION
ACRA went Kotlin-first and changed the way it is initialized to use Kotlin DSL.

**Changes**

- Update ACRA to 5.8.x

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
