### PR TITLE
Use parentThumbItemId in LeanbackChannelWorker

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -25,6 +25,7 @@ import org.jellyfin.sdk.api.operations.ImageApi
 import org.jellyfin.sdk.api.operations.TvShowsApi
 import org.jellyfin.sdk.api.operations.UserViewsApi
 import org.jellyfin.sdk.model.api.*
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.core.component.KoinApiExtension
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -165,8 +166,8 @@ class LeanbackChannelWorker(
 	 * image when preferred.
 	 */
 	private fun BaseItemDto.getPosterArtImageUrl(preferParentThumb: Boolean): Uri = when {
-		preferParentThumb && this.parentThumbItemId != null && seriesId != null -> imageApi.getItemImageUrl(
-			itemId = seriesId!!,
+		preferParentThumb && parentThumbItemId?.toUUIDOrNull() != null -> imageApi.getItemImageUrl(
+			itemId = parentThumbItemId!!.toUUIDOrNull()!!,
 			imageType = ImageType.THUMB,
 			format = ImageFormat.WEBP,
 			width = 512,

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -166,7 +166,8 @@ class LeanbackChannelWorker(
 	 * image when preferred.
 	 */
 	private fun BaseItemDto.getPosterArtImageUrl(preferParentThumb: Boolean): Uri = when {
-		preferParentThumb && parentThumbItemId?.toUUIDOrNull() != null -> imageApi.getItemImageUrl(
+		(preferParentThumb || imageTags?.contains(ImageType.PRIMARY) != true)
+			&& parentThumbItemId?.toUUIDOrNull() != null -> imageApi.getItemImageUrl(
 			itemId = parentThumbItemId!!.toUUIDOrNull()!!,
 			imageType = ImageType.THUMB,
 			format = ImageFormat.WEBP,


### PR DESCRIPTION
**Changes**

- Uses `parentThumbItemId` instead of `seriesId` when fetching the leanback channel images
- Falls back to the parent thumb if the episode is missing a primary image
   - This behavior matches inside the app