### PR TITLE
audio play from here doesnt discard the preceding items in its parent

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -289,7 +289,7 @@ public class ItemListActivity extends FragmentActivity {
         playFromHere.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                play(mItems.subList(row.getIndex(), mItems.size()));
+                play(mItems, row.getIndex());
                 return true;
             }
         });
@@ -511,6 +511,10 @@ public class ItemListActivity extends FragmentActivity {
     }
 
     private void play(List<BaseItemDto> items) {
+        play(items, 0);
+    }
+
+    private void play(List<BaseItemDto> items, int ndx) {
         PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
         if (playbackLauncher.interceptPlayRequest(this, items.size() > 0 ? items.get(0) : null)) return;
 
@@ -527,7 +531,7 @@ public class ItemListActivity extends FragmentActivity {
             startActivity(intent);
 
         } else {
-            mediaManager.getValue().playNow(items);
+            mediaManager.getValue().playNow(items, ndx);
 
         }
 


### PR DESCRIPTION
<!--
audio play from doesnt discard the preceding items in its parent
-->

**Changes**
* `ItemListActivity`'s `play()` takes a queue index for starting playback (for audio only right now)
* `play()` has an overload that excludes the index

**Issues**
`play from here`, in the dropdown menu, would create an audio queue only containing the selected item and all subsequent items, and discard the preceding ones.

Using an album as an example, it was impossible to have a full album in the queue and start playback from a specific song without using play all -> changing the song in the now playing activity
