### PR TITLE
patch bug where video queue can be messed up and item progress is incorrect after playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -138,6 +138,10 @@ public class PlaybackController {
         return mFragment != null;
     }
 
+    public IPlaybackOverlayFragment getFragment() {
+        return mFragment;
+    }
+
     public void init(VideoManager mgr, IPlaybackOverlayFragment fragment) {
         mVideoManager = mgr;
         mFragment = fragment;
@@ -984,6 +988,8 @@ public class PlaybackController {
 
     public void endPlayback() {
         stop();
+        removePreviousQueueItems();
+        mVideoManager.destroy();
         mFragment = null;
         mVideoManager = null;
     }
@@ -1269,9 +1275,7 @@ public class PlaybackController {
     }
 
     private void itemComplete() {
-        mPlaybackState = PlaybackState.IDLE;
-        stopReportLoop();
-        ReportingHelper.reportStopped(getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 1000);
+        stop();
         vlcErrorEncountered = false;
         exoErrorEncountered = false;
 
@@ -1286,7 +1290,9 @@ public class PlaybackController {
                 // Show "Next Up" fragment
                 spinnerOff = false;
                 mediaManager.getValue().setCurrentVideoQueue(mItems);
+                mediaManager.getValue().setVideoQueueModified(true);
                 if (mFragment != null) mFragment.showNextUp(nextItem.getId());
+                endPlayback();
             } else {
                 mCurrentIndex++;
                 play(0);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -989,7 +989,8 @@ public class PlaybackController {
     public void endPlayback() {
         stop();
         removePreviousQueueItems();
-        mVideoManager.destroy();
+        if (mVideoManager != null)
+            mVideoManager.destroy();
         mFragment = null;
         mVideoManager = null;
     }


### PR DESCRIPTION
**Causes**
* #1368 put logic in the fragment lifecycle methods that shouldnt have been there. The code in onStop() for the prior fragment would run after the new already session started.
* `onStop()` and other lifecycle related methods in the fragment can't be relied on to perform operations on the video queue
* In those same methods, it can be expected that by the time they run PlaybackController is using a new instance of the fragment and videoManager
* more generally, to get the intended behavior those operations needed to be done in a specific order - in this case when one session ends and before another starts.

**Changes**
* call `stop()` in `itemComplete()` to ensure that the stop position and `PlaybackPositionTicks`/resume time is set

* handle the queue related operations like `setVideoQueueModified(true)` and `removePreviousQueueItems()` in `PlaybackController`

* in `endPlayback()`, do the player release - `videoManager.destroy()` - and `removePreviousQueueItems()` instead of in `CustomPlaybackOverlayFragment`

* only call `endPlayback()` in `CustomPlaybackOverlayFragment` if it is the fragment that currently belongs to the controller.
If a new playback session is created from NextUp, by the time the fragment catches onStop the reference to it will have been replaced in PlaybackController.

**Issues**
* completing playback of an item could count it as played but its resume time wouldn't be cleared
* using the NextUp activity to play the next item would mess up the video queue so that the progress reporting would go to the item after the one just loaded (nextup loads item 2, progress counts toward item 3).
* the `CustomPlaybackOverlayFragment` from the previous session could mess up the current session (loaded by NextUp) by clearing PlaybackController's references to its fragment and VideoManager