### PR TITLE
Fix VLC error reporting and black screens

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -24,8 +24,8 @@ import com.google.android.exoplayer2.Renderer;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.text.TextOutput;
-import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
+import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 
@@ -472,6 +472,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             options.add("--audio-desync");
             options.add(String.valueOf(get(UserPreferences.class).get(UserPreferences.Companion.getLibVLCAudioDelay())));
             options.add("-v");
+            options.add("--vout=android-display");
 
             mLibVLC = new LibVLC(TvApp.getApplication(), options);
             Timber.i("Network buffer set to %d", buffer);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VlcEventHandler.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VlcEventHandler.java
@@ -9,10 +9,21 @@ public class VlcEventHandler implements org.videolan.libvlc.MediaPlayer.EventLis
     private PlaybackListener onPreparedListener;
     private PlaybackListener onProgressListener;
 
-    public void setOnCompletionListener(PlaybackListener listener) { onCompletionListener = listener; }
-    public void setOnErrorListener(PlaybackListener listener) { onErrorListener = listener; }
-    public void setOnPreparedListener(PlaybackListener listener) { onPreparedListener = listener; }
-    public void setOnProgressListener(PlaybackListener listener) { onProgressListener = listener; }
+    public void setOnCompletionListener(PlaybackListener listener) {
+        onCompletionListener = listener;
+    }
+
+    public void setOnErrorListener(PlaybackListener listener) {
+        onErrorListener = listener;
+    }
+
+    public void setOnPreparedListener(PlaybackListener listener) {
+        onPreparedListener = listener;
+    }
+
+    public void setOnProgressListener(PlaybackListener listener) {
+        onProgressListener = listener;
+    }
 
     @Override
     public void onEvent(Event event) {
@@ -26,6 +37,8 @@ public class VlcEventHandler implements org.videolan.libvlc.MediaPlayer.EventLis
             case Event.PositionChanged:
                 if (onProgressListener != null) onProgressListener.onEvent();
                 break;
+            case Event.EncounteredError:
+                if (onErrorListener != null) onErrorListener.onEvent();
             case Event.Paused:
             case Event.Stopped:
             default:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VlcEventHandler.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VlcEventHandler.java
@@ -39,6 +39,7 @@ public class VlcEventHandler implements org.videolan.libvlc.MediaPlayer.EventLis
                 break;
             case Event.EncounteredError:
                 if (onErrorListener != null) onErrorListener.onEvent();
+                break;
             case Event.Paused:
             case Event.Stopped:
             default:


### PR DESCRIPTION

**Changes**
- Fix VLC error reporting

  No idea why but the errors where ignored, this might help fixing some of our playback issues

- Fix VLC output not using android-display

  The onNewVideoLayout function we use to scale the video view does not work on the opengl video output from LibVLC

**Issues**

Possibly a few of them..
