### PR TITLE
Hide system bars during video playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
@@ -5,6 +5,9 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.ui.shared.BaseActivity
 
@@ -20,6 +23,13 @@ class PlaybackOverlayActivity : BaseActivity() {
 		// Workaround for Sony Bravia devices that show a "grey" background on HDR videos
 		// Note: Should NOT be applied to the decorView as this introduces artifacts
 		window.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+		// Hide system bars
+		WindowCompat.setDecorFitsSystemWindows(window, false)
+		WindowInsetsControllerCompat(window, findViewById(android.R.id.content)).apply {
+			hide(WindowInsetsCompat.Type.systemBars())
+			systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+		}
 
 		supportFragmentManager
 			.beginTransaction()


### PR DESCRIPTION
Although we don't support phones with the ATV app some custom ROM's apparently have system bars. This PR hides them during playback.

**Changes**
- Hide system bars (status bar / navigation) in video player

**Issues**

Closes #1044 
