### PR TITLE
bring firetv controls in line with the new player controls

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -569,7 +569,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                     }
 
                     if (!mIsVisible) {
-                        if (!DeviceUtils.isFireTv() && !mPlaybackController.isLiveTv()) {
+                        if (!mPlaybackController.isLiveTv()) {
                             if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                                 mIsVisible = true;
                                 setFadingEnabled(true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -104,7 +104,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
     }
 
     boolean canSeek() {
-        return !DeviceUtils.isFireTv() && playbackController.canSeek();
+        return playbackController.canSeek();
     }
 
     boolean isLiveTv() {


### PR DESCRIPTION
<!--
bring firetv controls in line with the new player controls
-->

**Changes**
* during playback with the overlay hidden, d-pad left/right should reveal the overlay, typically used to begin scrobbling the seekbar. I removed a check that would disable this behavior on fire tv devices
* `videoPlayerAdapter` would always return false on firetv when `canSeek()` is called (this is used by various objects like the seekbar and control glue to allow/disallow seeking & seekbar interaction)

**Issues**
https://www.reddit.com/r/jellyfin/comments/rfs766/comment/hogi4ih/?utm_source=share&utm_medium=web2x&context=3