### PR TITLE
Remove vpx (unused) as a CodecType

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@
  - [AndreasGB](https://github.com/andreasgb)
  - [joern-h](https://github.com/joern-h)
  - [Niels van Velzen](https://github.com/nielsvanvelzen)
+ - [GodTamIt](https://github.com/GodTamIt)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/constant/CodecTypes.java
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/CodecTypes.java
@@ -33,5 +33,4 @@ public class CodecTypes {
     public static final String MPEG4 = "mpeg4";
     public static final String VP8 = "vp8";
     public static final String VP9 = "vp9";
-    public static final String VPX = "vpx";
 }


### PR DESCRIPTION
**Changes**
Remove the unused `vpx` video codec, which is actually ambiguous between VP8 and VP9, as part of a bigger shift to be specific between the codecs in the VPx.

**Issues**
Progress on jellyfin/jellyfin#6455