### PR TITLE
Fix missing string variables in affected translation strings.xml files.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 android {
-	compileSdkVersion(30)
+	compileSdk = 30
 
 	defaultConfig {
 		// Android version targets
-		minSdkVersion(21)
-		targetSdkVersion(30)
+		minSdk = 21
+		targetSdk = 30
 
 		// Release version
 		versionName = project.getVersionName()
@@ -57,10 +57,11 @@ android {
 		}
 	}
 
-	lintOptions {
+	lint {
 		lintConfig = file("$rootDir/android-lint.xml")
 		isAbortOnError = false
 		sarifReport = true
+		isCheckDependencies = true
 	}
 }
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -289,7 +289,7 @@
     <string name="login_authenticating">S\'està autenticant ...</string>
     <string name="server_field_empty">L\'adreça no pot estar buida</string>
     <string name="server_connection_failed">No es pot connectar al servidor: %1$s</string>
-    <string name="server_connecting">Connectant al servidor...</string>
+    <string name="server_connecting">Connectant al servidor: %1$s...</string>
     <string name="pref_clock_display_playback">Durant la reproducció</string>
     <string name="pref_clock_display_browsing">Mentre navega</string>
     <string name="lbl_always">Sempre</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -352,7 +352,7 @@
     <string name="login_authenticating">Verificerer...</string>
     <string name="server_field_empty">Addressen må ikke være tom</string>
     <string name="server_connection_failed">Kan ikke forbinde til serveren: %1$s</string>
-    <string name="server_connecting">Forbinder til server...</string>
+    <string name="server_connecting">Forbinder til server: %1$s...</string>
     <string name="pref_clock_display_playback">Under afspilning</string>
     <string name="pref_clock_display_browsing">Imens du søger</string>
     <string name="lbl_always">Altid</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -264,7 +264,7 @@
     <string name="login_authenticating">Έλεγχος ταυτότητας...</string>
     <string name="server_field_empty">Η διεύθυνση δε μπορεί να είναι κενή</string>
     <string name="server_connection_failed">Αδύνατη η σύνδεση με τον διακομιστή: %1$s</string>
-    <string name="server_connecting">Γίνεται σύνδεση στον διακομιστή...</string>
+    <string name="server_connecting">Γίνεται σύνδεση στον διακομιστή: %1$s...</string>
     <string name="pref_clock_display_playback">Κατά την αναπαραγωγή</string>
     <string name="pref_clock_display_browsing">Κατά την περιήγηση</string>
     <string name="lbl_always">Πάντα</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -358,7 +358,7 @@
     <string name="login_invalid_credentials">Invalid username and/or password</string>
     <string name="server_field_empty">The address cannot be empty</string>
     <string name="server_connection_failed">Unable to connect to server: %1$s</string>
-    <string name="server_connecting">Connecting to server...</string>
+    <string name="server_connecting">Connecting to server: %1$s...</string>
     <string name="login_authenticating">Authenticating...</string>
     <string name="login_help_title">Need help\?</string>
     <string name="user_picker_last_user_summary">Use the last active user</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -350,5 +350,5 @@
     <string name="login_invalid_credentials">Neispravno korisničko ime i/ili lozinka</string>
     <string name="login_authenticating">Autentifikacija...</string>
     <string name="server_field_empty">Adresa ne može biti prazna</string>
-    <string name="server_connecting">Spajanje na server...</string>
+    <string name="server_connecting">Spajanje na server: %1$s...</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -352,7 +352,7 @@
     <string name="login_authenticating">Se autentifică...</string>
     <string name="server_field_empty">Adresa nu poate fi vidă</string>
     <string name="server_connection_failed">Imposibil de conectat la server: %1$s</string>
-    <string name="server_connecting">Conectare la server...</string>
+    <string name="server_connecting">Conectare la server: %1$s...</string>
     <string name="pref_clock_display_playback">În timpul redării</string>
     <string name="pref_clock_display_browsing">În timp ce navigați</string>
     <string name="lbl_always">Mereu</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -359,7 +359,7 @@
     <string name="login_authenticating">Аутентификација...</string>
     <string name="server_field_empty">Адреса не може да буде празна</string>
     <string name="server_connection_failed">Немогуће је повезати се са сервером: %1$s</string>
-    <string name="server_connecting">Повезујем се на сервер...</string>
+    <string name="server_connecting">Повезујем се на сервер: %1$s...</string>
     <string name="lbl_use_series_thumbnails_description">Користите сличице при приказивању епизода</string>
     <string name="user_picker_last_user_summary">Користи последњег активног корисника</string>
     <string name="user_picker_last_user_title">Недавно коришћени</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -351,7 +351,7 @@
     <string name="login_invalid_credentials">Ogiltigt användarnamn och/eller lösenord</string>
     <string name="login_authenticating">Autentiserar...</string>
     <string name="server_connection_failed">Kunde inte ansluta till server: %1$s</string>
-    <string name="server_connecting">Ansluter till server...</string>
+    <string name="server_connecting">Ansluter till server: %1$s...</string>
     <string name="pref_clock_display_playback">Under uppspelning</string>
     <string name="pref_clock_display_browsing">Vid bläddring</string>
     <string name="lbl_always">Alltid</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -350,7 +350,7 @@
     <string name="login_invalid_credentials">Geçersiz kullanıcı adı veya şifre</string>
     <string name="server_field_empty">Adres boş olamaz</string>
     <string name="server_connection_failed">Sunucuya bağlanılamadı: %1$s</string>
-    <string name="server_connecting">Sunucuya bağlanılıyor...</string>
+    <string name="server_connecting">Sunucuya bağlanılıyor: %1$s...</string>
     <string name="pref_clock_display_playback">Oynatma sırasında</string>
     <string name="lbl_always">Her zaman</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -343,7 +343,7 @@
     <string name="login_authenticating">驗證中...</string>
     <string name="server_field_empty">地址不能留空</string>
     <string name="server_connection_failed">無法連接至伺服器： %s</string>
-    <string name="server_connecting">正在與伺服器連接...</string>
+    <string name="server_connecting">正在與伺服器連接: %1$s...</string>
     <string name="pref_clock_display_playback">在播放時</string>
     <string name="pref_clock_display_browsing">在瀏覽時</string>
     <string name="lbl_always">永遠</string>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -31,7 +31,7 @@ object Plugins {
 	object Versions {
 		const val kotlin = "1.5.10"
 		const val detekt = "1.17.1"
-		const val androidBuildTools = "4.2.1"
+		const val androidBuildTools = "7.0.0"
 	}
 
 	const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"


### PR DESCRIPTION
**Changes**
I added changes to the _server_connecting_ id in the relevant strings.xml translation files that were causing an _Invalid string format error_ in _AddServerAlertFragment.kt_

**Issues**
Resolves merge error when migrating to Android Gradle Plugin 7.0.0, referenced in #1050 review checks.
