### PR TITLE
Backport minimal core changes for new playback module

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -31,9 +31,9 @@ class PlaybackForwardingActivity : FragmentActivity() {
 
 		if (itemId == null) {
 			Toast.makeText(
-					this,
-					"Could not find item to play (itemId=null)",
-					Toast.LENGTH_LONG
+				this,
+				"Could not find item to play (itemId=null)",
+				Toast.LENGTH_LONG
 			).show()
 			finishAfterTransition()
 			return
@@ -45,9 +45,9 @@ class PlaybackForwardingActivity : FragmentActivity() {
 
 			// Log info
 			Toast.makeText(
-					this@PlaybackForwardingActivity,
-					"Found item of type ${item.type} - ${item.name} (${item.id}",
-					Toast.LENGTH_LONG
+				this@PlaybackForwardingActivity,
+				"Found item of type ${item.type} - ${item.name} (${item.id}",
+				Toast.LENGTH_LONG
 			).show()
 			Timber.i(item.toString())
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -23,7 +23,7 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.debuggingEnabled)
 			}
 
-			// Only show in debug mode
+			// Only show in development mode
 			if (BuildConfig.DEVELOPMENT) {
 				checkbox {
 					setTitle(R.string.enable_playback_module_title)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlinx-coroutines = "1.4.3"
+kotlinx-coroutines = "1.5.2"
 kotlinx-serialization = "1.1.0"
 androidx-leanback = "1.1.0-beta01"
 androidx-lifecycle = "2.3.1"
@@ -7,6 +7,7 @@ koin = "3.1.2"
 glide = "4.12.0"
 acra = "5.8.4"
 aboutlibraries = "8.9.3"
+androidx-media2 = "1.2.0"
 
 [libraries]
 # Jellyfin apiclient
@@ -16,6 +17,7 @@ jellyfin-sdk = { module = "org.jellyfin.sdk:jellyfin-core", version = "1.1.0" }
 
 # Kotlin
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-guava = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-guava", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Android(x)
@@ -37,6 +39,7 @@ androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", 
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-window = { module = "androidx.window:window", version = "1.0.0-alpha09" }
 androidx-cardview = { module = "androidx.cardview:cardview", version = "1.0.0" }
+androidx-media2-session = { module = "androidx.media2:media2-session", version = "androidx-media2"}
 
 # Dependency Injection
 koin-android-core = { module = "io.insert-koin:koin-android", version.ref = "koin" }


### PR DESCRIPTION
Nothing major changed in this PR, it's only small stuff that is not in the playback module. The only reason for this early backport is to make rebasing easier when any of these files change (especially the libs.versions.toml file).

**Changes**

- Update kotlinx.coroutines to fix binary incompatibility
- Add kotlinx.coroutines guava module for playback module MediaSessions
- Add androidx.media2 session module for playback module MediaSessions
- Fix formatting in PlaybackForwardingActivity
- Fix typo in DeveloperPreferencesScreen

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Part of #1057