### PR TITLE
Remove is50 check (always true)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -31,7 +31,6 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.preference.UserPreferences;
-import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.entities.MediaStream;
@@ -80,7 +79,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private boolean nativeMode = false;
     private boolean mSurfaceReady = false;
     public boolean isContracted = false;
-    private boolean hasSubtitlesSurface = false;
     private PlaybackListener errorListener;
     private PlaybackListener completionListener;
     private PlaybackListener preparedListener;
@@ -92,13 +90,8 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         mSurfaceHolder.addCallback(mSurfaceCallback);
         mSurfaceFrame = view.findViewById(R.id.player_surface_frame);
         mSubtitlesSurface = view.findViewById(R.id.subtitles_surface);
-        if (DeviceUtils.is50()) {
-            mSubtitlesSurface.setZOrderMediaOverlay(true);
-            mSubtitlesSurface.getHolder().setFormat(PixelFormat.TRANSLUCENT);
-            hasSubtitlesSurface = true;
-        } else {
-            mSubtitlesSurface.setVisibility(View.GONE);
-        }
+        mSubtitlesSurface.setZOrderMediaOverlay(true);
+        mSubtitlesSurface.getHolder().setFormat(PixelFormat.TRANSLUCENT);
 
         mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication(), new DefaultRenderersFactory(TvApp.getApplication()) {
             @Override
@@ -499,7 +492,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             //setup surface
             mVlcPlayer.getVLCVout().detachViews();
             mVlcPlayer.getVLCVout().setVideoView(mSurfaceView);
-            if (hasSubtitlesSurface) mVlcPlayer.getVLCVout().setSubtitlesView(mSubtitlesSurface);
+            mVlcPlayer.getVLCVout().setSubtitlesView(mSubtitlesSurface);
             mVlcPlayer.getVLCVout().attachViews(this);
             Timber.d("Surface attached");
             mSurfaceReady = true;
@@ -627,7 +620,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         normalWidth = lp.width;
         normalHeight = lp.height;
         mSurfaceView.setLayoutParams(lp);
-        if (hasSubtitlesSurface) mSubtitlesSurface.setLayoutParams(lp);
+        mSubtitlesSurface.setLayoutParams(lp);
 
         // set frame size (crop if necessary)
         if (mSurfaceFrame != null) {
@@ -640,7 +633,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
         Timber.d("Surface sized %d x %d ", lp.width, lp.height);
         mSurfaceView.invalidate();
-        if (hasSubtitlesSurface) mSubtitlesSurface.invalidate();
+        mSubtitlesSurface.invalidate();
     }
 
     public void setOnErrorListener(final PlaybackListener listener) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -95,7 +95,7 @@ fun OptionsScreen.playbackCategory(
 	enum<AudioBehavior> {
 		setTitle(R.string.lbl_audio_output)
 		bind(userPreferences, UserPreferences.audioBehaviour)
-		depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL && !DeviceUtils.isFireTv() && DeviceUtils.is50() }
+		depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL && !DeviceUtils.isFireTv() }
 	}
 
 	checkbox {

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -44,10 +44,6 @@ public class DeviceUtils {
         ).contains(Build.MODEL);
     }
 
-    public static boolean is50() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
-    }
-
     public static boolean is60() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -164,6 +164,6 @@ public class Utils {
             return true;
         }
 
-        return (DeviceUtils.isFireTv() && !DeviceUtils.is50()) || get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
+        return DeviceUtils.isFireTv() || get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
     }
 }


### PR DESCRIPTION
The app only supports Android API 21 and up, the check would always return true.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- remove is50 check
  - remove hasSubtitlesSurface from VideoManager
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
