### PR TITLE
fixed a regression in player prepare

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -309,9 +309,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             try {
                 DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(TvApp.getApplication(), "ATV/ExoPlayer");
 
-                // reset position and state when changing video path so the player doesn't use the state and position from the prior media.
+                // reset position to the new videos default position
                 // exoplayer currently sees transcode streams as live windows, a fix is needed.
-                mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(path)), true, true);
+                mExoPlayer.prepare(new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(Uri.parse(path)), true, false);
             } catch (IllegalStateException e) {
                 Timber.e(e, "Unable to set video path.  Probably backing out.");
             }


### PR DESCRIPTION
<!--
fixed a regression in player prepare
-->

**Changes**
* fixed a regression I introduced: changed `resetState` to `false` in `exoplayer.prepare(media, resetPosition, resetState)`

**Issues**
*  With `resetState` = `true`, the player doesn't recover from a player error. Instead it will continuously error until the limit is reached.

**Notes**
* `exoplayer.prepare(media, resetPosition, resetState)` is deprecated. The new spec excludes `resetState`. Perhaps it's excluded because it causes problems

* I'm also testing a replacement for `prepare(mediaitem, resetpos, resetstate)` that instead uses `setmediasource(media, resetpos)`, and uses a `mediaItem.Factory()`