### PR TITLE
Bypass hls seeking behavior for devices not using exoplayerprofile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1343,7 +1343,11 @@ public class PlaybackController {
                     boolean continueUpdate = true;
                     if (!spinnerOff) {
                         if (mStartPosition > 0) {
-                            if ((isNativeMode() && !(ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer()))) || mPlaybackMethod != PlayMethod.Transcode) {
+                            // handle starting streams that support seeking
+                            // use if direct-playing
+                            // use if using hls with exoplayer, which will use fMP4, so ignore if stream is the default container from the default profile
+                            // ignore if exoplayer with hls, transcoding, but is live tv
+                            if ((isNativeMode() && !isLiveTv() && !(ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer()))) || mPlaybackMethod != PlayMethod.Transcode) {
                                 mPlaybackState = PlaybackState.SEEKING;
                                 delayedSeek(mStartPosition);
                                 continueUpdate = false;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1010,7 +1010,9 @@ public class PlaybackController {
         if (!hasInitializedVideoManager()) {
             return;
         }
-        if (mPlaybackMethod == PlayMethod.Transcode && !isNativeMode() && ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer())) {
+        // rebuild the stream for libVLC
+        // if an older device uses exoplayer to play a transcoded stream but falls back to the generic http stream instead of hls, rebuild the stream
+        if (mPlaybackMethod == PlayMethod.Transcode && (!isNativeMode() || ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer()))) {
             //mkv transcodes require re-start of stream for seek
             mVideoManager.stopPlayback();
 
@@ -1339,7 +1341,7 @@ public class PlaybackController {
                     boolean continueUpdate = true;
                     if (!spinnerOff) {
                         if (mStartPosition > 0) {
-                            if (isNativeMode() || mPlaybackMethod != PlayMethod.Transcode) {
+                            if (isNativeMode() && !(ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer())) || mPlaybackMethod != PlayMethod.Transcode) {
                                 mPlaybackState = PlaybackState.SEEKING;
                                 delayedSeek(mStartPosition);
                                 continueUpdate = false;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1012,7 +1012,8 @@ public class PlaybackController {
         }
         // rebuild the stream for libVLC
         // if an older device uses exoplayer to play a transcoded stream but falls back to the generic http stream instead of hls, rebuild the stream
-        if (mPlaybackMethod == PlayMethod.Transcode && (!isNativeMode() || ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer()))) {
+        if (mPlaybackMethod == PlayMethod.Transcode && ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer())) {
+            Timber.d("Seek method - rebuilding the stream");
             //mkv transcodes require re-start of stream for seek
             mVideoManager.stopPlayback();
 
@@ -1051,6 +1052,7 @@ public class PlaybackController {
                 // if seek succeeds call play and mirror the logic in play() for unpausing. if fails call pause()
                 // stopProgressLoop() being called at the beginning of startProgressLoop keeps this from breaking. otherwise it would start twice
                 // if seek() is called from skip()
+                Timber.d("Seek method - native");
                 updateProgress = false;
                 mPlaybackState = PlaybackState.SEEKING;
                 if (mVideoManager.seekTo(pos) < 0) {
@@ -1341,7 +1343,7 @@ public class PlaybackController {
                     boolean continueUpdate = true;
                     if (!spinnerOff) {
                         if (mStartPosition > 0) {
-                            if (isNativeMode() && !(ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer())) || mPlaybackMethod != PlayMethod.Transcode) {
+                            if ((isNativeMode() && !(ContainerTypes.MKV.equals(mCurrentStreamInfo.getContainer()))) || mPlaybackMethod != PlayMethod.Transcode) {
                                 mPlaybackState = PlaybackState.SEEKING;
                                 delayedSeek(mStartPosition);
                                 continueUpdate = false;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -293,15 +293,14 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
     public long seekTo(long pos) {
         if (nativeMode) {
-            Long intPos = pos;
-            Timber.i("Exo length in seek is: %d", mExoPlayer.getDuration());
-            mExoPlayer.seekTo(intPos.intValue());
+            Timber.i("Exo length in seek is: %d", getDuration());
+            mExoPlayer.seekTo(pos);
             return pos;
         } else {
             if (mVlcPlayer == null || !mVlcPlayer.isSeekable()) return -1;
             mForcedTime = pos;
             mLastTime = mVlcPlayer.getTime();
-            Timber.i("VLC length in seek is: %d", mVlcPlayer.getLength());
+            Timber.i("VLC length in seek is: %d", getDuration());
             try {
                 if (getDuration() > 0) mVlcPlayer.setPosition((float) pos / getDuration());
                 else mVlcPlayer.setTime(pos);


### PR DESCRIPTION
**Changes**
* added conditions for the new HLS behavior so it can be ignored in cases where exoplayer is used for transcodes but hls isn't used. This applies when the baseprofile instead of the exoplayerprofile is used.

**Notes**
It's likely that devices which aren't eligible to use exoplayerprofile could still use hls.

In that case I guess a new exoplayer profile could be created which adds basic exoplayer-specific features.

They could be renamed to exoplayer-base and exoplayer-enhanced, or something.

**Issues**
Fixes #1353 