### PR TITLE
Fix app crash when opening photo album

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -29,7 +29,8 @@ public class BrowseGridFragment extends StdGridFragment {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount,
                 ItemFields.MediaSources,
-                ItemFields.MediaStreams
+                ItemFields.MediaStreams,
+                ItemFields.DisplayPreferencesId
         });
         query.setParentId(mParentId.toString());
         if (mFolder.getType().equalsIgnoreCase(BaseItemType.UserView.toString()) || mFolder.getType().equalsIgnoreCase(BaseItemType.CollectionFolder.toString())) {


### PR DESCRIPTION
I hate the browsing UI code

**Changes**
- Fix app crash when opening photo album
  - because it was missing the displayPreferencesId

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
