### PR TITLE
Remove unused tile colors and update default theme

### DIFF
--- a/app/src/main/res/drawable/tile_land_series_timer.xml
+++ b/app/src/main/res/drawable/tile_land_series_timer.xml
@@ -5,7 +5,7 @@
             <size
                 android:width="384dp"
                 android:height="256dp" />
-            <solid android:color="?attr/tile_port_series_timer_bg" />
+            <solid android:color="?attr/tile_land_series_timer_bg" />
         </shape>
     </item>
 

--- a/app/src/main/res/values/attrs_tiles.xml
+++ b/app/src/main/res/values/attrs_tiles.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <attr name="tile_port_person_bg" format="color" />
-    <attr name="tile_port_record_bg" format="color" />
     <attr name="tile_port_series_timer_bg" format="color" />
     <attr name="tile_port_server_bg" format="color" />
     <attr name="tile_port_time_bg" format="color" />
@@ -14,11 +13,9 @@
     <attr name="tile_artists_bg" format="color" />
     <attr name="tile_audio_bg" format="color" />
     <attr name="tile_chapter_bg" format="color" />
-    <attr name="tile_edit_bg" format="color" />
     <attr name="tile_genres_bg" format="color" />
     <attr name="tile_land_folder_bg" format="color" />
     <attr name="tile_land_photo_bg" format="color" />
-    <attr name="tile_land_series_timer_bg" format="color" />
     <attr name="tile_land_tv_bg" format="color" />
     <attr name="tile_letters_bg" format="color" />
     <attr name="tile_port_folder_bg" format="color" />

--- a/app/src/main/res/values/attrs_tiles.xml
+++ b/app/src/main/res/values/attrs_tiles.xml
@@ -16,6 +16,7 @@
     <attr name="tile_genres_bg" format="color" />
     <attr name="tile_land_folder_bg" format="color" />
     <attr name="tile_land_photo_bg" format="color" />
+    <attr name="tile_land_series_timer_bg" format="color" />
     <attr name="tile_land_tv_bg" format="color" />
     <attr name="tile_letters_bg" format="color" />
     <attr name="tile_port_folder_bg" format="color" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,9 @@
     <!-- Base Colors -->
     <color name="jellyfin_blue">#00a4dc</color>
     <color name="jellyfin_purple">#aa5cc3</color>
+    <color name="midnight_blue">#031A6B</color>
+    <color name="indigo_dye">#033860</color>
+    <color name="spanish_blue">#1E76BA</color>
     <color name="grey">#303030</color>
     <color name="not_quite_black">#101010</color>
     <color name="black">#000000</color>

--- a/app/src/main/res/values/theme_emerald.xml
+++ b/app/src/main/res/values/theme_emerald.xml
@@ -34,6 +34,7 @@
         <item name="tile_letters_bg">@color/theme_emerald_light</item>
         <item name="tile_land_folder_bg">@color/theme_emerald_light</item>
         <item name="tile_land_photo_bg">@color/theme_emerald_light</item>
+        <item name="tile_land_series_timer_bg">@color/theme_emerald_light</item>
         <item name="tile_land_tv_bg">@color/theme_emerald_light</item>
         <item name="tile_port_server_bg">@color/theme_emerald_light</item>
         <item name="tile_port_time_bg">@color/theme_emerald_light</item>

--- a/app/src/main/res/values/theme_emerald.xml
+++ b/app/src/main/res/values/theme_emerald.xml
@@ -24,7 +24,6 @@
         <item name="qrForeground">@color/theme_emerald_dark</item>
 
         <!-- Tile colors -->
-        <item name="tile_edit_bg">@color/theme_emerald_light</item>
         <item name="tile_search_bg">@color/theme_emerald_light</item>
         <item name="tile_suggestions_bg">@color/theme_emerald_light</item>
         <item name="tile_actors_bg">@color/theme_emerald_light</item>
@@ -35,7 +34,6 @@
         <item name="tile_letters_bg">@color/theme_emerald_light</item>
         <item name="tile_land_folder_bg">@color/theme_emerald_light</item>
         <item name="tile_land_photo_bg">@color/theme_emerald_light</item>
-        <item name="tile_land_series_timer_bg">@color/theme_emerald_light</item>
         <item name="tile_land_tv_bg">@color/theme_emerald_light</item>
         <item name="tile_port_server_bg">@color/theme_emerald_light</item>
         <item name="tile_port_time_bg">@color/theme_emerald_light</item>
@@ -46,7 +44,6 @@
         <item name="tile_port_grid_bg">@color/theme_emerald_light</item>
         <item name="tile_port_guide_bg">@color/theme_emerald_light</item>
         <item name="tile_port_person_bg">@color/theme_emerald_light</item>
-        <item name="tile_port_record_bg">@color/theme_emerald_light</item>
         <item name="tile_port_series_timer_bg">@color/theme_emerald_light</item>
     </style>
 </resources>

--- a/app/src/main/res/values/theme_hotdogstand.xml
+++ b/app/src/main/res/values/theme_hotdogstand.xml
@@ -40,6 +40,7 @@
         <item name="tile_letters_bg">@color/theme_hotdog_black</item>
         <item name="tile_land_folder_bg">@color/theme_hotdog_black</item>
         <item name="tile_land_photo_bg">@color/theme_hotdog_black</item>
+        <item name="tile_land_series_timer_bg">@color/theme_hotdog_black</item>
         <item name="tile_land_tv_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_server_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_time_bg">@color/theme_hotdog_black</item>

--- a/app/src/main/res/values/theme_hotdogstand.xml
+++ b/app/src/main/res/values/theme_hotdogstand.xml
@@ -30,7 +30,6 @@
         <item name="qrForeground">@color/theme_hotdog_red</item>
 
         <!-- Tile colors -->
-        <item name="tile_edit_bg">@color/theme_hotdog_black</item>
         <item name="tile_search_bg">@color/theme_hotdog_black</item>
         <item name="tile_suggestions_bg">@color/theme_hotdog_black</item>
         <item name="tile_actors_bg">@color/theme_hotdog_black</item>
@@ -41,7 +40,6 @@
         <item name="tile_letters_bg">@color/theme_hotdog_black</item>
         <item name="tile_land_folder_bg">@color/theme_hotdog_black</item>
         <item name="tile_land_photo_bg">@color/theme_hotdog_black</item>
-        <item name="tile_land_series_timer_bg">@color/theme_hotdog_black</item>
         <item name="tile_land_tv_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_server_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_time_bg">@color/theme_hotdog_black</item>
@@ -52,7 +50,6 @@
         <item name="tile_port_grid_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_guide_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_person_bg">@color/theme_hotdog_black</item>
-        <item name="tile_port_record_bg">@color/theme_hotdog_black</item>
         <item name="tile_port_series_timer_bg">@color/theme_hotdog_black</item>
     </style>
 </resources>

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -54,31 +54,32 @@
         <item name="qrForeground">@color/black</item>
 
         <!-- Tile colors -->
-        <item name="tile_edit_bg">#4b41ae</item>
-        <item name="tile_search_bg">#3486BD</item>
-        <item name="tile_suggestions_bg">#DFCD41</item>
-        <item name="tile_actors_bg">#720826</item>
-        <item name="tile_artists_bg">#4A3F87</item>
-        <item name="tile_audio_bg">#253D63</item>
-        <item name="tile_chapter_bg">#007F7F</item>
-        <item name="tile_genres_bg">#0B4B08</item>
-        <item name="tile_letters_bg">#1D0472</item>
-        <item name="tile_land_folder_bg">#003C68</item>
-        <item name="tile_land_photo_bg">#224982</item>
-        <item name="tile_land_series_timer_bg">#014A7F</item>
-        <item name="tile_land_tv_bg">#145A98</item>
-        <item name="tile_port_server_bg">#145A98</item>
-        <item name="tile_port_time_bg">#145A99</item>
-        <item name="tile_port_tv_bg">#014A7F</item>
-        <item name="tile_port_video_bg">#006309</item>
-        <item name="tile_port_video_queue_bg">#006853</item>
-        <item name="tile_port_folder_bg">#003C68</item>
-        <item name="tile_port_grid_bg">#3486BD</item>
-        <item name="tile_port_guide_bg">#132DA1</item>
-        <item name="tile_port_person_bg">#7E0001</item>
-        <item name="tile_port_record_bg">#101777</item>
-        <item name="tile_port_series_timer_bg">#014A7F</item>
-        <item name="tile_port_user_bg">#7E0001</item>
+        <item name="tile_port_person_bg">@color/indigo_dye</item>
+        <item name="tile_port_user_bg">@color/indigo_dye</item>
+        <item name="tile_port_video_bg">@color/indigo_dye</item>
+        <item name="tile_land_folder_bg">@color/indigo_dye</item>
+        <item name="tile_chapter_bg">@color/indigo_dye</item>
+        <item name="tile_land_tv_bg">@color/indigo_dye</item>
+        <item name="tile_port_tv_bg">@color/indigo_dye</item>
+        <item name="tile_actors_bg">@color/indigo_dye</item>
+        <item name="tile_land_photo_bg">@color/indigo_dye</item>
+        <item name="tile_port_video_queue_bg">@color/indigo_dye</item>
+        <item name="tile_port_folder_bg">@color/indigo_dye</item>
+
+        <item name="tile_audio_bg">@color/midnight_blue</item>
+        <item name="tile_artists_bg">@color/spanish_blue</item>
+        <item name="tile_genres_bg">@color/midnight_blue</item>
+        <item name="tile_search_bg">@color/spanish_blue</item>
+
+        <item name="tile_suggestions_bg">@color/spanish_blue</item>
+        <item name="tile_port_grid_bg">@color/midnight_blue</item>
+        <item name="tile_letters_bg">@color/spanish_blue</item>
+
+        <item name="tile_port_guide_bg">@color/spanish_blue</item>
+        <item name="tile_port_series_timer_bg">@color/midnight_blue</item>
+        <item name="tile_port_time_bg">@color/spanish_blue</item>
+
+        <item name="tile_port_server_bg">@color/midnight_blue</item>
     </style>
 
     <style name="Theme.Jellyfin.Preferences" parent="Theme.Jellyfin">

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -65,6 +65,7 @@
         <item name="tile_land_photo_bg">@color/indigo_dye</item>
         <item name="tile_port_video_queue_bg">@color/indigo_dye</item>
         <item name="tile_port_folder_bg">@color/indigo_dye</item>
+        <item name="tile_land_series_timer_bg">@color/indigo_dye</item>
 
         <item name="tile_audio_bg">@color/midnight_blue</item>
         <item name="tile_artists_bg">@color/spanish_blue</item>


### PR DESCRIPTION
**Changes**
* Removes unused tile attributes
* Updates default theme colors

The "smart screens" were the worst offenders of using completely random colors, but it can also be seen in the red background for user avatars and the various shades of blue or green used for placeholders throughout the app. This reduces the colors used to only those in [this theme](https://coolors.co/031a6b-033860-1e76ba-00a4dc-aa5cc3).

| This PR | Current |
|--|--|
| ![tile colors](https://user-images.githubusercontent.com/3450688/132449653-0435ac1b-675d-4977-ae8f-a2d9b5e76be0.png) | ![current tile colors](https://user-images.githubusercontent.com/3450688/132449625-271325cb-efe1-4ddb-9192-5b95aa5276bd.png) |




**Issues**
N/A
