### PR TITLE
fixed audio repeat mode crash when going from first to last item

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -693,18 +693,16 @@ public class MediaManager {
             return mCurrentAudioQueuePosition;
         }
 
-        if ( !mRepeat && mCurrentAudioQueuePosition < 1) {
+        if (!mRepeat && mCurrentAudioQueuePosition < 1) {
             //nowhere to go
             return mCurrentAudioQueuePosition;
         }
 
-
-        stopAudio();
-        int ndx = mCurrentAudioQueuePosition - 1;
+        stopAudio(false);
+        int ndx = mCurrentAudioQueuePosition == 0 ? mCurrentAudioQueue.size() - 1 : mCurrentAudioQueuePosition - 1;
         if (mManagedAudioQueue != null) {
             mManagedAudioQueue.add(0, mCurrentAudioQueue.get(ndx));
         }
-        if (ndx < 0) ndx = mCurrentAudioQueue.size() - 1;
         playInternal(getPrevAudioItem(), ndx);
         return ndx;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -698,7 +698,7 @@ public class MediaManager {
             return mCurrentAudioQueuePosition;
         }
 
-        stopAudio(false);
+        stopAudio();
         int ndx = mCurrentAudioQueuePosition == 0 ? mCurrentAudioQueue.size() - 1 : mCurrentAudioQueuePosition - 1;
         if (mManagedAudioQueue != null) {
             mManagedAudioQueue.add(0, mCurrentAudioQueue.get(ndx));


### PR DESCRIPTION
<!--
fixed audio repeat mode crash when going from first to last item
-->

**Changes**
* in `prevAudioItem()` adjust `ndx` to accommodate for repeat mode **before** using `ndx` to modify `mManagedAudioQueue` -
to avoid attempting to `add()` at index `-1`

**Issues**
* in `prevAudioItem()`, an item is added to `mManagedAudioQueue` at index `ndx`. This is done prior to compensating for repeat mode, which would result in `ndx` == -1