### PR TITLE
Allow user sessions to be set to null again

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -95,7 +95,7 @@ class SessionRepositoryImpl(
 
 	private fun setCurrentSession(session: Session?, includeSystemUser: Boolean, callback: ((Boolean) -> Unit)? = null) {
 		// No change in session - don't switch
-		if (currentSession.value?.userId == session?.userId) return
+		if (session != null && currentSession.value?.userId == session.userId) return
 
 		if (session != null) authenticationPreferences[AuthenticationPreferences.lastUserId] = session.userId.toString()
 
@@ -120,7 +120,7 @@ class SessionRepositoryImpl(
 
 	private fun setCurrentSystemSession(session: Session?) {
 		// No change in session - don't switch
-		if (currentSession.value?.userId == session?.userId) return
+		if (session != null && currentSession.value?.userId == session.userId) return
 
 		_currentSystemSession.postValue(session)
 


### PR DESCRIPTION
**Changes**
Fixes a slight regression from https://github.com/jellyfin/jellyfin-androidtv/pull/1074 that prevented user sessions from being explicitly set to null on startup. This caused the loading screen to never be replaced by the correct activity to enter a server or select a user.

**Issues**
N/A
