### PR TITLE
Refresh server info after migration

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/LegacyAccountMigration.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/LegacyAccountMigration.kt
@@ -55,6 +55,7 @@ class LegacyAccountMigration(
 							address = serverAddress ?: "",
 							loginDisclaimer = null,
 							version = serverVersion,
+							lastRefreshed = 0,
 						)
 					)
 				}


### PR DESCRIPTION
When I opened the Jellyfin app on a device that did not use it for the past few months (last connection was when the app was at version 0.11 and server at 10.6) it complained about the server version being outdated.

This issue was caused by the data migration not putting a value into `lastRefreshed` and it used the default: now. The ServerRepository wouldn't refresh the server info because of that. This change forces a refresh so people that did not use Jellyfin for a longer period can use it without waiting or re-adding the server.

**Changes**
- Set lastRefreshed to 0 to force a server refresh

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
