### PR TITLE
Add PlaybackForwardingActivity for bridging to new playback module

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -167,5 +167,8 @@
             android:name=".ui.playback.nextup.NextUpActivity"
             android:noHistory="true"
             android:screenOrientation="landscape" />
+
+        <!-- Playback Rewrite - Temporary -->
+        <activity android:name=".ui.playback.rewrite.PlaybackForwardingActivity" />
     </application>
 </manifest>

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.playback
 import android.app.Activity
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
+import org.jellyfin.androidtv.ui.playback.rewrite.PlaybackForwardingActivity
 import org.jellyfin.apiclient.model.dto.BaseItemType
 
 interface PlaybackLauncher {
@@ -32,8 +33,7 @@ class GarbagePlaybackLauncher(
 	}
 }
 
-// TODO: Move to playback module
 class RewritePlaybackLauncher : PlaybackLauncher {
 	override fun useExternalPlayer(itemType: BaseItemType?) = false
-	override fun getPlaybackActivityClass(itemType: BaseItemType?) = TODO("Not yet implemented")
+	override fun getPlaybackActivityClass(itemType: BaseItemType?) = PlaybackForwardingActivity::class.java
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -1,0 +1,69 @@
+package org.jellyfin.androidtv.ui.playback.rewrite
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import org.jellyfin.androidtv.di.userApiClient
+import org.jellyfin.androidtv.ui.playback.MediaManager
+import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.apiclient.model.dto.BaseItemType
+import org.jellyfin.sdk.api.operations.UserLibraryApi
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.koin.android.ext.android.get
+import org.koin.android.ext.android.inject
+import timber.log.Timber
+
+class PlaybackForwardingActivity : FragmentActivity() {
+	private val mediaManager by inject<MediaManager>()
+	private val userLibraryApi by lazy {
+		UserLibraryApi(get(userApiClient))
+	}
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+
+		// Try find the item id
+		val itemId = findItem()?.id?.toUUIDOrNull()
+
+		if (itemId == null) {
+			Toast.makeText(
+				this,
+				"Could not find item to play (itemId=null)",
+				Toast.LENGTH_LONG
+			).show()
+			finishAfterTransition()
+			return
+		}
+
+		lifecycleScope.launchWhenCreated {
+			// Get fresh info from API in SDK format
+			val item by userLibraryApi.getItem(itemId = itemId)
+
+			// Log info
+			Toast.makeText(
+				this@PlaybackForwardingActivity,
+				"Found item of type ${item.type} - ${item.name} (${item.id}",
+				Toast.LENGTH_LONG
+			).show()
+			Timber.i(item.toString())
+
+			// TODO: Create queue, send to new playback manager, start new player UI
+			finishAfterTransition()
+		}
+	}
+
+	private fun findItem(): BaseItemDto? {
+		var first: BaseItemDto? = null
+		var best: BaseItemDto? = null
+
+		for (item in mediaManager.currentVideoQueue) {
+			if (first == null) first = item
+			if (best == null && item.baseItemType !== BaseItemType.Trailer) best = item
+
+			if (first != null && best != null) break
+		}
+
+		return best ?: first
+	}
+}


### PR DESCRIPTION
**Changes**

This is a small change that does not modify any behavior in the normal app flow (and thus is safe for 0.12 inclusion). It adds a new activity "PlaybackForwardingActivity" that is used to bridge all playback requests to the new playback module.
Right now it extracts the to-be-played item from the current playback code and retrieves the BaseItemDto from the api using the SDK. It then quits the activity. This code is backported from my playback scratch branch.

With this the app will not crash anymore when playback is started with the new playback module enabled.

**Issues**

Part of #1057
