### PR TITLE
Fix going back from home screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -128,7 +128,7 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 				itemIsUserView -> callApi<BaseItemDto?> {
 					apiClient.GetItemAsync(itemId, apiClient.currentUserId, it)
 				}?.let { item ->
-					suspendCoroutine<Intent?> { continuation ->
+					suspendCoroutine { continuation ->
 						ItemLauncher.createUserViewIntent(item, this) { intent ->
 							continuation.resume(intent)
 						}
@@ -143,6 +143,10 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 			else -> null
 		} ?: Intent(this, MainActivity::class.java)
 
+
+		// Clear navigation history
+		intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_TASK_ON_HOME)
+		Timber.d("Opening next activity $intent")
 		startActivity(intent)
 		finishAfterTransition()
 	}


### PR DESCRIPTION
Turns out due too some race conditions the app sometimes started the home screen four times. This PR fixes the cause of that and adds a debug log that could help when similar issues happen in the future.

**Changes**
- Add debug log statement in StartupActivity to log the next activity
- Add intent flags to StartupActivity.openNextActivity that make sure the navigation history is cleared (no going back to startup activity)
- Add some checks in SessionRepository to prevent setting the same user twice


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
