### PR TITLE
prevent double pausing, allow d-pad center to unpause with overlay hidden

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -584,7 +584,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                         }
 
                         if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER && mPlaybackController.canSeek()) {
-                            mPlaybackController.pause();
+                            // if the player is playing and the overlay is hidden, this will pause
+                            // if the player is paused and then 'back' is pressed to hide the overlay, this will play
+                            mPlaybackController.playPause();
                             return true;
                         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -793,7 +793,7 @@ public class PlaybackController {
         // if playback is paused and the seekbar is scrubbed, it will call pause even if already paused
         if (mPlaybackState == PlaybackState.PAUSED) {
             Timber.d("already paused, ignoring");
-            return ;
+            return;
         }
         mPlaybackState = PlaybackState.PAUSED;
         mVideoManager.pause();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -790,6 +790,11 @@ public class PlaybackController {
     }
 
     public void pause() {
+        // if playback is paused and the seekbar is scrubbed, it will call pause even if already paused
+        if (mPlaybackState == PlaybackState.PAUSED) {
+            Timber.d("already paused, ignoring");
+            return ;
+        }
         mPlaybackState = PlaybackState.PAUSED;
         mVideoManager.pause();
         if (mFragment != null) {


### PR DESCRIPTION
<!--
prevent double pausing, allow d-pad center to unpause with overlay hidden
-->

**Changes**
1) `CustomPlaybackOverlayFragment` will now `playPause()` when it catches a
`DPAD_CENTER` keyEvent instead of just calling `pause()`. If allowing playing in this context isn't desired, 2) will prevent double pausing and this change could be excluded.

2) `pause()` in `playbackController` now checks if already paused and returns if it is to prevent double pausing.

**Issues**
When the seekbar is interacted with `pause()` is always called. 1) stops this from potentially causing issues

When playback is paused and the overlay is hidden `CustomPlaybackOverlayFragment` called `pause()` on d-pad center keyEvent, even if already paused.
