### PR TITLE
audioNowPlaying button state, queue state, and screensaver fixes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -354,6 +354,8 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 if (currentItem != mBaseItem) {
                     // new item started
                     loadItem();
+                    // immediately move the queue row to the current song
+                    // disable queue refresh in onProgress since the queue position is already set
                     if (mAudioQueuePresenter != null && mediaManager.getValue().hasAudioQueueItems()) {
                         mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
                         shouldRefreshQueue = false;
@@ -380,7 +382,8 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     updateButtons(mediaManager.getValue().isPlayingAudio());
                     if (shouldRefreshQueue && mediaManager.getValue().hasAudioQueueItems()) {
                         mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
-                        updateSSInfo();
+                        // start screensaver calls updateSSInfo so only subsequent items need this
+                        if (ssActive) updateSSInfo();
                         shouldRefreshQueue = false;
                     }
                 }
@@ -573,6 +576,8 @@ public class AudioNowPlayingActivity extends BaseActivity {
     protected void startScreenSaver() {
         if (ssActive) return;
         dismissPopup();
+        // update ss info since current item may not have ss info if screensaver opens too soon
+        updateSSInfo();
         mArtistName.setAlpha(.3f);
         mGenreRow.setVisibility(View.INVISIBLE);
         mClock.setAlpha(.3f);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -580,7 +580,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
         ObjectAnimator fadeIn = ObjectAnimator.ofFloat(mScrollView, "alpha", 0f, 1f);
         fadeIn.setDuration(1000);
         fadeIn.start();
-
+        lastUserInteraction = System.currentTimeMillis();
         ssActive = false;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -127,6 +127,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
 
         mPlayPauseButton = findViewById(R.id.playPauseBtn);
         mPlayPauseButton.setContentDescription(getString(R.string.lbl_pause));
+        mPlayPauseButton.setOnFocusChangeListener(mainAreaFocusListener);
         mPrevButton = findViewById(R.id.prevBtn);
         mPrevButton.setContentDescription(getString(R.string.lbl_prev_item));
         mPrevButton.setOnClickListener(new View.OnClickListener() {
@@ -245,8 +246,12 @@ public class AudioNowPlayingActivity extends BaseActivity {
             @Override
             public void run() {
                 updateButtons(mediaManager.getValue().isPlayingAudio());
+                if (mediaManager.getValue().hasAudioQueueItems()) {
+                    //also re-position queue to current in case they scrolled around
+                    mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
+                }
             }
-        }, 1500);
+        }, 1000);
     }
 
     @Override
@@ -336,7 +341,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     public void run() {
                         updateButtons(mediaManager.getValue().isPlayingAudio());
                     }
-                }, 1500);
+                }, 1000);
             } else {
                 finish(); // entire queue removed nothing to do here
             }
@@ -356,8 +361,10 @@ public class AudioNowPlayingActivity extends BaseActivity {
 
             //scroll so entire main area is in view
             mScrollView.smoothScrollTo(0, 0);
-            //also re-position queue to current in case they scrolled around
-            mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
+            if (mediaManager.getValue().hasAudioQueueItems()) {
+                //also re-position queue to current in case they scrolled around
+                mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
+            }
         }
     };
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -346,7 +346,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     isNewItem = true;
                 }
                 // skip update since button handler will trigger it
-                queueNowplayingUIUpdate(ssActive ? 750 : 0, ssActive || isNewItem ? true : false);
+                queueNowplayingUIUpdate(250, ssActive || isNewItem ? true : false);
             } else if (newState == PlaybackController.PlaybackState.PAUSED || newState == PlaybackController.PlaybackState.IDLE) {
                 // skip update since button handler will trigger it
                 if (!ssActive) updateButtons(false);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -246,7 +246,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
             public void run() {
                 updateButtons(mediaManager.getValue().isPlayingAudio());
             }
-        }, 750);
+        }, 1500);
     }
 
     @Override
@@ -330,7 +330,13 @@ public class AudioNowPlayingActivity extends BaseActivity {
         public void onQueueStatusChanged(boolean hasQueue) {
             if (hasQueue) {
                 loadItem();
-                updateButtons(mediaManager.getValue().isPlayingAudio());
+                //Make sure our initial button state reflects playback properly accounting for late loading of the audio stream
+                mLoopHandler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        updateButtons(mediaManager.getValue().isPlayingAudio());
+                    }
+                }, 1500);
             } else {
                 finish(); // entire queue removed nothing to do here
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -283,8 +283,13 @@ public class AudioNowPlayingActivity extends BaseActivity {
         super.onResume();
         loadItem();
         rotateBackdrops();
-        // refresh as soon as the audioEventListener is active
-        queueNowplayingUIUpdate(500,true);
+        if (!mediaManager.getValue().getIsAudioInitialized()) {
+            Timber.d("audio player not initialized - setting buttons to state: not playing");
+            updateButtons(false);
+        } else {
+            // refresh as soon as the audioEventListener is active
+            queueNowplayingUIUpdate(500,true);
+        }
         //link events
         mediaManager.getValue().addAudioEventListener(audioEventListener);
     }
@@ -361,6 +366,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                         shouldRefreshQueue = false;
                     }
                 }
+                // if audio player was recently null then playbackStateChange may be fired before all the button states are available
                 if (ssActive) {
                     queueNowplayingUIUpdate(500, true);
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -569,7 +569,9 @@ public class AudioNowPlayingActivity extends BaseActivity {
         mScrollView.setAlpha(1f);
         ssActive = false;
         setCurrentTime(mediaManager.getValue().getCurrentAudioPosition());
-
+        if (mediaManager.getValue().hasAudioQueueItems()) {
+            mPlayPauseButton.requestFocus();
+        }
     }
 
     protected void updateSSInfo() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -273,7 +273,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
         loadItem();
         rotateBackdrops();
         // refresh as soon as the audioEventListener is active
-        queueNowplayingUIUpdate(0,true);
+        queueNowplayingUIUpdate(500,true);
         //link events
         mediaManager.getValue().addAudioEventListener(audioEventListener);
     }
@@ -345,8 +345,11 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     loadItem();
                     isNewItem = true;
                 }
-                // skip update since button handler will trigger it
-                queueNowplayingUIUpdate(250, ssActive || isNewItem ? true : false);
+                if (ssActive) {
+                    queueNowplayingUIUpdate(500, true);
+                } else {
+                    updateButtons(true);
+                }
             } else if (newState == PlaybackController.PlaybackState.PAUSED || newState == PlaybackController.PlaybackState.IDLE) {
                 // skip update since button handler will trigger it
                 if (!ssActive) updateButtons(false);
@@ -563,17 +566,22 @@ public class AudioNowPlayingActivity extends BaseActivity {
 
     protected void stopScreenSaver() {
         if (!ssActive) return;
-        mLogoImage.setVisibility(View.GONE);
-        mSSArea.setAlpha(0f);
-        mArtistName.setAlpha(1f);
-        mGenreRow.setVisibility(View.VISIBLE);
-        mClock.setAlpha(1f);
-        mScrollView.setAlpha(1f);
-        ssActive = false;
-        setCurrentTime(mediaManager.getValue().getCurrentAudioPosition());
         if (mediaManager.getValue().hasAudioQueueItems()) {
             mPlayPauseButton.requestFocus();
         }
+        mLogoImage.setVisibility(View.GONE);
+        mArtistName.setAlpha(1f);
+        mGenreRow.setVisibility(View.VISIBLE);
+        mClock.setAlpha(1f);
+        setCurrentTime(mediaManager.getValue().getCurrentAudioPosition());
+        ObjectAnimator fadeOut = ObjectAnimator.ofFloat(mSSArea, "alpha", 1f, 0f);
+        fadeOut.setDuration(1000);
+        fadeOut.start();
+        ObjectAnimator fadeIn = ObjectAnimator.ofFloat(mScrollView, "alpha", 0f, 1f);
+        fadeIn.setDuration(1000);
+        fadeIn.start();
+
+        ssActive = false;
     }
 
     protected void updateSSInfo() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -141,6 +141,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 } else {
                     mediaManager.getValue().prevAudioItem();
                 }
+                lastUserInteraction = System.currentTimeMillis();
             }
         });
         mPrevButton.setOnFocusChangeListener(mainAreaFocusListener);
@@ -154,6 +155,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 } else {
                     mediaManager.getValue().nextAudioItem();
                 }
+                lastUserInteraction = System.currentTimeMillis();
             }
         });
         mNextButton.setOnFocusChangeListener(mainAreaFocusListener);
@@ -168,6 +170,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     mediaManager.getValue().toggleRepeat();
                     updateButtons(mediaManager.getValue().isPlayingAudio());
                 }
+                lastUserInteraction = System.currentTimeMillis();
             }
         });
         mSaveButton = findViewById(R.id.saveBtn);
@@ -180,6 +183,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 } else {
                     mediaManager.getValue().saveAudioQueue(mActivity);
                 }
+                lastUserInteraction = System.currentTimeMillis();
             }
         });
         mRepeatButton.setOnFocusChangeListener(mainAreaFocusListener);
@@ -193,6 +197,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 } else {
                     mediaManager.getValue().shuffleAudioQueue();
                 }
+                lastUserInteraction = System.currentTimeMillis();
             }
         });
         mShuffleButton.setOnFocusChangeListener(mainAreaFocusListener);
@@ -203,6 +208,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
             public void onClick(View v) {
                 if (ssActive) {
                     stopScreenSaver();
+                    lastUserInteraction = System.currentTimeMillis();
                 } else {
                     Intent album = new Intent(mActivity, ItemListActivity.class);
                     album.putExtra("ItemId", mBaseItem.getAlbumId());
@@ -218,6 +224,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
             public void onClick(View v) {
                 if (ssActive) {
                     stopScreenSaver();
+                    lastUserInteraction = System.currentTimeMillis();
                 } else if (mBaseItem.getAlbumArtists() != null && mBaseItem.getAlbumArtists().size() > 0) {
                     Intent artist = new Intent(mActivity, FullDetailsActivity.class);
                     artist.putExtra("ItemId", mBaseItem.getAlbumArtists().get(0).getId());
@@ -241,6 +248,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                         mediaManager.getValue().pauseAudio();
                     else mediaManager.getValue().resumeAudio();
                 }
+                lastUserInteraction = System.currentTimeMillis();
             }
         });
 
@@ -443,7 +451,6 @@ public class AudioNowPlayingActivity extends BaseActivity {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                Timber.d("updating buttons");
                 mPoster.setKeepScreenOn(playing);
                 if (!playing) {
                     mPlayPauseButton.setImageResource(R.drawable.ic_play);
@@ -505,6 +512,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
             if (!(item instanceof BaseRowItem)) return;
             if (ssActive) {
                 stopScreenSaver();
+                lastUserInteraction = System.currentTimeMillis();
             } else {
                 KeyProcessor.HandleKey(KeyEvent.KEYCODE_MENU, (BaseRowItem) item, mActivity);
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -356,6 +356,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     loadItem();
                     if (mAudioQueuePresenter != null && mediaManager.getValue().hasAudioQueueItems()) {
                         mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
+                        shouldRefreshQueue = false;
                     }
                 }
                 if (ssActive) {
@@ -390,7 +391,6 @@ public class AudioNowPlayingActivity extends BaseActivity {
         public void onQueueStatusChanged(boolean hasQueue) {
             if (hasQueue) {
                 loadItem();
-                shouldRefreshQueue = true;
             } else {
                 finish(); // entire queue removed nothing to do here
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -439,6 +439,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
     }
 
     private void updateButtons(final boolean playing) {
+        lastUIRefresh = System.currentTimeMillis();
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -460,7 +461,6 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     mAlbumButton.setEnabled(mBaseItem.getAlbumId() != null);
                     mArtistButton.setEnabled(mBaseItem.getAlbumArtists() != null && mBaseItem.getAlbumArtists().size() > 0);
                 }
-                lastUIRefresh = System.currentTimeMillis();
             }
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -351,11 +351,12 @@ public class AudioNowPlayingActivity extends BaseActivity {
         public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {
             Timber.d("**** Got playstate change: %s", newState.toString());
             if (newState == PlaybackController.PlaybackState.PLAYING) {
-                boolean isNewItem = false;
                 if (currentItem != mBaseItem) {
                     // new item started
                     loadItem();
-                    isNewItem = true;
+                    if (mAudioQueuePresenter != null && mediaManager.getValue().hasAudioQueueItems()) {
+                        mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
+                    }
                 }
                 if (ssActive) {
                     queueNowplayingUIUpdate(500, true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -339,12 +339,14 @@ public class AudioNowPlayingActivity extends BaseActivity {
         public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {
             Timber.d("**** Got playstate change: %s", newState.toString());
             if (newState == PlaybackController.PlaybackState.PLAYING) {
+                boolean isNewItem = false;
                 if (currentItem != mBaseItem) {
                     // new item started
                     loadItem();
+                    isNewItem = true;
                 }
                 // skip update since button handler will trigger it
-                queueNowplayingUIUpdate(ssActive ? 750 : 0, ssActive || currentItem != mBaseItem ? true : false);
+                queueNowplayingUIUpdate(ssActive ? 750 : 0, ssActive || isNewItem ? true : false);
             } else if (newState == PlaybackController.PlaybackState.PAUSED || newState == PlaybackController.PlaybackState.IDLE) {
                 // skip update since button handler will trigger it
                 if (!ssActive) updateButtons(false);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -73,7 +73,7 @@ public class MediaManager {
     private VlcEventHandler mVlcHandler = new VlcEventHandler();
     private SimpleExoPlayer mExoPlayer;
     private AudioManager mAudioManager;
-    private boolean audioInitialized;
+    private boolean audioInitialized = false;
     private boolean nativeMode = false;
     private boolean videoQueueModified = false;
 
@@ -113,6 +113,10 @@ public class MediaManager {
 
     public boolean toggleRepeat() { mRepeat = !mRepeat; return mRepeat; }
     public boolean isRepeatMode() { return mRepeat; }
+
+    public boolean getIsAudioInitialized() {
+        return audioInitialized;
+    }
 
     public ItemRowAdapter getCurrentAudioQueue() { return mCurrentAudioQueue; }
     public ItemRowAdapter getManagedAudioQueue() {
@@ -165,10 +169,15 @@ public class MediaManager {
     }
 
     private boolean isPaused() {
-        return nativeMode ? !mExoPlayer.isPlaying() : !mVlcPlayer.isPlaying();
+        // report true if player is null - reporting paused is better than reporting playing if the playing isn't playing
+        return nativeMode ? (mExoPlayer != null ? !mExoPlayer.isPlaying() : true) : (mVlcPlayer != null ? !mVlcPlayer.isPlaying() : true);
     }
 
     private void reportProgress() {
+        if (mCurrentAudioItem == null || !getIsAudioInitialized()) {
+            stopProgressLoop();
+            return;
+        }
         //Don't need to be too aggressive with these calls - just be sure every second
         if (System.currentTimeMillis() < lastProgressEvent + 750) return;
         lastProgressEvent = System.currentTimeMillis();
@@ -184,14 +193,14 @@ public class MediaManager {
         if (System.currentTimeMillis() > lastProgressReport + 5000) {
 
             // FIXME: Don't use the getApplication method..
-            PlaybackController playbackController = TvApp.getApplication().getPlaybackController();
-            ReportingHelper.reportProgress(playbackController, mCurrentAudioItem, mCurrentAudioStreamInfo, mCurrentAudioPosition*10000, isPaused());
+            ReportingHelper.reportProgress(null, mCurrentAudioItem, mCurrentAudioStreamInfo, mCurrentAudioPosition*10000, isPaused());
             lastProgressReport = System.currentTimeMillis();
         }
 
     }
 
     private void onComplete() {
+        stopProgressLoop();
         ReportingHelper.reportStopped(mCurrentAudioItem, mCurrentAudioStreamInfo, mCurrentAudioPosition);
         if (hasNextAudioItem()) {
             nextAudioItem();
@@ -207,11 +216,27 @@ public class MediaManager {
 
     }
 
+    private void releasePlayer() {
+        if (mVlcPlayer != null) {
+            mVlcPlayer.setEventListener(null);
+            mVlcPlayer.release();
+            mLibVLC.release();
+            mLibVLC = null;
+            mVlcPlayer = null;
+        }
+        if (mExoPlayer != null) {
+            mExoPlayer.release();
+            mExoPlayer = null;
+        }
+        audioInitialized = false;
+    }
+
     private boolean createPlayer(int buffer) {
         try {
 
             // Create a new media player based on platform
             if (DeviceUtils.is60()) {
+                Timber.i("creating audio player using: exoplayer");
                 nativeMode = true;
                 mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication()).build();
                 mExoPlayer.addListener(new Player.EventListener() {
@@ -222,6 +247,8 @@ public class MediaManager {
                         } else if (playbackState == Player.STATE_ENDED) {
                             onComplete();
                             stopProgressLoop();
+                        } else if (playbackState == Player.STATE_IDLE) {
+                            stopProgressLoop();
                         }
                     }
 
@@ -231,6 +258,7 @@ public class MediaManager {
                     }
                 });
             } else {
+                Timber.i("creating audio player using: libVLC");
                 ArrayList<String> options = new ArrayList<>(20);
                 options.add("--network-caching=" + buffer);
                 options.add("--no-audio-time-stretch");
@@ -246,11 +274,20 @@ public class MediaManager {
                     mVlcPlayer.setAudioOutputDevice("hdmi");
                 }
 
+                mVlcHandler.setOnPreparedListener(new PlaybackListener() {
+                    @Override
+                    public void onEvent() {
+                        Timber.i("libVLC onPrepared - starting progress loop");
+                        startProgressLoop();
+                    }
+                });
 
                 mVlcHandler.setOnProgressListener(new PlaybackListener() {
                     @Override
                     public void onEvent() {
-                        reportProgress();
+                        if (!isPlayingAudio()) {
+                            stopProgressLoop();
+                        }
                     }
                 });
 
@@ -264,7 +301,6 @@ public class MediaManager {
                 mVlcPlayer.setEventListener(mVlcHandler);
 
             }
-
         } catch (Exception e) {
             Timber.e(e, "Error creating VLC player");
             Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_video_playback_error));
@@ -277,6 +313,8 @@ public class MediaManager {
     private Runnable progressLoop;
     private Handler mHandler = new Handler(Looper.getMainLooper());
     private void startProgressLoop() {
+        stopProgressLoop();
+        Timber.i("starting progress loop");
         progressLoop = new Runnable() {
             @Override
             public void run() {
@@ -289,7 +327,9 @@ public class MediaManager {
 
     private void stopProgressLoop() {
         if (progressLoop != null) {
+            Timber.i("stopping progress loop");
             mHandler.removeCallbacks(progressLoop);
+            progressLoop = null;
         }
     }
 
@@ -710,22 +750,25 @@ public class MediaManager {
     }
 
     private void stop() {
+        if (!getIsAudioInitialized()) return ;
         if (nativeMode) mExoPlayer.stop(true);
         else mVlcPlayer.stop();
     }
 
     public void stopAudio() {
-        if (mCurrentAudioItem != null && isPlayingAudio()) {
+        if (mCurrentAudioItem != null) {
             stop();
             updateCurrentAudioItemPlaying(false);
             ReportingHelper.reportStopped(mCurrentAudioItem, mCurrentAudioStreamInfo, mCurrentAudioPosition*10000);
             for (AudioEventListener listener : mAudioEventListeners) {
                 listener.onPlaybackStateChange(PlaybackController.PlaybackState.IDLE, mCurrentAudioItem);
             }
+            releasePlayer();
         }
     }
 
     private void pause() {
+        if (!getIsAudioInitialized()) return;
         if (nativeMode) mExoPlayer.setPlayWhenReady(false);
         else mVlcPlayer.pause();
     }
@@ -743,7 +786,7 @@ public class MediaManager {
     }
 
     public void resumeAudio() {
-        if (mCurrentAudioItem != null) {
+        if (mCurrentAudioItem != null && getIsAudioInitialized()) {
             ensureAudioFocus();
             if (nativeMode) mExoPlayer.setPlayWhenReady(true);
             else mVlcPlayer.play();
@@ -754,7 +797,7 @@ public class MediaManager {
             }
         } else if (hasAudioQueueItems()) {
             //play from start
-            playInternal(((BaseRowItem)mCurrentAudioQueue.get(0)).getBaseItem(), 0);
+            playInternal(mCurrentAudioItem != null ? mCurrentAudioItem : ((BaseRowItem)mCurrentAudioQueue.get(0)).getBaseItem(), mCurrentAudioItem != null ? mCurrentAudioQueuePosition : 0);
         }
     }
 
@@ -767,6 +810,7 @@ public class MediaManager {
     }
 
     public BaseRowItem getCurrentMediaItem() { return getMediaItem(mCurrentMediaPosition); }
+
     public BaseRowItem nextMedia() {
         if (hasNextMediaItem()) {
             mCurrentMediaPosition++;

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -221,7 +221,7 @@ public class KeyProcessor {
         return false;
     }
 
-    private static void createItemMenu(BaseRowItem rowItem, UserItemDataDto userData, Activity activity) {
+    public static PopupMenu createItemMenu(BaseRowItem rowItem, UserItemDataDto userData, Activity activity) {
         BaseItemDto item = rowItem.getBaseItem();
         PopupMenu menu = new PopupMenu(activity, activity.getCurrentFocus(), Gravity.END);
         int order = 0;
@@ -305,6 +305,7 @@ public class KeyProcessor {
 
         menu.setOnMenuItemClickListener(menuItemClickListener);
         menu.show();
+        return (menu);
     }
 
     private static void createPlayMenu(BaseItemDto item, boolean isFolder, boolean isMusic, Activity activity) {


### PR DESCRIPTION
<!--
Fixed audioNowPlaying playPause button state being incorrect
-->

**Changes**
* Use the player's onProgressListener to update the playPause button state after an event is caught. A slight negative side-effect of this change is that navigating into the activity when playback is paused shows the playPause button in the "playing" state briefly and then correctly changes. I think this is a fair trade-off to have the playPause button display correctly at all times.

* Fixed queue row not scrolling to selected song `onResume`

* Gave the `mPlayPauseButton` button the same `mainAreaFocusListener` as the other buttons in that row for consistency

* tweaked the screensaver activation timer so all user interactions would delay its opening

* Button presses while screen saver is active now close the screen saver when appropriate instead of activating buttons/behaving as if the screen saver wasn't active

* modified `KeyProcessor` so its method `createItemMenu` returns the created menu

* the popup menu opened by selecting an item from the queue will be dismissed by the screensaver activating or the queue changing

* playPause button is now focused when the screensaver is closed

**Issues**
* When playback first starts, `AudioNowPlayingActivity` catches `onResume` and `onQueueStatusChanged` before playback actually starts or has the ability to query `mediaManager`. Because of that, `isPlayingAudio()` is always false is that context. This is why the delay is needed when updating the `playPause` button state by checking `isPlaying()` in the `onResume` and `onQueueStatusChanged` methods

* When activity is resumed the queue would be positioned at the beginning

* the screensaver didn't prevent interactions with the buttons/items underneath it

* the popup menu from clicking on a queue item stayed open with the screen saver active

**To do for another time**
* fix focus on queue row not scrolling to the bottom of the view
* -done- fix nowPlaying "screen saver" not preventing interaction with the nowPlayingActivity UI
* fix performing "remove from queue" on currently playing song causing multiple subsequent songs to display the "playing" triangle icon