### PR TITLE
fixed crashes on failing to start playback of an unsupported or unavailable video

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -420,7 +420,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 if (mPlaybackController.isLiveTv()) hide();
             } else if (mGuideVisible) {
                 hideGuide();
-            } else {
+            } else if (!requireActivity().isFinishing()) {
                 requireActivity().finish();
             }
         }
@@ -1365,7 +1365,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
 
     @Override
     public void finish() {
-        requireActivity().finish();
+        if (!requireActivity().isFinishing()) {
+            requireActivity().finish();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -706,7 +706,12 @@ public class PlaybackController {
         } else {
             Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_cannot_play));
         }
-
+        // give the user a second to read the error message
+        try {
+            Thread.sleep(750);
+        } catch (InterruptedException e) {
+            Timber.e(e);
+        }
         if (mFragment != null) mFragment.finish();
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -290,7 +290,6 @@ public class PlaybackController {
         } else {
             Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.too_many_errors));
             mPlaybackState = PlaybackState.ERROR;
-            endPlayback();
             if (mFragment != null) mFragment.finish();
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1051,7 +1051,7 @@ public class PlaybackController {
                 }
             });
         } else {
-            if (!hasInitializedVideoManager() || (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer()))) {
+            if (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer())) {
                 //Exo does not support seeking in .ts
                 Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
             } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -200,9 +200,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
     public long getDuration() {
         if (nativeMode) {
-            return mExoPlayer.getDuration() > 0 ? mExoPlayer.getDuration() : mMetaDuration;
+            return isInitialized() && mExoPlayer.getDuration() > 0 ? mExoPlayer.getDuration() : mMetaDuration;
         } else {
-            return mVlcPlayer.getLength() > 0 ? mVlcPlayer.getLength() : mMetaDuration;
+            return isInitialized() && mVlcPlayer.getLength() > 0 ? mVlcPlayer.getLength() : mMetaDuration;
         }
     }
 
@@ -292,6 +292,8 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     public long seekTo(long pos) {
+        if (!isInitialized())
+            return -1;
         if (nativeMode) {
             Long intPos = pos;
             Timber.i("Exo length in seek is: %d", mExoPlayer.getDuration());


### PR DESCRIPTION
**Changes**
* prevent NPE from pausing, playing, and seeking if the video isn't loaded due to an error
* prevent NPE from calling `mVideoManager.getCurrentPosition()` by using the internal `refreshCurrentPosition()` instead
* prevent NPE from referencing `mCurrentStreamInfo` if the server can't provide a stream

* added a generic "cannot play item" toast to `handlePlaybackInfoError()`
* wait a beat and then end the session in `handlePlaybackInfoError()`

**Notes**
The primary fixes in the PR were made prior to making the activity finish on error. For testing, that line could be removed. All the media controls should be interactive (but non functional) without any issues.

**Issues**
* fixes NPEs caused by accesing `videoManager` via pausing, playing, seeking, and reporting in situations where the video not loading didn't result in a clean end of the activity
* `PlaybackInfoError`s didn't end the session. Prior to the leak fixes PR, a black screen was shown in this situation. The leaks PR caused crash(es) in this situation in addition to that.
