### PR TITLE
Downmix audio by default on Chromecast with Google TV

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -4,7 +4,14 @@ import android.content.Context
 import android.view.KeyEvent
 import androidx.preference.PreferenceManager
 import org.acra.ACRA
-import org.jellyfin.androidtv.preference.constant.*
+import org.jellyfin.androidtv.preference.constant.AppTheme
+import org.jellyfin.androidtv.preference.constant.AudioBehavior
+import org.jellyfin.androidtv.preference.constant.ClockBehavior
+import org.jellyfin.androidtv.preference.constant.NextUpBehavior
+import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
+import org.jellyfin.androidtv.preference.constant.RatingType
+import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
+import org.jellyfin.androidtv.preference.constant.defaultAudioBehavior
 import org.jellyfin.androidtv.util.DeviceUtils
 
 /**
@@ -96,7 +103,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Preferred behavior for audio streaming.
 		 */
-		var audioBehaviour = Preference.enum("audio_behavior", AudioBehavior.DIRECT_STREAM)
+		var audioBehaviour = Preference.enum("audio_behavior", defaultAudioBehavior)
 
 		/**
 		 * Enable DTS

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/AudioBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/AudioBehavior.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.preference.constant
 
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.preference.dsl.EnumDisplayOptions
+import org.jellyfin.androidtv.util.DeviceUtils
 
 enum class AudioBehavior {
 	/**
@@ -16,3 +17,6 @@ enum class AudioBehavior {
 	@EnumDisplayOptions(R.string.pref_audio_compat)
 	DOWNMIX_TO_STEREO
 }
+
+val defaultAudioBehavior = if (DeviceUtils.isChromecastWithGoogleTV()) AudioBehavior.DOWNMIX_TO_STEREO
+	else AudioBehavior.DIRECT_STREAM

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -5,6 +5,9 @@ import android.os.Build;
 import java.util.Arrays;
 
 public class DeviceUtils {
+    // Chromecast with Google TV
+    private static final String CHROMECAST_GOOGLE_TV = "Chromecast";
+
     private static final String FIRE_TV_PREFIX = "AFT";
     // Fire TV Stick Models
     private static final String FIRE_STICK_MODEL_GEN_1 = "AFTM";
@@ -19,6 +22,10 @@ public class DeviceUtils {
     private static final String FIRE_TV_MODEL_GEN_1 = "AFTB";
     private static final String FIRE_TV_MODEL_GEN_2 = "AFTS";
     private static final String FIRE_TV_MODEL_GEN_3 = "AFTN";
+
+    public static boolean isChromecastWithGoogleTV() {
+        return Build.MODEL.equals(CHROMECAST_GOOGLE_TV);
+    }
 
     public static boolean isFireTv() {
         return Build.MODEL.startsWith(FIRE_TV_PREFIX);


### PR DESCRIPTION
**Changes**
Downmixes multichannel audio by default on Chromecast with Google TV devices.

**Issues**
Fixes #1032 (hopefully)
