### PR TITLE
Only show the nextup button for a series after a valid response from nextUpQuery

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -260,10 +260,11 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
                                         if (response.getCanResume()) {
                                             mResumeButton.setText(getString(R.string.lbl_resume_from, TimeUtils.formatMillis((response.getUserData().getPlaybackPositionTicks()/10000) - getResumePreroll())));
-                                            mResumeButton.requestFocus();
                                         }
-
-                                        showNextUpButton();
+                                        else {
+                                            mResumeButton.setText(getString(R.string.lbl_play_next_up));
+                                        }
+                                        ChoosePrimaryButton(response.getCanResume());
                                         showMoreButtonIfNeeded();
                                     }
                                     updatePlayedDate();
@@ -900,7 +901,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
 
     // query for nextup items and make the mresumebutton visible if there are
-    private void showNextUpButton() {
+    private void ChoosePrimaryButton(boolean canResume) {
+
         if (mBaseItem.getBaseItemType() == BaseItemType.Series) {
             //play next up
             NextUpQuery nextUpQuery = new NextUpQuery();
@@ -915,6 +917,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                     }
                     else {
                         mResumeButton.setVisibility(View.GONE);
+                        playButton.requestFocus();
                     }
                 }
 
@@ -923,6 +926,12 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                     Timber.e(exception, "Error getting next up for series");
                 }
             });
+        }
+        else if (canResume) {
+            mResumeButton.requestFocus();
+        }
+        else {
+            playButton.requestFocus();
         }
     }
 
@@ -999,12 +1008,6 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 });
 
                 mDetailsOverviewRow.addAction(playButton);
-
-                if (mBaseItem.getCanResume()) {
-                    mResumeButton.requestFocus();
-                } else {
-                    playButton.requestFocus();
-                }
 
                 if (!mBaseItem.getIsFolderItem() && !BaseItemUtils.isLiveTv(mBaseItem)) {
                     queueButton = new TextUnderButton(this, R.drawable.ic_add, buttonSize, 2, getString(R.string.lbl_add_to_queue), new View.OnClickListener() {
@@ -1382,7 +1385,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         mDetailsOverviewRow.addAction(moreButton);
         if (mBaseItem.getBaseItemType() != BaseItemType.Episode) showMoreButtonIfNeeded();  //Episodes check for previous and then call this above
 
-        showNextUpButton();
+        ChoosePrimaryButton(mBaseItem.getCanResume());
     }
 
     private void addVersionsMenu(View v) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -954,7 +954,8 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         } else { //here playButton is only a play button
             if (BaseItemUtils.canPlay(mBaseItem)) {
                 mDetailsOverviewRow.addAction(mResumeButton);
-                boolean resumeButtonVisible = (mBaseItem.getBaseItemType() == BaseItemType.Series && !mBaseItem.getUserData().getPlayed()) || (mBaseItem.getCanResume());
+                // hide mresume button by default when its used for nextup, which it always is for series. the button can be made visible later once its verified that there are nextup items
+                boolean resumeButtonVisible = !(mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) && mBaseItem.getCanResume();
                 mResumeButton.setVisibility(resumeButtonVisible ? View.VISIBLE : View.GONE);
 
                 playButton = new TextUnderButton(this, R.drawable.ic_play, buttonSize, 2, getString(BaseItemUtils.isLiveTv(mBaseItem) ? R.string.lbl_tune_to_channel : mBaseItem.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -253,14 +253,16 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                                 if (!isFinishing()) {
                                     mBaseItem = response;
                                     if (mResumeButton != null) {
-                                        boolean resumeVisible = !(mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) && mBaseItem.getCanResume();
+                                        boolean resumeVisible = mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer || mBaseItem.getCanResume();
+                                        //mResumeButton.setVisibility(resumeButtonVisible ? View.VISIBLE : View.GONE);
                                         mResumeButton.setVisibility(resumeVisible ? View.VISIBLE : View.GONE);
+                                        mResumeButton.setEnabled(resumeVisible);
+
                                         if (response.getCanResume()) {
                                             mResumeButton.setText(getString(R.string.lbl_resume_from, TimeUtils.formatMillis((response.getUserData().getPlaybackPositionTicks()/10000) - getResumePreroll())));
-                                        }
-                                        if (resumeVisible) {
                                             mResumeButton.requestFocus();
                                         }
+
                                         showNextUpButton();
                                         showMoreButtonIfNeeded();
                                     }
@@ -908,8 +910,11 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                 @Override
                 public void onResponse(ItemsResult response) {
                     if (response.getItems().length > 0) {
-                        mResumeButton.setVisibility(View.VISIBLE);
+                        mResumeButton.setEnabled(true);
                         mResumeButton.requestFocus();
+                    }
+                    else {
+                        mResumeButton.setVisibility(View.GONE);
                     }
                 }
 
@@ -981,8 +986,10 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             if (BaseItemUtils.canPlay(mBaseItem)) {
                 mDetailsOverviewRow.addAction(mResumeButton);
                 // hide mresume button by default when its used for nextup, which it always is for series. the button can be made visible later once its verified that there are nextup items
-                boolean resumeButtonVisible = !(mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) && mBaseItem.getCanResume();
+                boolean resumeButtonVisible = mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer || mBaseItem.getCanResume();
+                //mResumeButton.setVisibility(resumeButtonVisible ? View.VISIBLE : View.GONE);
                 mResumeButton.setVisibility(resumeButtonVisible ? View.VISIBLE : View.GONE);
+                mResumeButton.setEnabled(resumeButtonVisible);
 
                 playButton = new TextUnderButton(this, R.drawable.ic_play, buttonSize, 2, getString(BaseItemUtils.isLiveTv(mBaseItem) ? R.string.lbl_tune_to_channel : mBaseItem.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
                     @Override
@@ -993,7 +1000,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
                 mDetailsOverviewRow.addAction(playButton);
 
-                if (resumeButtonVisible) {
+                if (mBaseItem.getCanResume()) {
                     mResumeButton.requestFocus();
                 } else {
                     playButton.requestFocus();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -253,7 +253,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                                 if (!isFinishing()) {
                                     mBaseItem = response;
                                     if (mResumeButton != null) {
-                                        boolean resumeVisible = !(mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) && mBaseItem.getCanResume(); //(mBaseItem.getBaseItemType() == BaseItemType.Series && !mBaseItem.getUserData().getPlayed()) || (mBaseItem.getCanResume());
+                                        boolean resumeVisible = !(mBaseItem.getBaseItemType() == BaseItemType.Series || mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) && mBaseItem.getCanResume();
                                         mResumeButton.setVisibility(resumeVisible ? View.VISIBLE : View.GONE);
                                         if (response.getCanResume()) {
                                             mResumeButton.setText(getString(R.string.lbl_resume_from, TimeUtils.formatMillis((response.getUserData().getPlaybackPositionTicks()/10000) - getResumePreroll())));


### PR DESCRIPTION
<!--
Only show the nextup button for a series after a valid response from nextUpQuery
-->

**Changes**
These changes will hide the 'play next up' button by default for series and then query the server with the same request that pressing the button would. If the query finds episodes then the button will be shown and given focus.

**Issues**
Often series will end up without 'next up' episodes. Currently the android-tv client will always show the 'play next up' button for series even when invalid. Clicking on the button results in the toast "Unable to find next up episode".
