### PR TITLE
Fix trailing slashes causing connection issues in apiclient

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/ApiBinder.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ApiBinder.kt
@@ -51,7 +51,7 @@ class ApiBinder(
 		api.EnableAutomaticNetworking(ServerInfo().apply {
 			id = session.serverId.toString()
 			name = server.name
-			address = server.address
+			address = server.address.removeSuffix("/")
 			userId = session.userId.toString()
 			accessToken = session.accessToken
 		})


### PR DESCRIPTION
Not sure how I triggered the issue exactly but sometimes when adding a trailing slash to your server address the app explodes. It didn't happen all the time though /shrug. Fix works

**Changes**
- Remove trailing slash in ApiBinder because dumb apiclient stuff

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
