### PR TITLE
Add MigrationContext for improved preference migration behavior

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -183,37 +183,36 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 	}
 
 	init {
-		// Migrations
-		// v0.10.x to v0.11.x: Old migrations
-		migration(toVersion = 2) {
-			// Migrate to video player enum
-			// Note: This is the only time we need to check if the value is not set yet because the version numbers were reset
-			if (!it.contains("video_player"))
-				putEnum("video_player", if (it.getBoolean("pref_video_use_external", false)) PreferredVideoPlayer.EXTERNAL else PreferredVideoPlayer.AUTO)
-		}
+		// Note: Create a single migration per app version
+		// Note: Migrations are never executed for fresh installs
+		runMigrations {
+			// v0.10.x to v0.11.x
+			migration(toVersion = 2) {
+				// Migrate to video player enum
+				// Note: This is the only time we need to check if the value is not set yet because the version numbers were reset
+				if (!it.contains("video_player"))
+					putEnum("video_player", if (it.getBoolean("pref_video_use_external", false)) PreferredVideoPlayer.EXTERNAL else PreferredVideoPlayer.AUTO)
+			}
 
-		// v0.11.x to v0.12.x: Migrates from the old way of storing preferences to the current
-		migration(toVersion = 3) {
-			// Migrate to audio behavior enum
-			putEnum("audio_behavior", if (it.getString("pref_audio_option", "0") == "1") AudioBehavior.DOWNMIX_TO_STEREO else AudioBehavior.DIRECT_STREAM)
+			// v0.11.x to v0.12.x
+			migration(toVersion = 5) {
+				// Migrate to audio behavior enum
+				putEnum("audio_behavior", if (it.getString("pref_audio_option", "0") == "1") AudioBehavior.DOWNMIX_TO_STEREO else AudioBehavior.DIRECT_STREAM)
 
-			// Migrate live tv player to use enum
-			putEnum("live_tv_video_player",
-				when {
-					it.getBoolean("pref_live_tv_use_external", false) -> PreferredVideoPlayer.EXTERNAL
-					it.getBoolean("pref_enable_vlc_livetv", false) -> PreferredVideoPlayer.VLC
-					else -> PreferredVideoPlayer.AUTO
-				})
-		}
+				// Migrate live tv player to use enum
+				putEnum("live_tv_video_player",
+					when {
+						it.getBoolean("pref_live_tv_use_external", false) -> PreferredVideoPlayer.EXTERNAL
+						it.getBoolean("pref_enable_vlc_livetv", false) -> PreferredVideoPlayer.VLC
+						else -> PreferredVideoPlayer.AUTO
+					})
 
-		// Change audio delay type from long to int
-		migration(toVersion = 4) {
-			putInt("libvlc_audio_delay", it.getLong("libvlc_audio_delay", 0).toInt())
-		}
+				// Change audio delay type from long to int
+				putInt("libvlc_audio_delay", it.getLong("libvlc_audio_delay", 0).toInt())
 
-		// Disable AC3 (Dolby Digital) on Fire Stick Gen 1 devices
-		migration(toVersion = 5) {
-			if (DeviceUtils.isFireTvStickGen1()) putBoolean("pref_bitstream_ac3", false)
+				// Disable AC3 (Dolby Digital) on Fire Stick Gen 1 devices
+				if (DeviceUtils.isFireTvStickGen1()) putBoolean("pref_bitstream_ac3", false)
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/migrations/MigrationContext.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/migrations/MigrationContext.kt
@@ -1,0 +1,64 @@
+package org.jellyfin.androidtv.preference.migrations
+
+import timber.log.Timber
+import java.lang.Integer.max
+
+class MigrationContext<E, V> {
+	private val migrations = mutableListOf<Migration<E, V>>()
+	private var highVersion: Int = -1
+
+	/**
+	 * Migration function to upgrade the preferences from older app versions.
+	 *
+	 * Migrations look like this:
+	 * ```kotlin
+	 * migration(toVersion = 1) {
+	 * 	// Get a value
+	 * 	it.getString("example", "default")
+	 * 	// Set a value
+	 * 	setString("example", "new value")
+	 * }
+	 *
+	 * @param toVersion The new version to upgrade to
+	 * @param body Actual migration code
+	 */
+	inline fun migration(toVersion: Int, noinline body: E.(V) -> Unit) = migration(Migration(toVersion, body))
+
+	fun migration(definition: Migration<E, V>) {
+		if (definition.toVersion > highVersion) highVersion = definition.toVersion
+		migrations.add(definition)
+	}
+
+	/**
+	 * Apply all defined migrations. Do not call manually.
+	 * When [currentVersion] is -1 all migrations are skipped.
+	 *
+	 * @return The new version of the store. This is the highest "toVersion" number.
+	 */
+	fun applyMigrations(currentVersion: Int, executeMigration: (Migration<E, V>) -> Unit): Int {
+		Timber.i("Requested migration from $currentVersion to $highVersion. Found ${migrations.size} migrations in total.")
+		return when {
+			// No migrations
+			highVersion == -1 -> currentVersion
+			// All migrations already applied
+			currentVersion >= highVersion -> currentVersion
+			// Skip migrations (fresh install)
+			currentVersion == -1 -> highVersion
+			// Run migrations
+			else -> migrations
+				// Filter out old migrations
+				.filter { it.toVersion > currentVersion }
+				// Execute in order
+				.sortedBy { it.toVersion }
+				// Call executor
+				.forEach { executeMigration(it) }
+				// Return highest version
+				.let { max(highVersion, currentVersion) }
+		}
+	}
+
+	data class Migration<E, V>(
+		val toVersion: Int,
+		val body: E.(V) -> Unit
+	)
+}


### PR DESCRIPTION
To fix an issue where new installs would execute all migrations I made some changes to the code.

**Changes**
- Add new MigrationContext
  - Implementation unaware, meaning we can add migrations for display preferences at some point
  - Works in 2 steps:
    1. Define migrations
    2. Run migrations
  - Skips migrating when current store version is -1 (new install)
  - Skips migrations already executed (previous behavior)
  - All migration run in their own transaction (previous behavior)
- Remove .migration from SharedPreferencesStore and add .runMigrations instead
- Merge UserPreferences migrations meant for 0.11->0.12 into a single block. (keeps the toVersion for compatibility with current installs)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
