### PR TITLE
Add opus as supported audio codec for ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -69,6 +69,7 @@ class ExoPlayerProfile(
 							CodecTypes.MP2,
 							CodecTypes.DCA,
 							CodecTypes.DTS,
+							CodecTypes.OPUS,
 						).joinToString(",")
 					}
 				})


### PR DESCRIPTION
Tested on Nvidia Shield Pro

**Changes**

- Add opus to ExoPlayer direct play profile when down mixing is disabled

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
