### PR TITLE
fix crash from empty or null browsecommand sent from android client

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -140,13 +140,17 @@ public class TvApiEventListener extends ApiEventListener {
                 Timber.i("Command ignored due to no activity or playback in progress");
                 return;
             }
-            client.GetItemAsync(command.getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
-                @Override
-                public void onResponse(BaseItemDto response) {
-                    //Create a rowItem and pass to our handler
-                    ItemLauncher.launch(new BaseRowItem(0, response), null, -1, TvApp.getApplication().getCurrentActivity(), true);
-                }
-            });
+            try {
+                client.GetItemAsync(command.getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                    @Override
+                    public void onResponse(BaseItemDto response) {
+                        //Create a rowItem and pass to our handler
+                        ItemLauncher.launch(new BaseRowItem(0, response), null, -1, TvApp.getApplication().getCurrentActivity(), true);
+                    }
+                });
+            } catch (IllegalArgumentException e) {
+                Timber.i("invalid BrowseRequest command");
+            }
         });
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -133,7 +133,7 @@ public class TvApiEventListener extends ApiEventListener {
     @Override
     public void onBrowseCommand(ApiClient client, BrowseRequest command) {
         Timber.d("Browse command received");
-        if (command.getItemId() == null || command.getItemId().equals("")) return;
+        if (Utils.isEmpty(command.getItemId())) return;
 
         mainThreadHandler.post(() -> {
             if (TvApp.getApplication().getCurrentActivity() == null ||

--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -133,6 +133,7 @@ public class TvApiEventListener extends ApiEventListener {
     @Override
     public void onBrowseCommand(ApiClient client, BrowseRequest command) {
         Timber.d("Browse command received");
+        if (command.getItemId() == null || command.getItemId().equals("")) return;
 
         mainThreadHandler.post(() -> {
             if (TvApp.getApplication().getCurrentActivity() == null ||
@@ -140,17 +141,13 @@ public class TvApiEventListener extends ApiEventListener {
                 Timber.i("Command ignored due to no activity or playback in progress");
                 return;
             }
-            try {
-                client.GetItemAsync(command.getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
-                    @Override
-                    public void onResponse(BaseItemDto response) {
-                        //Create a rowItem and pass to our handler
-                        ItemLauncher.launch(new BaseRowItem(0, response), null, -1, TvApp.getApplication().getCurrentActivity(), true);
-                    }
-                });
-            } catch (IllegalArgumentException e) {
-                Timber.i("invalid BrowseRequest command");
-            }
+            client.GetItemAsync(command.getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                @Override
+                public void onResponse(BaseItemDto response) {
+                    //Create a rowItem and pass to our handler
+                    ItemLauncher.launch(new BaseRowItem(0, response), null, -1, TvApp.getApplication().getCurrentActivity(), true);
+                }
+            });
         });
     }
 


### PR DESCRIPTION
**Changes**
* catch the `IllegalArgumentException` GetItemAsync throws when `itemId` is null or empty in this situation

**Issues**
* `command.getItemId()` could return a null or empty string when remote controlling the app from the android client and quickly pressing the back button (on the phone) until the app is closed