### PR TITLE
Don't load multiple display preferences at once

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/PreferencesRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/PreferencesRepository.kt
@@ -1,8 +1,5 @@
 package org.jellyfin.androidtv.preference
 
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import org.jellyfin.sdk.api.client.ApiClient
 import kotlin.collections.set
 
@@ -27,11 +24,11 @@ class PreferencesRepository(
 		return store
 	}
 
-	suspend fun onSessionChanged() = coroutineScope {
-		awaitAll(
-			async { liveTvPreferences.update() },
-			async { userSettingPreferences.update() },
-		)
+	suspend fun onSessionChanged() {
+		// Note: Do not run parallel as the server can't deal with that
+		// Relevant server issue: https://github.com/jellyfin/jellyfin/issues/5261
+		liveTvPreferences.update()
+		userSettingPreferences.update()
 
 		libraryPreferences.clear()
 	}


### PR DESCRIPTION
A bug in 10.7(.7) doesn't allow multiple reads/writes at the same time in the display preferences. Although this should be fixed in the server it's unlikely to create a 10.7.8 release so we'll have to workaround the issue by making our app slower.

**Changes**
- Don't load multiple display preferences at once

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
https://github.com/jellyfin/jellyfin/issues/5261
