### PR TITLE
Fix touch support in home/auth screens

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
@@ -20,6 +20,7 @@ class ServerButtonView @JvmOverloads constructor(
 
 	init {
 		isFocusable = true
+		isClickable = true
 		descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeToolbarFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeToolbarFragment.kt
@@ -1,17 +1,18 @@
 package org.jellyfin.androidtv.ui.home
 
 import android.content.Intent
+import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomViewTarget
 import com.bumptech.glide.request.transition.Transition
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.databinding.FragmentToolbarHomeBinding
@@ -40,7 +41,7 @@ class HomeToolbarFragment : Fragment() {
 			activity?.startActivity(settingsIntent)
 		}
 
-		binding.switchUsersContainer.setOnClickListener {
+		binding.switchUsers.setOnClickListener {
 			switchUser()
 		}
 
@@ -55,25 +56,23 @@ class HomeToolbarFragment : Fragment() {
 	private fun setUserImage(image: String?) {
 		Glide.with(requireContext())
 			.load(image)
+			.placeholder(R.drawable.ic_switch_users)
 			.centerInside()
 			.circleCrop()
-			.into(object : CustomViewTarget<ImageButton, Drawable>(binding.switchUsersImage) {
+			.into(object : CustomViewTarget<ImageButton, Drawable>(binding.switchUsers) {
 				override fun onLoadFailed(errorDrawable: Drawable?) {
-					binding.switchUsersImage.isVisible = false
-					binding.switchUsersIcon.isVisible = true
-					binding.switchUsersImage.setImageDrawable(null)
+					binding.switchUsers.imageTintMode = PorterDuff.Mode.SRC_IN
+					binding.switchUsers.setImageDrawable(errorDrawable)
 				}
 
 				override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
-					binding.switchUsersImage.isVisible = true
-					binding.switchUsersIcon.isVisible = false
-					binding.switchUsersImage.setImageDrawable(resource)
+					binding.switchUsers.imageTintMode = null
+					binding.switchUsers.setImageDrawable(resource)
 				}
 
 				override fun onResourceCleared(placeholder: Drawable?) {
-					binding.switchUsersImage.isVisible = false
-					binding.switchUsersIcon.isVisible = true
-					binding.switchUsersImage.setImageDrawable(null)
+					binding.switchUsers.imageTintMode = PorterDuff.Mode.SRC_IN
+					binding.switchUsers.setImageDrawable(placeholder)
 				}
 			})
 	}

--- a/app/src/main/res/layout/fragment_toolbar_home.xml
+++ b/app/src/main/res/layout/fragment_toolbar_home.xml
@@ -36,33 +36,12 @@
             android:layout_width="8dp"
             android:layout_height="0dp" />
 
-        <!-- Only one of the next 2 buttons should be shown at a time -->
-        <FrameLayout
-            android:id="@+id/switch_users_container"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:descendantFocusability="blocksDescendants"
-            android:focusable="true">
-
-            <ImageButton
-                android:id="@+id/switch_users_icon"
-                style="@style/Button.Icon"
-                android:layout_width="41dp"
-                android:layout_height="41dp"
-                android:contentDescription="@string/lbl_switch_user"
-                android:duplicateParentState="true"
-                android:src="@drawable/ic_switch_users" />
-
-            <ImageButton
-                android:id="@+id/switch_users_image"
-                style="@style/Button.Icon"
-                android:layout_width="41dp"
-                android:layout_height="41dp"
-                android:contentDescription="@string/lbl_switch_user"
-                android:duplicateParentState="true"
-                android:tint="@null"
-                android:visibility="gone" />
-        </FrameLayout>
+        <ImageButton
+            android:id="@+id/switch_users"
+            style="@style/Button.Icon"
+            android:layout_width="41dp"
+            android:layout_height="41dp"
+            android:contentDescription="@string/lbl_switch_user"
+            android:src="@drawable/ic_switch_users" />
     </LinearLayout>
 </org.jellyfin.androidtv.ui.shared.ToolbarView>

--- a/app/src/main/res/layout/view_button_server.xml
+++ b/app/src/main/res/layout/view_button_server.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Button.Default"
+    android:clickable="false"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:duplicateParentState="true"


### PR DESCRIPTION
Although mobile is not supported the app works reasonably on tablets and it works with VR 😉. Two buttons added in 0.12 didn't work with touch - now they do!

**Changes**

- Fix touch support for "switch user" button
  - Also switched from framelayout + 2 image buttons that toggled visibility based on image/icon to a single image button
- Fix touch support for server button

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
