### PR TITLE
swap play for add to queue when an audio queue is present and viewing an album

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -535,6 +535,7 @@ public class ItemListActivity extends FragmentActivity {
 
     private void addButtons(int buttonSize) {
         if (BaseItemUtils.canPlay(mBaseItem)) {
+            // add play button but don't show and focus yet
             TextUnderButton play = new TextUnderButton(this, R.drawable.ic_play, buttonSize, 2, getString(mBaseItem.getIsFolderItem() ? R.string.lbl_play_all : R.string.lbl_play), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -547,7 +548,30 @@ public class ItemListActivity extends FragmentActivity {
             });
             play.setGotFocusListener(mainAreaFocusListener);
             mButtonRow.addView(play);
-            play.requestFocus();
+
+            boolean hidePlayButton = false;
+            TextUnderButton queueButton = null;
+            // add to queue if a queue exists and mBaseItem is a MusicAlbum
+            if (mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum && mediaManager.getValue().hasAudioQueueItems()) {
+                queueButton = new TextUnderButton(this, R.drawable.ic_add, buttonSize, 2, getString(R.string.lbl_add_to_queue), new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        mediaManager.getValue().addToAudioQueue(mItems);
+                    }
+                });
+                hidePlayButton = true;
+                mButtonRow.addView(queueButton);
+                queueButton.setGotFocusListener(mainAreaFocusListener);
+            }
+
+            // hide the play button and show add to queue if eligible
+            if (hidePlayButton) {
+                play.setVisibility(View.GONE);
+                queueButton.requestFocus();
+            } else {
+                play.requestFocus();
+            }
+
             if (mBaseItem.getIsFolderItem()) {
                 TextUnderButton shuffle = new TextUnderButton(this, R.drawable.ic_shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
                     @Override


### PR DESCRIPTION
<!--
swap play for add to queue when an audio queue is present and viewing an album-->

**Changes**
* gave `itemListActivity` an add to queue button for `MusicAlbum`s
* the add to queue button replaces play/play all only when a queue exists and viewing a `MusicAlbum`, and is otherwise hidden

**Notes**
The reason for swapping the buttons is the limit of 5 buttons to a row. A "show more" button could be used instead, like in fullDetailsActivity

It's debatable whether replacing play with add to queue is a good UX choice.
An album can still easily be played by playing the first song.
Gelli for instance doesn't have a "play/play all" button and you just tap on the song