### PR TITLE
Initial ImageUtils SDK migration

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/UtilsModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/UtilsModule.kt
@@ -1,8 +1,10 @@
 package org.jellyfin.androidtv.di
 
 import org.jellyfin.androidtv.util.AutoBitrate
+import org.jellyfin.androidtv.util.ImageHelper
 import org.koin.dsl.module
 
 val utilsModule = module {
 	single { AutoBitrate(get(userApiClient)) }
+	single { ImageHelper(get(userApiClient)) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
@@ -40,7 +40,7 @@ class ClockUserView @JvmOverloads constructor(
 		if (currentUser != null && !isInEditMode) {
 			if (currentUser.primaryImageTag != null) {
 				Glide.with(context)
-					.load(ImageUtils.getPrimaryImageUrl(currentUser, get()))
+					.load(ImageUtils.getPrimaryImageUrl(currentUser))
 					.placeholder(R.drawable.ic_user)
 					.centerInside()
 					.circleCrop()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingBug.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingBug.java
@@ -21,9 +21,7 @@ import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
-import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.koin.java.KoinJavaComponent;
 
 import kotlin.Lazy;
 
@@ -125,7 +123,7 @@ public class NowPlayingBug extends FrameLayout {
         if (item == null) return;
 
         Glide.with(context)
-                .load(ImageUtils.getPrimaryImageUrl(item, KoinJavaComponent.<ApiClient>get(ApiClient.class)))
+                .load(ImageUtils.getPrimaryImageUrl(item))
                 .error(R.drawable.ic_album)
                 .centerInside()
                 .into(npIcon);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeToolbarFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeToolbarFragment.kt
@@ -20,19 +20,17 @@ import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.search.SearchActivity
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.ImageUtils
-import org.jellyfin.apiclient.interaction.ApiClient
 import org.koin.android.ext.android.inject
 
 class HomeToolbarFragment : Fragment() {
 	private lateinit var binding: FragmentToolbarHomeBinding
-	private val apiClient: ApiClient by inject()
 	private val sessionRepository: SessionRepository by inject()
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		binding = FragmentToolbarHomeBinding.inflate(inflater, container, false)
 
 		TvApp.getApplication()!!.currentUserLiveData.observe(viewLifecycleOwner) { currentUser ->
-			val image = currentUser?.let { ImageUtils.getPrimaryImageUrl(it, apiClient) }
+			val image = currentUser?.let { ImageUtils.getPrimaryImageUrl(it) }
 			setUserImage(image)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -413,9 +413,9 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
 
             mDetailsOverviewRow = new MyDetailsOverviewRow(item);
 
-            String primaryImageUrl = ImageUtils.getLogoImageUrl(mBaseItem, apiClient.getValue(), 600, true);
+            String primaryImageUrl = ImageUtils.getLogoImageUrl(mBaseItem, 600, true);
             if (primaryImageUrl == null) {
-                primaryImageUrl = ImageUtils.getPrimaryImageUrl(mActivity, mBaseItem, apiClient.getValue(), false, posterHeight);
+                primaryImageUrl = ImageUtils.getPrimaryImageUrl(mActivity, mBaseItem, false, posterHeight);
                 if (item.getRunTimeTicks() != null && item.getRunTimeTicks() > 0 && item.getUserData() != null && item.getUserData().getPlaybackPositionTicks() > 0)
                     mDetailsOverviewRow.setProgress(((int) (item.getUserData().getPlaybackPositionTicks() * 100.0 / item.getRunTimeTicks())));
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -491,7 +491,7 @@ public class ItemListActivity extends FragmentActivity {
                 int posterWidth = (int)((aspect) * posterHeight);
                 if (posterHeight < 10) posterWidth = Utils.convertDpToPixel(this, 150);  //Guard against zero size images causing picasso to barf
 
-                String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, apiClient.getValue(), false, posterHeight);
+                String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, false, posterHeight);
 
 
                 Glide.with(this)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
@@ -337,7 +337,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
             if (target == prevImage) isLoadingPrev = true;
 
             Glide.with(this)
-                    .load(ImageUtils.getPrimaryImageUrl(photo, displayWidth, displayHeight, apiClient.getValue()))
+                    .load(ImageUtils.getPrimaryImageUrl(photo, displayWidth, displayHeight))
                     .override(displayWidth, displayHeight)
                     .centerInside()
                     .error(R.drawable.tile_land_photo)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
@@ -37,6 +37,7 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.util.ImageUtils;
+import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
 import kotlin.Lazy;
@@ -68,6 +69,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
 
     Handler handler;
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private Lazy<ApiClient> apiClient = inject(ApiClient.class);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -335,7 +337,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
             if (target == prevImage) isLoadingPrev = true;
 
             Glide.with(this)
-                    .load(ImageUtils.getPrimaryImageUrl(photo, displayWidth, displayHeight))
+                    .load(ImageUtils.getPrimaryImageUrl(photo, displayWidth, displayHeight, apiClient.getValue()))
                     .override(displayWidth, displayHeight)
                     .centerInside()
                     .error(R.drawable.tile_land_photo)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -246,11 +246,11 @@ public class BaseRowItem {
             case BaseItem:
             case LiveTvProgram:
             case LiveTvRecording:
-                return ImageUtils.getPrimaryImageUrl(context, baseItem, apiClient.getValue(), preferParentThumb, maxHeight);
+                return ImageUtils.getPrimaryImageUrl(context, baseItem, preferParentThumb, maxHeight);
             case Person:
-                return ImageUtils.getPrimaryImageUrl(person, apiClient.getValue(), maxHeight);
+                return ImageUtils.getPrimaryImageUrl(person, maxHeight);
             case User:
-                return ImageUtils.getPrimaryImageUrl(user, apiClient.getValue());
+                return ImageUtils.getPrimaryImageUrl(user);
             case Chapter:
                 return chapterInfo.getImagePath();
             case LiveTvChannel:
@@ -263,9 +263,9 @@ public class BaseRowItem {
                 return ImageUtils.getResourceUrl(context, R.drawable.tile_land_series_timer);
             case SearchHint:
                 if (Utils.isNonEmpty(searchHint.getPrimaryImageTag())) {
-                    return ImageUtils.getImageUrl(searchHint.getItemId(), ImageType.Primary, searchHint.getPrimaryImageTag(), apiClient.getValue());
+                    return ImageUtils.getImageUrl(searchHint.getItemId(), ImageType.Primary, searchHint.getPrimaryImageTag());
                 } else if (Utils.isNonEmpty(searchHint.getThumbImageItemId())) {
-                    return ImageUtils.getImageUrl(searchHint.getThumbImageItemId(), ImageType.Thumb, searchHint.getThumbImageTag(), apiClient.getValue());
+                    return ImageUtils.getImageUrl(searchHint.getThumbImageItemId(), ImageType.Thumb, searchHint.getThumbImageTag());
                 }
         }
         return null;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -995,7 +995,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
 
         if (mSelectedProgram.getId() != null) {
             mDisplayDate.setText(TimeUtils.getFriendlyDate(this, TimeUtils.convertToLocalDate(mSelectedProgram.getStartDate())));
-            String url = ImageUtils.getPrimaryImageUrl(mSelectedProgram, KoinJavaComponent.<ApiClient>get(ApiClient.class));
+            String url = ImageUtils.getPrimaryImageUrl(mSelectedProgram);
             int imageSize = Utils.convertDpToPixel(this, 150);
             Glide.with(mActivity)
                     .load(url)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -42,7 +42,6 @@ import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
-import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
 import java.util.ArrayList;
@@ -98,7 +97,6 @@ public class AudioNowPlayingActivity extends BaseActivity {
     private long lastUserInteraction;
     private boolean ssActive;
 
-    private Lazy<ApiClient> apiClient = inject(ApiClient.class);
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
 
@@ -423,7 +421,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
         if (posterHeight < 10)
             posterWidth = Utils.convertDpToPixel(mActivity, 150);  //Guard against zero size images causing picasso to barf
 
-        String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, apiClient.getValue(), false, posterHeight);
+        String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, false, posterHeight);
         Timber.d("Audio Poster url: %s", primaryImageUrl);
         Glide.with(mActivity)
                 .load(primaryImageUrl)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -13,7 +13,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.Spannable;
 import android.text.SpannableString;
-import android.text.style.ForegroundColorSpan;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -47,10 +46,10 @@ import com.bumptech.glide.request.target.Target;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.constant.CustomMessage;
-import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
 import org.jellyfin.androidtv.databinding.OverlayTvGuideBinding;
 import org.jellyfin.androidtv.databinding.VlcPlayerInterfaceBinding;
+import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.ui.GuideChannelHeader;
 import org.jellyfin.androidtv.ui.GuidePagingButton;
 import org.jellyfin.androidtv.ui.HorizontalScrollViewListener;
@@ -70,7 +69,6 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.ChannelCardPresenter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.shared.PaddedLineBackgroundSpan;
-import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TextUtilsKt;
@@ -1298,7 +1296,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
                 binding.itemTitle.setText(current.getName());
             }
             // Update the logo
-            String imageUrl = ImageUtils.getLogoImageUrl(current, apiClient.getValue(), 440, false);
+            String imageUrl = ImageUtils.getLogoImageUrl(current, 440, false);
             if (imageUrl != null) {
                 binding.itemLogo.setVisibility(View.VISIBLE);
                 binding.itemTitle.setVisibility(View.GONE);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import timber.log.Timber;
 
 public class CardPresenter extends Presenter {
-    private static final double ASPECT_RATIO_BANNER = 5.414;
+    private static final double ASPECT_RATIO_BANNER = 434 / 79;
 
     private int mStaticHeight = 300;
     private ImageType mImageType = ImageType.DEFAULT;
@@ -136,7 +136,8 @@ public class CardPresenter extends Presenter {
                         case Season:
                         case Series:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_tv);
-                            if (imageType.equals(ImageType.DEFAULT)) aspect = ImageUtils.ASPECT_RATIO_2_3;
+                            if (imageType.equals(ImageType.DEFAULT))
+                                aspect = ImageUtils.ASPECT_RATIO_2_3;
                             break;
                         case Episode:
                             //TvApp.getApplication().getLogger().Debug("**** Image width: "+ cardWidth + " Aspect: " + Utils.getImageAspectRatio(itemDto, m.getPreferParentThumb()) + " Item: "+itemDto.getName());
@@ -186,12 +187,14 @@ public class CardPresenter extends Presenter {
                         case Movie:
                         case Video:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_video);
-                            if (imageType.equals(ImageType.DEFAULT)) aspect = ImageUtils.ASPECT_RATIO_2_3;
+                            if (imageType.equals(ImageType.DEFAULT))
+                                aspect = ImageUtils.ASPECT_RATIO_2_3;
                             showProgress = true;
                             break;
                         default:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_video);
-                            if (imageType.equals(ImageType.DEFAULT)) aspect = ImageUtils.ASPECT_RATIO_2_3;
+                            if (imageType.equals(ImageType.DEFAULT))
+                                aspect = ImageUtils.ASPECT_RATIO_2_3;
                             break;
                     }
                     cardHeight = !m.isStaticHeight() ? (aspect > 1 ? lHeight : pHeight) : sHeight;
@@ -346,24 +349,24 @@ public class CardPresenter extends Presenter {
             try {
                 if (url == null) {
                     Glide.with(mCardView.getContext())
-                        .load(mDefaultCardImage)
-                        .into(mCardView.getMainImageView());
+                            .load(mDefaultCardImage)
+                            .into(mCardView.getMainImageView());
                 } else {
                     BlurHashUtils.createBlurHashDrawable(
-                        lifecycleOwner,
-                        blurHash,
-                        (aspect > 1) ? (int) Math.round(32 * aspect) : 32,
-                        (aspect >= 1) ? 32 : (int) Math.round(32 / aspect),
-                        bitmap -> {
-                            Glide.with(mCardView.getContext())
-                                .load(url)
-                                .error(mDefaultCardImage)
-                                .thumbnail(Glide.with(mCardView.getContext()).load(bitmap != null ? bitmap : mDefaultCardImage).centerCrop())
-                                .transition(DrawableTransitionOptions.withCrossFade(200))
-                                .into(mCardView.getMainImageView());
+                            lifecycleOwner,
+                            blurHash,
+                            (aspect > 1) ? (int) Math.round(32 * aspect) : 32,
+                            (aspect >= 1) ? 32 : (int) Math.round(32 / aspect),
+                            bitmap -> {
+                                Glide.with(mCardView.getContext())
+                                        .load(url)
+                                        .error(mDefaultCardImage)
+                                        .thumbnail(Glide.with(mCardView.getContext()).load(bitmap != null ? bitmap : mDefaultCardImage).centerCrop())
+                                        .transition(DrawableTransitionOptions.withCrossFade(200))
+                                        .into(mCardView.getMainImageView());
 
-                            return null;
-                        }
+                                return null;
+                            }
                     );
                 }
             } catch (IllegalArgumentException e) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -1,0 +1,138 @@
+package org.jellyfin.androidtv.util
+
+import org.jellyfin.apiclient.model.dto.BaseItemType
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemPerson
+import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.serializer.toUUID
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.jellyfin.apiclient.model.dto.UserDto as LegacyUserDto
+
+class ImageHelper(
+	private val api: ApiClient,
+) {
+	fun getPrimaryImageUrl(item: BaseItemPerson, maxHeight: Int? = null): String? {
+		if (item.primaryImageTag == null) return null
+
+		return item.id?.toUUIDOrNull()?.let { itemId ->
+			api.imageApi.getItemImageUrl(
+				itemId = itemId,
+				imageType = ImageType.PRIMARY,
+				tag = item.primaryImageTag,
+				maxHeight = maxHeight,
+			)
+		}
+	}
+
+	fun getPrimaryImageUrl(item: LegacyUserDto): String? {
+		if (item.primaryImageTag == null) return null
+
+		return item.id?.toUUIDOrNull()?.let { userId ->
+			api.imageApi.getUserImageUrl(
+				userId = userId,
+				imageType = ImageType.PRIMARY,
+				tag = item.primaryImageTag,
+				maxHeight = ImageUtils.MAX_PRIMARY_IMAGE_HEIGHT,
+			)
+		}
+	}
+
+	fun getPrimaryImageUrl(item: BaseItemDto, width: Int?, height: Int?): String? {
+		val primaryImageTag = item.imageTags?.get(ImageType.PRIMARY) ?: return null
+
+		return api.imageApi.getItemImageUrl(
+			itemId = item.id,
+			imageType = ImageType.PRIMARY,
+			tag = primaryImageTag,
+			maxWidth = width,
+			maxHeight = height,
+		)
+	}
+
+	fun getImageUrl(item: String, imageType: ImageType, imageTag: String): String? = item.toUUIDOrNull()?.let { itemId ->
+		api.imageApi.getItemImageUrl(
+			itemId = itemId,
+			imageType = imageType,
+			tag = imageTag,
+			maxHeight = ImageUtils.MAX_PRIMARY_IMAGE_HEIGHT,
+		)
+	}
+
+	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, maxHeight: Int): String {
+		var itemId = item.id
+		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
+		var imageType = ImageType.PRIMARY
+
+		if (preferParentThumb && item.type.equals(BaseItemType.Episode.toString(), ignoreCase = true) && imageTag == null) {
+			if (item.parentThumbItemId != null && item.parentThumbImageTag != null) {
+				itemId = item.parentThumbItemId!!.toUUID()
+				imageTag = item.parentThumbImageTag
+				imageType = ImageType.THUMB
+			} else if (item.seriesId != null && item.seriesThumbImageTag != null) {
+				itemId = item.seriesId!!
+				imageTag = item.seriesThumbImageTag
+				imageType = ImageType.THUMB
+			}
+		} else if (item.type.equals(BaseItemType.Season.toString(), ignoreCase = true) && imageTag == null) {
+			if (item.seriesId != null && item.seriesPrimaryImageTag != null) {
+				itemId = item.seriesId!!
+				imageTag = item.seriesPrimaryImageTag
+			}
+		} else if (item.type.equals(BaseItemType.Program.toString(), ignoreCase = true) && item.imageTags?.containsKey(ImageType.THUMB) == true) {
+			imageTag = item.imageTags!![ImageType.THUMB]
+			imageType = ImageType.THUMB
+		} else if (item.type.equals(BaseItemType.Audio.toString(), ignoreCase = true) && imageTag == null) {
+			if (item.albumId != null && item.albumPrimaryImageTag != null) {
+				itemId = item.albumId!!
+				imageTag = item.albumPrimaryImageTag
+			} else if (!item.albumArtists.isNullOrEmpty()) {
+				itemId = item.albumArtists!!.first().id
+				imageTag = null
+			}
+		}
+
+		return api.imageApi.getItemImageUrl(
+			itemId = itemId,
+			imageType = imageType,
+			tag = imageTag,
+			maxHeight = maxHeight,
+		)
+	}
+
+	fun getLogoImageUrl(item: BaseItemDto?, maxWidth: Int, useSeriesFallback: Boolean): String? {
+		val logoTag = item?.imageTags?.get(ImageType.LOGO)
+		return when {
+			// No item
+			item == null -> null
+			// Item has a logo
+			logoTag != null -> {
+				api.imageApi.getItemImageUrl(
+					itemId = item.id,
+					imageType = ImageType.LOGO,
+					maxWidth = maxWidth,
+					tag = logoTag
+				)
+			}
+			// Item parent has a logo
+			item.parentLogoItemId != null && item.parentLogoImageTag != null -> {
+				api.imageApi.getItemImageUrl(
+					itemId = item.parentLogoItemId!!.toUUID(),
+					imageType = ImageType.LOGO,
+					maxWidth = maxWidth,
+					tag = item.parentLogoImageTag
+				)
+			}
+			// Series might have a logo
+			useSeriesFallback && item.seriesId != null -> {
+				api.imageApi.getItemImageUrl(
+					itemId = item.seriesId!!,
+					imageType = ImageType.LOGO,
+					maxWidth = maxWidth,
+				)
+			}
+			else -> null
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -56,19 +56,19 @@ public class ImageUtils {
         return item.getPrimaryImageAspectRatio() != null ? item.getPrimaryImageAspectRatio() : ASPECT_RATIO_7_9;
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable ApiClient apiClient, @Nullable int maxHeight) {
+    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int maxHeight) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(ModelCompat.asSdk(item), maxHeight);
     }
 
-    public static String getPrimaryImageUrl(@NonNull UserDto item, @Nullable ApiClient apiClient) {
+    public static String getPrimaryImageUrl(@NonNull UserDto item) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item);
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemDto item, @NonNull int width, @NonNull int height, @Nullable ApiClient apiClient) {
+    public static String getPrimaryImageUrl(@NonNull BaseItemDto item, @NonNull int width, @NonNull int height) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(ModelCompat.asSdk(item), width, height);
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemDto item, @Nullable ApiClient apiClient) {
+    public static String getPrimaryImageUrl(@NonNull BaseItemDto item) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(ModelCompat.asSdk(item), null, MAX_PRIMARY_IMAGE_HEIGHT);
     }
 
@@ -83,13 +83,13 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item, options);
     }
 
-    public static String getImageUrl(@NonNull String itemId, @NonNull ImageType imageType, @NonNull String imageTag, @Nullable ApiClient apiClient) {
+    public static String getImageUrl(@NonNull String itemId, @NonNull ImageType imageType, @NonNull String imageTag) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getImageUrl(itemId, ModelCompat.asSdk(imageType), imageTag);
     }
 
     public static String getBannerImageUrl(Context context, BaseItemDto item, ApiClient apiClient, int maxHeight) {
         if (!item.getHasBanner()) {
-            return getPrimaryImageUrl(context, item, apiClient, false, maxHeight);
+            return getPrimaryImageUrl(context, item, false, maxHeight);
         }
 
         ImageOptions options = new ImageOptions();
@@ -112,7 +112,7 @@ public class ImageUtils {
 
     public static String getThumbImageUrl(Context context, BaseItemDto item, ApiClient apiClient, int maxHeight) {
         if (!item.getHasThumb()) {
-            return getPrimaryImageUrl(context, item, apiClient, true, maxHeight);
+            return getPrimaryImageUrl(context, item, true, maxHeight);
         }
 
         ImageOptions options = new ImageOptions();
@@ -121,7 +121,7 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId(), options);
     }
 
-    public static String getPrimaryImageUrl(@NonNull Context context, @NonNull BaseItemDto item, @Nullable ApiClient apiClient, @NonNull boolean preferParentThumb, @NonNull int maxHeight) {
+    public static String getPrimaryImageUrl(@NonNull Context context, @NonNull BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int maxHeight) {
         if (item.getBaseItemType() == BaseItemType.SeriesTimer) {
             return getResourceUrl(context, R.drawable.tile_land_series_timer);
         }
@@ -129,7 +129,7 @@ public class ImageUtils {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(ModelCompat.asSdk(item), preferParentThumb, maxHeight);
     }
 
-    public static String getLogoImageUrl(@Nullable BaseItemDto item, @Nullable ApiClient apiClient, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {
+    public static String getLogoImageUrl(@Nullable BaseItemDto item, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getLogoImageUrl(ModelCompat.asSdk(item), maxWidth, useSeriesFallback);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -16,7 +16,6 @@ import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
-import org.koin.java.KoinJavaComponent;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,7 +68,7 @@ public class ImageUtils {
         return apiClient.GetUserImageUrl(item, options);
     }
 
-    public static String getPrimaryImageUrl(BaseItemDto item, int width, int height) {
+    public static String getPrimaryImageUrl(BaseItemDto item, int width, int height, ApiClient apiClient) {
         if (!item.getHasPrimaryImage()) {
             return null;
         }
@@ -78,7 +77,7 @@ public class ImageUtils {
         options.setMaxWidth(width);
         options.setMaxHeight(height);
         options.setImageType(ImageType.Primary);
-        return KoinJavaComponent.<ApiClient>get(ApiClient.class).GetImageUrl(item, options);
+        return apiClient.GetImageUrl(item, options);
     }
 
     public static String getPrimaryImageUrl(BaseItemDto item, ApiClient apiClient) {


### PR DESCRIPTION
Most of the image url building in the app is done with the ImageUtils class. I've migrated all functions I could test (everything not live tv) to use the SDK. This generates slightly different URL's.

**Changes**

- Add ImageHelper to create image urls using the SDK
  - Migrate all non-livetv image url builder functions in ImageUtils to new ImageHelper
- Remove apiclient parameter from ImageUtils functions

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
