### PR TITLE
Add libraries link to customization preferences

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.androidtv.data.repository
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.liveData
+import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.userViewsApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+
+interface UserViewsRepository {
+	val views: LiveData<Collection<BaseItemDto>>
+}
+
+class UserViewsRepositoryImpl(
+	private val api: ApiClient,
+) : UserViewsRepository {
+	override val views: LiveData<Collection<BaseItemDto>> = liveData {
+		val views by api.userViewsApi.getUserViews()
+		val filteredViews = views.items
+			.orEmpty()
+			.filterNot { it.collectionType in ItemRowAdapter.ignoredCollectionTypes }
+		emit(filteredViews)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
@@ -2,13 +2,16 @@ package org.jellyfin.androidtv.data.repository
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.liveData
-import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
+import org.jellyfin.apiclient.model.entities.CollectionType
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 
 interface UserViewsRepository {
 	val views: LiveData<Collection<BaseItemDto>>
+
+	fun isSupported(collectionType: String): Boolean
+	fun allowViewSelection(collectionType: String): Boolean
 }
 
 class UserViewsRepositoryImpl(
@@ -18,7 +21,18 @@ class UserViewsRepositoryImpl(
 		val views by api.userViewsApi.getUserViews()
 		val filteredViews = views.items
 			.orEmpty()
-			.filterNot { it.collectionType in ItemRowAdapter.ignoredCollectionTypes }
+			.filter { isSupported(it.collectionType.orEmpty()) }
 		emit(filteredViews)
+	}
+
+	override fun isSupported(collectionType: String) = collectionType !in unsupportedCollectionTypes
+	override fun allowViewSelection(collectionType: String) = collectionType != CollectionType.Music
+
+	private companion object {
+		private val unsupportedCollectionTypes = arrayOf(
+			CollectionType.Books,
+			CollectionType.Games,
+			CollectionType.Folders
+		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -6,6 +6,8 @@ import org.jellyfin.androidtv.auth.ServerRepository
 import org.jellyfin.androidtv.auth.ServerRepositoryImpl
 import org.jellyfin.androidtv.data.eventhandling.TvApiEventListener
 import org.jellyfin.androidtv.data.model.DataRefreshService
+import org.jellyfin.androidtv.data.repository.UserViewsRepository
+import org.jellyfin.androidtv.data.repository.UserViewsRepositoryImpl
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
@@ -81,6 +83,7 @@ val appModule = module {
 	factory { WorkManager.getInstance(androidContext()) }
 
 	single<ServerRepository> { ServerRepositoryImpl(get(), get(), get(), get()) }
+	single<UserViewsRepository> { UserViewsRepositoryImpl(get(userApiClient)) }
 
 	viewModel { LoginViewModel(get(), get(), get()) }
 	viewModel { NextUpViewModel(get(), get(), get(), get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -16,9 +16,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.di.systemApiClient
 import org.jellyfin.androidtv.preference.UserPreferences
-import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.dp
@@ -59,6 +59,7 @@ class LeanbackChannelWorker(
 
 	private val api by inject<ApiClient>(systemApiClient)
 	private val userPreferences by inject<UserPreferences>()
+	private val userViewsRepository by inject<UserViewsRepository>()
 
 	/**
 	 * Check if the app can use Leanback features and is API level 26 or higher.
@@ -142,7 +143,7 @@ class LeanbackChannelWorker(
 		// Add new items
 		val items = response.items
 			.orEmpty()
-			.filterNot { it.collectionType in ItemRowAdapter.ignoredCollectionTypes }
+			.filter { userViewsRepository.isSupported(it.collectionType.orEmpty()) }
 			.map { item ->
 				val imageUri = if (item.imageTags?.contains(ImageType.PRIMARY) == true)
 					api.imageApi.getItemImageUrl(item.id, ImageType.PRIMARY).toUri()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -50,7 +50,6 @@ public class BrowseGridFragment extends StdGridFragment {
                     query.setRecursive(true);
                     break;
                 case "music":
-                    mAllowViewSelection = false;
                     //Special queries needed for album artists
                     String includeType = getActivity().getIntent().getStringExtra(Extras.IncludeType);
                     if ("AlbumArtist".equals(includeType)) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -34,6 +34,7 @@ import org.jellyfin.androidtv.constant.PosterSize;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.model.FilterOptions;
 import org.jellyfin.androidtv.data.querying.ViewQuery;
+import org.jellyfin.androidtv.data.repository.UserViewsRepository;
 import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.preference.LibraryPreferences;
 import org.jellyfin.androidtv.preference.PreferencesRepository;
@@ -85,10 +86,10 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
 
     private int mCardHeight = SMALL_CARD;
 
-    protected boolean mAllowViewSelection = true;
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
     private Lazy<PreferencesRepository> preferencesRepository = inject(PreferencesRepository.class);
+    private Lazy<UserViewsRepository> userViewsRepository = inject(UserViewsRepository.class);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -465,7 +466,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
                 settingsIntent.putExtra(PreferencesActivity.EXTRA_SCREEN, DisplayPreferencesScreen.class.getCanonicalName());
                 Bundle screenArgs = new Bundle();
                 screenArgs.putString(DisplayPreferencesScreen.ARG_PREFERENCES_ID, mFolder.getDisplayPreferencesId());
-                screenArgs.putBoolean(DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION, mAllowViewSelection);
+                screenArgs.putBoolean(DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION, userViewsRepository.getValue().allowViewSelection(mFolder.getCollectionType()));
                 settingsIntent.putExtra(PreferencesActivity.EXTRA_SCREEN_ARGS, screenArgs);
                 getActivity().startActivity(settingsIntent);
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsFragment.kt
@@ -55,10 +55,14 @@ abstract class OptionsFragment : LeanbackPreferenceFragmentCompat() {
 		preferenceScreen = screen.build(preferenceManager)
 	}
 
+	protected fun rebuild() {
+		screen.build(preferenceManager, preferenceScreen)
+	}
+
 	override fun onResume() {
 		super.onResume()
 
-		if (skippedInitialResume && rebuildOnResume) screen.build(preferenceManager, preferenceScreen)
+		if (skippedInitialResume && rebuildOnResume) rebuild()
 
 		skippedInitialResume = true
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -73,13 +73,12 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 				withFragment<HomePreferencesScreen>()
 			}
 
-			// TODO implement
-			// link {
-			// 	setTitle(R.string.libraries)
-			// 	setContent(R.string.libraries_description)
-			// 	icon = R.drawable.ic_grid
-			// 	withFragment<HomePreferencesScreen>()
-			// }
+			link {
+				setTitle(R.string.pref_libraries)
+				setContent(R.string.pref_libraries_description)
+				icon = R.drawable.ic_grid
+				withFragment<LibrariesPreferencesScreen>()
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
@@ -1,0 +1,38 @@
+package org.jellyfin.androidtv.ui.preference.screen
+
+import androidx.core.os.bundleOf
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.UserViewsRepository
+import org.jellyfin.androidtv.ui.browsing.DisplayPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.link
+import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.apiclient.model.entities.CollectionType
+import org.koin.android.ext.android.inject
+
+class LibrariesPreferencesScreen : OptionsFragment() {
+	private val userViewsRepository by inject<UserViewsRepository>()
+
+	override fun onStart() {
+		super.onStart()
+
+		userViewsRepository.views.observe(viewLifecycleOwner) { rebuild() }
+	}
+
+	override val screen by optionsScreen {
+		setTitle(R.string.pref_libraries)
+
+		category {
+			userViewsRepository.views.value.orEmpty().forEach {
+				link {
+					title = it.name
+					icon = R.drawable.ic_folder
+					withFragment<DisplayPreferencesScreen>(bundleOf(
+						DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to (it.collectionType != CollectionType.Music),
+						DisplayPreferencesScreen.ARG_PREFERENCES_ID to it.displayPreferencesId,
+					))
+				}
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
@@ -7,7 +7,6 @@ import org.jellyfin.androidtv.ui.browsing.DisplayPreferencesScreen
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
-import org.jellyfin.apiclient.model.entities.CollectionType
 import org.koin.android.ext.android.inject
 
 class LibrariesPreferencesScreen : OptionsFragment() {
@@ -24,11 +23,13 @@ class LibrariesPreferencesScreen : OptionsFragment() {
 
 		category {
 			userViewsRepository.views.value.orEmpty().forEach {
+				val allowViewSelection = userViewsRepository.allowViewSelection(it.collectionType.orEmpty())
+
 				link {
 					title = it.name
 					icon = R.drawable.ic_folder
 					withFragment<DisplayPreferencesScreen>(bundleOf(
-						DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to (it.collectionType != CollectionType.Music),
+						DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to allowViewSelection,
 						DisplayPreferencesScreen.ARG_PREFERENCES_ID to it.displayPreferencesId,
 					))
 				}


### PR DESCRIPTION
This is a shortcut to open the display preferences for user views

**Changes**

- Add "rebuild()" function to trigger a preferences screen rebuilding
  - Useful when data is asynchronously loaded
- Add "UserViewsRepository"
  - It's a layer between UI and API to get user view (library) specific things
- Add "LibrariesPreferencesScreen" to open display preference screens
- Move user view related logic to UserViewsRepository
  - The list of (un)supported collection types
  - The collection types that allow view selection

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
