### PR TITLE
Fix nullability for UserViewsRepository.isSupported and UserViewsRepository.allowViewSelection

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
@@ -10,8 +10,8 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 interface UserViewsRepository {
 	val views: LiveData<Collection<BaseItemDto>>
 
-	fun isSupported(collectionType: String): Boolean
-	fun allowViewSelection(collectionType: String): Boolean
+	fun isSupported(collectionType: String?): Boolean
+	fun allowViewSelection(collectionType: String?): Boolean
 }
 
 class UserViewsRepositoryImpl(
@@ -21,12 +21,12 @@ class UserViewsRepositoryImpl(
 		val views by api.userViewsApi.getUserViews()
 		val filteredViews = views.items
 			.orEmpty()
-			.filter { isSupported(it.collectionType.orEmpty()) }
+			.filter { isSupported(it.collectionType) }
 		emit(filteredViews)
 	}
 
-	override fun isSupported(collectionType: String) = collectionType !in unsupportedCollectionTypes
-	override fun allowViewSelection(collectionType: String) = collectionType != CollectionType.Music
+	override fun isSupported(collectionType: String?) = collectionType !in unsupportedCollectionTypes
+	override fun allowViewSelection(collectionType: String?) = collectionType != CollectionType.Music
 
 	private companion object {
 		private val unsupportedCollectionTypes = arrayOf(

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -143,7 +143,7 @@ class LeanbackChannelWorker(
 		// Add new items
 		val items = response.items
 			.orEmpty()
-			.filter { userViewsRepository.isSupported(it.collectionType.orEmpty()) }
+			.filter { userViewsRepository.isSupported(it.collectionType) }
 			.map { item ->
 				val imageUri = if (item.imageTags?.contains(ImageType.PRIMARY) == true)
 					api.imageApi.getItemImageUrl(item.id, ImageType.PRIMARY).toUri()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
@@ -23,7 +23,7 @@ class LibrariesPreferencesScreen : OptionsFragment() {
 
 		category {
 			userViewsRepository.views.value.orEmpty().forEach {
-				val allowViewSelection = userViewsRepository.allowViewSelection(it.collectionType.orEmpty())
+				val allowViewSelection = userViewsRepository.allowViewSelection(it.collectionType)
 
 				link {
 					title = it.name


### PR DESCRIPTION
Fixes an issue in #1352 

**Changes**

- Allow `null` values in UserViewsRepository functions isSupported and allowViewSelection
- Remove `.orEmpty()` when calling UserViewsRepository functions from Kotlin

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
