### PR TITLE
Emit JUnit output whilst running Gradle through CLI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,3 +23,20 @@ subprojects {
 		}
 	}
 }
+
+tasks.withType<Test> {
+	// Ensure Junit emits the full stack trace when a unit test fails through gradle
+	useJUnit()
+
+	testLogging {
+		events(
+			org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
+			org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_ERROR,
+			org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
+		)
+		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+		showExceptions = true
+		showCauses = true
+		showStackTraces = true
+	}
+}


### PR DESCRIPTION
**Changes**
Tweaks the gradle script to forward on test failures in a way that the
stack trace is preserved.

Previously, the stack pointed to a line after the test suite, e.g. line
101 on an 80 line file.

**To Test**
- Go to a test, e.g. `TimeUtilsTest` and change the expected output
- Run `gradlew test`, check the output points to the line changed 