### PR TITLE
Add android-opaque to supported as supported VLC video output

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -472,7 +472,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             options.add("--audio-desync");
             options.add(String.valueOf(get(UserPreferences.class).get(UserPreferences.Companion.getLibVLCAudioDelay())));
             options.add("-v");
-            options.add("--vout=android-display");
+            options.add("--vout=android-opaque,android-display");
 
             mLibVLC = new LibVLC(TvApp.getApplication(), options);
             Timber.i("Network buffer set to %d", buffer);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Add "android-opaque" as possible video output.

**Issues**

Fixes #1107