### PR TITLE
Round up runtime calculation and match server resolution text in InfoLayoutHelper

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -338,15 +338,20 @@ public class InfoLayoutHelper {
             addBlockText(activity, layout, item.getOfficialRating());
             addSpacer(activity, layout, "  ");
         }
-        if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0 && item.getMediaStreams().get(0).getWidth() != null) {
+        if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0 && item.getMediaStreams().get(0).getWidth() != null && item.getMediaStreams().get(0).getHeight() != null) {
             int width = item.getMediaStreams().get(0).getWidth();
-            if (width > 2000) {
-                addBlockText(activity, layout, "4K");
-            }else if (width > 1910) {
-                addBlockText(activity, layout, "1080");
-            } else if (width > 1270) {
+            int height = item.getMediaStreams().get(0).getHeight();
+            if (width <= 960 && height <= 576) {
+                addBlockText(activity, layout, activity.getString(R.string.lbl_sd));
+            } else if (width <= 1280 && height <= 962) {
                 addBlockText(activity, layout, "720");
-            } else addBlockText(activity, layout, activity.getString(R.string.lbl_sd));
+            } else if (width <= 1920 && height <= 1440) {
+                addBlockText(activity, layout, "1080");
+            } else if (width <= 4096 && height <= 3072) {
+                addBlockText(activity, layout, "4K");
+            } else {
+                addBlockText(activity, layout, "8K");
+            }
 
             addSpacer(activity, layout, "  ");
         }

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -213,7 +213,7 @@ public class InfoLayoutHelper {
         Long runtime = Utils.getSafeValue(item.getRunTimeTicks(), item.getOriginalRunTimeTicks());
         if (runtime != null && runtime > 0) {
             long endTime = includeEndtime ? System.currentTimeMillis() + runtime / 10000 - (item.getUserData() != null && item.getCanResume() ? item.getUserData().getPlaybackPositionTicks()/10000 : 0) : 0;
-            String text = runtime / 600000000 + activity.getString(R.string.lbl_min) + (endTime > 0 ? " (" + activity.getResources().getString(R.string.lbl_ends) + " " + android.text.format.DateFormat.getTimeFormat(activity).format(new Date(endTime)) + ")  " : "  ");
+            String text = (int) Math.ceil((double) runtime / 600000000) + activity.getString(R.string.lbl_min) + (endTime > 0 ? " (" + activity.getResources().getString(R.string.lbl_ends) + " " + android.text.format.DateFormat.getTimeFormat(activity).format(new Date(endTime)) + ")  " : "  ");
             TextView time = new TextView(activity);
             time.setTextSize(textSize);
             time.setText(text);


### PR DESCRIPTION
**Changes**

- Rounds up the runtime calculation -- pretty much the same reasoning as #836
- Matches the resolution text conditions to the values used by the server (added in https://github.com/jellyfin/jellyfin/pull/6256)
   - This fixes 4:3 content being displayed a tier lower than the actual resolution (ex. 1440x1080 was displayed as '720')
