### PR TITLE
Fixed libvlc reporting incorrect currentPosition when transcoding

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -305,7 +305,7 @@ public class PlaybackController {
     }
 
     private void play(long position, int transcodedSubtitle) {
-        Timber.d("Play called with pos: %d and sub index: %d", position, transcodedSubtitle);
+        Timber.d("Play called from state: %s with pos: %d and sub index: %d", mPlaybackState, position, transcodedSubtitle);
 
         if (position < 0) {
             Timber.i("Negative start requested - adjusting to zero");
@@ -654,6 +654,12 @@ public class PlaybackController {
         mVideoManager.setVideoPath(response.getMediaUrl());
         mVideoManager.setVideoTrack(response.getMediaSource());
 
+        // save the position where the stream starts. vlc gettime() will return ms since this point, which will be
+        // added to this to get actual position
+        if ((forceVlc || useVlc) && getPlaybackMethod().equals(PlayMethod.Transcode)) {
+            mVideoManager.setMetaVLCStreamStartPosition(position);
+        }
+
         //wait a beat before attempting to start so the player surface is fully initialized and video is ready
         mHandler.postDelayed(new Runnable() {
             @Override
@@ -790,6 +796,7 @@ public class PlaybackController {
     }
 
     public void pause() {
+        Timber.d("pause called at %s", mCurrentPosition);
         // if playback is paused and the seekbar is scrubbed, it will call pause even if already paused
         if (mPlaybackState == PlaybackState.PAUSED) {
             Timber.d("already paused, ignoring");
@@ -822,6 +829,7 @@ public class PlaybackController {
     }
 
     public void stop() {
+        Timber.d("stop called at %s", mCurrentPosition);
         stopReportLoop();
         if (mPlaybackState != PlaybackState.IDLE && mPlaybackState != PlaybackState.UNDEFINED) {
             mPlaybackState = PlaybackState.IDLE;
@@ -876,6 +884,11 @@ public class PlaybackController {
             mVideoManager.stopPlayback();
             // update mCurrentPosition because when play() is called after seeking it uses its value
             mCurrentPosition = pos;
+
+            // this value should only NOT be -1 if vlc is being used for transcoding
+            if (mVideoManager.getMetaVLCStreamStartPosition() != -1) {
+                mVideoManager.setMetaVLCStreamStartPosition(pos);
+            }
             playbackManager.getValue().changeVideoStream(mCurrentStreamInfo, apiClient.getValue().getServerInfo().getId(), mCurrentOptions, pos * 10000, apiClient.getValue(), new Response<StreamInfo>() {
                 @Override
                 public void onResponse(StreamInfo response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -75,6 +75,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private long mForcedTime = -1;
     private long mLastTime = -1;
     private long mMetaDuration = -1;
+    private long mMetaVLCStreamStartPosition = -1;
     private long lastExoPlayerPosition = -1;
 
     private boolean nativeMode = false;
@@ -157,6 +158,15 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
     }
 
+    // set by playbackController when a new vlc transcode stream starts, and before seeking
+    public void setMetaVLCStreamStartPosition(long value) {
+        mMetaVLCStreamStartPosition = value;
+    }
+
+    public long getMetaVLCStreamStartPosition() {
+        return mMetaVLCStreamStartPosition;
+    }
+
     public void setMetaDuration(long duration) {
         mMetaDuration = duration;
     }
@@ -183,6 +193,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         if (mVlcPlayer == null) return 0;
 
         long time = mVlcPlayer.getTime();
+
+        // vlc returns ms from stream start. metaStartPosition + time = actual position
+        time = mMetaVLCStreamStartPosition != -1 ? time + getMetaVLCStreamStartPosition() : time;
         if (mForcedTime != -1 && mLastTime != -1) {
             /* XXX: After a seek, mLibVLC.getTime can return the position before or after
              * the seek position. Therefore we return mForcedTime in order to avoid the seekBar


### PR DESCRIPTION
<!--
Fixed libvlc reporting incorrect currentPosition when transcoding
-->

**Changes**
libvlc `getTime()` reports ms from stream start during transcode. Now, that value alone is not used to report position.

In videoManager a new property `mMetaVLCStreamStartPosition` stores the timestamp of the media where playback began.
This value is added to the return from `getTime` to get an accurate timestamp from the player.

The values being added is done in `getCurrentPosition()`

The value of `mMetaVLCStreamStartPosition` is set before `videoManager.start()` is called, and before seeking an mkv transcode.

**Issues**
during transcoded playback, libvlc `getTime()` is used by `videoManager` to get the current player position in `getCurrentPosition()`, which is used to display timestamps in the overlay and report progress to the server. `getTime()` only reports ms since stream start in this situation, and that breaks things like the seekbar, timestamps, and sending erroneous reports to the server.
