### PR TITLE
fix crash in playFrom where queue is replaced but old queue item is referenced

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -608,6 +608,10 @@ public class MediaManager {
     }
 
     private void playNowInternal(List<BaseItemDto> items, int position) {
+        // stop current item before queue is cleared so it can still be referenced
+        if (isPlayingAudio()) {
+            stopAudio(false);
+        }
         clearUnShuffledQueue();
         createAudioQueue(items);
         if (!(position > 0 && playFrom(position))) {


### PR DESCRIPTION
**Changes**
* call `stopAudio` in `playNowInternal`, before replacing the queue, so that the logic in `stopAudio` doesn't index a now non-existent item.

**Issues**
* If music is playing from a queue of `n` size, particularly if playing the last item in the queue (index n - 1), and the user tries to start playback from another album/artist that would create of queue of `< n` size, `stopAudio` calling `updateCurrentAudioItemPlaying` attempts to access an index only valid in the old queue.

**Notes**
This is another example of correcting for edge cases before passing data to a method, which isn't ideal.
