### PR TITLE
Migrate to androidx.startup for app initialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
 	implementation(libs.bundles.androidx.lifecycle)
 	implementation(libs.androidx.window)
 	implementation(libs.androidx.cardview)
+	implementation(libs.androidx.startup)
 
 	// Dependency Injection
 	implementation(libs.bundles.koin)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,9 @@
             <meta-data
                 android:name="org.jellyfin.androidtv.di.KoinInitializer"
                 android:value="androidx.startup" />
+            <meta-data
+                android:name="org.jellyfin.androidtv.SessionInitializer"
+                android:value="androidx.startup" />
         </provider>
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,9 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
+                android:name="org.jellyfin.androidtv.LogInitializer"
+                android:value="androidx.startup" />
+            <meta-data
                 android:name="org.jellyfin.androidtv.di.KoinInitializer"
                 android:value="androidx.startup" />
         </provider>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,16 @@
             </intent-filter>
         </service>
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="org.jellyfin.androidtv.di.KoinInitializer"
+                android:value="androidx.startup" />
+        </provider>
+
         <activity
             android:name=".ui.browsing.MainActivity"
             android:screenOrientation="landscape" />

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -22,33 +22,13 @@ import org.jellyfin.androidtv.util.AutoBitrate
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.android.inject
-import org.koin.core.KoinExperimentalAPI
 import timber.log.Timber
-import timber.log.Timber.DebugTree
 import java.util.concurrent.TimeUnit
 
 @Suppress("unused")
 class JellyfinApplication : TvApp(), LifecycleObserver {
-	@OptIn(KoinExperimentalAPI::class)
 	override fun onCreate() {
 		super.onCreate()
-
-		// Enable improved logging for leaking resources
-		// https://wh0.github.io/2020/08/12/closeguard.html
-		if (BuildConfig.DEBUG) {
-			try {
-				Class.forName("dalvik.system.CloseGuard")
-					.getMethod("setEnabled", Boolean::class.javaPrimitiveType)
-					.invoke(null, true)
-			} catch (e: ReflectiveOperationException) {
-				@Suppress("TooGenericExceptionThrown")
-				throw RuntimeException(e)
-			}
-		}
-
-		// Initialize the logging library
-		Timber.plant(DebugTree())
-		Timber.i("Application object created")
 
 		// Register lifecycle callbacks
 		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -17,15 +17,12 @@ import org.acra.data.StringFormat
 import org.acra.ktx.initAcra
 import org.acra.sender.HttpSender
 import org.jellyfin.androidtv.auth.SessionRepository
-import org.jellyfin.androidtv.di.*
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.jellyfin.androidtv.util.AutoBitrate
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.android.inject
-import org.koin.android.ext.koin.androidContext
 import org.koin.core.KoinExperimentalAPI
-import org.koin.core.context.startKoin
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.util.concurrent.TimeUnit
@@ -52,20 +49,6 @@ class JellyfinApplication : TvApp(), LifecycleObserver {
 		// Initialize the logging library
 		Timber.plant(DebugTree())
 		Timber.i("Application object created")
-
-		// Dependency Injection
-		startKoin {
-			androidContext(this@JellyfinApplication)
-
-			modules(
-				appModule,
-				authModule,
-				activityLifecycleCallbacksModule,
-				playbackModule,
-				preferenceModule,
-				utilsModule
-			)
-		}
 
 		// Register lifecycle callbacks
 		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -34,9 +34,6 @@ class JellyfinApplication : TvApp(), LifecycleObserver {
 		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)
 
 		ProcessLifecycleOwner.get().lifecycle.addObserver(this)
-
-		// Restore system session
-		get<SessionRepository>().restoreDefaultSystemSession()
 	}
 
 	/**

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -30,10 +30,17 @@ class JellyfinApplication : TvApp(), LifecycleObserver {
 	override fun onCreate() {
 		super.onCreate()
 
-		// Register lifecycle callbacks
-		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)
-
+		// Register application lifecycle events
 		ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+	}
+
+	/**
+	 * Called by the Process Lifecycle when the app is created. It is called after [onCreate].
+	 */
+	@OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+	fun onCreated() {
+		// Register activity lifecycle callbacks
+		getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)
 	}
 
 	/**

--- a/app/src/main/java/org/jellyfin/androidtv/LogInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/LogInitializer.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.androidtv
+
+import android.content.Context
+import androidx.startup.Initializer
+import timber.log.Timber
+
+class LogInitializer : Initializer<Unit> {
+	override fun create(context: Context) {
+		// Enable improved logging for leaking resources
+		// https://wh0.github.io/2020/08/12/closeguard.html
+		if (BuildConfig.DEBUG) {
+			try {
+				Class.forName("dalvik.system.CloseGuard")
+					.getMethod("setEnabled", Boolean::class.javaPrimitiveType)
+					.invoke(null, true)
+			} catch (e: ReflectiveOperationException) {
+				@Suppress("TooGenericExceptionThrown")
+				throw RuntimeException(e)
+			}
+		}
+
+		// Initialize the logging library
+		Timber.plant(Timber.DebugTree())
+		Timber.i("Debug tree planted")
+	}
+
+	override fun dependencies() = emptyList<Class<out Initializer<*>>>()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/SessionInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/SessionInitializer.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.androidtv
+
+import android.content.Context
+import androidx.startup.AppInitializer
+import androidx.startup.Initializer
+import org.jellyfin.androidtv.auth.SessionRepository
+import org.jellyfin.androidtv.di.KoinInitializer
+
+@Suppress("unused")
+class SessionInitializer : Initializer<Unit> {
+	override fun create(context: Context) {
+		val koin = AppInitializer.getInstance(context)
+			.initializeComponent(KoinInitializer::class.java)
+			.koin
+
+		// Restore system session
+		koin.get<SessionRepository>().restoreDefaultSystemSession()
+	}
+
+	override fun dependencies() = listOf(KoinInitializer::class.java)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
@@ -7,7 +7,6 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.KoinApplication
 import org.koin.core.context.startKoin
 
-@Suppress("unused")
 class KoinInitializer : Initializer<KoinApplication> {
 	override fun create(context: Context): KoinApplication = startKoin {
 		androidContext(context)

--- a/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
@@ -1,0 +1,25 @@
+package org.jellyfin.androidtv.di
+
+import android.content.Context
+import androidx.startup.Initializer
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.KoinApplication
+import org.koin.core.context.startKoin
+
+@Suppress("unused")
+class KoinInitializer : Initializer<KoinApplication> {
+	override fun create(context: Context): KoinApplication = startKoin {
+		androidContext(context)
+
+		modules(
+			appModule,
+			authModule,
+			activityLifecycleCallbacksModule,
+			playbackModule,
+			preferenceModule,
+			utilsModule
+		)
+	}
+
+	override fun dependencies() = emptyList<Class<out Initializer<*>>>()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.di
 
 import android.content.Context
 import androidx.startup.Initializer
+import org.jellyfin.androidtv.LogInitializer
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.KoinApplication
 import org.koin.core.context.startKoin
@@ -21,5 +22,6 @@ class KoinInitializer : Initializer<KoinApplication> {
 		)
 	}
 
-	override fun dependencies() = emptyList<Class<out Initializer<*>>>()
+	override fun dependencies() = listOf(LogInitializer::class.java)
 }
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlinx-coroutines = "1.4.3"
 kotlinx-serialization = "1.1.0"
 androidx-leanback = "1.1.0-beta01"
 androidx-lifecycle = "2.3.1"
+androidx-startup = "1.1.0"
 koin = "3.1.2"
 glide = "4.12.0"
 acra = "5.8.4"
@@ -37,6 +38,7 @@ androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", 
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-window = { module = "androidx.window:window", version = "1.0.0-alpha09" }
 androidx-cardview = { module = "androidx.cardview:cardview", version = "1.0.0" }
+androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
 
 # Dependency Injection
 koin-android-core = { module = "io.insert-koin:koin-android", version.ref = "koin" }


### PR DESCRIPTION
This PR is required to properly initialize ContentProvider's (like in #900) and declutters the JellyfinApplication class.

I did not move ACRA as it unfortunately requires an instance of Application.

**Changes**

- Add androidx.startup
  - Move Koin initialization code to a androidx.startup initializer
  - Move logging initialization code to a androidx.startup initializer
  - Move session initialization code to a androidx.startup initializer

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
