### PR TITLE
Fix race condition in loading async preferences

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -117,14 +117,11 @@ class SessionRepositoryImpl(
 
 			if (success) {
 				userApiClient.applySession(session)
+				runBlocking { preferencesRepository.onSessionChanged() }
 				_currentSession.postValue(session)
 			} else {
 				userApiClient.applySession(null)
 				_currentSession.postValue(null)
-			}
-
-			runBlocking {
-				preferencesRepository.onSessionChanged()
 			}
 
 			callback?.invoke(success)


### PR DESCRIPTION
This issue didn't happen all the time but it sometimes caused the home activity to load default home sections because display prefs were still loading.

**Changes**

- Fix race condition in loading async preferences

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
