### PR TITLE
add star rating sort to grid view

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -152,8 +152,8 @@ public class GridFragment extends Fragment {
         sortOptions.put(1, new SortOption(TvApp.getApplication().getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
         sortOptions.put(2, new SortOption(TvApp.getApplication().getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
         sortOptions.put(3,new SortOption(TvApp.getApplication().getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
-        sortOptions.put(4,new SortOption(TvApp.getApplication().getString(R.string.lbl_stars), "CommunityRating,SortName", SortOrder.Descending));
-	sortOptions.put(5,new SortOption(TvApp.getApplication().getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
+        sortOptions.put(4,new SortOption(TvApp.getApplication().getString(R.string.lbl_community_rating), "CommunityRating,SortName", SortOrder.Descending));
+        sortOptions.put(5,new SortOption(TvApp.getApplication().getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
         sortOptions.put(6,new SortOption(TvApp.getApplication().getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -152,8 +152,9 @@ public class GridFragment extends Fragment {
         sortOptions.put(1, new SortOption(TvApp.getApplication().getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
         sortOptions.put(2, new SortOption(TvApp.getApplication().getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
         sortOptions.put(3,new SortOption(TvApp.getApplication().getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
-        sortOptions.put(4,new SortOption(TvApp.getApplication().getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
-        sortOptions.put(5,new SortOption(TvApp.getApplication().getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
+        sortOptions.put(4,new SortOption(TvApp.getApplication().getString(R.string.lbl_stars), "CommunityRating,SortName", SortOrder.Descending));
+	sortOptions.put(5,new SortOption(TvApp.getApplication().getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
+        sortOptions.put(6,new SortOption(TvApp.getApplication().getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
     }
 
     protected String getSortFriendlyName(String value) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="lbl_date_added">Date Added</string>
     <string name="lbl_premier_date">Premier Date</string>
     <string name="lbl_critic_rating">Critic Rating</string>
+    <string name="lbl_community_rating">Community Rating</string>
     <string name="lbl_rating">Rating</string>
     <string name="lbl_starting_with">beginning with those whose name starts with</string>
     <string name="btn_done">Done</string>


### PR DESCRIPTION
**Changes**
Added sorting by star rating(called CommunityRating in the jellyfin-api) to the sortOption HashMap
Tested it in the android studio emulator and it worked.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/1135
