### PR TITLE
Remove unused QueryType values

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.java
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.java
@@ -10,8 +10,6 @@ public enum QueryType {
     SimilarMovies,
     StaticPeople,
     StaticChapters,
-    StaticServers,
-    Users,
     Search,
     Specials,
     Trailers,

--- a/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.java
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.java
@@ -22,7 +22,6 @@ public enum QueryType {
     StaticAudioQueueItems,
     AlbumArtists,
     AudioPlaylists,
-    ContinueWatching,
     LatestItems,
     SeriesTimer,
     Premieres

--- a/app/src/main/java/org/jellyfin/androidtv/constant/ViewType.java
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/ViewType.java
@@ -1,6 +1,0 @@
-package org.jellyfin.androidtv.constant;
-
-public enum ViewType {
-    SMART,
-    GRID
-}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -67,8 +67,6 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 		// Update audio queue
 		Timber.i("Updating audio queue in HomeFragment (onResume)")
 		nowPlaying.update(mRowsAdapter)
-
-		if (helper.hasResumeRow(mRowsAdapter)) refreshRows()
 	}
 
 	override fun onQueueStatusChanged(hasQueue: Boolean) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -1,16 +1,12 @@
 package org.jellyfin.androidtv.ui.home
 
 import android.content.Context
-import androidx.leanback.widget.ArrayObjectAdapter
-import androidx.leanback.widget.ListRow
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.constant.ChangeTriggerType
-import org.jellyfin.androidtv.constant.QueryType
 import org.jellyfin.androidtv.data.querying.StdItemQuery
 import org.jellyfin.androidtv.data.querying.ViewQuery
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
-import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
 import org.jellyfin.apiclient.model.entities.LocationType
 import org.jellyfin.apiclient.model.entities.MediaType
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery
@@ -101,15 +97,6 @@ class HomeFragmentHelper(
 		}
 
 		return HomeFragmentBrowseRowDefRow(BrowseRowDef(context.getString(R.string.lbl_on_now), query))
-	}
-
-	fun hasResumeRow(rowsAdapter: ArrayObjectAdapter): Boolean {
-		for (i in 0 until rowsAdapter.size()) {
-			val adapter = (rowsAdapter[i] as? ListRow)?.adapter as? ItemRowAdapter
-			if (adapter?.queryType == QueryType.ContinueWatching) return true
-		}
-
-		return false
 	}
 
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -33,7 +33,6 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
-import org.jellyfin.apiclient.model.apiclient.ServerInfo;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -101,7 +100,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
     private Calendar lastFullRetrieve;
 
     private BaseItemPerson[] mPersons;
-    private ServerInfo[] mServers;
     private List<ChapterItemInfo> mChapters;
     private List<BaseItemDto> mItems;
 
@@ -264,13 +262,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         queryType = QueryType.StaticItems;
     }
 
-    public ItemRowAdapter(ServerInfo[] servers, Presenter presenter, ArrayObjectAdapter parent) {
-        super(presenter);
-        mParent = parent;
-        mServers = servers;
-        queryType = QueryType.StaticServers;
-    }
-
     public ItemRowAdapter(SpecialsQuery query, Presenter presenter, ArrayObjectAdapter parent) {
         super(presenter);
         mParent = parent;
@@ -370,12 +361,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         mParent = parent;
         queryType = QueryType.Views;
         staticHeight = true;
-    }
-
-    public ItemRowAdapter(Presenter presenter, ArrayObjectAdapter parent) {
-        super(presenter);
-        mParent = parent;
-        queryType = QueryType.Users;
     }
 
     public void setItemsLoaded(int itemsLoaded) {
@@ -662,9 +647,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
             case StaticPeople:
                 loadPeople();
                 break;
-            case StaticServers:
-                loadServers();
-                break;
             case StaticChapters:
                 loadChapters();
                 break;
@@ -679,9 +661,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                 break;
             case Trailers:
                 retrieve(mTrailersQuery);
-                break;
-            case Users:
-                retrieveUsers();
                 break;
             case Search:
                 retrieve(mSearchQuery);
@@ -702,35 +681,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                 retrieve(mSeriesTimerQuery);
                 break;
         }
-    }
-
-    private void retrieveUsers() {
-        final ItemRowAdapter adapter = this;
-        apiClient.getValue().GetPublicUsersAsync(new Response<UserDto[]>() {
-            @Override
-            public void onResponse(UserDto[] response) {
-                for (UserDto user : response) {
-                    adapter.add(new BaseRowItem(user));
-                }
-                totalItems = response.length;
-                setItemsLoaded(totalItems);
-                if (totalItems == 0) {
-                    removeRow();
-                }
-
-                notifyRetrieveFinished();
-            }
-
-            @Override
-            public void onError(Exception exception) {
-                Timber.e(exception, "Error retrieving users");
-                Utils.showToast(TvApp.getApplication(), exception.getLocalizedMessage());
-                removeRow();
-
-                notifyRetrieveFinished();
-            }
-        });
-
     }
 
     private void loadPeople() {
@@ -780,19 +730,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
             }
             itemsLoaded = i;
 
-        } else {
-            removeRow();
-        }
-
-        notifyRetrieveFinished();
-    }
-
-    private void loadServers() {
-        if (mServers != null) {
-            for (ServerInfo server : mServers) {
-                add(new BaseRowItem(server));
-            }
-            itemsLoaded = mServers.length;
         } else {
             removeRow();
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -674,9 +674,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
             case Premieres:
                 retrievePremieres(mQuery);
                 break;
-            case ContinueWatching:
-                retrieveContinueWatching(mQuery);
-                break;
             case SeriesTimer:
                 retrieve(mSeriesTimerQuery);
                 break;
@@ -932,17 +929,6 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         clear();
         add(new GridButton(EnhancedBrowseFragment.FAVSONGS, TvApp.getApplication().getString(R.string.lbl_favorites), R.drawable.favorites, null));
         itemsLoaded = 1;
-        retrieve(query);
-    }
-
-    private void retrieveContinueWatching(final ItemQuery query) {
-        //Add current video queue first if there
-        clear();
-        if (mediaManager.getValue().hasVideoQueueItems()) {
-            Timber.d("Adding video queue...");
-            add(new BaseRowItem(new GridButton(TvApp.VIDEO_QUEUE_OPTION_ID, TvApp.getApplication().getString(R.string.lbl_current_queue), R.drawable.tile_port_video_queue, null)));
-            itemsLoaded = 1;
-        }
         retrieve(query);
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Remove unused ViewType enum
- Remove unused StaticServers and Users QueryTypes
  - Unused since new login UI
- Remove unused ContinueWatching QueryType 
  - Never used
  - Continue watching in the home screen uses a different type (probably StaticItems)
- Remove HomeFragmentHelper.hasResumeRow (always false)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
