### PR TITLE
Fix session loading twice on app startup

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -73,11 +73,6 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 			serverRepository.migrateLegacyCredentials()
 		}
 
-		// Always restore the default session when starting from launcher
-		if (intent.action == Intent.ACTION_MAIN) {
-			sessionRepository.restoreDefaultSession()
-		}
-
 		// Ensure basic permissions
 		networkPermissionsRequester.launch(arrayOf(Manifest.permission.INTERNET, Manifest.permission.ACCESS_NETWORK_STATE))
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-window = { module = "androidx.window:window", version = "1.0.0-alpha09" }
 androidx-cardview = { module = "androidx.cardview:cardview", version = "1.0.0" }
 
@@ -78,6 +79,7 @@ androidx-lifecycle = [
     "androidx-lifecycle-viewmodel",
     "androidx-lifecycle-livedata",
     "androidx-lifecycle-service",
+    "androidx-lifecycle-process",
 ]
 koin = [
     "koin-android-core",


### PR DESCRIPTION
So I made quite a few changes in when this single function (restoreDefaultSession) is called in the past few weeks but I'm now confident this is the correct way. The process lifecycle allows us to observe the process and restore the session when the process is started (not created).

The app will now (re)load the session only in this lifecycle event which is called everytime the app is visible. This can happen due too a user launching the app or opening it via a view action (leanback integration) or when reopening after a soft-close.

**Changes**

- Use the process lifecycle to (re)load user sessions

**Issues**

Closes #1081