### PR TITLE
Exoplayer: Replace setPlaybackSpeed with setPlaybackParameters

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackException;
+import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Renderer;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -436,7 +437,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
 
         if (nativeMode) {
-            mExoPlayer.setPlaybackSpeed(speed.floatValue());
+            mExoPlayer.setPlaybackParameters(new PlaybackParameters(speed.floatValue()));
         } else {
             mVlcPlayer.setRate(speed.floatValue());
         }


### PR DESCRIPTION
**Changes**
Replace the setPlaybackSpeed with the more modern setPlaybackParameters. 
This matches the current docs / examples I've seen for Exoplayer

See: https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.html#setPlaybackParameters(com.google.android.exoplayer2.PlaybackParameters)

This also exposes the ability to shift pitches, which was how I noticed it whilst investigating pitch shifting issues reported in my original speed controls PR
