### PR TITLE
Enable multichannel audio support for Fire TVs

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -95,7 +95,7 @@ fun OptionsScreen.playbackCategory(
 	enum<AudioBehavior> {
 		setTitle(R.string.lbl_audio_output)
 		bind(userPreferences, UserPreferences.audioBehaviour)
-		depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL && !DeviceUtils.isFireTv() }
+		depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL }
 	}
 
 	checkbox {

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -137,6 +137,6 @@ public class Utils {
             return true;
         }
 
-        return DeviceUtils.isFireTv() || get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
+        return get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
     }
 }


### PR DESCRIPTION
**Changes**
Reviewing the codec support for Fire TVs, it seems they all support multichannel audio. This seems to just be a legacy holdover. I tested this on a 2nd Gen Fire Stick and it seems to work as expected.

**Issues**
N/A
