### PR TITLE
allow setting the nextup timer duration to infinite

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -64,7 +64,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Next up timeout before playing next item
 		 * Stored in milliseconds
 		 */
-		var nextUpTimeout = Preference.int("next_up_timeout", 1000 * 7)
+		var nextUpTimeout = Preference.int("next_up_timeout", 1000 * 6)
 
 		/**
 		 * Duration in seconds to subtract from resume time

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -64,7 +64,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Next up timeout before playing next item
 		 * Stored in milliseconds
 		 */
-		var nextUpTimeout = Preference.int("next_up_timeout", 1000 * 6)
+		var nextUpTimeout = Preference.int("next_up_timeout", 1000 * 7)
 
 		/**
 		 * Duration in seconds to subtract from resume time

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/NextUpBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/NextUpBehavior.kt
@@ -23,4 +23,4 @@ enum class NextUpBehavior {
 	DISABLED
 }
 
-val NEXTUP_TIMER_DISABLED: Int = 0
+const val NEXTUP_TIMER_DISABLED: Int = 0

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/NextUpBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/NextUpBehavior.kt
@@ -22,3 +22,5 @@ enum class NextUpBehavior {
 	@EnumDisplayOptions(R.string.lbl_never)
 	DISABLED
 }
+
+val NEXTUP_TIMER_DISABLED: Int = 0

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -9,20 +9,20 @@ import android.widget.FrameLayout
 import android.widget.ProgressBar
 import androidx.appcompat.widget.AppCompatButton
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.preference.UserPreferences
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 
 class NextUpButtons(
 	context: Context,
 	attrs: AttributeSet? = null,
 	defStyleAttr: Int = 0,
 	defStyle: Int = 0
-) : FrameLayout(context, attrs, defStyleAttr, defStyle), KoinComponent {
+) : FrameLayout(context, attrs, defStyleAttr, defStyle) {
 	constructor(context: Context, attrs: AttributeSet) : this(context, attrs, 0, 0)
 
 	private var countdownTimer: CountDownTimer? = null
 	private val view = View.inflate(context, R.layout.fragment_next_up_buttons, null)
+
+	var countdownTimerEnabled: Boolean = true
+	var duration: Long = 6
 
 	init {
 		addView(view)
@@ -35,15 +35,13 @@ class NextUpButtons(
 		}
 	}
 
-	fun startTimer(): Boolean {
-		val duration = get<UserPreferences>()[UserPreferences.nextUpTimeout].toLong()
+	fun startTimer() {
 
 		// Cancel current timer if one is already set
 		countdownTimer?.cancel()
 
-		// value of 0 disables timer
-		if (duration == 0L) {
-			return false
+		if (!countdownTimerEnabled) {
+			return
 		}
 
 		// Create timer
@@ -60,7 +58,6 @@ class NextUpButtons(
 				view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next).performClick()
 			}
 		}.start()
-		return true
 	}
 
 	fun stopTimer() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -41,8 +41,8 @@ class NextUpButtons(
 		// Cancel current timer if one is already set
 		countdownTimer?.cancel()
 
-		// for some reason a timer duration of 0s == 100
-		if (duration == 100L) {
+		// value of 0 disables timer
+		if (duration == 0L) {
 			return false
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -21,8 +21,8 @@ class NextUpButtons(
 	private var countdownTimer: CountDownTimer? = null
 	private val view = View.inflate(context, R.layout.fragment_next_up_buttons, null)
 
-	var countdownTimerEnabled: Boolean = true
-	var duration: Long = 6
+	var countdownTimerEnabled: Boolean = false
+	var duration: Long = 0
 
 	init {
 		addView(view)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -40,9 +40,7 @@ class NextUpButtons(
 		// Cancel current timer if one is already set
 		countdownTimer?.cancel()
 
-		if (!countdownTimerEnabled) {
-			return
-		}
+		if (!countdownTimerEnabled) return
 
 		// Create timer
 		countdownTimer = object : CountDownTimer(duration, 1) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -35,11 +35,16 @@ class NextUpButtons(
 		}
 	}
 
-	fun startTimer() {
+	fun startTimer(): Boolean {
 		val duration = get<UserPreferences>()[UserPreferences.nextUpTimeout].toLong()
 
 		// Cancel current timer if one is already set
 		countdownTimer?.cancel()
+
+		// for some reason a timer duration of 0s == 100
+		if (duration == 100L) {
+			return false
+		}
 
 		// Create timer
 		countdownTimer = object : CountDownTimer(duration, 1) {
@@ -55,6 +60,7 @@ class NextUpButtons(
 				view.findViewById<AppCompatButton>(R.id.fragment_next_up_buttons_play_next).performClick()
 			}
 		}.start()
+		return true
 	}
 
 	fun stopTimer() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtons.kt
@@ -22,7 +22,7 @@ class NextUpButtons(
 	private val view = View.inflate(context, R.layout.fragment_next_up_buttons, null)
 
 	var countdownTimerEnabled: Boolean = false
-	var duration: Long = 0
+	var duration: Int = 0
 
 	init {
 		addView(view)
@@ -43,7 +43,7 @@ class NextUpButtons(
 		if (!countdownTimerEnabled) return
 
 		// Create timer
-		countdownTimer = object : CountDownTimer(duration, 1) {
+		countdownTimer = object : CountDownTimer(duration.toLong(), 1) {
 			override fun onTick(millisUntilFinished: Long) {
 				view.findViewById<ProgressBar>(R.id.fragment_next_up_buttons_play_next_progress).apply {
 					max = duration.toInt()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -42,9 +42,7 @@ class NextUpFragment : Fragment() {
 		super.onStart()
 
 		if (!timerStarted) {
-			binding.fragmentNextUpButtons.startTimer()
-
-			timerStarted = true
+			timerStarted = binding.fragmentNextUpButtons.startTimer()
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -8,15 +8,15 @@ import androidx.fragment.app.Fragment
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.databinding.FragmentNextUpBinding
 import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 
-class NextUpFragment : Fragment(), KoinComponent {
+class NextUpFragment : Fragment() {
 	private val viewModel: NextUpViewModel by sharedViewModel()
 	private lateinit var binding: FragmentNextUpBinding
 	private val backgroundService: BackgroundService by inject()
+	private val userPreferences: UserPreferences by inject()
 	private var timerStarted = false
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -34,9 +34,9 @@ class NextUpFragment : Fragment(), KoinComponent {
 		}
 
 		binding.fragmentNextUpButtons.apply {
-			duration = get<UserPreferences>()[UserPreferences.nextUpTimeout].toLong()
+			duration = userPreferences[UserPreferences.nextUpTimeout]
 			countdownTimerEnabled = when {
-				duration == 0L -> false
+				duration == NEXTUP_TIMER_DISABLED -> false
 				else -> true
 			}
 			setPlayNextListener(viewModel::playNext)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -35,10 +35,7 @@ class NextUpFragment : Fragment() {
 
 		binding.fragmentNextUpButtons.apply {
 			duration = userPreferences[UserPreferences.nextUpTimeout]
-			countdownTimerEnabled = when {
-				duration == NEXTUP_TIMER_DISABLED -> false
-				else -> true
-			}
+			countdownTimerEnabled = duration != NEXTUP_TIMER_DISABLED
 			setPlayNextListener(viewModel::playNext)
 			setCancelListener(viewModel::close)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -18,11 +18,9 @@ class NextUpFragment : Fragment(), KoinComponent {
 	private lateinit var binding: FragmentNextUpBinding
 	private val backgroundService: BackgroundService by inject()
 	private var timerStarted = false
-	private var duration = 0L;
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		binding = FragmentNextUpBinding.inflate(inflater, container, false)
-		duration = get<UserPreferences>()[UserPreferences.nextUpTimeout].toLong()
 
 		viewModel.item.observe(viewLifecycleOwner) { data ->
 			// No data, keep current

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -7,17 +7,22 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.databinding.FragmentNextUpBinding
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
 
-class NextUpFragment : Fragment() {
+class NextUpFragment : Fragment(), KoinComponent {
 	private val viewModel: NextUpViewModel by sharedViewModel()
 	private lateinit var binding: FragmentNextUpBinding
 	private val backgroundService: BackgroundService by inject()
 	private var timerStarted = false
+	private var duration = 0L;
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		binding = FragmentNextUpBinding.inflate(inflater, container, false)
+		duration = get<UserPreferences>()[UserPreferences.nextUpTimeout].toLong()
 
 		viewModel.item.observe(viewLifecycleOwner) { data ->
 			// No data, keep current
@@ -31,6 +36,11 @@ class NextUpFragment : Fragment() {
 		}
 
 		binding.fragmentNextUpButtons.apply {
+			duration = get<UserPreferences>()[UserPreferences.nextUpTimeout].toLong()
+			countdownTimerEnabled = when {
+				duration == 0L -> false
+				else -> true
+			}
 			setPlayNextListener(viewModel::playNext)
 			setCancelListener(viewModel::close)
 		}
@@ -42,7 +52,8 @@ class NextUpFragment : Fragment() {
 		super.onStart()
 
 		if (!timerStarted) {
-			timerStarted = binding.fragmentNextUpButtons.startTimer()
+			binding.fragmentNextUpButtons.startTimer()
+			timerStarted = true
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -50,6 +50,7 @@ fun OptionsScreen.playbackCategory(
 		depends { userPreferences[UserPreferences.mediaQueuingEnabled] }
 	}
 
+	// for some reason a timer duration of 0s == 100
 	seekbar {
 		setTitle(R.string.pref_next_up_timeout_title)
 		setContent(R.string.pref_next_up_timeout_summary)
@@ -57,7 +58,7 @@ fun OptionsScreen.playbackCategory(
 		max = 30000
 		increment = 1000
 		valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-			override fun display(value: Int) = "${value / 1000}s"
+			override fun display(value: Int) = if (value == 100) "∞" else "${value / 1000}s"
 		}
 		bind(userPreferences, UserPreferences.nextUpTimeout)
 		depends { userPreferences[UserPreferences.mediaQueuingEnabled]

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -55,9 +55,12 @@ fun OptionsScreen.playbackCategory(
 		setContent(R.string.pref_next_up_timeout_summary)
 		min = 0
 		max = 30000
-		increment = 1000
+		increment = 3000
 		valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-			override fun display(value: Int) = if (value == 0) "∞" else "${value / 1000}s"
+			override fun display(value: Int) = when {
+				value == 0 -> "∞" // disables the timer and displays infinity character
+				else -> "${value / 1000}s"
+			}
 		}
 		bind(userPreferences, UserPreferences.nextUpTimeout)
 		depends { userPreferences[UserPreferences.mediaQueuingEnabled]

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -50,15 +50,14 @@ fun OptionsScreen.playbackCategory(
 		depends { userPreferences[UserPreferences.mediaQueuingEnabled] }
 	}
 
-	// for some reason a timer duration of 0s == 100
 	seekbar {
 		setTitle(R.string.pref_next_up_timeout_title)
 		setContent(R.string.pref_next_up_timeout_summary)
-		min = 3000
+		min = 0
 		max = 30000
 		increment = 1000
 		valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-			override fun display(value: Int) = if (value == 100) "∞" else "${value / 1000}s"
+			override fun display(value: Int) = if (value == 0) "∞" else "${value / 1000}s"
 		}
 		bind(userPreferences, UserPreferences.nextUpTimeout)
 		depends { userPreferences[UserPreferences.mediaQueuingEnabled]

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/playback.kt
@@ -5,6 +5,7 @@ import android.app.AlertDialog
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AudioBehavior
+import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
@@ -53,12 +54,12 @@ fun OptionsScreen.playbackCategory(
 	seekbar {
 		setTitle(R.string.pref_next_up_timeout_title)
 		setContent(R.string.pref_next_up_timeout_summary)
-		min = 0
+		min = 0 // value of 0 disables timer
 		max = 30000
-		increment = 3000
+		increment = 1000
 		valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-			override fun display(value: Int) = when {
-				value == 0 -> "∞" // disables the timer and displays infinity character
+			override fun display(value: Int): String = when (value) {
+				NEXTUP_TIMER_DISABLED -> activity.getString(R.string.pref_next_up_timeout_disabled)
 				else -> "${value / 1000}s"
 			}
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
     <string name="pref_media_player">Preferred media player</string>
     <string name="pref_next_up_timeout_summary">How long to wait before playing the next item</string>
     <string name="pref_next_up_timeout_title">Next Up timer duration</string>
+    <string name="pref_next_up_timeout_disabled">∞</string>
     <string name="watch_now">Watch now</string>
     <string name="pref_next_up_behavior_title">Show next video info</string>
     <string name="pref_libvlc_audio_delay_title">Default Audio Delay for libVLC</string>


### PR DESCRIPTION
<!--
allow setting the nextup timer duration to infinite-->

**Changes**
* in the preferences display class 0s is displayed as the infinity character
* in `nextUpButtons` if the value of the timer is 0s it won't start the timer

![20211128_014643.jpg](https://user-images.githubusercontent.com/28824542/143763140-c821966e-decc-45fe-a4a1-70f3cb42d494.jpg)

**Issues**
https://features.jellyfin.org/posts/1383/next-up-episode-queue-without-autoplay

**Notes**
100 is the actual value used to check if the timer is 0s. I'm not sure where that comes from but 0s = 100, 1s = 1100, etc

If this is an acceptable implementation then it might be good to add a migration for users who have their timeout set to 0s, and change it to 1s