### PR TITLE
Move useExternalPlayer and getPlaybackActivityClass functions to new PlaybackLauncher interface

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,8 @@ android {
 
 			// Set flavored application name
 			resValue("string", "app_name", "@string/app_name_release")
+
+			buildConfigField("boolean", "DEVELOPMENT", "false")
 		}
 
 		val debug by getting {
@@ -50,6 +52,8 @@ android {
 
 			// Set flavored application name
 			resValue("string", "app_name", "@string/app_name_debug")
+
+			buildConfigField("boolean", "DEVELOPMENT", (defaultConfig.versionCode!! < 100).toString())
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv;
 
+import static org.koin.java.KoinJavaComponent.inject;
+
 import android.app.Activity;
 import android.app.Application;
 
@@ -8,17 +10,12 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MediatorLiveData;
 
-import org.jellyfin.androidtv.preference.UserPreferences;
-import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
-import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
-import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.entities.DisplayPreferences;
 
@@ -26,8 +23,6 @@ import java.util.HashMap;
 
 import kotlin.Lazy;
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.inject;
 
 public class TvApp extends Application {
     public static final String DISPLAY_PREFS_APP_NAME = "ATV";
@@ -48,7 +43,6 @@ public class TvApp extends Application {
     private Activity currentActivity;
 
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);
-    private Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
 
     @Override
     public void onCreate() {
@@ -100,27 +94,6 @@ public class TvApp extends Application {
 
     public void setPlaybackController(PlaybackController playbackController) {
         this.playbackController = playbackController;
-    }
-
-    public boolean useExternalPlayer(BaseItemType itemType) {
-        switch (itemType) {
-            case Movie:
-            case Episode:
-            case Video:
-            case Series:
-            case Recording:
-                return userPreferences.getValue().get(UserPreferences.Companion.getVideoPlayer()) == PreferredVideoPlayer.EXTERNAL;
-            case TvChannel:
-            case Program:
-                return userPreferences.getValue().get(UserPreferences.Companion.getLiveTvVideoPlayer()) == PreferredVideoPlayer.EXTERNAL;
-            default:
-                return false;
-        }
-    }
-
-    @NonNull
-    public Class<? extends Activity> getPlaybackActivityClass(BaseItemType itemType) {
-        return useExternalPlayer(itemType) ? ExternalPlayerActivity.class : PlaybackOverlayActivity.class;
     }
 
     @NonNull

--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.data.eventhandling;
 
+import static org.koin.java.KoinJavaComponent.get;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -14,6 +16,7 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
@@ -33,8 +36,6 @@ import org.jellyfin.apiclient.model.session.SessionInfoDto;
 import java.util.Arrays;
 
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
 
 public class TvApiEventListener extends ApiEventListener {
     private final DataRefreshService dataRefreshService;
@@ -179,8 +180,9 @@ public class TvApiEventListener extends ApiEventListener {
                         //peek at first item to see what type it is
                         switch (response.getItems()[0].getMediaType()) {
                             case "Video":
+                                Class activity = get(PlaybackLauncher.class).getPlaybackActivityClass(response.getItems()[0].getBaseItemType());
                                 mediaManager.setCurrentVideoQueue(Arrays.asList(response.getItems()));
-                                Intent intent = new Intent(TvApp.getApplication().getCurrentActivity(), TvApp.getApplication().getPlaybackActivityClass(response.getItems()[0].getBaseItemType()));
+                                Intent intent = new Intent(TvApp.getApplication().getCurrentActivity(), activity);
                                 TvApp.getApplication().getCurrentActivity().startActivity(intent);
                                 break;
                             case "Audio":

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -20,7 +20,7 @@ val playbackModule = module {
 
 	factory {
 		val preferences = get<UserPreferences>()
-		val useRewrite = preferences[UserPreferences.playbackRewriteEnabled] && BuildConfig.DEBUG
+		val useRewrite = preferences[UserPreferences.playbackRewriteEnabled] && BuildConfig.DEVELOPMENT
 
 		// TODO Inject PlaybackLauncher for playback rewrite here
 		if (useRewrite) RewritePlaybackLauncher()

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -1,8 +1,10 @@
 package org.jellyfin.androidtv.di
 
+import org.jellyfin.androidtv.BuildConfig
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.playback.GarbagePlaybackLauncher
-import org.jellyfin.androidtv.ui.playback.PlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.PlaybackManager
+import org.jellyfin.androidtv.ui.playback.RewritePlaybackLauncher
 import org.jellyfin.apiclient.interaction.AndroidDevice
 import org.jellyfin.apiclient.logging.AndroidLogger
 import org.koin.android.ext.koin.androidApplication
@@ -16,5 +18,12 @@ val playbackModule = module {
 		)
 	}
 
-	single<PlaybackLauncher> { GarbagePlaybackLauncher(get()) }
+	factory {
+		val preferences = get<UserPreferences>()
+		val useRewrite = preferences[UserPreferences.playbackRewriteEnabled] && BuildConfig.DEBUG
+
+		// TODO Inject PlaybackLauncher for playback rewrite here
+		if (useRewrite) RewritePlaybackLauncher()
+		else GarbagePlaybackLauncher(get())
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.di
 
+import org.jellyfin.androidtv.ui.playback.GarbagePlaybackLauncher
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.PlaybackManager
 import org.jellyfin.apiclient.interaction.AndroidDevice
 import org.jellyfin.apiclient.logging.AndroidLogger
@@ -13,4 +15,6 @@ val playbackModule = module {
 			AndroidLogger("PlaybackManager")
 		)
 	}
+
+	single<PlaybackLauncher> { GarbagePlaybackLauncher(get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -43,11 +43,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var seasonalGreetingsEnabled = Preference.boolean("pref_enable_themes", true)
 
-		/**
-		 * Show additional debug information
-		 */
-		var debuggingEnabled = Preference.boolean("pref_enable_debug", false)
-
 		/* Playback - General*/
 		/**
 		 * Maximum bitrate in megabit for playback. A value of [MAX_BITRATE_AUTO] is used when
@@ -138,6 +133,17 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Shortcut used for changing the subtitle track
 		 */
 		var shortcutSubtitleTrack = Preference.int("shortcut_subtitle_track", KeyEvent.KEYCODE_CAPTIONS)
+
+		/* Developer options */
+		/**
+		 * Show additional debug information
+		 */
+		var debuggingEnabled = Preference.boolean("pref_enable_debug", false)
+
+		/**
+		 * Use playback rewrite module
+		 */
+		var playbackRewriteEnabled = Preference.boolean("playback_new", false)
 
 		/* ACRA */
 		/**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -1,5 +1,8 @@
 package org.jellyfin.androidtv.ui.itemdetail;
 
+import static org.koin.java.KoinJavaComponent.get;
+import static org.koin.java.KoinJavaComponent.inject;
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -53,6 +56,7 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.CustomListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.InfoCardPresenter;
@@ -103,9 +107,6 @@ import java.util.concurrent.ExecutionException;
 
 import kotlin.Lazy;
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
-import static org.koin.java.KoinJavaComponent.inject;
 
 public class FullDetailsActivity extends BaseActivity implements IRecordingIndicatorView {
 
@@ -1566,7 +1567,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 if (item.getBaseItemType() == BaseItemType.MusicArtist) {
                     mediaManager.getValue().playNow(response);
                 } else {
-                    Intent intent = new Intent(FullDetailsActivity.this, TvApp.getApplication().getPlaybackActivityClass(item.getBaseItemType()));
+                    Class activity = get(PlaybackLauncher.class).getPlaybackActivityClass(item.getBaseItemType());
+                    Intent intent = new Intent(FullDetailsActivity.this, activity);
                     mediaManager.getValue().setCurrentVideoQueue(response);
                     intent.putExtra("Position", pos);
                     startActivity(intent);
@@ -1578,7 +1580,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
     protected void play(final BaseItemDto[] items, final int pos, final boolean shuffle) {
         List<BaseItemDto> itemsToPlay = Arrays.asList(items);
-        Intent intent = new Intent(this, TvApp.getApplication().getPlaybackActivityClass(items[0].getBaseItemType()));
+        Class activity = get(PlaybackLauncher.class).getPlaybackActivityClass(items[0].getBaseItemType());
+        Intent intent = new Intent(this, activity);
         if (shuffle) Collections.shuffle(itemsToPlay);
         mediaManager.getValue().setCurrentVideoQueue(itemsToPlay);
         intent.putExtra("Position", pos);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -1,5 +1,8 @@
 package org.jellyfin.androidtv.ui.itemdetail;
 
+import static org.koin.java.KoinJavaComponent.get;
+import static org.koin.java.KoinJavaComponent.inject;
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -38,6 +41,7 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.playback.AudioEventListener;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.MathUtils;
@@ -64,8 +68,6 @@ import java.util.List;
 
 import kotlin.Lazy;
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.inject;
 
 public class ItemListActivity extends FragmentActivity {
     private int BUTTON_SIZE;
@@ -510,7 +512,8 @@ public class ItemListActivity extends FragmentActivity {
 
     private void play(List<BaseItemDto> items) {
         if ("Video".equals(mBaseItem.getMediaType())) {
-            Intent intent = new Intent(mActivity, TvApp.getApplication().getPlaybackActivityClass(mBaseItem.getBaseItemType()));
+            Class activity = get(PlaybackLauncher.class).getPlaybackActivityClass(mBaseItem.getBaseItemType());
+            Intent intent = new Intent(mActivity, activity);
             //Resume first item if needed
             BaseItemDto first = items.size() > 0 ? items.get(0) : null;
             if (first != null && first.getUserData() != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -25,6 +25,7 @@ import org.jellyfin.androidtv.ui.itemdetail.ItemListActivity;
 import org.jellyfin.androidtv.ui.itemdetail.PhotoPlayerActivity;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
@@ -219,7 +220,8 @@ public class ItemLauncher {
                                 PlaybackHelper.getItemsToPlay(baseItem, baseItem.getBaseItemType() == BaseItemType.Movie, false, new Response<List<BaseItemDto>>() {
                                     @Override
                                     public void onResponse(List<BaseItemDto> response) {
-                                        Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(baseItem.getBaseItemType()));
+                                        Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(baseItem.getBaseItemType());
+                                        Intent intent = new Intent(activity, newActivity);
                                         get(MediaManager.class).setCurrentVideoQueue(response);
                                         intent.putExtra("Position", 0);
                                         activity.startActivity(intent);
@@ -252,7 +254,8 @@ public class ItemLauncher {
                         List<BaseItemDto> items = new ArrayList<>();
                         items.add(response);
                         get(MediaManager.class).setCurrentVideoQueue(items);
-                        Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(response.getBaseItemType()));
+                        Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(response.getBaseItemType());
+                        Intent intent = new Intent(activity, newActivity);
                         Long start = chapter.getStartPositionTicks() / 10000;
                         intent.putExtra("Position", start.intValue());
                         activity.startActivity(intent);
@@ -326,7 +329,8 @@ public class ItemLauncher {
                                 public void onResponse(BaseItemDto response) {
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
-                                    Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(response.getBaseItemType()));
+                                    Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(response.getBaseItemType());
+                                    Intent intent = new Intent(activity, newActivity);
                                     get(MediaManager.class).setCurrentVideoQueue(items);
                                     intent.putExtra("Position", 0);
                                     activity.startActivity(intent);
@@ -349,7 +353,8 @@ public class ItemLauncher {
                             @Override
                             public void onResponse(List<BaseItemDto> response) {
                                 // TODO Check whether this usage of BaseItemType.valueOf is okay.
-                                Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(BaseItemType.valueOf(channel.getType())));
+                                Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(BaseItemType.valueOf(channel.getType()));
+                                Intent intent = new Intent(activity, newActivity);
                                 get(MediaManager.class).setCurrentVideoQueue(response);
                                 intent.putExtra("Position", 0);
                                 activity.startActivity(intent);
@@ -376,7 +381,8 @@ public class ItemLauncher {
                             get(ApiClient.class).GetItemAsync(rowItem.getRecordingInfo().getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
-                                    Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(rowItem.getBaseItemType()));
+                                    Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(rowItem.getBaseItemType());
+                                    Intent intent = new Intent(activity, newActivity);
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
                                     get(MediaManager.class).setCurrentVideoQueue(items);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -1,0 +1,33 @@
+package org.jellyfin.androidtv.ui.playback
+
+import android.app.Activity
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
+import org.jellyfin.apiclient.model.dto.BaseItemType
+
+interface PlaybackLauncher {
+	fun useExternalPlayer(itemType: BaseItemType?): Boolean
+	fun getPlaybackActivityClass(itemType: BaseItemType?): Class<out Activity>
+}
+
+class GarbagePlaybackLauncher(
+	private val userPreferences: UserPreferences
+) : PlaybackLauncher {
+	override fun useExternalPlayer(itemType: BaseItemType?) = when (itemType) {
+		BaseItemType.Movie,
+		BaseItemType.Episode,
+		BaseItemType.Video,
+		BaseItemType.Series,
+		BaseItemType.Recording,
+		-> userPreferences[UserPreferences.videoPlayer] === PreferredVideoPlayer.EXTERNAL
+		BaseItemType.TvChannel,
+		BaseItemType.Program,
+		-> userPreferences[UserPreferences.liveTvVideoPlayer] === PreferredVideoPlayer.EXTERNAL
+		else -> false
+	}
+
+	override fun getPlaybackActivityClass(itemType: BaseItemType?) = when {
+		useExternalPlayer(itemType) -> ExternalPlayerActivity::class.java
+		else -> PlaybackOverlayActivity::class.java
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -31,3 +31,9 @@ class GarbagePlaybackLauncher(
 		else -> PlaybackOverlayActivity::class.java
 	}
 }
+
+// TODO: Move to playback module
+class RewritePlaybackLauncher : PlaybackLauncher {
+	override fun useExternalPlayer(itemType: BaseItemType?) = false
+	override fun getPlaybackActivityClass(itemType: BaseItemType?) = TODO("Not yet implemented")
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -24,7 +24,7 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 			}
 
 			// Only show in debug mode
-			if (BuildConfig.DEBUG) {
+			if (BuildConfig.DEVELOPMENT) {
 				checkbox {
 					setTitle(R.string.enable_playback_module_title)
 					setContent(R.string.enable_playback_module_description)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.ui.preference.screen
 
+import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
@@ -20,6 +21,16 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.lbl_enable_debug)
 				setContent(R.string.desc_debug)
 				bind(userPreferences, UserPreferences.debuggingEnabled)
+			}
+
+			// Only show in debug mode
+			if (BuildConfig.DEBUG) {
+				checkbox {
+					setTitle(R.string.enable_playback_module_title)
+					setContent(R.string.enable_playback_module_description)
+
+					bind(userPreferences, UserPreferences.playbackRewriteEnabled)
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.util;
 
+import static org.koin.java.KoinJavaComponent.get;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.view.Gravity;
@@ -18,6 +20,7 @@ import org.jellyfin.androidtv.ui.itemhandling.AudioQueueItem;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.playback.AudioNowPlayingActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
@@ -33,8 +36,6 @@ import org.jellyfin.apiclient.model.querying.ItemsResult;
 import java.util.List;
 
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
 
 public class KeyProcessor {
 
@@ -153,7 +154,8 @@ public class KeyProcessor {
                         if (rowItem.getGridButton().getId() == TvApp.VIDEO_QUEUE_OPTION_ID) {
                             //Queue already there - just kick off playback
                             BaseItemType itemType = get(MediaManager.class).getCurrentVideoQueue().size() > 0 ? get(MediaManager.class).getCurrentVideoQueue().get(0).getBaseItemType() : null;
-                            Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(itemType));
+                            Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(itemType);
+                            Intent intent = new Intent(activity, newActivity);
                             activity.startActivity(intent);
                         }
                         break;

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.util.apiclient;
 
+import static org.koin.java.KoinJavaComponent.get;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -9,6 +11,7 @@ import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.ui.itemdetail.ItemListActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
@@ -31,8 +34,6 @@ import java.util.Collections;
 import java.util.List;
 
 import timber.log.Timber;
-
-import static org.koin.java.KoinJavaComponent.get;
 
 public class PlaybackHelper {
     private static final int ITEM_QUERY_LIMIT = 150; // limit the number of items retrieved for playback
@@ -228,7 +229,7 @@ public class PlaybackHelper {
                 break;
 
             default:
-                if (allowIntros && !TvApp.getApplication().useExternalPlayer(mainItem.getBaseItemType()) && get(UserPreferences.class).get(UserPreferences.Companion.getCinemaModeEnabled())) {
+                if (allowIntros && !get(PlaybackLauncher.class).useExternalPlayer(mainItem.getBaseItemType()) && get(UserPreferences.class).get(UserPreferences.Companion.getCinemaModeEnabled())) {
                     //Intros
                     get(ApiClient.class).GetIntrosAsync(mainItem.getId(), currentUser.getId(), new Response<ItemsResult>() {
                         @Override
@@ -274,7 +275,8 @@ public class PlaybackHelper {
 
                         } else {
                             BaseItemType itemType = response.size() > 0 ? response.get(0).getBaseItemType() : null;
-                            Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(itemType));
+                            Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(itemType);
+                            Intent intent = new Intent(activity, newActivity);
                             get(MediaManager.class).setCurrentVideoQueue(response);
                             intent.putExtra("Position", pos);
                             if (!(activity instanceof Activity))
@@ -289,7 +291,8 @@ public class PlaybackHelper {
                         break;
 
                     default:
-                        Intent intent = new Intent(activity, TvApp.getApplication().getPlaybackActivityClass(item.getBaseItemType()));
+                        Class newActivity = get(PlaybackLauncher.class).getPlaybackActivityClass(item.getBaseItemType());
+                        Intent intent = new Intent(activity, newActivity);
                         get(MediaManager.class).setCurrentVideoQueue(response);
                         intent.putExtra("Position", pos);
                         if (!(activity instanceof Activity))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,4 +436,6 @@
     <string name="lbl_one_song">1 Song</string>
     <string name="lbl_name_date">%1$s (%2$s)</string>
     <string name="lbl_time_range">%1$s–%2$s</string>
+    <string name="enable_playback_module_title">Enable new playback module</string>
+    <string name="enable_playback_module_description">This is an experimental feature. No support is provided.</string>
 </resources>

--- a/buildSrc/src/main/kotlin/VersionUtils.kt
+++ b/buildSrc/src/main/kotlin/VersionUtils.kt
@@ -31,7 +31,7 @@ fun Project.getVersionName(fallback: String = "0.0.0-dev.1") =
  * 2.0.0         ->  2000099
  * 99.99.99-rc.1 -> 99999901
  */
-fun getVersionCode(versionName: String): Int? {
+fun getVersionCode(versionName: String): Int {
 	// Split to core and pre release parts with a default for pre release (null)
 	val (versionCore, versionPreRelease) =
 		when (val index = versionName.indexOf('-')) {


### PR DESCRIPTION
This change is to make sure development for the new playback code can happen in the master branch while still being able to release updates with the old code. It does this by adding a new interface "PlaybackLauncher" that is used when launching the playback activity and a toggle for which implementation to use.

When the initial playback module is added this will launch an activity that reads the data from the current playback code (item to play etc.) and converts it to the new playback module format before launching the new playback module activity. This is a bit hacky but good enough for development.

The implementation toggle only works on debug builds of the app and will never show up on releases.

**Changes**
- Move useExternalPlayer and getPlaybackActivityClass functions to new PlaybackLauncher interface
- Implement PlaybackLauncher interface with old code
- "Implement" PlaybackLauncher interface for new playback code 
- Add toggle to enable new playback module

**Issues**

Part of #1057