### PR TITLE
Restore user session when starting after soft-closing the app

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -73,6 +73,9 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 			serverRepository.migrateLegacyCredentials()
 		}
 
+		// Always restore the default session in case the "default user" changed
+		sessionRepository.restoreDefaultSession()
+
 		// Ensure basic permissions
 		networkPermissionsRequester.launch(arrayOf(Manifest.permission.INTERNET, Manifest.permission.ACCESS_NETWORK_STATE))
 	}


### PR DESCRIPTION
This fixes an "issue" where closing the app using the back button (a "soft-close") wouldn't restore the default user session on re-opening. This is mostly notable when changing the default user.

**Changes**

- Always restore user session in StartupActivity

**Issues**

https://github.com/jellyfin/jellyfin-androidtv/issues/1058#issuecomment-890512663 (does not close the issue)