### PR TITLE
Fix H264 52 Level available on NVIDIA Shield but not detected Fixes #1231

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.java
@@ -22,6 +22,8 @@ public class DeviceUtils {
     private static final String FIRE_TV_MODEL_GEN_1 = "AFTB";
     private static final String FIRE_TV_MODEL_GEN_2 = "AFTS";
     private static final String FIRE_TV_MODEL_GEN_3 = "AFTN";
+    // Nvidia Shield TV Model
+    private static final String SHIELD_TV_MODEL = "SHIELD Android TV";
 
     public static boolean isChromecastWithGoogleTV() {
         return Build.MODEL.equals(CHROMECAST_GOOGLE_TV);
@@ -37,6 +39,10 @@ public class DeviceUtils {
 
     public static boolean isFireTvStick4k() {
         return Build.MODEL.equals(FIRE_STICK_4K_MODEL);
+    }
+
+    public static boolean isShieldTv() {
+        return Build.MODEL.equals(SHIELD_TV_MODEL);
     }
 
     public static boolean has4kVideoSupport() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -74,6 +74,7 @@ object ProfileHelper {
 				// https://developer.amazon.com/docs/fire-tv/device-specifications.html
 				DeviceUtils.isFireTvStick4k() -> H264_LEVEL_5_2
 				DeviceUtils.isFireTv() -> H264_LEVEL_4_1
+				DeviceUtils.isShieldTv() -> H264_LEVEL_5_2
 				else -> H264_LEVEL_5_1
 			}
 		)


### PR DESCRIPTION
**Changes**
H264 level 52 support added for all NVIDIA Shield TV models, to prevent transcoding when video can be decoded directly by the android-tv client.

**Issues**
Fixes #1231
