### PR TITLE
Use actions/setup-java caching

### DIFF
--- a/.github/workflows/app-build.yaml
+++ b/.github/workflows/app-build.yaml
@@ -17,15 +17,7 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-      - name: Setup Gradle cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: gradle
       - name: Assemble debug APKs
         run: ./gradlew --build-cache --no-daemon --info assembleDebug
       - name: Upload artifacts

--- a/.github/workflows/app-lint.yaml
+++ b/.github/workflows/app-lint.yaml
@@ -18,15 +18,7 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-      - name: Setup Gradle cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: gradle
       - name: Run detekt and lint task
         run: ./gradlew --build-cache --no-daemon --info detekt lint
       - name: Upload SARIF files

--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -18,14 +18,6 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-      - name: Setup Gradle cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: gradle
       - name: Run test task
         run: ./gradlew --build-cache --no-daemon --info test


### PR DESCRIPTION
See https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/

Results in smaller workflow files etc.