### PR TITLE
position the audio player queue row without user interaction

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -95,6 +95,8 @@ public class AudioNowPlayingActivity extends BaseActivity {
     private BaseItemDto mBaseItem;
     private ListRow mQueueRow;
 
+    private boolean queueRowHasFocus = false;
+
     private long lastUserInteraction;
     private boolean ssActive;
 
@@ -361,7 +363,6 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 // new item started
                 loadItem();
                 updateButtons(true);
-                mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
             } else {
                 updateButtons(newState == PlaybackController.PlaybackState.PLAYING);
                 if (newState == PlaybackController.PlaybackState.IDLE && !mediaManager.getValue().hasNextAudioItem())
@@ -372,6 +373,9 @@ public class AudioNowPlayingActivity extends BaseActivity {
         @Override
         public void onProgress(long pos) {
             setCurrentTime(pos);
+            if (mAudioQueuePresenter != null && !queueRowHasFocus && mAudioQueuePresenter.getPosition() != mediaManager.getValue().getCurrentAudioQueuePosition()) {
+                mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
+            }
         }
 
         @Override
@@ -402,15 +406,12 @@ public class AudioNowPlayingActivity extends BaseActivity {
                 // when the playback control buttons lose focus, the only other focusable object is the queue row.
                 // Scroll to the bottom of the scrollView
                 mScrollView.smoothScrollTo(0, mScrollView.getHeight() - 1);
+                queueRowHasFocus = true;
                 return;
             }
-
+            queueRowHasFocus = false;
             //scroll so entire main area is in view
             mScrollView.smoothScrollTo(0, 0);
-            if (mediaManager.getValue().hasAudioQueueItems()) {
-                //also re-position queue to current in case they scrolled around
-                mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
-            }
         }
     };
 
@@ -473,7 +474,6 @@ public class AudioNowPlayingActivity extends BaseActivity {
                     mAlbumButton.setEnabled(mBaseItem.getAlbumId() != null);
                     mArtistButton.setEnabled(mBaseItem.getAlbumArtists() != null && mBaseItem.getAlbumArtists().size() > 0);
                 }
-
             }
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -116,9 +116,9 @@ public class MediaManager {
     public List<BaseItemDto> getCurrentVideoQueue() { return mCurrentVideoQueue; }
 
     public int getCurrentAudioQueueSize() { return mCurrentAudioQueue != null ? mCurrentAudioQueue.size() : 0; }
-    public int getCurrentAudioQueuePosition() { return mCurrentAudioQueuePosition; }
+    public int getCurrentAudioQueuePosition() { return hasAudioQueueItems() && mCurrentAudioQueuePosition >= 0 ? mCurrentAudioQueuePosition : 0; }
     public long getCurrentAudioPosition() { return mCurrentAudioPosition; }
-    public String getCurrentAudioQueueDisplayPosition() { return Integer.toString(mCurrentAudioQueuePosition >=0 ? mCurrentAudioQueuePosition+1 : 1); }
+    public String getCurrentAudioQueueDisplayPosition() { return Integer.toString(getCurrentAudioQueuePosition() + 1); }
     public String getCurrentAudioQueueDisplaySize() { return mCurrentAudioQueue != null ? Integer.toString(mCurrentAudioQueue.size()) : "0"; }
 
     public BaseItemDto getCurrentAudioItem() { return mCurrentAudioItem != null ? mCurrentAudioItem : hasAudioQueueItems() ? ((BaseRowItem)mCurrentAudioQueue.get(0)).getBaseItem() : null; }
@@ -152,12 +152,12 @@ public class MediaManager {
             if (mManagedAudioQueue != null) {
                 //re-create existing one
                 mManagedAudioQueue.clear();
-                for (int i = mCurrentAudioQueuePosition >= 0 ? mCurrentAudioQueuePosition : 0; i < mCurrentAudioQueue.size(); i++) {
+                for (int i = getCurrentAudioQueuePosition(); i < mCurrentAudioQueue.size(); i++) {
                     mManagedAudioQueue.add(mCurrentAudioQueue.get(i));
                 }
             } else {
                 List<BaseItemDto> managedItems = new ArrayList<>();
-                for (int i = mCurrentAudioQueuePosition >= 0 ? mCurrentAudioQueuePosition : 0; i < mCurrentAudioQueue.size(); i++) {
+                for (int i = getCurrentAudioQueuePosition(); i < mCurrentAudioQueue.size(); i++) {
                     managedItems.add(((BaseRowItem)mCurrentAudioQueue.get(i)).getBaseItem());
                 }
                 mManagedAudioQueue = new ItemRowAdapter(managedItems, new CardPresenter(true, Utils.convertDpToPixel(TvApp.getApplication(), 150)), null, QueryType.StaticAudioQueueItems);


### PR DESCRIPTION
**Changes**
* update the row position in `onProgress` if the row isn't focused (so it doesn't jump around while a user is navigating within it)
* track the row being focused or not using a boolean set in the button row focus listener

* ensure `getCurrentAudioQueuePosition()` never returns -1
* use `getCurrentAudioQueuePosition()` in `getCurrentAudioQueueDisplayPosition()` so it never displays -1

**Issues**
* the user had to select a new button or move focus for the queue row to select the current queue item

**Notes**
* I'm not sure if querying `mediaManager` for the current position, and querying the row for its position, has a significant performance impact when its done this frequently.

Edit:
* I removed the nowplaying button changes via force push and they'll go in a new PR related to handling the player being released