### PR TITLE
Adjust person/user card colors and non-active button color for Muted Purple theme

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -159,7 +159,7 @@ class ServerFragment : Fragment() {
 
 		override fun onBindViewHolder(holder: ViewHolder, user: User) {
 			holder.cardView.title = user.name
-			holder.cardView.setImage(loginViewModel.getUserImage(server, user), R.drawable.tile_port_person)
+			holder.cardView.setImage(loginViewModel.getUserImage(server, user), R.drawable.tile_port_user)
 
 			holder.cardView.setOnClickListener {
 				onItemPressed(user)

--- a/app/src/main/res/drawable/button_default_normal.xml
+++ b/app/src/main/res/drawable/button_default_normal.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="3dp" />
-    <solid android:color="@color/button_default_normal_background" />
+    <solid android:color="?attr/button_default_normal_background" />
 </shape>

--- a/app/src/main/res/drawable/tile_port_user.xml
+++ b/app/src/main/res/drawable/tile_port_user.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size
+                android:width="256dp"
+                android:height="384dp" />
+            <solid android:color="?attr/tile_port_user_bg" />
+        </shape>
+    </item>
+
+    <item
+        android:bottom="124dp"
+        android:drawable="@drawable/ic_user"
+        android:left="60dp"
+        android:right="60dp"
+        android:top="124dp" />
+</layer-list>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -21,6 +21,7 @@
         <attr name="controlIconBackground" format="reference|color" />
         <attr name="controlIconForegroundActive" format="reference|color" />
         <attr name="controlIconForegroundInactive" format="reference|color" />
+        <attr name="button_default_normal_background" format="reference|color" />
         <!-- QR drawables -->
         <attr name="qrBackground" format="color" />
         <attr name="qrForeground" format="color" />

--- a/app/src/main/res/values/attrs_tiles.xml
+++ b/app/src/main/res/values/attrs_tiles.xml
@@ -24,4 +24,5 @@
     <attr name="tile_port_folder_bg" format="color" />
     <attr name="tile_port_grid_bg" format="color" />
     <attr name="tile_port_guide_bg" format="color" />
+    <attr name="tile_port_user_bg" format="color" />
 </resources>

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -77,6 +77,7 @@
         <item name="tile_port_person_bg">#7E0001</item>
         <item name="tile_port_record_bg">#101777</item>
         <item name="tile_port_series_timer_bg">#014A7F</item>
+        <item name="tile_port_user_bg">#7E0001</item>
     </style>
 
     <style name="Theme.Jellyfin.Preferences" parent="Theme.Jellyfin">

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -17,6 +17,7 @@
         <item name="defaultSearchColor">@color/jellyfin_blue</item>
         <!-- Default (non-active) button color -->
         <item name="android:colorButtonNormal">@color/grey</item>
+        <item name="button_default_normal_background">@color/button_default_normal_background</item>
         <!-- Toolbar background color -->
         <item name="toolbarBackground">@color/not_quite_black</item>
         <!-- Header text color -->

--- a/app/src/main/res/values/theme_mutedpurple.xml
+++ b/app/src/main/res/values/theme_mutedpurple.xml
@@ -10,6 +10,7 @@
         <item name="defaultSearchColor">@color/theme_muted_purple_accent</item>
         <item name="progressPrimary">@color/theme_muted_purple_accent</item>
         <item name="android:colorButtonNormal">@color/light_grey_transparent</item>
+        <item name="button_default_normal_background">@color/light_grey_transparent</item>
 
         <!-- Control icons -->
         <item name="controlIconForegroundActive">@color/theme_muted_purple_accent</item>

--- a/app/src/main/res/values/theme_mutedpurple.xml
+++ b/app/src/main/res/values/theme_mutedpurple.xml
@@ -23,5 +23,9 @@
 
         <!-- Watched Indicator Shape -->
         <item name="accentShape">@drawable/square_accent</item>
+
+        <!-- Tile colors -->
+        <item name="tile_port_person_bg">#212121</item>
+        <item name="tile_port_user_bg">#384873</item>
     </style>
 </resources>


### PR DESCRIPTION
**Changes**

- Separates person (cast/crew) and user cards to allow for different colors
- Makes the `button_default_normal` color themeable
- Changes the colors for the above elements in the Muted Purple theme

**Screenshots (Before/After)**

<details>
<summary>User selection screen</summary>

![before-userselection](https://user-images.githubusercontent.com/46704654/130397939-01dcee91-869a-4511-9689-e526e855d619.png)
![after-userselection](https://user-images.githubusercontent.com/46704654/130397944-084f74d5-10cf-479f-8005-feeaf2ed80c2.png)
</details>

<details>
<summary>Cast/crew cards</summary>

![before-castcrew](https://user-images.githubusercontent.com/46704654/130397958-99e56c27-bde4-417b-9c7d-1b3533b7d4cf.png)
![after-castcrew](https://user-images.githubusercontent.com/46704654/130397962-eb09201a-eb1e-485b-941a-1d6579755c4a.png)
</details>

<details>
<summary>Next Up buttons</summary>

![before-nextup](https://user-images.githubusercontent.com/46704654/130397970-62590227-c4cb-4e57-b928-783a23edc664.png)
![after-nextup](https://user-images.githubusercontent.com/46704654/130397986-b21c0cb5-d428-48ae-902e-58582e0b1733.png)
</details>
