### PR TITLE
Remove GSON usages when (de)serializing activity extras

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.java
@@ -17,12 +17,9 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.constant.Extras;
 import org.jellyfin.androidtv.ui.GridButton;
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
-import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.serialization.GsonJsonSerializer;
+import org.jellyfin.sdk.model.api.BaseItemDto;
 
-import kotlin.Lazy;
-
-import static org.koin.java.KoinJavaComponent.inject;
+import kotlinx.serialization.json.Json;
 
 public class BrowseFolderFragment extends StdBrowseFragment {
 
@@ -35,11 +32,9 @@ public class BrowseFolderFragment extends StdBrowseFragment {
     protected String itemTypeString;
     protected boolean showViews = true;
 
-    private Lazy<GsonJsonSerializer> serializer = inject(GsonJsonSerializer.class);
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        mFolder = serializer.getValue().DeserializeFromString(getActivity().getIntent().getStringExtra(Extras.Folder), BaseItemDto.class);
+        mFolder = Json.Default.decodeFromString(BaseItemDto.Companion.serializer(), getActivity().getIntent().getStringExtra(Extras.Folder));
         if (MainTitle == null) MainTitle = mFolder.getName();
         ShowBadge = false;
         if (mFolder.getCollectionType() != null) {
@@ -94,28 +89,28 @@ public class BrowseFolderFragment extends StdBrowseFragment {
                 switch (((GridButton) item).getId()) {
                     case BY_LETTER:
                         Intent intent = new Intent(getActivity(), ByLetterActivity.class);
-                        intent.putExtra(Extras.Folder, serializer.getValue().SerializeToString(mFolder));
+                        intent.putExtra(Extras.Folder, Json.Default.encodeToString(BaseItemDto.Companion.serializer(), mFolder));
                         intent.putExtra(Extras.IncludeType, itemTypeString);
 
                         getActivity().startActivity(intent);
                         break;
                     case GENRES:
                         Intent genreIntent = new Intent(getActivity(), ByGenreActivity.class);
-                        genreIntent.putExtra(Extras.Folder, serializer.getValue().SerializeToString(mFolder));
+                        genreIntent.putExtra(Extras.Folder, Json.Default.encodeToString(BaseItemDto.Companion.serializer(), mFolder));
                         genreIntent.putExtra(Extras.IncludeType, itemTypeString);
 
                         getActivity().startActivity(genreIntent);
                         break;
                     case SUGGESTED:
                         Intent suggIntent = new Intent(getActivity(), SuggestedMoviesActivity.class);
-                        suggIntent.putExtra(Extras.Folder, serializer.getValue().SerializeToString(mFolder));
+                        suggIntent.putExtra(Extras.Folder, Json.Default.encodeToString(BaseItemDto.Companion.serializer(), mFolder));
                         suggIntent.putExtra(Extras.IncludeType, itemTypeString);
 
                         getActivity().startActivity(suggIntent);
                         break;
                     case PERSONS:
                         Intent personIntent = new Intent(getActivity(), BrowsePersonsActivity.class);
-                        personIntent.putExtra(Extras.Folder, serializer.getValue().SerializeToString(mFolder));
+                        personIntent.putExtra(Extras.Folder, Json.Default.encodeToString(BaseItemDto.Companion.serializer(), mFolder));
                         personIntent.putExtra(Extras.IncludeType, itemTypeString);
 
                         getActivity().startActivity(personIntent);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -32,7 +32,7 @@ public class BrowseGridFragment extends StdGridFragment {
                 ItemFields.MediaStreams
         });
         query.setParentId(mParentId.toString());
-        if (mFolder.getType() == BaseItemType.UserView.toString() || mFolder.getType() == BaseItemType.CollectionFolder.toString()) {
+        if (mFolder.getType().equalsIgnoreCase(BaseItemType.UserView.toString()) || mFolder.getType().equalsIgnoreCase(BaseItemType.CollectionFolder.toString())) {
             String type = mFolder.getCollectionType() != null ? mFolder.getCollectionType().toLowerCase() : "";
             switch (type) {
                 case "movies":

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -3,10 +3,9 @@ package org.jellyfin.androidtv.ui.browsing;
 import android.os.Bundle;
 
 import org.jellyfin.androidtv.TvApp;
-import org.jellyfin.androidtv.constant.Extras;
 import org.jellyfin.androidtv.constant.ChangeTriggerType;
+import org.jellyfin.androidtv.constant.Extras;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
-
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
@@ -32,8 +31,8 @@ public class BrowseGridFragment extends StdGridFragment {
                 ItemFields.MediaSources,
                 ItemFields.MediaStreams
         });
-        query.setParentId(mParentId);
-        if (mFolder.getBaseItemType() == BaseItemType.UserView || mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {
+        query.setParentId(mParentId.toString());
+        if (mFolder.getType() == BaseItemType.UserView.toString() || mFolder.getType() == BaseItemType.CollectionFolder.toString()) {
             String type = mFolder.getCollectionType() != null ? mFolder.getCollectionType().toLowerCase() : "";
             switch (type) {
                 case "movies":
@@ -61,7 +60,7 @@ public class BrowseGridFragment extends StdGridFragment {
                                 ItemFields.ItemCounts,
                                 ItemFields.ChildCount
                         });
-                        albumArtists.setParentId(mParentId);
+                        albumArtists.setParentId(mParentId.toString());
                         mRowDef = new BrowseRowDef("", albumArtists, CHUNK_SIZE, new ChangeTriggerType[] {});
                         gridLoader.loadGrid(mRowDef);
                         return;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsePersonsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsePersonsFragment.java
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.ui.browsing;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
-
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.PersonsQuery;
@@ -17,7 +16,7 @@ public class BrowsePersonsFragment extends CustomViewFragment {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //First add a '#' item
             PersonsQuery numbers = new PersonsQuery();
-            numbers.setParentId(mFolder.getId());
+            numbers.setParentId(mFolder.getId().toString());
             numbers.setSortBy(new String[]{ItemSortBy.SortName});
             if (includeType != null) numbers.setIncludeItemTypes(new String[]{includeType});
             numbers.setNameLessThan("A");
@@ -27,7 +26,7 @@ public class BrowsePersonsFragment extends CustomViewFragment {
             //Then all the defined letters
             for (Character letter : letters.toCharArray()) {
                 PersonsQuery letterQuery = new PersonsQuery();
-                letterQuery.setParentId(mFolder.getId());
+                letterQuery.setParentId(mFolder.getId().toString());
                 letterQuery.setSortBy(new String[]{ItemSortBy.SortName});
                 if (includeType != null) letterQuery.setIncludeItemTypes(new String[]{includeType});
                 letterQuery.setNameStartsWith(letter.toString());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.java
@@ -24,7 +24,7 @@ public class ByGenreFragment extends CustomViewFragment {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //Get all genres for this folder
             ItemsByNameQuery genres = new ItemsByNameQuery();
-            genres.setParentId(mFolder.getId());
+            genres.setParentId(mFolder.getId().toString());
             genres.setSortBy(new String[]{ItemSortBy.SortName});
             if (includeType != null) genres.setIncludeItemTypes(new String[]{includeType});
             genres.setRecursive(true);
@@ -34,7 +34,7 @@ public class ByGenreFragment extends CustomViewFragment {
                 public void onResponse(ItemsResult response) {
                     for (BaseItemDto genre : response.getItems()) {
                         StdItemQuery genreQuery = new StdItemQuery();
-                        genreQuery.setParentId(mFolder.getId());
+                        genreQuery.setParentId(mFolder.getId().toString());
                         genreQuery.setSortBy(new String[]{ItemSortBy.SortName});
                         if (includeType != null)
                             genreQuery.setIncludeItemTypes(new String[]{includeType});

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.ui.browsing;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
-
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 
@@ -17,7 +16,7 @@ public class ByLetterFragment extends CustomViewFragment {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //First add a '#' item
             StdItemQuery numbers = new StdItemQuery();
-            numbers.setParentId(mFolder.getId());
+            numbers.setParentId(mFolder.getId().toString());
             numbers.setSortBy(new String[]{ItemSortBy.SortName});
             if (includeType != null) numbers.setIncludeItemTypes(new String[]{includeType});
             numbers.setNameLessThan(letters.substring(0,1));
@@ -27,7 +26,7 @@ public class ByLetterFragment extends CustomViewFragment {
             //Then all the defined letters
             for (Character letter : letters.toCharArray()) {
                 StdItemQuery letterQuery = new StdItemQuery();
-                letterQuery.setParentId(mFolder.getId());
+                letterQuery.setParentId(mFolder.getId().toString());
                 letterQuery.setSortBy(new String[]{ItemSortBy.SortName});
                 if (includeType != null) letterQuery.setIncludeItemTypes(new String[]{includeType});
                 letterQuery.setNameStartsWith(letter.toString());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -472,7 +472,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), SearchActivity.class);
-                intent.putExtra("MusicOnly", "music".equals(mFolder.getCollectionType()) || mFolder.getType() == BaseItemType.MusicAlbum.toString() || mFolder.getType() == BaseItemType.MusicArtist.toString());
+                intent.putExtra("MusicOnly", "music".equals(mFolder.getCollectionType()) || mFolder.getType().equalsIgnoreCase(BaseItemType.MusicAlbum.toString()) || mFolder.getType().equalsIgnoreCase(BaseItemType.MusicArtist.toString()));
 
                 startActivity(intent);
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -52,16 +52,16 @@ import org.jellyfin.androidtv.ui.shared.IMessageListener;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
-import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.CollectionType;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
-import org.jellyfin.apiclient.serialization.GsonJsonSerializer;
-import org.koin.java.KoinJavaComponent;
+import org.jellyfin.sdk.model.api.BaseItemDto;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 import kotlin.Lazy;
+import kotlinx.serialization.json.Json;
 import timber.log.Timber;
 
 public class StdGridFragment extends GridFragment implements IGridLoader {
@@ -81,7 +81,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
     protected String mGridDirection = GridDirection.HORIZONTAL.name();
     protected boolean determiningPosterSize = false;
 
-    protected String mParentId;
+    protected UUID mParentId;
     protected BaseItemDto mFolder;
     protected DisplayPreferences mDisplayPrefs;
 
@@ -95,7 +95,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mFolder = KoinJavaComponent.<GsonJsonSerializer>get(GsonJsonSerializer.class).DeserializeFromString(requireActivity().getIntent().getStringExtra(Extras.Folder), BaseItemDto.class);
+        mFolder = Json.Default.decodeFromString(BaseItemDto.Companion.serializer(), requireActivity().getIntent().getStringExtra(Extras.Folder));
         mParentId = mFolder.getId();
         MainTitle = mFolder.getName();
         mDisplayPrefs = TvApp.getApplication().getCachedDisplayPrefs(mFolder.getDisplayPreferencesId()); //These should have already been loaded
@@ -472,7 +472,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), SearchActivity.class);
-                intent.putExtra("MusicOnly", "music".equals(mFolder.getCollectionType()) || mFolder.getBaseItemType() == BaseItemType.MusicAlbum || mFolder.getBaseItemType() == BaseItemType.MusicArtist);
+                intent.putExtra("MusicOnly", "music".equals(mFolder.getCollectionType()) || mFolder.getType() == BaseItemType.MusicAlbum.toString() || mFolder.getType() == BaseItemType.MusicArtist.toString());
 
                 startActivity(intent);
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -24,10 +24,18 @@ import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.model.entities.DisplayPreferences
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery
 import org.jellyfin.apiclient.model.querying.ItemsResult
-import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.List
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.forEach
+import kotlin.collections.isNullOrEmpty
+import kotlin.collections.mapOf
+import kotlin.collections.mutableListOf
+import kotlin.collections.set
+import kotlin.collections.toMutableMap
 
 class HomeFragment : StdRowsFragment(), AudioEventListener {
 	private val apiClient by inject<ApiClient>()
@@ -41,7 +49,7 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 
 	// Special rows
 	private val nowPlaying by lazy { HomeFragmentNowPlayingRow(requireActivity(), mediaManager) }
-	private val liveTVRow by lazy { HomeFragmentLiveTVRow(requireActivity(), get()) }
+	private val liveTVRow by lazy { HomeFragmentLiveTVRow(requireActivity()) }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		// Create adapter/presenter and set it to parent

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
@@ -3,6 +3,8 @@ package org.jellyfin.androidtv.ui.home
 import android.app.Activity
 import android.content.Intent
 import androidx.leanback.widget.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.constant.Extras
@@ -13,12 +15,11 @@ import org.jellyfin.androidtv.ui.browsing.UserViewActivity
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter
-import org.jellyfin.apiclient.model.dto.BaseItemDto
-import org.jellyfin.apiclient.serialization.GsonJsonSerializer
+import org.jellyfin.sdk.model.api.BaseItemDto
+import java.util.*
 
 class HomeFragmentLiveTVRow(
 	private val activity: Activity,
-	private val serializer: GsonJsonSerializer
 ) : HomeFragmentRow, OnItemViewClickedListener {
 	override fun addToRowsAdapter(cardPresenter: CardPresenter, rowsAdapter: ArrayObjectAdapter) {
 		val header = HeaderItem(rowsAdapter.size().toLong(), activity.getString(R.string.pref_live_tv_cat))
@@ -52,11 +53,11 @@ class HomeFragmentLiveTVRow(
 					Intent(activity, BrowseRecordingsActivity::class.java).apply {
 						putExtra(
 							Extras.Folder,
-							serializer.SerializeToString(
-								BaseItemDto().apply {
-									id = ""
+							Json.encodeToString(
+								BaseItemDto(
+									id = UUID(0L, 0L),
 									name = activity.getString(R.string.lbl_recorded_tv)
-								}
+								)
 							))
 					}
 				)
@@ -71,12 +72,12 @@ class HomeFragmentLiveTVRow(
 					Intent(activity, UserViewActivity::class.java).apply {
 						putExtra(
 							Extras.Folder,
-							serializer.SerializeToString(
-								BaseItemDto().apply {
-									id = "SERIESTIMERS"
+							Json.encodeToString(
+								BaseItemDto(
+									id = UUID(0L, 0L),
+									name = activity.getString(R.string.lbl_series_recordings),
 									collectionType = "SeriesTimers"
-									name = activity.getString(R.string.lbl_series_recordings)
-								}
+								)
 							)
 						)
 					}


### PR DESCRIPTION
Someone thought it was a great idea to send JSON blobs between activities. They use Gson for serializing/deserializing. This PR changes most of them to use the BaseItemDto from the SDK and kotlinx.serialization. I tested everything except for the Live TV activities to work.

**Changes**
- Remove GSON usages when (de)serializing for extras
  - Use SDK BaseItemDto
  - Use kotlinx.serialization

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
