### PR TITLE
Change default video player to ExoPlayer instead of auto detect

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -4,14 +4,7 @@ import android.content.Context
 import android.view.KeyEvent
 import androidx.preference.PreferenceManager
 import org.acra.ACRA
-import org.jellyfin.androidtv.preference.constant.AppTheme
-import org.jellyfin.androidtv.preference.constant.AudioBehavior
-import org.jellyfin.androidtv.preference.constant.ClockBehavior
-import org.jellyfin.androidtv.preference.constant.NextUpBehavior
-import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
-import org.jellyfin.androidtv.preference.constant.RatingType
-import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
-import org.jellyfin.androidtv.preference.constant.defaultAudioBehavior
+import org.jellyfin.androidtv.preference.constant.*
 import org.jellyfin.androidtv.util.DeviceUtils
 
 /**
@@ -87,7 +80,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Preferred video player.
 		 */
-		var videoPlayer = Preference.enum("video_player", PreferredVideoPlayer.AUTO)
+		var videoPlayer = Preference.enum("video_player", PreferredVideoPlayer.EXOPLAYER)
 
 		/**
 		 * Enable refresh rate switching when device supports it


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

- Change default video player to ExoPlayer instead of auto detect

**Issues**

I can link like 100 of them I guess