### PR TITLE
reset exoplay position and state on media change

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -292,7 +292,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             try {
                 DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(TvApp.getApplication(), "ATV/ExoPlayer");
 
-                mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(path)));
+                // reset position and state when changing video path so the player doesn't use the state and position from the prior media.
+                // exoplayer currently sees transcode streams as live windows, a fix is needed.
+                mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(path)), true, true);
             } catch (IllegalStateException e) {
                 Timber.e(e, "Unable to set video path.  Probably backing out.");
             }


### PR DESCRIPTION
<!--
reset exoplay position and state on media change
-->

**Changes**
changing the media for exoplayer clears its state and position so it uses the properties of the new media

**Issues**
on seeking transcoded media played with exo, the seekbar would briefly jump back to the start
on `changeVideoPath()` exoplayer either didn't or delayed using the new media's timeline position

**Docs**
https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/SimpleExoPlayer.html#prepare(com.google.android.exoplayer2.source.MediaSource,boolean,boolean)