### PR TITLE
prevent unwanted interactions when music player screensaver active

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -102,7 +102,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
 
-    private PopupMenu mPopupMenu;
+    private PopupMenu popupMenu;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -510,7 +510,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
             if (ssActive) {
                 stopScreenSaver();
             } else {
-                mPopupMenu =  KeyProcessor.createItemMenu((BaseRowItem) item, ((BaseRowItem) item).getBaseItem().getUserData(), mActivity);
+                popupMenu = KeyProcessor.createItemMenu((BaseRowItem) item, ((BaseRowItem) item).getBaseItem().getUserData(), mActivity);
             }
         }
     }
@@ -553,9 +553,9 @@ public class AudioNowPlayingActivity extends BaseActivity {
     }
 
     private void dismissPopup() {
-        if (mPopupMenu != null) {
-            mPopupMenu.dismiss();
-            mPopupMenu = null;
+        if (popupMenu != null) {
+            popupMenu.dismiss();
+            popupMenu = null;
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -221,7 +221,6 @@ public class KeyProcessor {
         return false;
     }
 
-    // return the created PopupMenu so that the caller can dismiss it if needed
     public static PopupMenu createItemMenu(BaseRowItem rowItem, UserItemDataDto userData, Activity activity) {
         BaseItemDto item = rowItem.getBaseItem();
         PopupMenu menu = new PopupMenu(activity, activity.getCurrentFocus(), Gravity.END);

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -306,7 +306,7 @@ public class KeyProcessor {
 
         menu.setOnMenuItemClickListener(menuItemClickListener);
         menu.show();
-        return (menu);
+        return menu;
     }
 
     private static void createPlayMenu(BaseItemDto item, boolean isFolder, boolean isMusic, Activity activity) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -221,7 +221,8 @@ public class KeyProcessor {
         return false;
     }
 
-    private static void createItemMenu(BaseRowItem rowItem, UserItemDataDto userData, Activity activity) {
+    // return the created PopupMenu so that the caller can dismiss it if needed
+    public static PopupMenu createItemMenu(BaseRowItem rowItem, UserItemDataDto userData, Activity activity) {
         BaseItemDto item = rowItem.getBaseItem();
         PopupMenu menu = new PopupMenu(activity, activity.getCurrentFocus(), Gravity.END);
         int order = 0;
@@ -305,6 +306,7 @@ public class KeyProcessor {
 
         menu.setOnMenuItemClickListener(menuItemClickListener);
         menu.show();
+        return (menu);
     }
 
     private static void createPlayMenu(BaseItemDto item, boolean isFolder, boolean isMusic, Activity activity) {


### PR DESCRIPTION
<!--
prevent unwanted interactions with screensaver active
-->

**Changes**
* made `KeyProcessor.createItemMenu()` public so it can be called directly, and it now returns the created menu so the caller can dismiss it
* if the created item menu is open during various events it's closed (screensaver starting, queue replaced)
* added checks for all interactive objects to account for the screensaver being active
* updated the animation for the screensaver to make the fade in and out look the same
* play/pause button gains focus when the screensaver is stopped for user convenience

**Issues**
* the screensaver being active didn't prevent interactions with objects like the buttons or the queue items
* the dropdown menu opened by clicking on a queue item would stay open if the screensaver starts and after a queue replace (which could result in the clicked item no longer being in the queue)
