### PR TITLE
fixed some playback leaks

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -88,7 +88,7 @@ public class TvApiEventListener extends ApiEventListener {
                 else {
                     Activity currentActivity = TvApp.getApplication().getCurrentActivity();
                     if(playbackController != null && mediaManager.hasVideoQueueItems() && playbackController.hasInitializedVideoManager())
-                        mainThreadHandler.post(() -> playbackController.stop());
+                        mainThreadHandler.post(() -> playbackController.endPlayback());
                     if(currentActivity instanceof PlaybackOverlayActivity)
                         currentActivity.finish();
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -238,7 +238,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
         if (TvApp.getApplication().getPlaybackController() != null) {
             videoManager = new VideoManager(((PlaybackOverlayActivity) requireActivity()), view);
-            TvApp.getApplication().getPlaybackController().init(videoManager);
+            TvApp.getApplication().getPlaybackController().init(videoManager, this);
         }
     }
 
@@ -689,8 +689,12 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Override
     public void onStop() {
         super.onStop();
-
-        mPlaybackController.stop();
+        Timber.d("Stopping!");
+        mPlaybackController.endPlayback();
+        if (!requireActivity().isFinishing()) {
+            // in case the app is suspended/stopped, eg: by pressing the home button, end the playback session.
+            requireActivity().finish();
+        }
     }
 
     public void show() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -291,6 +291,7 @@ public class PlaybackController {
             Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.too_many_errors));
             mPlaybackState = PlaybackState.ERROR;
             endPlayback();
+            if (mFragment != null) mFragment.finish();
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -259,7 +259,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 Timber.e("Attempt to play before surface ready");
                 return;
             }
-
             if (!mVlcPlayer.isPlaying()) {
                 mVlcPlayer.play();
             }
@@ -334,8 +333,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 Timber.e(e, "Unable to set video path.  Probably backing out.");
             }
         } else {
-            mSurfaceHolder.setKeepScreenOn(true);
-
             mCurrentMedia = new Media(mLibVLC, Uri.parse(path));
             mCurrentMedia.parse();
             mVlcPlayer.setMedia(mCurrentMedia);
@@ -564,7 +561,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             mExoPlayer = null;
         }
         clearPlayerListeners();
-        mSurfaceView.setKeepScreenOn(false);
     }
 
     int normalWidth;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -252,7 +252,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 return;
             }
             mExoPlayer.setPlayWhenReady(true);
-            mExoPlayerView.setKeepScreenOn(true);
             normalWidth = mExoPlayerView.getLayoutParams().width;
             normalHeight = mExoPlayerView.getLayoutParams().height;
         } else {
@@ -270,20 +269,16 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     public void play() {
         if (nativeMode) {
             mExoPlayer.setPlayWhenReady(true);
-            mExoPlayerView.setKeepScreenOn(true);
         } else {
             mVlcPlayer.play();
-            mSurfaceView.setKeepScreenOn(true);
         }
     }
 
     public void pause() {
         if (nativeMode) {
             mExoPlayer.setPlayWhenReady(false);
-            mExoPlayerView.setKeepScreenOn(false);
         } else {
             mVlcPlayer.pause();
-            mSurfaceView.setKeepScreenOn(false);
         }
     }
 
@@ -498,6 +493,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     public void destroy() {
+        stopPlayback();
         releasePlayer();
     }
 
@@ -567,7 +563,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             mExoPlayer.release();
             mExoPlayer = null;
         }
-
+        clearPlayerListeners();
         mSurfaceView.setKeepScreenOn(false);
     }
 
@@ -706,10 +702,18 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         mVlcHandler.setOnProgressListener(listener);
     }
 
+    public void clearPlayerListeners() {
+        mVlcHandler.setOnErrorListener(null);
+        mVlcHandler.setOnCompletionListener(null);
+        mVlcHandler.setOnPreparedListener(null);
+        mVlcHandler.setOnProgressListener(null);
+    }
+
     private PlaybackListener progressListener;
     private Runnable progressLoop;
 
     private void startProgressLoop() {
+        stopProgressLoop();
         progressLoop = new Runnable() {
             @Override
             public void run() {

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:keepScreenOn="true">
 
     <FrameLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
**Changes**
* fixed leaks caused by the `runnable` report loop in `videomanager`

* clear references to `videomanager` and `overlay fragment` in `playbackcontroller` when playback ends

* disabled screensaver

* handle home button interrupting playback by ending the playback activity

**Validating fixes**
_Validated results with a heap dump_
* start playback and then end it by pressing back
* start playback and then end it by pressing "home" on the controller
* start playback and skip to the next or previous item

**Remaining leaks I found**
* stopping playback from the jellyfin remote
* the live tv player is full of leaks
* a leak in a `textClock` leftover from the playback session when nextup is shown

**Reproducing remaining leaks I found**
* start playback and skip to the end so nextup is shown
* start playback and stop it from another client using the jellyfin remote
* play live tv and then stop playback