### PR TITLE
Replace deprecated SimpleExoPlayer -> ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -13,9 +13,9 @@ import android.text.InputType;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
@@ -70,7 +70,7 @@ public class MediaManager {
     private LibVLC mLibVLC;
     private org.videolan.libvlc.MediaPlayer mVlcPlayer;
     private VlcEventHandler mVlcHandler = new VlcEventHandler();
-    private SimpleExoPlayer mExoPlayer;
+    private ExoPlayer mExoPlayer;
     private AudioManager mAudioManager;
     private boolean audioInitialized = false;
     private boolean nativeMode = false;
@@ -263,7 +263,7 @@ public class MediaManager {
             if (DeviceUtils.is60()) {
                 Timber.i("creating audio player using: exoplayer");
                 nativeMode = true;
-                mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication()).build();
+                mExoPlayer = new ExoPlayer.Builder(TvApp.getApplication()).build();
                 mExoPlayer.addListener(new Player.EventListener() {
                     @Override
                     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -17,12 +17,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.android.exoplayer2.DefaultRenderersFactory;
+import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Renderer;
-import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.source.DefaultMediaSourceFactory;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.text.TextOutput;
@@ -60,7 +60,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private SurfaceView mSurfaceView;
     private SurfaceView mSubtitlesSurface;
     private FrameLayout mSurfaceFrame;
-    private SimpleExoPlayer mExoPlayer;
+    private ExoPlayer mExoPlayer;
     private PlayerView mExoPlayerView;
     private AspectRatioFrameLayout mAspectRatioFrameLayout;
     private LibVLC mLibVLC;
@@ -98,7 +98,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         mSubtitlesSurface.setZOrderMediaOverlay(true);
         mSubtitlesSurface.getHolder().setFormat(PixelFormat.TRANSLUCENT);
 
-        mExoPlayer = new SimpleExoPlayer.Builder(TvApp.getApplication(), new DefaultRenderersFactory(TvApp.getApplication()) {
+        mExoPlayer = new ExoPlayer.Builder(TvApp.getApplication(), new DefaultRenderersFactory(TvApp.getApplication()) {
             @Override
             protected void buildTextRenderers(Context context, TextOutput output, Looper outputLooper, int extensionRendererMode, ArrayList<Renderer> out) {
                 // Do not add text renderers since we handle subtitles


### PR DESCRIPTION
**Changes**
As per the 2.16.0 release notes:
https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#2160-2021-11-04

SimpleExoPlayer is deprecated, and all functionality has been moved to
ExoPlayer. This allows us to replace these calls as-is and future proofs
us too.

**Issues**
Noticed in #1369 
