### PR TITLE
FullDetailsActivity - dynamically fill button row and hide extra

### DIFF
--- a/app/src/main/res/menu/menu_details_more.xml
+++ b/app/src/main/res/menu/menu_details_more.xml
@@ -10,14 +10,23 @@
         android:id="@+id/remFav"
         android:icon="@drawable/ic_heart_red"
         />
-    <item android:title="@string/lbl_add_to_queue"
-        android:id="@+id/addQueue"
-        android:icon="@drawable/ic_add"
+    <item android:title="@string/lbl_play_trailers"
+        android:id="@+id/playTrailers"
+        android:icon="@drawable/ic_trailer"
         />
     <item android:title="@string/lbl_goto_series"
         android:id="@+id/gotoSeries"
         android:icon="@drawable/ic_tv"
         />
+    <item android:title="@string/lbl_shuffle_all"
+        android:id="@+id/shuffleAll"
+        android:icon="@drawable/ic_shuffle"
+        />
+    <item android:title="@string/lbl_add_to_queue"
+        android:id="@+id/addQueue"
+        android:icon="@drawable/ic_add"
+        />
+
     <item android:title="@string/lbl_delete"
         android:id="@+id/delete"
         android:icon="@drawable/ic_trash"


### PR DESCRIPTION
**Notes**
* the row = mDetailsOverviewRow
* the main drawback to this approach is that it assumes all the less important buttons, which should be hidden first, are visible when they are sorted. If they're not, they will be shown first and the more important buttons would be hidden.
Currently though, it looks like all the buttons (or almost all) are visible when `showMoreButtonIfNeeded()` is called.

**Changes**
* given a set of buttons to consider showing or hiding, loop through them and hide buttons until there either is extra space available or the buttons are already shown. the hidden buttons become part of the "more options" menu.

* the more options menu only shows items that are hidden in the row

* added the shuffle button and play trailers button to the more options menu. The trailer button is last in the list to be hidden so it's very unlikely that it ever will be. Future button could be added to the "more options" menu by default, in addition to the row, so that the row can always offload them into the menu if needed.

* renamed a couple buttons to standardize the naming.

* moved the onClick logic for the play trailers button to its own method so it can be called from the more options menu

**Issues**
* buttons were overflowing past the 5 button limit of the row
* there was a static set of buttons that would always go to the "more options" menu if the total number of buttons exceeded five, even if some could fit in the row