### PR TITLE
Fix irregular playback overlay showing and hiding

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -555,14 +555,12 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                     if (!mPlaybackController.isLiveTv()) {
                         if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BUTTON_R1 || keyCode == KeyEvent.KEYCODE_BUTTON_R2) {
                             mPlaybackController.fastForward();
-                            if (!mIsVisible) show();
                             setFadingEnabled(true);
                             return true;
                         }
 
                         if (keyCode == KeyEvent.KEYCODE_MEDIA_REWIND || keyCode == KeyEvent.KEYCODE_BUTTON_L1 || keyCode == KeyEvent.KEYCODE_BUTTON_L2) {
                             mPlaybackController.rewind();
-                            if (!mIsVisible) show();
                             setFadingEnabled(true);
                             return true;
                         }
@@ -571,13 +569,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                     if (!mIsVisible) {
                         if (!mPlaybackController.isLiveTv()) {
                             if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
-                                mIsVisible = true;
                                 setFadingEnabled(true);
                                 return true;
                             }
 
                             if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
-                                mIsVisible = true;
                                 setFadingEnabled(true);
                                 return true;
                             }
@@ -661,11 +657,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             Timber.e("Unable to get audio focus");
             Utils.showToast(getActivity(), R.string.msg_cannot_play_time);
             return;
-        }
-
-        if (!mIsVisible) {
-            show(); // in case we were paused during video playback
-            setFadingEnabled(true);
         }
     }
 
@@ -1265,11 +1256,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Override
     public void setFadingEnabled(boolean value) {
         mFadeEnabled = value;
+        if (!mIsVisible) requireActivity().runOnUiThread(this::show);
         if (mFadeEnabled) {
-            if (mIsVisible) startFadeTimer();
+            startFadeTimer();
         } else {
             mHandler.removeCallbacks(mHideTask);
-            if (!mIsVisible) requireActivity().runOnUiThread(this::show);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -646,6 +646,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     }
 
     private void startFadeTimer() {
+        mFadeEnabled = true;
         mHandler.removeCallbacks(mHideTask);
         mHandler.postDelayed(mHideTask, 6000);
     }
@@ -701,7 +702,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     }
 
     private void hidePopupPanel() {
-        setFadingEnabled(true);
+        startFadeTimer();
         binding.popupArea.startAnimation(hidePopup);
         mPopupPanelVisible = false;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -367,6 +367,9 @@ public class PlaybackController {
 
                 // set mSeekedPosition so the seekbar will not default to 0:00
                 mSeekedPosition = position;
+                if (mFragment != null) {
+                    mFragment.setFadingEnabled(false);
+                }
 
                 BaseItemDto item = getCurrentlyPlayingItem();
 
@@ -467,7 +470,6 @@ public class PlaybackController {
                 mPlaybackState = PlaybackState.BUFFERING;
                 if (mFragment != null) {
                     mFragment.setPlayPauseActionState(0);
-                    mFragment.setFadingEnabled(true);
                     mFragment.setCurrentTime(position);
                 }
 
@@ -1216,6 +1218,8 @@ public class PlaybackController {
             public void onEvent() {
 
                 if (mPlaybackState == PlaybackState.BUFFERING) {
+                    if (mFragment != null) mFragment.setFadingEnabled(true);
+
                     mPlaybackState = PlaybackState.PLAYING;
                     mCurrentTranscodeStartTime = mCurrentStreamInfo.getPlayMethod() == PlayMethod.Transcode ? System.currentTimeMillis() : 0;
                     startReportLoop();


### PR DESCRIPTION
**Changes**

* `setFadingEnabled()` always shows the overlay if not already shown

* in ` hidePopupPanel()` call `startFadeTimer()` instead of `setFadingEnabled(true)` now that the latter shows the overlay (this might not be needed but I left it in for feedback)

* removed calls to `show()` before calls to `setFadingEnabled()` in a few places

* removed showing overlay and enabling fading on activity resume. This prevents the overlay from immediately starting a fade timer when playback starts, hiding the overlay before playback finishes buffering, and then showing it again once playback actually begins.
afaik there isnt a situation where video can be playing, and have pausing and then resuming the activity occur without stopping/pausing playback.

* in `playbackController` use `setFadingEnabled(false)` when playback starts so that the overlay shows until in `onPrepared` `setFadingEnabled(true)` is used to fade out the overlay now that playback has begun

**Intended behavior**
* When playback is initiated, the overlay will remain visible until playing starts, and fade out after that
* When buttons are pressed that show the controls overlay, both the controls row and the title & clock row will always show
* After seeking, the overlay will always fade out and the title & clock row will not sometimes get stuck on screen

**Issues**
* The overlay would show and hide twice when playback starts
* After seeking the title & clock overlay row would get stuck on screen, and a "back" button press was needed to make it fade out
* pressing pause/d-pad center would inconsistently show the title & clock overlay row along with the controls row
