### PR TITLE
Pause video on "select" button press without extra navigation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -144,7 +144,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
             }
 
             @Override
-            protected void onProgressBarClicked (PlaybackTransportRowPresenter.ViewHolder vh) {
+            protected void onProgressBarClicked(PlaybackTransportRowPresenter.ViewHolder vh) {
                 CustomPlaybackTransportControlGlue controlglue = CustomPlaybackTransportControlGlue.this;
                 controlglue.onActionClicked(controlglue.playPauseAction);
             }


### PR DESCRIPTION
**Changes**
Overrides PlaybackTransportRowPresenter's onProgressBarClicked to use CustomPlaybackTransportControlGlue's playPauseAction.

The resulting behavior is that clicking the seekbar allows for pause/unpause action without extra navigation, and the behavior matches the default leanback player behavior.

**Reference for onProgressBarClicked**
https://developer.android.com/reference/androidx/leanback/widget/PlaybackTransportRowPresenter#onProgressBarClicked(androidx.leanback.widget.PlaybackTransportRowPresenter.ViewHolder)

**Issues**
#1101 

**Other thoughts**
Perhaps the lowercase 'p' is to blame for the default implementation not working.
Also, I am new to java & kotlin so maybe there is a better way to reference CustomPlaybackTransportControlGlue from within PlaybackTransportRowPresenter