### PR TITLE
fixed switching from playing music to playing video not stopping music report loop

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -169,6 +169,10 @@ public class MediaManager {
     }
 
     private void reportProgress() {
+        if (mCurrentAudioItem == null) {
+            stopProgressLoop();
+            return;
+        }
         //Don't need to be too aggressive with these calls - just be sure every second
         if (System.currentTimeMillis() < lastProgressEvent + 750) return;
         lastProgressEvent = System.currentTimeMillis();
@@ -715,13 +719,15 @@ public class MediaManager {
     }
 
     public void stopAudio() {
-        if (mCurrentAudioItem != null && isPlayingAudio()) {
+        if (mCurrentAudioItem != null) {
             stop();
             updateCurrentAudioItemPlaying(false);
-            ReportingHelper.reportStopped(mCurrentAudioItem, mCurrentAudioStreamInfo, mCurrentAudioPosition*10000);
+            stopProgressLoop();
+            ReportingHelper.reportStopped(mCurrentAudioItem, mCurrentAudioStreamInfo, mCurrentAudioPosition * 10000);
             for (AudioEventListener listener : mAudioEventListeners) {
                 listener.onPlaybackStateChange(PlaybackController.PlaybackState.IDLE, mCurrentAudioItem);
             }
+            mCurrentAudioItem = null;
         }
     }
 


### PR DESCRIPTION
<!--
fixed switching from playing music to playing video not stopping music report loop
-->

**Changes**

* `mediaManager`'s `stopAudio()` stops the `ProgressLoop` and sets `mCurrentAudioItem` to `null` (even if audio is paused)

* `reportProgress()` in `mediaManager` returns if `mCurrentAudioItem` is `null`. This is needed since several even handlers in `mediaManager` call `reportProgress()` regardless of whether `ProgressLoop` is running.

* with `mCurrentAudioItem` set to `null`, the audio queue remains and audio playback can be restarted after video playback. This is because `resumeAudio()` calls `playInternal()` to rebuffer if `mCurrentAudioItem` is null

**Issues**
going from audio playing to playing a video kept the audio session reporting playback, which would show in the dashboard as flashing between the two sessions.
