### PR TITLE
check for null currentUser in fullDetailActivity onResume

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -237,7 +237,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
         }
 
         //Update information that may have changed - delay slightly to allow changes to take on the server
-        if (dataRefreshService.getValue().getLastPlayback() > mLastUpdated.getTimeInMillis() && mBaseItem.getBaseItemType() != BaseItemType.MusicArtist) {
+        if (TvApp.getApplication().getCurrentUser() != null && dataRefreshService.getValue().getLastPlayback() > mLastUpdated.getTimeInMillis() && mBaseItem.getBaseItemType() != BaseItemType.MusicArtist) {
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
<!--
check for null currentUser in fullDetailActivity onResume
-->

**Changes**
check for null currentUser in fullDetailActivity onResume before referencing it

**Issues**
user reported a crash and the logs showed a null reference exceptionin fullDetailActivity
[crashonplayback.txt](https://github.com/jellyfin/jellyfin-androidtv/files/7586531/crashonplayback.txt)