### PR TITLE
on resuming fulldetails activity give play button focus if resume button isnt eligible

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -269,8 +269,6 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                                             playButton.requestFocus();
                                         }
                                         showMoreButtonIfNeeded();
-                                    } else if (playButton != null && playButton.isVisible()) {
-                                        playButton.requestFocus();
                                     }
                                     updatePlayedDate();
                                     updateWatched();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -265,8 +265,12 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                                         }
                                         if (resumeVisible) {
                                             mResumeButton.requestFocus();
+                                        } else if (playButton != null && playButton.isVisible()) {
+                                            playButton.requestFocus();
                                         }
                                         showMoreButtonIfNeeded();
+                                    } else if (playButton != null && playButton.isVisible()) {
+                                        playButton.requestFocus();
                                     }
                                     updatePlayedDate();
                                     updateWatched();


### PR DESCRIPTION
**Changes**
* ensure either play or resume/next up gets focus in fullDetailsActivity after playback

**Issues**
* sometimes buttons like "watched" get focus instead