### PR TITLE
reset player error count if playback stabilizes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -225,6 +225,13 @@ public class PlaybackController {
 
     public void playerErrorEncountered() {
         if (mVideoManager.isNativeMode()) exoErrorEncountered = true; else vlcErrorEncountered = true;
+
+        // reset the retry count if it's been more than 30s since previous error
+        if (playbackRetries > 0 && System.currentTimeMillis() - lastPlaybackError > 30000) {
+            Timber.d("playback stabilized - retry count reset to 0 from %s", playbackRetries);
+            playbackRetries = 0;
+        }
+
         playbackRetries++;
         lastPlaybackError = System.currentTimeMillis();
 
@@ -1283,12 +1290,6 @@ public class PlaybackController {
                         if (isLiveTv && mCurrentProgramEndTime > 0 && System.currentTimeMillis() >= mCurrentProgramEndTime) {
                             // crossed fire off an async routine to update the program info
                             updateTvProgramInfo();
-                        }
-
-                        // if no additional player errors occur within 30 seconds, reset the count
-                        if (playbackRetries > 0 && System.currentTimeMillis() - lastPlaybackError > 30000) {
-                            Timber.d("resetting playback errror count from %s to 0 because playback has become stable", playbackRetries);
-                            playbackRetries = 0;
                         }
 
                         refreshCurrentPosition();


### PR DESCRIPTION
**Changes**
* record the timestamp of the most recent error when it's caught
* in `OnProgressListener` check if more than 30 seconds has passed since the last player error, and reset the retry count if so

**Issues**
* users who experience repeated player errors that are recoverable would still have their stream stopped by the "too many errors, giving up" condition, despite the errors being recoverable.

**Expected behavior**
* Unrecoverable errors where the retries repeatedly fail in a short time will still end the session
* Repeated recoverable errors will not end the session until they either 1) happen too close to each other (within 30s) 2) the player does not recover within the 3 attempts allowed
