### PR TITLE
reworked playbackController position tracking and reporting system

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -195,7 +195,7 @@ public class PlaybackController {
     public BaseItemDto getNextItem() { return hasNextItem() ? mItems.get(mCurrentIndex+1) : null; }
 
     public boolean isPlaying() {
-        // since playbackController is so closed tied to videoManager, check if it is playing too since they can fall out of sync
+        // since playbackController is so closely tied to videoManager, check if it is playing too since they can fall out of sync
         return mPlaybackState == PlaybackState.PLAYING && (mVideoManager == null || mVideoManager.isPlaying());
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -958,12 +958,10 @@ public class PlaybackController {
                 // if seek succeeds call play and mirror the logic in play() for unpausing. if fails call pause()
                 // stopProgressLoop() being called at the beginning of startProgressLoop keeps this from breaking. otherwise it would start twice
                 // if seek() is called from skip()
-                mSeekedPosition = pos;
                 updateProgress = false;
                 mPlaybackState = PlaybackState.SEEKING;
                 if (mVideoManager.seekTo(pos) < 0) {
                     Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
-                    mSeekedPosition = -1;
                     updateProgress = true;
                     pause();
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -71,7 +71,7 @@ public class PlaybackController {
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
 
     List<BaseItemDto> mItems;
-    VideoManager mVideoManager = null;
+    VideoManager mVideoManager;
     int mCurrentIndex = 0;
     private long mCurrentPosition = 0;
     private PlaybackState mPlaybackState = PlaybackState.IDLE;
@@ -415,7 +415,7 @@ public class PlaybackController {
                 startSpinner();
 
                 // undo setting mSeekedPosition for liveTV
-                if (isLiveTv) { mSeekedPosition = -1;  }
+                if (isLiveTv) mSeekedPosition = -1;
 
                 //Build options for each player
                 VideoOptions vlcOptions = new VideoOptions();
@@ -1112,8 +1112,9 @@ public class PlaybackController {
                     if (mVideoManager.seekTo(position) < 0) {
                         Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
                         pause();
+                    } else {
+                        mPlaybackState = PlaybackState.PLAYING;
                     }
-                    else { mPlaybackState = PlaybackState.PLAYING; }
                     updateProgress = true;
                 }
             }


### PR DESCRIPTION
<!--
reworked playbackController position tracking and reporting system
-->

**Changes**
1) use tmp position value for seeking instead of modifying mCurrentPosition right away
2) new method for updating mCurrentPosition. This is called not only from progressListener, but from the audio and subtitle switching methods to make sure everything is synced
3) queries to playbackController for currentPosition will return seeked position if relevant
4) seekbar will hopefully be **extra** stable now. no more jumping from 0:00 to resume position
5) adjusted directplay seeking to prevent seekbar pos irregularities
6) startReportLoop calls stopReportLoop before starting. I saw a log where it looked like there were two instances running. This should prevent that.


**Issues**
playbackController would report wrong position during seeking and when initializing playback
seekbar starts at 0:00 then jumps to resume position during transcode
seekbar occasionally jumped around still during seeking
Hopeful fixes for #1260 and #1239

**Other notes**
I left the debug printouts in this one so people can test it and send logs
Based on the couple issues opened since 0.12.3, this is an attempt to reassess my approach to "fixing" transcoding seeking.