### PR TITLE
Add guide card to live tv library views

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -468,10 +468,31 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
             GridButtonPresenter mGridPresenter = new GridButtonPresenter();
             ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
-            gridRowAdapter.add(new GridButton(TvApp.LIVE_TV_RECORDINGS_OPTION_ID, TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record, null));
+            gridRowAdapter.add(new GridButton(
+                TvApp.LIVE_TV_GUIDE_OPTION_ID,
+                TvApp.getApplication().getResources().getString(R.string.lbl_live_tv_guide),
+                R.drawable.tile_port_guide,
+                null
+            ));
+            gridRowAdapter.add(new GridButton(
+                TvApp.LIVE_TV_RECORDINGS_OPTION_ID,
+                TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv),
+                R.drawable.tile_port_record,
+                null
+            ));
             if (TvApp.getApplication().canManageRecordings()) {
-                gridRowAdapter.add(new GridButton(TvApp.LIVE_TV_SCHEDULE_OPTION_ID, TvApp.getApplication().getResources().getString(R.string.lbl_schedule), R.drawable.tile_port_time, null));
-                gridRowAdapter.add(new GridButton(TvApp.LIVE_TV_SERIES_OPTION_ID, TvApp.getApplication().getResources().getString(R.string.lbl_series), R.drawable.tile_port_series_timer, null));
+                gridRowAdapter.add(new GridButton(
+                    TvApp.LIVE_TV_SCHEDULE_OPTION_ID,
+                    TvApp.getApplication().getResources().getString(R.string.lbl_schedule),
+                    R.drawable.tile_port_time,
+                    null
+                ));
+                gridRowAdapter.add(new GridButton(
+                    TvApp.LIVE_TV_SERIES_OPTION_ID,
+                    TvApp.getApplication().getResources().getString(R.string.lbl_series),
+                    R.drawable.tile_port_series_timer,
+                    null
+                ));
             }
 
             mRowsAdapter.add(new ListRow(gridHeader, gridRowAdapter));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -38,6 +38,7 @@ import org.jellyfin.androidtv.ui.itemdetail.ItemListActivity;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
@@ -483,6 +484,11 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
                         folder.setName(TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv));
                         recordings.putExtra(Extras.Folder, serializer.getValue().SerializeToString(folder));
                         mActivity.startActivity(recordings);
+                        break;
+
+                    case TvApp.LIVE_TV_GUIDE_OPTION_ID:
+                        Intent guide = new Intent(mActivity, LiveTvGuideActivity.class);
+                        mActivity.startActivity(guide);
                         break;
 
                     default:


### PR DESCRIPTION
**Changes**
Adds the Guide card to the list of "View" cards in the Live TV library view. Currently you can only get to the guide from the home screen.

**Issues**
N/A
