### PR TITLE
Fix app crash when opening photo albums

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -177,6 +177,13 @@ public class ItemLauncher {
 
                 // or generic handling
                 if (baseItem.getIsFolderItem()) {
+                    // Some items don't have a display preferences id, but it's required for StdGridFragment
+                    // Use the id of the item as a workaround, it's a unique key for the specific item
+                    // Which is exactly what we want
+                    if (baseItem.getDisplayPreferencesId() == null) {
+                        baseItem.setDisplayPreferencesId(baseItem.getId());
+                    }
+
                     Intent intent = new Intent(activity, GenericGridActivity.class);
                     intent.putExtra(Extras.Folder, KoinJavaComponent.<GsonJsonSerializer>get(GsonJsonSerializer.class).SerializeToString(baseItem));
                     if (noHistory) {


### PR DESCRIPTION
fix photo albums

**Changes**

- Use item id as display preferences key in ItemLauncher when opening items without a display preferences key
  - This fixes photo albums crashing the app
  - not sure if there's other item types with the same issue

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
