### PR TITLE
Migrate to Jellyfin Kotlin SDK v1.1

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.runBlocking
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.preference.PreferencesRepository
 import org.jellyfin.androidtv.preference.constant.UserSelectBehavior.*
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
 import java.util.*
@@ -35,8 +35,8 @@ class SessionRepositoryImpl(
 	private val accountManagerHelper: AccountManagerHelper,
 	private val apiBinder: ApiBinder,
 	private val authenticationStore: AuthenticationStore,
-	private val userApiClient: KtorClient,
-	private val systemApiClient: KtorClient,
+	private val userApiClient: ApiClient,
+	private val systemApiClient: ApiClient,
 	private val preferencesRepository: PreferencesRepository,
 ) : SessionRepository {
 	private val _currentSession = MutableLiveData<Session?>()
@@ -158,7 +158,7 @@ class SessionRepositoryImpl(
 		)
 	}
 
-	private fun KtorClient.applySession(session: Session?) {
+	private fun ApiClient.applySession(session: Session?) {
 		if (session == null) {
 			baseUrl = null
 			accessToken = null

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -16,7 +16,7 @@ import org.jellyfin.apiclient.interaction.AndroidDevice
 import org.jellyfin.apiclient.interaction.device.IDevice
 import org.jellyfin.apiclient.logging.AndroidLogger
 import org.jellyfin.apiclient.serialization.GsonJsonSerializer
-import org.jellyfin.sdk.android
+import org.jellyfin.sdk.createJellyfin
 import org.jellyfin.sdk.model.ClientInfo
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
@@ -32,9 +32,8 @@ val systemApiClient = named("systemApiClient")
 val appModule = module {
 	// New SDK
 	single {
-		JellyfinSdk {
-			// Set deviceInfo and discovery provider
-			android(androidContext())
+		createJellyfin {
+			context = androidContext()
 
 			// Add client info
 			clientInfo = ClientInfo("Android TV", BuildConfig.VERSION_NAME)

--- a/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
@@ -1,15 +1,14 @@
 package org.jellyfin.androidtv.di
 
 import org.jellyfin.androidtv.preference.*
-import org.jellyfin.sdk.api.operations.DisplayPreferencesApi
 import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 
 val preferenceModule = module {
 	single { PreferencesRepository(get(userApiClient), get(), get()) }
 
-	single { LiveTvPreferences(DisplayPreferencesApi(get(userApiClient))) }
-	single { UserSettingPreferences(DisplayPreferencesApi(get(userApiClient))) }
+	single { LiveTvPreferences(get(userApiClient)) }
+	single { UserSettingPreferences(get(userApiClient)) }
 	single { AuthenticationPreferences(androidApplication()) }
 	single { UserPreferences(androidApplication()) }
 	single { SystemPreferences(androidApplication()) }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/DisplayPreferencesStore.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/DisplayPreferencesStore.kt
@@ -1,7 +1,8 @@
 package org.jellyfin.androidtv.preference
 
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
-import org.jellyfin.sdk.api.operations.DisplayPreferencesApi
+import org.jellyfin.sdk.api.client.extensions.displayPreferencesApi
 import org.jellyfin.sdk.model.api.DisplayPreferencesDto
 import org.jellyfin.sdk.model.api.ScrollDirection
 import org.jellyfin.sdk.model.api.SortOrder
@@ -10,7 +11,7 @@ import timber.log.Timber
 abstract class DisplayPreferencesStore(
 	protected var displayPreferencesId: String,
 	protected var app: String = "jellyfin-androidtv",
-	private val displayPreferencesApi: DisplayPreferencesApi,
+	private val api: ApiClient,
 ) : AsyncPreferenceStore {
 	private var displayPreferencesDto: DisplayPreferencesDto? = null
 	private var cachedPreferences: MutableMap<String, String> = mutableMapOf()
@@ -21,7 +22,7 @@ abstract class DisplayPreferencesStore(
 		if (displayPreferencesDto == null) return false
 
 		try {
-			displayPreferencesApi.updateDisplayPreferences(
+			api.displayPreferencesApi.updateDisplayPreferences(
 				displayPreferencesId = displayPreferencesId,
 				client = app,
 				data = displayPreferencesDto!!.copy(
@@ -50,7 +51,7 @@ abstract class DisplayPreferencesStore(
 
 	override suspend fun update(): Boolean {
 		try {
-			val result by displayPreferencesApi.getDisplayPreferences(
+			val result by api.displayPreferencesApi.getDisplayPreferences(
 				displayPreferencesId = displayPreferencesId,
 				client = app
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
@@ -4,14 +4,14 @@ import org.jellyfin.androidtv.constant.GridDirection
 import org.jellyfin.androidtv.constant.ImageType
 import org.jellyfin.androidtv.constant.PosterSize
 import org.jellyfin.apiclient.model.entities.SortOrder
-import org.jellyfin.sdk.api.operations.DisplayPreferencesApi
+import org.jellyfin.sdk.api.client.ApiClient
 
 class LibraryPreferences(
 	displayPreferencesId: String,
-	displayPreferencesApi: DisplayPreferencesApi,
+	api: ApiClient,
 ) : DisplayPreferencesStore(
 	displayPreferencesId = displayPreferencesId,
-	displayPreferencesApi = displayPreferencesApi
+	api = api,
 ) {
 	companion object {
 		val posterSize = Preference.enum("PosterSize", PosterSize.AUTO)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/LiveTvPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LiveTvPreferences.kt
@@ -1,12 +1,12 @@
 package org.jellyfin.androidtv.preference
 
-import org.jellyfin.sdk.api.operations.DisplayPreferencesApi
+import org.jellyfin.sdk.api.client.ApiClient
 
 class LiveTvPreferences(
-	displayPreferencesApi: DisplayPreferencesApi,
+	api: ApiClient,
 ) : DisplayPreferencesStore(
 	displayPreferencesId = "livetv",
-	displayPreferencesApi = displayPreferencesApi
+	api = api,
 ) {
 	companion object {
 		val channelOrder = Preference.string("livetv-channelorder", "DatePlayed")

--- a/app/src/main/java/org/jellyfin/androidtv/preference/PreferencesRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/PreferencesRepository.kt
@@ -3,24 +3,21 @@ package org.jellyfin.androidtv.preference
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import org.jellyfin.sdk.api.client.KtorClient
-import org.jellyfin.sdk.api.operations.DisplayPreferencesApi
+import org.jellyfin.sdk.api.client.ApiClient
 import kotlin.collections.set
 
 /**
  * Repository to access special preference stores.
  */
 class PreferencesRepository(
-	private val apiClient: KtorClient,
+	private val api: ApiClient,
 	private val liveTvPreferences: LiveTvPreferences,
 	private val userSettingPreferences: UserSettingPreferences,
 ) {
-	private val displayPreferencesApi = DisplayPreferencesApi(apiClient)
 	private val libraryPreferences = mutableMapOf<String, LibraryPreferences>()
 
 	fun getLibraryPreferences(preferencesId: String): LibraryPreferences {
-		val store = libraryPreferences[preferencesId]
-			?: LibraryPreferences(preferencesId, displayPreferencesApi)
+		val store = libraryPreferences[preferencesId] ?: LibraryPreferences(preferencesId, api)
 
 		libraryPreferences[preferencesId] = store
 

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserSettingPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserSettingPreferences.kt
@@ -1,12 +1,12 @@
 package org.jellyfin.androidtv.preference
 
-import org.jellyfin.sdk.api.operations.DisplayPreferencesApi
+import org.jellyfin.sdk.api.client.ApiClient
 
 class UserSettingPreferences(
-	displayPreferencesApi: DisplayPreferencesApi,
+	api: ApiClient,
 ) : DisplayPreferencesStore(
 	displayPreferencesId = "usersettings",
-	displayPreferencesApi = displayPreferencesApi,
+	api = api,
 	app = "emby",
 ) {
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -8,9 +8,9 @@ import org.jellyfin.androidtv.di.userApiClient
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.apiclient.model.dto.BaseItemDto
 import org.jellyfin.apiclient.model.dto.BaseItemType
-import org.jellyfin.sdk.api.operations.UserLibraryApi
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
-import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import java.util.*
@@ -21,9 +21,7 @@ class PlaybackForwardingActivity : FragmentActivity() {
 	}
 
 	private val mediaManager by inject<MediaManager>()
-	private val userLibraryApi by lazy {
-		UserLibraryApi(get(userApiClient))
-	}
+	private val api by inject<ApiClient>(userApiClient)
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -43,7 +41,7 @@ class PlaybackForwardingActivity : FragmentActivity() {
 
 		lifecycleScope.launchWhenCreated {
 			// Get fresh info from API in SDK format
-			val item by userLibraryApi.getItem(itemId = itemId)
+			val item by api.userLibraryApi.getItem(itemId = itemId)
 
 			// Log info
 			Toast.makeText(

--- a/app/src/main/java/org/jellyfin/androidtv/util/AutoBitrate.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/AutoBitrate.kt
@@ -1,23 +1,21 @@
 package org.jellyfin.androidtv.util
 
-import org.jellyfin.sdk.api.client.KtorClient
-import org.jellyfin.sdk.api.client.extensions.detectBitrate
-import org.jellyfin.sdk.api.operations.MediaInfoApi
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
+import org.jellyfin.sdk.api.extensions.detectBitrate
 import timber.log.Timber
 
 /**
  * Small utility class to store and automatically detect a preferred bitrate.
  */
 class AutoBitrate(
-	private val apiClient: KtorClient
+	private val api: ApiClient
 ) {
-	private val mediaInfoApi = MediaInfoApi(apiClient)
-
 	var bitrate: Long? = null
 		private set
 
 	suspend fun detect() {
-		val measurement = mediaInfoApi.detectBitrate()
+		val measurement = api.mediaInfoApi.detectBitrate()
 		bitrate = measurement.bitrate
 
 		Timber.i("Auto bitrate set to: %d", bitrate)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ acra = "5.8.4"
 # Jellyfin apiclient
 jellyfin-apiclient = { module = "com.github.jellyfin.jellyfin-sdk-kotlin:android", version = "v0.7.10" }
 # Jellyfin SDK
-jellyfin-sdk = { module = "org.jellyfin.sdk:jellyfin-platform-android", version = "1.0.1" }
+jellyfin-sdk = { module = "org.jellyfin.sdk:jellyfin-core", version = "1.1.0" }
 
 # Kotlin
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Updated to the new Kotlin SDK release.

- Fix imports
- Use api extensions (`UserApi(apiClient)` -> `apiClient.userapi`)
- Use `ApiClient` instead of `KtorClient`
- Use `createJellyfin`
- Change Gradle module (jellyfin-platform-android -> jellyfin-core)

**TODO**

- Implement https://github.com/jellyfin/jellyfin-sdk-kotlin/blob/master/docs/migration/v1.1.md#error-reporting-in-recommendedserverdiscovery in another PR

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
