### PR TITLE
shuffle the audio queue locally

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -193,7 +193,7 @@ public class TvApiEventListener extends ApiEventListener {
                                     TvApp.getApplication().getCurrentActivity().startActivity(intent);
                                     break;
                                 case "Audio":
-                                    mediaManager.playNow(Arrays.asList(response.getItems()), startIndex);
+                                    mediaManager.playNow(Arrays.asList(response.getItems()), startIndex, false);
                                     break;
                             }
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -1599,9 +1599,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     protected void play(final BaseItemDto item, final int pos, final boolean shuffle) {
-        boolean shuffleQuery = item.getBaseItemType() == BaseItemType.MusicAlbum || item.getBaseItemType() == BaseItemType.MusicArtist || item.getBaseItemType() == BaseItemType.Audio ? false : shuffle;
-
-        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffleQuery, new Response<List<BaseItemDto>>() {
+        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
                 PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -1448,7 +1448,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
                         @Override
                         public void onResponse(List<BaseItemDto> response) {
                             if (mBaseItem.getBaseItemType() == BaseItemType.MusicArtist) {
-                                mediaManager.getValue().playNow(response);
+                                mediaManager.getValue().playNow(response, false);
                             } else {
                                 Intent intent = new Intent(FullDetailsActivity.this, ExternalPlayerActivity.class);
                                 mediaManager.getValue().setCurrentVideoQueue(response);
@@ -1599,15 +1599,16 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
     }
 
     protected void play(final BaseItemDto item, final int pos, final boolean shuffle) {
+        boolean shuffleQuery = item.getBaseItemType() == BaseItemType.MusicAlbum || item.getBaseItemType() == BaseItemType.MusicArtist || item.getBaseItemType() == BaseItemType.Audio ? false : shuffle;
 
-        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
+        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffleQuery, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
                 PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
                 if (playbackLauncher.interceptPlayRequest(FullDetailsActivity.this, item)) return;
 
                 if (item.getBaseItemType() == BaseItemType.MusicArtist) {
-                    mediaManager.getValue().playNow(response);
+                    mediaManager.getValue().playNow(response, shuffle);
                 } else {
                     Class activity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(item.getBaseItemType());
                     Intent intent = new Intent(FullDetailsActivity.this, activity);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -289,7 +289,7 @@ public class ItemListActivity extends FragmentActivity {
         playFromHere.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                play(mItems, row.getIndex());
+                play(mItems, row.getIndex(), false);
                 return true;
             }
         });
@@ -297,7 +297,7 @@ public class ItemListActivity extends FragmentActivity {
         play.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                play(mItems.subList(row.getIndex(), row.getIndex()+1));
+                play(mItems.subList(row.getIndex(), row.getIndex()+1), false);
                 return true;
             }
         });
@@ -510,11 +510,11 @@ public class ItemListActivity extends FragmentActivity {
         else textView.setText(null);
     }
 
-    private void play(List<BaseItemDto> items) {
-        play(items, 0);
+    private void play(List<BaseItemDto> items, boolean shuffle) {
+        play(items, 0, shuffle);
     }
 
-    private void play(List<BaseItemDto> items, int ndx) {
+    private void play(List<BaseItemDto> items, int ndx, boolean shuffle) {
         PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
         if (playbackLauncher.interceptPlayRequest(this, items.size() > 0 ? items.get(0) : null)) return;
 
@@ -529,12 +529,9 @@ public class ItemListActivity extends FragmentActivity {
             }
             mediaManager.getValue().setCurrentVideoQueue(items);
             startActivity(intent);
-
         } else {
-            mediaManager.getValue().playNow(items, ndx);
-
+            mediaManager.getValue().playNow(items, ndx, shuffle);
         }
-
     }
 
     private void addButtons(int buttonSize) {
@@ -544,7 +541,7 @@ public class ItemListActivity extends FragmentActivity {
                 @Override
                 public void onClick(View v) {
                     if (mItems.size() > 0) {
-                        play(mItems);
+                        play(mItems, false);
                     } else {
                         Utils.showToast(mActivity, R.string.msg_no_playable_items);
                     }
@@ -585,14 +582,11 @@ public class ItemListActivity extends FragmentActivity {
                                     || mBaseItem.getId().equals(FAV_SONGS)
                                     || mBaseItem.getBaseItemType() == BaseItemType.Playlist
                                     || mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum) {
-                                List<BaseItemDto> shuffled = new ArrayList<>(mItems);
-                                Collections.shuffle(shuffled);
-                                play(shuffled);
+                                play(mItems, true);
                             } else {
                                 //use server retrieval in order to get all items
                                 PlaybackHelper.retrieveAndPlay(mBaseItem.getId(), true, mActivity);
                             }
-
                         } else {
                             Utils.showToast(mActivity, R.string.msg_no_playable_items);
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -133,10 +133,9 @@ public class PlaybackHelper {
                 query.setIsMissing(false);
                 query.setIsVirtualUnaired(false);
                 query.setMediaTypes(new String[]{"Audio"});
-                query.setSortBy(shuffle ?
-                        new String[] {ItemSortBy.Random} :
-                            mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.Album,ItemSortBy.SortName} :
-                                new String[] {ItemSortBy.SortName});
+                query.setSortBy(mainItem.getBaseItemType() == BaseItemType.MusicArtist ?
+                        new String[] {ItemSortBy.Album,ItemSortBy.SortName} :
+                            new String[] {ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(ITEM_QUERY_LIMIT);
                 query.setFields(new ItemFields[] {
@@ -260,9 +259,8 @@ public class PlaybackHelper {
     public static void play(final BaseItemDto item, final int pos, final boolean shuffle, final Context activity) {
         PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
         if (playbackLauncher.interceptPlayRequest(activity, item)) return;
-        boolean shuffleQuery = item.getBaseItemType() == BaseItemType.MusicAlbum || item.getBaseItemType() == BaseItemType.MusicAlbum || item.getBaseItemType() == BaseItemType.Audio ? false : shuffle;
 
-        getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffleQuery, new Response<List<BaseItemDto>>() {
+        getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
                 switch (item.getBaseItemType()) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -135,7 +135,7 @@ public class PlaybackHelper {
                 query.setMediaTypes(new String[]{"Audio"});
                 query.setSortBy(shuffle ?
                         new String[] {ItemSortBy.Random} :
-                            mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.SortName,ItemSortBy.Album} :
+                            mainItem.getBaseItemType() == BaseItemType.MusicArtist ? new String[] {ItemSortBy.Album,ItemSortBy.SortName} :
                                 new String[] {ItemSortBy.SortName});
                 query.setRecursive(true);
                 query.setLimit(ITEM_QUERY_LIMIT);
@@ -260,18 +260,19 @@ public class PlaybackHelper {
     public static void play(final BaseItemDto item, final int pos, final boolean shuffle, final Context activity) {
         PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
         if (playbackLauncher.interceptPlayRequest(activity, item)) return;
+        boolean shuffleQuery = item.getBaseItemType() == BaseItemType.MusicAlbum || item.getBaseItemType() == BaseItemType.MusicAlbum || item.getBaseItemType() == BaseItemType.Audio ? false : shuffle;
 
-        getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
+        getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffleQuery, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
                 switch (item.getBaseItemType()) {
                     case MusicAlbum:
                     case MusicArtist:
-                        KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response);
+                        KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response, shuffle);
                         break;
                     case Playlist:
                         if ("Audio".equals(item.getMediaType())) {
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response);
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response, shuffle);
 
                         } else {
                             BaseItemType itemType = response.size() > 0 ? response.get(0).getBaseItemType() : null;
@@ -342,7 +343,7 @@ public class PlaybackHelper {
             @Override
             public void onResponse(BaseItemDto[] response) {
                 if (response.length > 0) {
-                    KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(Arrays.asList(response));
+                    KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(Arrays.asList(response), false);
                 } else {
                     Utils.showToast(context, R.string.msg_no_playable_items);
                 }


### PR DESCRIPTION
**Changes**

* allow `mediaManager` to manage shuffling a new audio queue. This means clicking "shuffle (all)" will create a queue with the shuffle button enabled, and toggling it off will give the user an un-shuffled queue.

* gave the relevant `playNow()` methods a `shuffle` (boolean) parameter

* bypassed `getItemsToPlay()` handling shuffling audio items. This could be done more cleanly by having it internally ignore the `shuffle` parameter for audio

* fixed the query sorting of MusicArtist so songs are sorted by album and are in order within the albums

**Issues**
* starting audio playback by using the "shuffle (all)" buttons didn't allow for truly un-shuffling
* clicking "play all" on a music artist would sometimes (but not always) queue the songs unordered
