### PR TITLE
Add option to always require authentication

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
@@ -5,16 +5,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import org.jellyfin.androidtv.auth.model.*
+import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.apiclient.interaction.device.IDevice
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
-import org.jellyfin.sdk.api.client.extensions.authenticateUserByName;
+import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
 import org.jellyfin.sdk.api.operations.ImageApi
 import org.jellyfin.sdk.api.operations.UserApi
 import org.jellyfin.sdk.model.api.ImageType
-import org.jellyfin.sdk.model.api.UserDto
 import timber.log.Timber
 import java.util.*
 
@@ -38,6 +38,7 @@ class AuthenticationRepositoryImpl(
 	private val accountManagerHelper: AccountManagerHelper,
 	private val authenticationStore: AuthenticationStore,
 	private val userApiClient: KtorClient,
+	private val authenticationPreferences: AuthenticationPreferences,
 ) : AuthenticationRepository {
 	private val serverComparator = compareByDescending<Server> { it.dateLastAccessed }.thenBy { it.name }
 	private val userComparator = compareByDescending<PrivateUser> { it.lastUsed }.thenBy { it.name }
@@ -143,7 +144,7 @@ class AuthenticationRepositoryImpl(
 		when {
 			!server.versionSupported -> emit(ServerVersionNotSupported(server))
 			// Access token found, proceed with sign in
-			account?.accessToken != null -> when {
+			!authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate] && account?.accessToken != null -> when {
 				// Update session
 				setActiveSession(user, server) -> {
 					// Update stored user

--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -45,6 +45,8 @@ class SessionRepositoryImpl(
 	override fun restoreDefaultSession() {
 		Timber.d("Restoring default session")
 
+		if (authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]) return setCurrentSession(null, false)
+
 		val behavior = authenticationPreferences[AuthenticationPreferences.autoLoginUserBehavior]
 		val userId = authenticationPreferences[AuthenticationPreferences.autoLoginUserId].toUUIDOrNull()
 
@@ -57,6 +59,8 @@ class SessionRepositoryImpl(
 
 	override fun restoreDefaultSystemSession() {
 		Timber.d("Restoring default system session")
+
+		if (authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]) return setCurrentSession(null, false)
 
 		val behavior = authenticationPreferences[AuthenticationPreferences.systemUserBehavior]
 		val userId = authenticationPreferences[AuthenticationPreferences.systemUserId].toUUIDOrNull()

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -11,7 +11,7 @@ val authModule = module {
 	single { AuthenticationStore(androidContext()) }
 	single { AccountManagerHelper(androidContext().getSystemService()!!) }
 	single<AuthenticationRepository> {
-		AuthenticationRepositoryImpl(get(), get(), get(), get(), get(), get(userApiClient))
+		AuthenticationRepositoryImpl(get(), get(), get(), get(), get(), get(userApiClient), get())
 	}
 	single<SessionRepository> {
 		SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient))

--- a/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
@@ -15,6 +15,7 @@ class AuthenticationPreferences(context: Context) : SharedPreferenceStore(
 		val systemUserId = Preference.string("system_user_id", "")
 
 		val sortBy = Preference.enum("sort_by", AuthenticationSortBy.LAST_USE)
+		val alwaysAuthenticate = Preference.boolean("always_authenticate", false)
 
 		/**
 		 * Do not set directly, use [SessionRepository] instead.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/authentication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/authentication.kt
@@ -7,11 +7,8 @@ import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.preference.Preference
 import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
-import org.jellyfin.androidtv.ui.preference.dsl.OptionsBinder
+import org.jellyfin.androidtv.ui.preference.dsl.*
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsItemUserPicker.UserSelection
-import org.jellyfin.androidtv.ui.preference.dsl.OptionsScreen
-import org.jellyfin.androidtv.ui.preference.dsl.enum
-import org.jellyfin.androidtv.ui.preference.dsl.userPicker
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 
 fun OptionsScreen.authenticationCategory(
@@ -31,6 +28,10 @@ fun OptionsScreen.authenticationCategory(
 				AuthenticationPreferences.autoLoginUserId
 			)
 		}
+
+		depends {
+			!authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]
+		}
 	}
 
 	userPicker(authenticationRepository) {
@@ -47,11 +48,35 @@ fun OptionsScreen.authenticationCategory(
 				sessionRepository.restoreDefaultSystemSession()
 			}
 		}
+
+		depends {
+			!authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]
+		}
 	}
 
 	enum<AuthenticationSortBy> {
 		setTitle(R.string.lbl_sort_by)
 		bind(authenticationPreferences, AuthenticationPreferences.sortBy)
+	}
+}
+
+
+fun OptionsScreen.authenticationAdvancedCategory(
+	authenticationPreferences: AuthenticationPreferences,
+	sessionRepository: SessionRepository,
+) {
+	// Disallow changing the "always authenticate" option from the login screen
+	// because that would allow a kid to disable the function to access a parent's account
+	if (sessionRepository.currentSession.value == null) return
+
+	category {
+		setTitle(R.string.advanced_settings)
+
+		checkbox {
+			setTitle(R.string.always_authenticate)
+			setContent(R.string.always_authenticate_description)
+			bind(authenticationPreferences, AuthenticationPreferences.alwaysAuthenticate)
+		}
 	}
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -4,6 +4,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.AuthenticationRepository
 import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
+import org.jellyfin.androidtv.ui.preference.category.authenticationAdvancedCategory
 import org.jellyfin.androidtv.ui.preference.category.authenticationCategory
 import org.jellyfin.androidtv.ui.preference.category.manageServersCategory
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
@@ -24,5 +25,6 @@ class AuthPreferencesScreen : OptionsFragment() {
 
 		authenticationCategory(authenticationRepository, authenticationPreferences, sessionRepository)
 		manageServersCategory(authenticationRepository)
+		authenticationAdvancedCategory(authenticationPreferences, sessionRepository)
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -440,4 +440,7 @@
     <string name="enable_playback_module_description">This is an experimental feature. No support is provided.</string>
     <string name="last_use">Most recently used</string>
     <string name="alphabetical">Alphabetical</string>
+    <string name="always_authenticate">Always ask for credentials</string>
+    <string name="always_authenticate_description">Enabling this function disables auto sign in</string>
+    <string name="advanced_settings">Settings (advanced)</string>
 </resources>


### PR DESCRIPTION
This PR adds a new option at the bottom of the authentication preference screen called "always authenticate". When enabled it changes the behavior of the app:

**Changes**

- Option enabled behavior
  - Auto login is disabled
  - System users are disabled
    - System integrations are disabled (search, leanback, daydreams etc.)
  - User is required to enter the password when selecting a user
    - Access tokens are still stored in the system
- Option disabled behavior like it always was
- Option is hidden when not currently signed in ~~although a "kid account" could still disable it after signing in~~

**Issues**

Closes #1080