### PR TITLE
fixed nowplaying buttons not updating when playback starts

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -291,13 +291,9 @@ public class AudioNowPlayingActivity extends BaseActivity {
         lastUserInteraction = System.currentTimeMillis();
         //link events
         mediaManager.getValue().addAudioEventListener(audioEventListener);
-        //Make sure our initial button state reflects playback properly accounting for late loading of the audio stream
-        mLoopHandler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                updateButtons(mediaManager.getValue().isPlayingAudio());
-            }
-        }, 750);
+        if (mediaManager.getValue().getIsAudioPlayerInitialized()) {
+            updateButtons(mediaManager.getValue().isPlayingAudio());
+        }
     }
 
     @Override
@@ -380,9 +376,12 @@ public class AudioNowPlayingActivity extends BaseActivity {
 
         @Override
         public void onQueueStatusChanged(boolean hasQueue) {
+            Timber.d("Queue status changed");
             if (hasQueue) {
                 loadItem();
-                updateButtons(mediaManager.getValue().isPlayingAudio());
+                if (mediaManager.getValue().getIsAudioPlayerInitialized()) {
+                    updateButtons(mediaManager.getValue().isPlayingAudio());
+                }
             } else {
                 finish(); // entire queue removed nothing to do here
             }
@@ -452,6 +451,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
     }
 
     private void updateButtons(final boolean playing) {
+        Timber.d("Updating buttons");
         runOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -342,6 +342,10 @@ public class MediaManager {
     private void startProgressLoop() {
         stopProgressLoop();
         Timber.i("starting progress loop");
+        for (AudioEventListener listener : mAudioEventListeners) {
+            Timber.i("Firing playback state change listener for item: %s", mCurrentAudioItem.getName());
+            listener.onPlaybackStateChange(isPlayingAudio() ? PlaybackController.PlaybackState.PLAYING : PlaybackController.PlaybackState.PAUSED, mCurrentAudioItem);
+        }
         progressLoop = new Runnable() {
             @Override
             public void run() {
@@ -701,10 +705,6 @@ public class MediaManager {
                 dataRefreshService.setLastMusicPlayback(System.currentTimeMillis());
 
                 ReportingHelper.reportStart(item, mCurrentAudioPosition * 10000);
-                for (AudioEventListener listener : mAudioEventListeners) {
-                    Timber.i("Firing playback state change listener for item start. %s", mCurrentAudioItem.getName());
-                    listener.onPlaybackStateChange(PlaybackController.PlaybackState.PLAYING, mCurrentAudioItem);
-                }
             }
 
             @Override


### PR DESCRIPTION
**Changes**
* send `onPlaybackStateChange` to listeners in `startProgressLoop`, instead of in `playInternal`, so that the initial button update happens once the player is ready and can report accurate info

* replaced runnables with simple queries to `mediaManager`. It works well for me but perhaps situations exist that made the delays necessary. I will do some additional testing before marking this ready for review

**Issues**
When the first instance of music playback starts, the query to `mediaManager` for button states often happens too soon to get accurate info, and the play/pause button usually just shows the default state.
