### PR TITLE
Use context instead of activity in InfoLayoutHelper

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -128,7 +128,7 @@ public class GridFragment extends Fragment {
     public void setItem(BaseRowItem item) {
         if (item != null) {
             mTitleView.setText(item.getFullName(requireContext()));
-            InfoLayoutHelper.addInfoRow(getActivity(), item, mInfoRow, true, true);
+            InfoLayoutHelper.addInfoRow(requireContext(), item, mInfoRow, true, true);
         } else {
             mTitleView.setText("");
             mInfoRow.removeAllViews();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -539,7 +539,7 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
             if (summary != null) mSummary.setText(TextUtilsKt.toHtmlSpanned(summary));
             else mSummary.setText(null);
 
-            InfoLayoutHelper.addInfoRow(mActivity, rowItem, mInfoRow, true, true);
+            InfoLayoutHelper.addInfoRow(requireContext(), rowItem, mInfoRow, true, true);
 
             ItemRowAdapter adapter = (ItemRowAdapter) ((ListRow) row).getAdapter();
             adapter.loadMoreItemsIfNeeded(rowItem.getIndex());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1029,7 +1029,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
         tvGuideBinding.guideTitle.setText(mSelectedProgram.getName());
         tvGuideBinding.summary.setText(mSelectedProgram.getOverview());
         //info row
-        InfoLayoutHelper.addInfoRow(requireActivity(), mSelectedProgram, tvGuideBinding.guideInfoRow, false, false);
+        InfoLayoutHelper.addInfoRow(requireContext(), mSelectedProgram, tvGuideBinding.guideInfoRow, false, false);
         if (mSelectedProgram.getId() != null) {
             tvGuideBinding.displayDate.setText(TimeUtils.getFriendlyDate(requireContext(), TimeUtils.convertToLocalDate(mSelectedProgram.getStartDate())));
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
@@ -92,7 +92,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
         ViewHolder vh = (ViewHolder) holder;
 
         setTitle(row.getItem().getName());
-        InfoLayoutHelper.addInfoRow(TvApp.getApplication().getCurrentActivity(), row.getItem(), vh.mInfoRow, false, false);
+        InfoLayoutHelper.addInfoRow(holder.view.getContext(), row.getItem(), vh.mInfoRow, false, false);
         addGenres(vh.mGenreRow, row.getItem());
         setInfo1(row.getInfoItem1());
         setInfo2(row.getInfoItem2());

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.util;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.text.TextUtils;
@@ -31,81 +30,81 @@ public class InfoLayoutHelper {
 
     private static int textSize = 16;
 
-    public static void addInfoRow(Activity activity, BaseRowItem item, LinearLayout layout, boolean includeRuntime, boolean includeEndtime) {
+    public static void addInfoRow(Context context, BaseRowItem item, LinearLayout layout, boolean includeRuntime, boolean includeEndtime) {
         switch (item.getItemType()) {
 
             case BaseItem:
-                addInfoRow(activity, item.getBaseItem(), layout, includeRuntime, includeEndtime);
+                addInfoRow(context, item.getBaseItem(), layout, includeRuntime, includeEndtime);
                 break;
             default:
-                addSubText(activity, item, layout);
+                addSubText(context, item, layout);
                 break;
         }
     }
 
-    public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
+    public static void addInfoRow(Context context, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
         layout.removeAllViews();
         if (item.getId() != null) {
-            addInfoRow(activity, item, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
+            addInfoRow(context, item, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
         }else{
-            addProgramChannel(activity, item, layout);
+            addProgramChannel(context, item, layout);
         }
     }
 
-    public static void addInfoRow(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
+    public static void addInfoRow(Context context, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
         RatingType ratingType = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getDefaultRatingType());
         if (ratingType != RatingType.RATING_HIDDEN) {
-            addCriticInfo(activity, item, layout);
+            addCriticInfo(context, item, layout);
         }
         switch (item.getBaseItemType()) {
             case Episode:
-                addSeasonEpisode(activity, item, layout);
-                addDate(activity, item, layout);
+                addSeasonEpisode(context, item, layout);
+                addDate(context, item, layout);
                 break;
             case BoxSet:
-                addBoxSetCounts(activity, item, layout);
+                addBoxSetCounts(context, item, layout);
                 break;
             case Series:
-                //addSeasonCount(activity, item, layout);
-                addSeriesAirs(activity, item, layout);
-                addDate(activity, item, layout);
+                //addSeasonCount(context, item, layout);
+                addSeriesAirs(context, item, layout);
+                addDate(context, item, layout);
                 includeEndTime = false;
                 break;
             case Program:
-                addProgramInfo(activity, item, layout);
+                addProgramInfo(context, item, layout);
                 break;
             case RecordingGroup:
-                addRecordingCount(activity, item, layout);
+                addRecordingCount(context, item, layout);
                 break;
             case MusicArtist:
                 Integer artistAlbums = item.getAlbumCount() != null ? item.getAlbumCount() : item.getChildCount();
-                addCount(activity, artistAlbums, layout, artistAlbums != null && artistAlbums == 1 ? activity.getResources().getString(R.string.lbl_album) : activity.getResources().getString(R.string.lbl_albums));
+                addCount(context, artistAlbums, layout, artistAlbums != null && artistAlbums == 1 ? context.getResources().getString(R.string.lbl_album) : context.getResources().getString(R.string.lbl_albums));
                 return;
             case MusicAlbum:
                 String artist = item.getAlbumArtist() != null ? item.getAlbumArtist() : item.getArtists() != null && item.getAlbumArtists().size() > 0 ? item.getArtists().get(0) : null;
                 if (artist != null) {
-                    addText(activity, artist+" ", layout, 500);
+                    addText(context, artist+" ", layout, 500);
                 }
-                addDate(activity, item, layout);
+                addDate(context, item, layout);
                 Integer songCount = item.getSongCount() != null ? item.getSongCount() : item.getChildCount();
-                addCount(activity, songCount, layout, songCount == 1 ? activity.getResources().getString(R.string.lbl_song) : activity.getResources().getString(R.string.lbl_songs));
+                addCount(context, songCount, layout, songCount == 1 ? context.getResources().getString(R.string.lbl_song) : context.getResources().getString(R.string.lbl_songs));
                 return;
             case Playlist:
-                if (item.getChildCount() != null) addCount(activity, item.getChildCount(), layout, item.getChildCount() == 1 ? activity.getResources().getString(R.string.lbl_item) : activity.getResources().getString(R.string.lbl_items));
-                if (item.getCumulativeRunTimeTicks() != null) addText(activity, " ("+ TimeUtils.formatMillis(item.getCumulativeRunTimeTicks() / 10000)+")", layout, 300);
+                if (item.getChildCount() != null) addCount(context, item.getChildCount(), layout, item.getChildCount() == 1 ? context.getResources().getString(R.string.lbl_item) : context.getResources().getString(R.string.lbl_items));
+                if (item.getCumulativeRunTimeTicks() != null) addText(context, " ("+ TimeUtils.formatMillis(item.getCumulativeRunTimeTicks() / 10000)+")", layout, 300);
                 break;
             default:
-                addDate(activity, item, layout);
+                addDate(context, item, layout);
 
         }
-        if (includeRuntime) addRuntime(activity, item, layout, includeEndTime);
-        addSeriesStatus(activity, item, layout);
-        addRatingAndRes(activity, item, layout);
-        addMediaDetails(activity, audioStream, layout);
+        if (includeRuntime) addRuntime(context, item, layout, includeEndTime);
+        addSeriesStatus(context, item, layout);
+        addRatingAndRes(context, item, layout);
+        addMediaDetails(context, audioStream, layout);
     }
 
-    private static void addText(Activity activity, String text, LinearLayout layout, int maxWidth) {
-        TextView textView = new TextView(activity);
+    private static void addText(Context context, String text, LinearLayout layout, int maxWidth) {
+        TextView textView = new TextView(context);
         textView.setTextSize(textSize);
         textView.setMaxWidth(maxWidth);
         textView.setEllipsize(TextUtils.TruncateAt.END);
@@ -114,53 +113,53 @@ public class InfoLayoutHelper {
 
     }
 
-    private static void addBoxSetCounts(Activity activity, BaseItemDto item, LinearLayout layout) {
+    private static void addBoxSetCounts(Context context, BaseItemDto item, LinearLayout layout) {
         boolean hasSpecificCounts = false;
         if (item.getMovieCount() != null && item.getMovieCount() > 0) {
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
-            amt.setText(item.getMovieCount().toString()+" "+activity.getResources().getString(R.string.lbl_movies)+"  ");
+            amt.setText(item.getMovieCount().toString()+" "+context.getResources().getString(R.string.lbl_movies)+"  ");
             layout.addView(amt);
             hasSpecificCounts = true;
 
         }
         if (item.getSeriesCount() != null && item.getSeriesCount() > 0) {
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
-            amt.setText(item.getSeriesCount().toString()+" "+activity.getResources().getString(R.string.lbl_tv_series)+"  ");
+            amt.setText(item.getSeriesCount().toString()+" "+context.getResources().getString(R.string.lbl_tv_series)+"  ");
             layout.addView(amt);
             hasSpecificCounts = true;
         }
         if (!hasSpecificCounts && item.getChildCount() != null && item.getChildCount() > 0) {
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
-            amt.setText(item.getChildCount().toString()+" "+ activity.getResources().getString(item.getChildCount() > 1 ? R.string.lbl_items : R.string.lbl_item) +"  ");
+            amt.setText(item.getChildCount().toString()+" "+ context.getResources().getString(item.getChildCount() > 1 ? R.string.lbl_items : R.string.lbl_item) +"  ");
             layout.addView(amt);
 
         }
     }
 
-    private static void addCount(Activity activity, Integer count, LinearLayout layout, String label) {
+    private static void addCount(Context context, Integer count, LinearLayout layout, String label) {
         if (count != null && count > 0) {
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
             amt.setText(count.toString()+" "+ label +"  ");
             layout.addView(amt);
         }
     }
 
-    private static void addRecordingCount(Activity activity, BaseItemDto item, LinearLayout layout) {
+    private static void addRecordingCount(Context context, BaseItemDto item, LinearLayout layout) {
         if (item.getRecordingCount() != null && item.getRecordingCount() > 0) {
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
-            amt.setText(item.getRecordingCount().toString() + " " + activity.getResources().getString(item.getRecordingCount() > 1 ? R.string.lbl_recordings : R.string.lbl_recording) + "  ");
+            amt.setText(item.getRecordingCount().toString() + " " + context.getResources().getString(item.getRecordingCount() > 1 ? R.string.lbl_recordings : R.string.lbl_recording) + "  ");
             layout.addView(amt);
         }
     }
 
-    private static void addSeriesAirs(Activity activity, BaseItemDto item, LinearLayout layout) {
+    private static void addSeriesAirs(Context context, BaseItemDto item, LinearLayout layout) {
         if (item.getAirDays() != null && item.getAirDays().size() > 0) {
-            TextView textView = new TextView(activity);
+            TextView textView = new TextView(context);
             textView.setTextSize(textSize);
             textView.setText(item.getAirDays().get(0) + " " + Utils.getSafeValue(item.getAirTime(), "") +  "  ");
             layout.addView(textView);
@@ -168,43 +167,43 @@ public class InfoLayoutHelper {
         }
     }
 
-    private static void addProgramChannel(Activity activity, BaseItemDto item, LinearLayout layout){
-        TextView name = new TextView(activity);
+    private static void addProgramChannel(Context context, BaseItemDto item, LinearLayout layout){
+        TextView name = new TextView(context);
         name.setTextSize(textSize);
         name.setText(BaseItemUtils.getProgramUnknownChannelName(item));
         layout.addView(name);
     }
 
-    private static void addProgramInfo(@NonNull Activity activity, BaseItemDto item, LinearLayout layout) {
-        TextView name = new TextView(activity);
+    private static void addProgramInfo(@NonNull Context context, BaseItemDto item, LinearLayout layout) {
+        TextView name = new TextView(context);
         name.setTextSize(textSize);
-        name.setText(BaseItemUtils.getProgramSubText(item, activity)+"  ");
+        name.setText(BaseItemUtils.getProgramSubText(item, context)+"  ");
         layout.addView(name);
 
         if (BaseItemUtils.isNew(item)) {
-            addBlockText(activity, layout, activity.getString(R.string.lbl_new), 12, Color.GRAY, R.drawable.dark_green_gradient);
-            addSpacer(activity, layout, "  ");
+            addBlockText(context, layout, context.getString(R.string.lbl_new), 12, Color.GRAY, R.drawable.dark_green_gradient);
+            addSpacer(context, layout, "  ");
         } else if (Utils.isTrue(item.getIsSeries()) && !Utils.isTrue(item.getIsNews())) {
-            addBlockText(activity, layout, activity.getString(R.string.lbl_repeat), 12, Color.GRAY, R.color.lb_default_brand_color);
-            addSpacer(activity, layout, "  ");
+            addBlockText(context, layout, context.getString(R.string.lbl_repeat), 12, Color.GRAY, R.color.lb_default_brand_color);
+            addSpacer(context, layout, "  ");
         }
         if (Utils.isTrue(item.getIsLive())) {
-            addBlockText(activity, layout, activity.getString(R.string.lbl_live), 12, Color.GRAY, R.color.lb_default_brand_color);
-            addSpacer(activity, layout, "  ");
+            addBlockText(context, layout, context.getString(R.string.lbl_live), 12, Color.GRAY, R.color.lb_default_brand_color);
+            addSpacer(context, layout, "  ");
 
         }
     }
 
-    private static void addSubText(Activity activity, BaseRowItem item, LinearLayout layout) {
+    private static void addSubText(Context context, BaseRowItem item, LinearLayout layout) {
         layout.removeAllViews();
-        TextView text = new TextView(activity);
+        TextView text = new TextView(context);
         text.setTextSize(textSize);
-        text.setText(item.getSubText(activity) + " ");
+        text.setText(item.getSubText(context) + " ");
         layout.addView(text);
 
     }
 
-    private static void addRuntime(Activity activity, BaseItemDto item, LinearLayout layout, boolean includeEndtime) {
+    private static void addRuntime(Context context, BaseItemDto item, LinearLayout layout, boolean includeEndtime) {
         ClockBehavior clockBehavior = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getClockBehavior());
         if (clockBehavior != ClockBehavior.ALWAYS && clockBehavior != ClockBehavior.IN_MENUS) {
             includeEndtime = false;
@@ -212,39 +211,39 @@ public class InfoLayoutHelper {
         Long runtime = Utils.getSafeValue(item.getRunTimeTicks(), item.getOriginalRunTimeTicks());
         if (runtime != null && runtime > 0) {
             long endTime = includeEndtime ? System.currentTimeMillis() + runtime / 10000 - (item.getUserData() != null && item.getCanResume() ? item.getUserData().getPlaybackPositionTicks()/10000 : 0) : 0;
-            String text = (int) Math.ceil((double) runtime / 600000000) + activity.getString(R.string.lbl_min) + (endTime > 0 ? " (" + activity.getResources().getString(R.string.lbl_ends) + " " + android.text.format.DateFormat.getTimeFormat(activity).format(new Date(endTime)) + ")  " : "  ");
-            TextView time = new TextView(activity);
+            String text = (int) Math.ceil((double) runtime / 600000000) + context.getString(R.string.lbl_min) + (endTime > 0 ? " (" + context.getResources().getString(R.string.lbl_ends) + " " + android.text.format.DateFormat.getTimeFormat(context).format(new Date(endTime)) + ")  " : "  ");
+            TextView time = new TextView(context);
             time.setTextSize(textSize);
             time.setText(text);
             layout.addView(time);
         }
     }
 
-    private static void addSeasonEpisode(Activity activity, BaseItemDto item, LinearLayout layout) {
+    private static void addSeasonEpisode(Context context, BaseItemDto item, LinearLayout layout) {
         if (item.getIndexNumber() != null) {
-            String text = (item.getParentIndexNumber() != null ? activity.getString(R.string.lbl_season_number, item.getParentIndexNumber()) : "")
-                + (item.getIndexNumberEnd() != null && item.getIndexNumber() != null ? " " + activity.getString(R.string.lbl_episode_range, item.getIndexNumber(), item.getIndexNumberEnd())
-                : item.getIndexNumber() != null ? " " + activity.getString(R.string.lbl_episode_number, item.getIndexNumber()) : "")
+            String text = (item.getParentIndexNumber() != null ? context.getString(R.string.lbl_season_number, item.getParentIndexNumber()) : "")
+                + (item.getIndexNumberEnd() != null && item.getIndexNumber() != null ? " " + context.getString(R.string.lbl_episode_range, item.getIndexNumber(), item.getIndexNumberEnd())
+                : item.getIndexNumber() != null ? " " + context.getString(R.string.lbl_episode_number, item.getIndexNumber()) : "")
                 + "  ";
-            TextView time = new TextView(activity);
+            TextView time = new TextView(context);
             time.setTextSize(textSize);
             time.setText(text);
             layout.addView(time);
         }
     }
 
-    private static void addCriticInfo(Activity activity, BaseItemDto item, LinearLayout layout) {
-        int imagesize = Utils.convertDpToPixel(activity,textSize+2);
+    private static void addCriticInfo(Context context, BaseItemDto item, LinearLayout layout) {
+        int imagesize = Utils.convertDpToPixel(context,textSize+2);
         LinearLayout.LayoutParams imageParams = new LinearLayout.LayoutParams(imagesize,imagesize);
         imageParams.setMargins(0, 5, 10, 0);
         boolean hasSomething = false;
         if (item.getCommunityRating() != null) {
-            ImageView star = new ImageView(activity);
+            ImageView star = new ImageView(context);
             star.setImageResource(R.drawable.ic_star);
             star.setLayoutParams(imageParams);
             layout.addView(star);
 
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
             amt.setText(item.getCommunityRating().toString()+" ");
             layout.addView(amt);
@@ -253,7 +252,7 @@ public class InfoLayoutHelper {
         }
 
         if (item.getCriticRating() != null) {
-            ImageView tomato = new ImageView(activity);
+            ImageView tomato = new ImageView(context);
             tomato.setLayoutParams(imageParams);
             if (item.getCriticRating() > 59) {
                 tomato.setImageResource(R.drawable.ic_rt_fresh);
@@ -262,7 +261,7 @@ public class InfoLayoutHelper {
             }
 
             layout.addView(tomato);
-            TextView amt = new TextView(activity);
+            TextView amt = new TextView(context);
             amt.setTextSize(textSize);
             amt.setText(item.getCriticRating().toString() + "% ");
             layout.addView(amt);
@@ -271,7 +270,7 @@ public class InfoLayoutHelper {
 
         }
 
-        if (hasSomething) addSpacer(activity, layout, "  ");
+        if (hasSomething) addSpacer(context, layout, "  ");
     }
 
     private static void addDate(@NonNull Context context, BaseItemDto item, LinearLayout layout) {
@@ -332,75 +331,75 @@ public class InfoLayoutHelper {
 
     }
 
-    private static void addRatingAndRes(Activity activity, BaseItemDto item, LinearLayout layout) {
+    private static void addRatingAndRes(Context context, BaseItemDto item, LinearLayout layout) {
         if (item.getOfficialRating() != null && !item.getOfficialRating().equals("0")) {
-            addBlockText(activity, layout, item.getOfficialRating());
-            addSpacer(activity, layout, "  ");
+            addBlockText(context, layout, item.getOfficialRating());
+            addSpacer(context, layout, "  ");
         }
         if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0 && item.getMediaStreams().get(0).getWidth() != null && item.getMediaStreams().get(0).getHeight() != null) {
             int width = item.getMediaStreams().get(0).getWidth();
             int height = item.getMediaStreams().get(0).getHeight();
             if (width <= 960 && height <= 576) {
-                addBlockText(activity, layout, activity.getString(R.string.lbl_sd));
+                addBlockText(context, layout, context.getString(R.string.lbl_sd));
             } else if (width <= 1280 && height <= 962) {
-                addBlockText(activity, layout, "720");
+                addBlockText(context, layout, "720");
             } else if (width <= 1920 && height <= 1440) {
-                addBlockText(activity, layout, "1080");
+                addBlockText(context, layout, "1080");
             } else if (width <= 4096 && height <= 3072) {
-                addBlockText(activity, layout, "4K");
+                addBlockText(context, layout, "4K");
             } else {
-                addBlockText(activity, layout, "8K");
+                addBlockText(context, layout, "8K");
             }
 
-            addSpacer(activity, layout, "  ");
+            addSpacer(context, layout, "  ");
         }
         if (Utils.isTrue(item.getHasSubtitles())) {
-            addBlockText(activity, layout, "CC");
-            addSpacer(activity, layout, "  ");
+            addBlockText(context, layout, "CC");
+            addSpacer(context, layout, "  ");
 
         }
     }
 
-    private static void addSeriesStatus(Activity activity, BaseItemDto item, LinearLayout layout) {
+    private static void addSeriesStatus(Context context, BaseItemDto item, LinearLayout layout) {
         if (item.getBaseItemType() == BaseItemType.Series && item.getSeriesStatus() != null) {
             boolean continuing = item.getSeriesStatus() == SeriesStatus.Continuing;
-            String status = continuing ? activity.getString(R.string.lbl__continuing) : activity.getString(R.string.lbl_ended);
-            addBlockText(activity, layout, status, textSize-4, Color.LTGRAY, continuing ? R.drawable.green_gradient : R.drawable.red_gradient);
-            addSpacer(activity, layout, "  ");
+            String status = continuing ? context.getString(R.string.lbl__continuing) : context.getString(R.string.lbl_ended);
+            addBlockText(context, layout, status, textSize-4, Color.LTGRAY, continuing ? R.drawable.green_gradient : R.drawable.red_gradient);
+            addSpacer(context, layout, "  ");
         }
     }
 
-    private static void addMediaDetails(Activity activity, MediaStream stream, LinearLayout layout) {
+    private static void addMediaDetails(Context context, MediaStream stream, LinearLayout layout) {
 
         if (stream != null) {
             if (stream.getCodec() != null && stream.getCodec().trim().length() > 0) {
                 String codec = stream.getCodec().equals("dca") || stream.getCodec().equals("DCA") ? "DTS" : stream.getCodec().equals("ac3") || stream.getCodec().equals("AC3") ? "Dolby" : stream.getCodec().toUpperCase();
-                addBlockText(activity, layout, codec);
-                addSpacer(activity, layout, " ");
+                addBlockText(context, layout, codec);
+                addSpacer(context, layout, " ");
             }
             if (stream.getChannelLayout() != null && stream.getChannelLayout().trim().length() > 0) {
-                addBlockText(activity, layout, stream.getChannelLayout().toUpperCase());
-                addSpacer(activity, layout, "  ");
+                addBlockText(context, layout, stream.getChannelLayout().toUpperCase());
+                addSpacer(context, layout, "  ");
             }
         }
     }
 
-    public static void addBlockText(Activity activity, LinearLayout layout, String text) {
-        addBlockText(activity, layout, text, textSize-4);
+    public static void addBlockText(Context context, LinearLayout layout, String text) {
+        addBlockText(context, layout, text, textSize-4);
     }
 
-    public static void addBlockText(Activity activity, LinearLayout layout, String text, int size) {
-        addBlockText(activity, layout, text, size, Color.BLACK, R.drawable.block_text_bg);
+    public static void addBlockText(Context context, LinearLayout layout, String text, int size) {
+        addBlockText(context, layout, text, size, Color.BLACK, R.drawable.block_text_bg);
     }
 
-    public static void addBlockText(Activity activity, LinearLayout layout, String text, int size, int textColor, int backgroundRes) {
-        TextView view = new TextView(activity);
+    public static void addBlockText(Context context, LinearLayout layout, String text, int size, int textColor, int backgroundRes) {
+        TextView view = new TextView(context);
         view.setTextSize(size);
         view.setTextColor(textColor);
         view.setText(" " + text + " ");
         view.setBackgroundResource(backgroundRes);
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
-        params.setMargins(0,Utils.convertDpToPixel(activity, -2),0,0);
+        params.setMargins(0,Utils.convertDpToPixel(context, -2),0,0);
         view.setLayoutParams(params);
         layout.addView(view);
     }


### PR DESCRIPTION
Requiring an activity is often not needed. This is one of those cases.
A context can contain theme information and other stuff that the activity context might not have. It's always recommended to use `requireContext()` when possible.

**Changes**
- Use context instead of activity in InfoLayoutHelper
- Remove a `TvApp.getCurrentActivity()` usage in MyDetailsOverviewRowPresenter

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
