### PR TITLE
more playback leak fixes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -242,11 +242,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     }
 
     @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-    }
-
-    @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) return;
@@ -662,11 +657,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
             Utils.showToast(getActivity(), R.string.msg_cannot_play_time);
             return;
         }
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -244,9 +244,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-
-        if (videoManager != null)
-            videoManager.destroy();
     }
 
     @Override
@@ -670,9 +667,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if (mPlaybackController != null && mPlaybackController.hasFragment()) {
-            mPlaybackController.removePreviousQueueItems();
-        }
     }
 
     @Override
@@ -689,7 +683,24 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     public void onStop() {
         super.onStop();
         Timber.d("Stopping!");
-        mPlaybackController.endPlayback();
+
+        if (leanbackOverlayFragment != null)
+            leanbackOverlayFragment.setOnKeyInterceptListener(null);
+        if (backPressedCallback != null) {
+            backPressedCallback.remove();
+            backPressedCallback = null;
+        }
+
+        if (mPlaybackController != null) {
+            mPlaybackController.endPlayback();
+            mPlaybackController.removePreviousQueueItems();
+        }
+        if (videoManager != null)
+            videoManager.destroy();
+
+        ((PlaybackOverlayActivity) requireActivity()).removeMessageListener();
+        ((PlaybackOverlayActivity) requireActivity()).setKeyListener(null);
+
         if (!requireActivity().isFinishing()) {
             // in case the app is suspended/stopped, eg: by pressing the home button, end the playback session.
             requireActivity().finish();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1065,7 +1065,7 @@ public class PlaybackController {
                 }
             });
         } else {
-            if (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer())) {
+            if (!hasInitializedVideoManager() || (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer()))) {
                 //Exo does not support seeking in .ts
                 Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
             } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1065,7 +1065,7 @@ public class PlaybackController {
                 }
             });
         } else {
-            if (!hasInitializedVideoManager() || (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer()))) {
+            if (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer())) {
                 //Exo does not support seeking in .ts
                 Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
             } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -96,7 +96,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     }
 
     @Override
-    protected void onDetachedFromHost () {
+    protected void onDetachedFromHost() {
         mHandler.removeCallbacks(mRefreshEndTime);
         mHandler.removeCallbacks(mRefreshViewVisibility);
         super.onDetachedFromHost();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -60,9 +60,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     private GuideAction guideAction;
     private RecordAction recordAction;
 
-    private final VideoPlayerAdapter playerAdapter;
     private final PlaybackController playbackController;
-    private final LeanbackOverlayFragment leanbackOverlayFragment;
     private ArrayObjectAdapter primaryActionsAdapter;
     private ArrayObjectAdapter secondaryActionsAdapter;
 
@@ -75,11 +73,9 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     private LinearLayout mButtonRef;
 
-    CustomPlaybackTransportControlGlue(Context context, VideoPlayerAdapter playerAdapter, PlaybackController playbackController, LeanbackOverlayFragment leanbackOverlayFragment) {
+    CustomPlaybackTransportControlGlue(Context context, VideoPlayerAdapter playerAdapter, PlaybackController playbackController) {
         super(context, playerAdapter);
-        this.playerAdapter = playerAdapter;
         this.playbackController = playbackController;
-        this.leanbackOverlayFragment = leanbackOverlayFragment;
 
         mRefreshEndTime = () -> {
             if (!isPlaying()) {
@@ -97,6 +93,12 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
         };
 
         initActions(context);
+    }
+
+    @Override
+    protected void onDetachedFromHost () {
+        mHandler.removeCallbacks(mRefreshEndTime);
+        super.onDetachedFromHost();
     }
 
     @Override
@@ -283,41 +285,41 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     public void onCustomActionClicked(Action action, View view) {
         // Handle custom action clicks which require a popup menu
         if (action == selectAudioAction) {
-            leanbackOverlayFragment.setFading(false);
-            selectAudioAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), view);
+            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
+            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
         } else if (action == closedCaptionsAction) {
-            leanbackOverlayFragment.setFading(false);
-            closedCaptionsAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), view);
+            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
+            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
         } else if (action == playbackSpeedAction) {
-            leanbackOverlayFragment.setFading(false);
-            playbackSpeedAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), view);
+            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
+            playbackSpeedAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
         } else if (action == adjustAudioDelayAction) {
-            leanbackOverlayFragment.setFading(false);
-            adjustAudioDelayAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), view);
+            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
+            adjustAudioDelayAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
         } else if (action == zoomAction) {
-            leanbackOverlayFragment.setFading(false);
-            zoomAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), view);
+            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
+            zoomAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
         } else if (action == chapterAction) {
-            leanbackOverlayFragment.hideOverlay();
-            playerAdapter.getMasterOverlayFragment().showChapterSelector();
+            getPlayerAdapter().getLeanbackOverlayFragment().hideOverlay();
+            getPlayerAdapter().getMasterOverlayFragment().showChapterSelector();
         } else if (action == previousLiveTvChannelAction) {
-            playerAdapter.getMasterOverlayFragment().switchChannel(TvManager.getPrevLiveTvChannel());
+            getPlayerAdapter().getMasterOverlayFragment().switchChannel(TvManager.getPrevLiveTvChannel());
         } else if (action == channelBarChannelAction) {
-            leanbackOverlayFragment.hideOverlay();
-            playerAdapter.getMasterOverlayFragment().showQuickChannelChanger();
+            getPlayerAdapter().getLeanbackOverlayFragment().hideOverlay();
+            getPlayerAdapter().getMasterOverlayFragment().showQuickChannelChanger();
         } else if (action == guideAction) {
-            leanbackOverlayFragment.hideOverlay();
-            playerAdapter.getMasterOverlayFragment().showGuide();
+            getPlayerAdapter().getLeanbackOverlayFragment().hideOverlay();
+            getPlayerAdapter().getMasterOverlayFragment().showGuide();
         } else if (action == recordAction) {
-            playerAdapter.toggleRecording();
+            getPlayerAdapter().toggleRecording();
             // Icon will be updated via callback recordingStateChanged
         }
     }
 
     private void setEndTime() {
-        if (mEndsText == null || playerAdapter.getDuration() < 1)
+        if (mEndsText == null || getPlayerAdapter().getDuration() < 1)
             return;
-        long msLeft = playerAdapter.getDuration() - playerAdapter.getCurrentPosition();
+        long msLeft = getPlayerAdapter().getDuration() - getPlayerAdapter().getCurrentPosition();
         Calendar ends = Calendar.getInstance();
         ends.setTimeInMillis(ends.getTimeInMillis() + msLeft);
         mEndsText.setText(getContext().getString(R.string.lbl_playback_control_ends, DateFormat.getTimeFormat(getContext()).format(ends.getTime())));
@@ -341,35 +343,35 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     }
 
     private boolean hasSubs() {
-        return playerAdapter.hasSubs();
+        return getPlayerAdapter().hasSubs();
     }
 
     private boolean hasMultiAudio() {
-        return playerAdapter.hasMultiAudio();
+        return getPlayerAdapter().hasMultiAudio();
     }
 
     private boolean hasNextItem() {
-        return playerAdapter.hasNextItem();
+        return getPlayerAdapter().hasNextItem();
     }
 
     private boolean isNativeMode() {
-        return playerAdapter.isNativeMode();
+        return getPlayerAdapter().isNativeMode();
     }
 
     private boolean canSeek() {
-        return playerAdapter.canSeek();
+        return getPlayerAdapter().canSeek();
     }
 
     private boolean isLiveTv() {
-        return playerAdapter.isLiveTv();
+        return getPlayerAdapter().isLiveTv();
     }
 
     private boolean canRecordLiveTv() {
-        return playerAdapter.canRecordLiveTv();
+        return getPlayerAdapter().canRecordLiveTv();
     }
 
     private boolean hasChapters() {
-        return playerAdapter.hasChapters();
+        return getPlayerAdapter().hasChapters();
     }
 
     void invalidatePlaybackControls() {
@@ -379,7 +381,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     }
 
     void recordingStateChanged() {
-        if (playerAdapter.isRecording()) {
+        if (getPlayerAdapter().isRecording()) {
             recordAction.setIndex(RecordAction.INDEX_RECORDING);
         } else {
             recordAction.setIndex(RecordAction.INDEX_INACTIVE);
@@ -410,10 +412,10 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         if (hasSubs() && event.getAction() == KeyEvent.ACTION_UP && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutSubtitleTrack())) {
-            closedCaptionsAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), v);
+            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
         }
         if (hasMultiAudio() && event.getAction() == KeyEvent.ACTION_UP && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutAudioTrack())) {
-            selectAudioAction.handleClickAction(playbackController, leanbackOverlayFragment, getContext(), v);
+            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
         }
         return super.onKey(v, keyCode, event);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -98,6 +98,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     @Override
     protected void onDetachedFromHost () {
         mHandler.removeCallbacks(mRefreshEndTime);
+        mHandler.removeCallbacks(mRefreshViewVisibility);
         super.onDetachedFromHost();
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -24,8 +24,8 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
 
         PlaybackController playbackController = TvApp.getApplication().getPlaybackController();
 
-        playerAdapter = new VideoPlayerAdapter(playbackController);
-        playerGlue = new CustomPlaybackTransportControlGlue(getContext(), playerAdapter, playbackController, this);
+        playerAdapter = new VideoPlayerAdapter(playbackController, this);
+        playerGlue = new CustomPlaybackTransportControlGlue(getContext(), playerAdapter, playbackController);
         playerGlue.setHost(new CustomPlaybackFragmentGlueHost(this));
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.playback.overlay;
 import androidx.leanback.media.PlayerAdapter;
 
 import org.jellyfin.androidtv.TvApp;
+import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.util.DeviceUtils;
@@ -16,9 +17,11 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     private final PlaybackController playbackController;
     private CustomPlaybackOverlayFragment customPlaybackOverlayFragment;
+    private LeanbackOverlayFragment leanbackOverlayFragment;
 
-    VideoPlayerAdapter(PlaybackController playbackController) {
+    VideoPlayerAdapter(PlaybackController playbackController, LeanbackOverlayFragment leanbackOverlayFragment) {
         this.playbackController = playbackController;
+        this.leanbackOverlayFragment = leanbackOverlayFragment;
     }
 
     @Override
@@ -117,6 +120,16 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     CustomPlaybackOverlayFragment getMasterOverlayFragment() {
         return customPlaybackOverlayFragment;
+    }
+
+    LeanbackOverlayFragment getLeanbackOverlayFragment() {
+        return leanbackOverlayFragment;
+    }
+
+    @Override
+    public void onDetachedFromHost() {
+        customPlaybackOverlayFragment = null;
+        leanbackOverlayFragment = null;
     }
 
     boolean canRecordLiveTv() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/BaseActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/BaseActivity.java
@@ -30,6 +30,10 @@ public abstract class BaseActivity extends FragmentActivity {
         messageListener = listener;
     }
 
+    public void removeMessageListener() {
+        messageListener = null;
+    }
+
     public void sendMessage(CustomMessage message) {
         if (messageListener != null) {
             messageListener.onMessageReceived(message);


### PR DESCRIPTION
**Changes**
* remove all direct references to `leanbackOverlayFragment` and `playerAdapter` from `CustomPlaybackTransportControlGlue`. Instead use its built in `getPlayerAdapter()`. This maintains the right relationship between fragment, videoAdapter, host, and glue. The host can be detached and will signal the adapter and glue to release their resources.
_This is done by using `playerAdapter` to store the references to `leanbackOverlayFragment` and `CustomPlaybackOverlayFragment`._

* kill runnables when finishing/detaching so they don't cause leaks via context

* on finish/detach, break the chain of keylisteners and message listener that tied `PlaybackOverlayActivity` <- -> `CustomPlaybackOverlayFragment` <- -> `LeanbackOverlayFragment` <- -> `CustomPlaybackTransportControlGlue`


**Issues**
* leaks in player when watching movies & tv shows
* leaks in player when it closed unexpectedly via remote command or error
* leaks in player when switching to the "next up" fragment

* leaks in player from the live tv overlays not being GCd