### PR TITLE
Misc playback adjustments (d-pad click can play/pause, stop drift during pause, libvlc time fix)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -687,6 +687,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     @Override
     public void onStop() {
+        Timber.d("playback overlay fragment - caught onStop");
         super.onStop();
 
         mPlaybackController.stop();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -584,7 +584,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                         }
 
                         if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER && mPlaybackController.canSeek()) {
-                            mPlaybackController.pause();
+                            mPlaybackController.playPause();
                             return true;
                         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -678,20 +678,18 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     @Override
     public void onPause() {
+        Timber.d("playback overlay fragment - caught onPause");
         super.onPause();
-
         setPlayPauseActionState(0);
-
         // give back audio focus
         mAudioManager.abandonAudioFocus(mAudioFocusChanged);
+        mPlaybackController.stop();
     }
 
     @Override
     public void onStop() {
         Timber.d("playback overlay fragment - caught onStop");
         super.onStop();
-
-        mPlaybackController.stop();
     }
 
     public void show() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -584,6 +584,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                         }
 
                         if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER && mPlaybackController.canSeek()) {
+                            Timber.d("playback overlay fragment - got d pad click to playPause");
                             mPlaybackController.playPause();
                             return true;
                         }
@@ -1281,6 +1282,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     public void updateDisplay() {
         BaseItemDto current = mPlaybackController.getCurrentlyPlayingItem();
         if (current != null && getActivity() != null && !getActivity().isFinishing()) {
+            Timber.d("playback overlay fragment - updating display");
             leanbackOverlayFragment.mediaInfoChanged();
             leanbackOverlayFragment.onFullyInitialized();
             leanbackOverlayFragment.recordingStateChanged();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -679,11 +679,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Override
     public void onPause() {
         Timber.d("playback overlay fragment - caught onPause");
-        super.onPause();
         setPlayPauseActionState(0);
         // give back audio focus
         mAudioManager.abandonAudioFocus(mAudioFocusChanged);
         mPlaybackController.stop();
+        super.onPause();
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -805,6 +805,7 @@ public class PlaybackController {
             mFragment.setPlayPauseActionState(0);
 
         }
+        Timber.d("pause called at %s", mCurrentPosition);
         // start a slower report for pause state to keep session alive
         startPauseReportLoop();
     }
@@ -840,6 +841,7 @@ public class PlaybackController {
                 getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
             }
         }
+        Timber.d("stop called at %s", mCurrentPosition);
     }
 
     public void next() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -893,7 +893,7 @@ public class PlaybackController {
             // update mCurrentPosition because when play() is called after seeking it uses its value
             mCurrentPosition = pos;
 
-            if (!(mVideoManager.isNativeMode())) {
+            if (mVideoManager.getMetaVLCStreamStartPosition() != -1) {
                 mVideoManager.setMetaVLCStreamStartPosition(pos);
             }
             playbackManager.getValue().changeVideoStream(mCurrentStreamInfo, apiClient.getValue().getServerInfo().getId(), mCurrentOptions, pos * 10000, apiClient.getValue(), new Response<StreamInfo>() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -807,6 +807,7 @@ public class PlaybackController {
         }
         // start a slower report for pause state to keep session alive
         startPauseReportLoop();
+        Timber.d("Paused Playback");
     }
 
     public void playPause() {
@@ -840,6 +841,7 @@ public class PlaybackController {
                 getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
             }
         }
+        Timber.d("Stopped Playback");
     }
 
     public void next() {
@@ -1222,6 +1224,11 @@ public class PlaybackController {
     }
 
     public long getCurrentPosition() {
+        long currentTime = isLiveTv ? getTimeShiftedProgress() : mVideoManager.getCurrentPosition();
+
+        if (currentTime != -1) {
+            mCurrentPosition = currentTime;
+        }
         return mCurrentPosition;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -654,6 +654,11 @@ public class PlaybackController {
         mVideoManager.setVideoPath(response.getMediaUrl());
         mVideoManager.setVideoTrack(response.getMediaSource());
 
+        if ((forceVlc || useVlc) && getPlaybackMethod().equals(PlayMethod.Transcode)) {
+            Timber.i("Setting VLC Stream Start Position to %s", position);
+            mVideoManager.setMetaVLCStreamStartPosition(position);
+        }
+
         //wait a beat before attempting to start so the player surface is fully initialized and video is ready
         mHandler.postDelayed(new Runnable() {
             @Override
@@ -871,6 +876,7 @@ public class PlaybackController {
             mVideoManager.stopPlayback();
             // update mCurrentPosition because when play() is called after seeking it uses its value
             mCurrentPosition = pos;
+            mVideoManager.setMetaVLCStreamStartPosition(pos);
             playbackManager.getValue().changeVideoStream(mCurrentStreamInfo, apiClient.getValue().getServerInfo().getId(), mCurrentOptions, pos * 10000, apiClient.getValue(), new Response<StreamInfo>() {
                 @Override
                 public void onResponse(StreamInfo response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -852,7 +852,9 @@ public class PlaybackController {
                 getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
             }
         }
-
+        else {
+            Timber.d("Video is already stopped, ignoring");
+        }
     }
 
     public void next() {
@@ -890,7 +892,10 @@ public class PlaybackController {
             mVideoManager.stopPlayback();
             // update mCurrentPosition because when play() is called after seeking it uses its value
             mCurrentPosition = pos;
-            mVideoManager.setMetaVLCStreamStartPosition(pos);
+
+            if (!(mVideoManager.isNativeMode())) {
+                mVideoManager.setMetaVLCStreamStartPosition(pos);
+            }
             playbackManager.getValue().changeVideoStream(mCurrentStreamInfo, apiClient.getValue().getServerInfo().getId(), mCurrentOptions, pos * 10000, apiClient.getValue(), new Response<StreamInfo>() {
                 @Override
                 public void onResponse(StreamInfo response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -807,7 +807,6 @@ public class PlaybackController {
         }
         // start a slower report for pause state to keep session alive
         startPauseReportLoop();
-        Timber.d("Paused Playback");
     }
 
     public void playPause() {
@@ -841,7 +840,6 @@ public class PlaybackController {
                 getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
             }
         }
-        Timber.d("Stopped Playback");
     }
 
     public void next() {
@@ -1224,11 +1222,6 @@ public class PlaybackController {
     }
 
     public long getCurrentPosition() {
-        long currentTime = isLiveTv ? getTimeShiftedProgress() : mVideoManager.getCurrentPosition();
-
-        if (currentTime != -1) {
-            mCurrentPosition = currentTime;
-        }
         return mCurrentPosition;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -796,6 +796,11 @@ public class PlaybackController {
     }
 
     public void pause() {
+        Timber.d("pause called at %s", mCurrentPosition);
+        if (mPlaybackState == PlaybackState.PAUSED) {
+            Timber.d("pause called - already paused, ignoring");
+            return ;
+        }
         stopReportLoop();
         mPlaybackState = PlaybackState.PAUSED;
         mVideoManager.pause();
@@ -805,7 +810,6 @@ public class PlaybackController {
             mFragment.setPlayPauseActionState(0);
 
         }
-        Timber.d("pause called at %s", mCurrentPosition);
         // start a slower report for pause state to keep session alive
         startPauseReportLoop();
     }
@@ -824,6 +828,8 @@ public class PlaybackController {
     }
 
     public void stop() {
+        Timber.d("stop called at %s", mCurrentPosition);
+
         stopReportLoop();
         if (mPlaybackState != PlaybackState.IDLE && mPlaybackState != PlaybackState.UNDEFINED) {
             mPlaybackState = PlaybackState.IDLE;
@@ -835,13 +841,17 @@ public class PlaybackController {
                 Timber.e(e);
             }
             Long mbPos = mCurrentPosition * 10000;
+
+            if (getCurrentlyPlayingItem() == null) {
+                Timber.d("stop called - current item is null!");
+            }
             ReportingHelper.reportStopped(getCurrentlyPlayingItem(), getCurrentStreamInfo(), mbPos);
             if (!isLiveTv) {
                 // update the actual items resume point
                 getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
             }
         }
-        Timber.d("stop called at %s", mCurrentPosition);
+
     }
 
     public void next() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -896,6 +896,7 @@ public class PlaybackController {
             if (mVideoManager.getMetaVLCStreamStartPosition() != -1) {
                 mVideoManager.setMetaVLCStreamStartPosition(pos);
             }
+            mPlaybackState = PlaybackState.BUFFERING;
             playbackManager.getValue().changeVideoStream(mCurrentStreamInfo, apiClient.getValue().getServerInfo().getId(), mCurrentOptions, pos * 10000, apiClient.getValue(), new Response<StreamInfo>() {
                 @Override
                 public void onResponse(StreamInfo response) {
@@ -995,7 +996,7 @@ public class PlaybackController {
     private void startReportLoop() {
         stopReportLoop();
         Timber.d("started playback controller report loop");
-        ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
+        //ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
         mReportLoop = new Runnable() {
             @Override
             public void run() {
@@ -1015,7 +1016,7 @@ public class PlaybackController {
     private void startPauseReportLoop() {
         stopReportLoop();
         Timber.d("started playback controller pause report loop");
-        ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
+        //ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
         mReportLoop = new Runnable() {
             @Override
             public void run() {
@@ -1157,7 +1158,6 @@ public class PlaybackController {
         mVideoManager.setOnPreparedListener(new PlaybackListener() {
             @Override
             public void onEvent() {
-
                 if (mPlaybackState == PlaybackState.BUFFERING) {
                     mPlaybackState = PlaybackState.PLAYING;
                     mCurrentTranscodeStartTime = mCurrentStreamInfo.getPlayMethod() == PlayMethod.Transcode ? System.currentTimeMillis() : 0;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -988,6 +988,7 @@ public class PlaybackController {
     }
 
     private void startReportLoop() {
+        stopReportLoop();
         Timber.d("started playback controller report loop");
         ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
         mReportLoop = new Runnable() {
@@ -1007,6 +1008,7 @@ public class PlaybackController {
     }
 
     private void startPauseReportLoop() {
+        stopReportLoop();
         Timber.d("started playback controller pause report loop");
         ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
         mReportLoop = new Runnable() {
@@ -1157,6 +1159,7 @@ public class PlaybackController {
                     startReportLoop();
                 }
                 Timber.i("Play method: %s", mCurrentStreamInfo.getPlayMethod() == PlayMethod.Transcode ? "Trans" : "Direct");
+                Timber.d("OnPreparedListener - current playback state: %s", mPlaybackState);
 
                 if (mPlaybackState == PlaybackState.PAUSED) {
                     mPlaybackState = PlaybackState.PLAYING;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -225,6 +225,7 @@ public class PlaybackController {
             play(mCurrentPosition);
 
         } else {
+            Timber.d("Player error encountered - out of retries");
             Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.too_many_errors));
             mPlaybackState = PlaybackState.ERROR;
             stop();
@@ -311,7 +312,7 @@ public class PlaybackController {
             Timber.i("Negative start requested - adjusting to zero");
             position = 0;
         }
-
+        Timber.d("Play called - current playback state: %s", mPlaybackState);
         switch (mPlaybackState) {
             case PLAYING:
                 // do nothing
@@ -987,6 +988,7 @@ public class PlaybackController {
     }
 
     private void startReportLoop() {
+        Timber.d("started playback controller report loop");
         ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
         mReportLoop = new Runnable() {
             @Override
@@ -1005,11 +1007,13 @@ public class PlaybackController {
     }
 
     private void startPauseReportLoop() {
+        Timber.d("started playback controller pause report loop");
         ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mVideoManager.getCurrentPosition() * 10000, false);
         mReportLoop = new Runnable() {
             @Override
             public void run() {
                 BaseItemDto currentItem = getCurrentlyPlayingItem();
+
                 if (currentItem == null) {
                     // Loop was called while nothing was playing!
                     stopReportLoop();
@@ -1018,6 +1022,7 @@ public class PlaybackController {
 
                 if (mPlaybackState != PlaybackState.PAUSED) {
                     // Playback is not paused anymore, stop reporting
+                    Timber.d("stopping playback controller pause report loop because playback state is: %s", mPlaybackState);
                     return;
                 }
 
@@ -1042,6 +1047,7 @@ public class PlaybackController {
     }
 
     private void stopReportLoop() {
+        Timber.d("stopping playback controller report loop");
         if (mHandler != null && mReportLoop != null) {
             mHandler.removeCallbacks(mReportLoop);
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -304,7 +304,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             try {
                 DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(TvApp.getApplication(), "ATV/ExoPlayer");
 
-                mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(path)));
+                mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(path)), true, true);
             } catch (IllegalStateException e) {
                 Timber.e(e, "Unable to set video path.  Probably backing out.");
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -75,6 +75,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private long mForcedTime = -1;
     private long mLastTime = -1;
     private long mMetaDuration = -1;
+    private long mMetaVLCStreamStartPosition = -1;
     private long lastExoPlayerPosition = -1;
 
     private boolean nativeMode = false;
@@ -157,6 +158,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
     }
 
+    public void setMetaVLCStreamStartPosition(long value) {
+        mMetaVLCStreamStartPosition = value;
+    }
+
     public void setMetaDuration(long duration) {
         mMetaDuration = duration;
     }
@@ -183,6 +188,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         if (mVlcPlayer == null) return 0;
 
         long time = mVlcPlayer.getTime();
+        time = mMetaVLCStreamStartPosition != -1 ? time + mMetaVLCStreamStartPosition : time;
         if (mForcedTime != -1 && mLastTime != -1) {
             /* XXX: After a seek, mLibVLC.getTime can return the position before or after
              * the seek position. Therefore we return mForcedTime in order to avoid the seekBar

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -662,6 +662,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private PlaybackListener progressListener;
     private Runnable progressLoop;
     private void startProgressLoop() {
+        stopProgressLoop();
         Timber.d("started video manager report loop");
         progressLoop = new Runnable() {
             @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -180,6 +180,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 return lastExoPlayerPosition;
             } else {
                 long mExoPlayerCurrentPosition = mExoPlayer.getCurrentPosition();
+                Timber.d("mExoPlayer time got: %s", mExoPlayerCurrentPosition);
                 lastExoPlayerPosition = mExoPlayerCurrentPosition;
                 return mExoPlayerCurrentPosition;
             }
@@ -204,6 +205,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                     mLastTime = mForcedTime = -1;
             }
         }
+        Timber.d("mVlcPlayer time got: %s returned: %s", time, (mForcedTime == -1 ? time : mForcedTime));
         return mForcedTime == -1 ? time : mForcedTime;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -662,6 +662,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private PlaybackListener progressListener;
     private Runnable progressLoop;
     private void startProgressLoop() {
+        Timber.d("started video manager report loop");
         progressLoop = new Runnable() {
             @Override
             public void run() {
@@ -673,6 +674,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     private void stopProgressLoop() {
+        Timber.d("stopped video manager report loop");
         if (progressLoop != null) {
             mHandler.removeCallbacks(progressLoop);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -162,6 +162,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         mMetaVLCStreamStartPosition = value;
     }
 
+    public long getMetaVLCStreamStartPosition() {
+        return mMetaVLCStreamStartPosition;
+    }
+
     public void setMetaDuration(long duration) {
         mMetaDuration = duration;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -39,6 +39,8 @@ import org.koin.java.KoinJavaComponent;
 
 import java.util.Calendar;
 
+import timber.log.Timber;
+
 public class CustomPlaybackTransportControlGlue extends PlaybackTransportControlGlue<VideoPlayerAdapter> {
 
     // Normal playback actions
@@ -145,6 +147,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
             @Override
             protected void onProgressBarClicked(PlaybackTransportRowPresenter.ViewHolder vh) {
+                Timber.d("overlay glue - got progress bar clicked");
                 CustomPlaybackTransportControlGlue controlglue = CustomPlaybackTransportControlGlue.this;
                 controlglue.onActionClicked(controlglue.playPauseAction);
             }
@@ -257,6 +260,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     @Override
     public void onActionClicked(Action action) {
         if (action == playPauseAction) {
+            Timber.d("overlay glue - got playPause action");
             if (playPauseAction.getIndex() == PlaybackControlsRow.PlayPauseAction.INDEX_PAUSE) {
                 getPlayerAdapter().pause();
                 playPauseAction.setIndex(PlaybackControlsRow.PlayPauseAction.INDEX_PLAY);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -9,6 +9,8 @@ import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
+import timber.log.Timber;
+
 public class LeanbackOverlayFragment extends PlaybackSupportFragment {
 
     private PlaybackController playbackController;
@@ -65,6 +67,7 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
     }
 
     public void mediaInfoChanged() {
+        Timber.d("leanback overlay fragment - media info changed");
         BaseItemDto currentlyPlayingItem = playbackController.getCurrentlyPlayingItem();
         if (currentlyPlayingItem == null) return;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -12,6 +12,8 @@ import org.jellyfin.apiclient.model.dto.ChapterInfoDto;
 
 import java.util.List;
 
+import timber.log.Timber;
+
 public class VideoPlayerAdapter extends PlayerAdapter {
 
     private final PlaybackController playbackController;
@@ -45,6 +47,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     @Override
     public void seekTo(long positionInMs) {
+        Timber.d("player adapter - caught seekTo %s", positionInMs);
         playbackController.seek(positionInMs);
         updateCurrentPosition();
     }


### PR DESCRIPTION
<!--
Misc playback adjustments (d-pad click can play/pause, stop drift during pause, libvlc time fix)
-->

1) during transcoded playback libvlc `getTime()` and other libvlc methods don't know its playback ticks or duration. libvlc `getTime()` reports ms since playback started, not actual position. The patch in this PR adds that value to the position in the media when playback began.

2) clicking the d-pad center button when the exo glue overlay is hidden no longer just calls `pause()`. It now calls `playPause()`. This allows for predictable behavior, and avoids any potential issues from excessive calls to `pause()`.

3) when playback is paused there is a slight drift between the position the player reports and playbackController's mCurrentPosition. My patch for that is to update mCurrentPosition during `PauseReportLoop`.