### PR TITLE
Add preference to change user sort order in login screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationSortBy.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationSortBy.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.androidtv.auth
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.preference.dsl.EnumDisplayOptions
+
+enum class AuthenticationSortBy {
+	@EnumDisplayOptions(name = R.string.last_use)
+	LAST_USE,
+	@EnumDisplayOptions(name = R.string.alphabetical)
+	ALPHABETICAL
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -83,7 +83,7 @@ val appModule = module {
 
 	single<ServerRepository> { ServerRepositoryImpl(get(), get(), get(), get()) }
 
-	viewModel { LoginViewModel(get(), get()) }
+	viewModel { LoginViewModel(get(), get(), get()) }
 	viewModel { NextUpViewModel(get(), get(), get()) }
 
 	single { BackgroundService(get(), get(), get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
@@ -1,17 +1,20 @@
 package org.jellyfin.androidtv.preference
 
 import android.content.Context
+import org.jellyfin.androidtv.auth.AuthenticationSortBy
 import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
 
 class AuthenticationPreferences(context: Context) : SharedPreferenceStore(
 	sharedPreferences = context.getSharedPreferences("authentication", Context.MODE_PRIVATE)
 ) {
 	companion object {
-		val autoLoginUserBehavior = Preference.enum<UserSelectBehavior>("auto_login_user_behavior", UserSelectBehavior.LAST_USER)
+		val autoLoginUserBehavior = Preference.enum("auto_login_user_behavior", UserSelectBehavior.LAST_USER)
 		val autoLoginUserId = Preference.string("auto_login_user_id", "")
 
-		val systemUserBehavior = Preference.enum<UserSelectBehavior>("system_user_behavior", UserSelectBehavior.LAST_USER)
+		val systemUserBehavior = Preference.enum("system_user_behavior", UserSelectBehavior.LAST_USER)
 		val systemUserId = Preference.string("system_user_id", "")
+
+		val sortBy = Preference.enum("sort_by", AuthenticationSortBy.LAST_USE)
 
 		/**
 		 * Do not set directly, use [SessionRepository] instead.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/authentication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/authentication.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui.preference.category
 
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.AuthenticationRepository
+import org.jellyfin.androidtv.auth.AuthenticationSortBy
 import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.preference.Preference
@@ -9,6 +10,7 @@ import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsBinder
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsItemUserPicker.UserSelection
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsScreen
+import org.jellyfin.androidtv.ui.preference.dsl.enum
 import org.jellyfin.androidtv.ui.preference.dsl.userPicker
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 
@@ -45,6 +47,11 @@ fun OptionsScreen.authenticationCategory(
 				sessionRepository.restoreDefaultSystemSession()
 			}
 		}
+	}
+
+	enum<AuthenticationSortBy> {
+		setTitle(R.string.lbl_sort_by)
+		bind(authenticationPreferences, AuthenticationPreferences.sortBy)
 	}
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -69,13 +69,14 @@ class ServerFragment : Fragment() {
 		}
 		binding.users.adapter = userAdapter
 
-		loginViewModel.getUsers(server).observe(viewLifecycleOwner) { users ->
+		loginViewModel.users.observe(viewLifecycleOwner) { users ->
 			userAdapter.items = users
 
 			binding.users.isFocusable = users.any()
 			binding.noUsersWarning.isVisible = users.isEmpty()
 			binding.root.requestFocus()
 		}
+		loginViewModel.loadUsers(server)
 
 		onServerChange(server)
 
@@ -134,6 +135,9 @@ class ServerFragment : Fragment() {
 		super.onResume()
 
 		loginViewModel.reloadServers()
+
+		val server = serverIdArgument?.let(loginViewModel::getServer)
+		if (server != null) loginViewModel.loadUsers(server)
 	}
 
 	private class UserAdapter(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,4 +438,6 @@
     <string name="lbl_time_range">%1$s–%2$s</string>
     <string name="enable_playback_module_title">Enable new playback module</string>
     <string name="enable_playback_module_description">This is an experimental feature. No support is provided.</string>
+    <string name="last_use">Most recently used</string>
+    <string name="alphabetical">Alphabetical</string>
 </resources>


### PR DESCRIPTION
Adds an option to change the sorting of the users and servers lists. Additionally reload users on resume (to update the sorting if it changes).

**Changes**
- New preference: authentication -> Sort by
- Added a few line breaks to the LoginViewModel
- Not much else

**Issues**

Fixes #1078