### PR TITLE
Dont report real exoplayer position when not playing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -171,8 +171,8 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
     public long getCurrentPosition() {
         if (nativeMode) {
-            if (mExoPlayer == null) {
-                return lastExoPlayerPosition;
+            if (mExoPlayer == null || !isPlaying()) {
+                return lastExoPlayerPosition == -1 ? 0 : lastExoPlayerPosition;
             } else {
                 long mExoPlayerCurrentPosition = mExoPlayer.getCurrentPosition();
                 lastExoPlayerPosition = mExoPlayerCurrentPosition;


### PR DESCRIPTION
<!--
Dont report real exoplayer position when not playing
-->

**Changes**
use `lastExoPlayerPosition` when `!isPlaying()`. This should finally prevent any seekbar irregularities when seeking.

**Issues**
when seeking trancoded media using exoplayer, the seekbar would jump around before playing because the `playbackController` report loops ask `mExoPlayer` for its position even when it can't report an accurate value.
