### PR TITLE
Cap playback speed to 1 watching live tv

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -753,7 +753,9 @@ public class PlaybackController {
 
         // get subtitle info
         mSubtitleStreams = response.GetSubtitleProfiles(false, apiClient.getValue().getApiUrl(), apiClient.getValue().getAccessToken());
-        if (mVideoManager != null) mVideoManager.setPlaybackSpeed(mRequestedPlaybackSpeed);
+
+        // set playback speed to user selection, or 1 if we're watching live-tv
+        if (mVideoManager != null) mVideoManager.setPlaybackSpeed(isLiveTv() ? 1.0 : mRequestedPlaybackSpeed);
 
         if (mFragment != null) mFragment.updateDisplay();
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoSpeedController.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoSpeedController.kt
@@ -23,9 +23,11 @@ class VideoSpeedController(
 
 	var currentSpeed = previousSpeedSelection
 		set(value) {
-			parentController.setPlaybackSpeed(value.speed)
-			previousSpeedSelection = value
-			field = value
+			val checkedVal = if (parentController.isLiveTv) SpeedSteps.SPEED_1_00 else value
+			parentController.setPlaybackSpeed(checkedVal.speed)
+
+			previousSpeedSelection = checkedVal
+			field = checkedVal
 		}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -226,7 +226,9 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
             primaryActionsAdapter.add(closedCaptionsAction);
         }
 
-        primaryActionsAdapter.add(playbackSpeedAction);
+        if (!isLiveTv()) {
+            primaryActionsAdapter.add(playbackSpeedAction);
+        }
 
         if (hasMultiAudio()) {
             primaryActionsAdapter.add(selectAudioAction);


### PR DESCRIPTION
**Changes**
    Cap speed at 1.0 when live TV is on
    
    We could allow various things, like a speed less than 1 or greater than
    until we exhaust the buffer.
    
    Unfortunately I don't have the equipment to test more complex
    interactions, so lets play it safe and force it always to 1.0
    Additionally we hide the playback speed button in live TV too

**Issues**
Mentioned in #1302 

**To test**
Could someone check the button is hidden watching live TV, as I don't have this available locally
