### PR TITLE
Add Koin unit testing deps implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -145,4 +145,6 @@ dependencies {
 	// Testing
 	testImplementation(libs.junit)
 	testImplementation(libs.mockito)
+	testImplementation(libs.koin.test)
+	testImplementation(libs.koin.test.junit4)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,8 @@ android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref =
 # Testing
 junit = { module = "junit:junit", version.ref = "junit" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
 
 [bundles]
 acra = [


### PR DESCRIPTION
**Changes**
This allows Koin to do DI during unit tests and allows us to establish
Junit rules which involve Koin

This is essential for testing some classes as the playback code, where
DI is used heavily.

Prerequisite of #1302 