### PR TITLE
fixed add artist to queue, added shuffle artist

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -830,9 +830,17 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     private void addItemToQueue() {
-        if (mBaseItem.getBaseItemType() == BaseItemType.Audio) {
-            mediaManager.getValue().addToAudioQueue(Arrays.asList(mBaseItem));
-
+        if (mBaseItem.getBaseItemType() == BaseItemType.Audio || mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum || mBaseItem.getBaseItemType() == BaseItemType.MusicArtist) {
+            if (mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum || mBaseItem.getBaseItemType() == BaseItemType.MusicArtist) {
+                PlaybackHelper.getItemsToPlay(mBaseItem, false, false, new Response<List<BaseItemDto>>() {
+                    @Override
+                    public void onResponse(List<BaseItemDto> response) {
+                        mediaManager.getValue().addToAudioQueue(response);
+                    }
+                });
+            } else {
+                mediaManager.getValue().addToAudioQueue(Arrays.asList(mBaseItem));
+            }
         } else {
             mediaManager.getValue().addToVideoQueue(mBaseItem);
         }
@@ -982,7 +990,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                     mDetailsOverviewRow.addAction(queueButton);
                 }
 
-                if (mBaseItem.getIsFolderItem()) {
+                if (mBaseItem.getIsFolderItem() || mBaseItem.getBaseItemType() == BaseItemType.MusicArtist) {
                     TextUnderButton shuffle = new TextUnderButton(this, R.drawable.ic_shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -133,7 +133,10 @@ public class PlaybackHelper {
                 query.setIsMissing(false);
                 query.setIsVirtualUnaired(false);
                 query.setMediaTypes(new String[]{"Audio"});
-                query.setSortBy(shuffle ? new String[] {ItemSortBy.Random} : mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.Album} : new String[] {ItemSortBy.SortName});
+                query.setSortBy(shuffle ?
+                        new String[] {ItemSortBy.Random} :
+                            mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.SortName,ItemSortBy.Album} :
+                                new String[] {ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(ITEM_QUERY_LIMIT);
                 query.setFields(new ItemFields[] {


### PR DESCRIPTION
<!--
fixed add artist to queue, added shuffle artist
-->

**Changes**
* added "add to queue" and "shuffle all" buttons to `fullDetailsActivity` for music artists
* updated `playbackHelper`'s artist query so all song by an artist can be played, arranged by album, and songs keep their order within the album

**Issues**
* `FullDetailsActivity.addItemToQueue()` would pass `mBaseItem` to `mediaManager` even when `mBaseItem` was a "parent" item like an artist or an album
(I added logic for albums just in case even though they arent handled here. There is logic elsewhere in `FullDetailsActivity` for `MusicAlbum` so I added it just to be safe)
