### PR TITLE
fixed crash when closing the player - introduced by leaks PR

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -283,9 +283,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     public void stopPlayback() {
-        if (nativeMode) {
+        if (nativeMode && mExoPlayer != null) {
             mExoPlayer.stop();
-        } else {
+        } else if (mVlcPlayer != null) {
             mVlcPlayer.stop();
         }
         stopProgressLoop();


### PR DESCRIPTION
**Changes**
* protect `stopPlayback()` against null reference

**Issues**
* `destroy()` calls `stop()` just in case, and that causes a crash without the guard against the players being null
