### PR TITLE
Remove build number from internal version reference

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
@@ -31,7 +31,7 @@ interface ServerRepository {
 	suspend fun refreshServerInfo(server: Server): Boolean
 
 	companion object {
-		val minimumServerVersion = Jellyfin.minimumVersion
+		val minimumServerVersion = Jellyfin.minimumVersion.copy(build = null)
 	}
 }
 


### PR DESCRIPTION
This fixes the "server version not supported" toast from showing the build number. 10.7.7.0 now shows as 10.7.7

**Changes**
- Remove build number from internal version reference

**Issues**

Fixes #1162