### PR TITLE
fix handling of null music player, audio focus loss, and device going to sleep while playing audio

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingBug.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingBug.java
@@ -76,7 +76,14 @@ public class NowPlayingBug extends FrameLayout {
     AudioEventListener listener = new AudioEventListener() {
         @Override
         public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {
-            if (newState == PlaybackController.PlaybackState.PLAYING && currentItem != null) setInfo(currentItem);
+            if (currentItem == null)
+                return;
+
+            if (newState == PlaybackController.PlaybackState.PLAYING) {
+                setInfo(currentItem);
+            } else if (newState == PlaybackController.PlaybackState.IDLE && isShown()) {
+                setStatus(mediaManager.getValue().getCurrentAudioPosition());
+            }
         }
 
         @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -289,9 +289,11 @@ public class AudioNowPlayingActivity extends BaseActivity {
         lastUserInteraction = System.currentTimeMillis();
         //link events
         mediaManager.getValue().addAudioEventListener(audioEventListener);
-        if (mediaManager.getValue().getIsAudioPlayerInitialized()) {
-            updateButtons(mediaManager.getValue().isPlayingAudio());
-        }
+        updateButtons(mediaManager.getValue().isPlayingAudio());
+
+        // load the item duration and set the position to 0 since it won't be set elsewhere until playback is initialized
+        if (!mediaManager.getValue().getIsAudioPlayerInitialized())
+            setCurrentTime(0);
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -360,6 +360,8 @@ public class MediaManager {
     }
 
     private void stopProgressLoop() {
+        lastUniqueProgressEvent = -1;
+        lastReportedPlaybackPosition = -1;
         if (progressLoop != null) {
             Timber.i("stopping progress loop");
             mHandler.removeCallbacks(progressLoop);


### PR DESCRIPTION
**Changes**
* in the `now playing bug`:
> * update the timestamp if the playstate is idle, at this time the position mediamanger reports will be 0.

* in `now playing activity` `onResume`:
> * always update the player buttons in now playing activity. This seems stable now - prior to recent changes it needed a runnable.
> * update the timestamp to 0 if the player isn't initialized. In this situation a given song will need to start from the beginning. Without this the timestamp won't show at all.

* in `MediaManager`:
> * **stop the audio playback session and release the player:**
> > * on player error
> > * on audio focus loss. This can be tested by playing music, switching to youtube, and starting a youtube video
> > * when the last item in the queue finishes playing

> * **when the playback session is stopped:**
> > * reset the current position (timestamp) to 0
> > * if the player should be released, also abandon audio focus

> * simplified the logic of `onComplete()` - made it so the player  can be released if the queue if finished

> * handle the device going to sleep while playing music by checking if, while the PlayState is `PLAYING`, the same position has been reported in `reportProgress()` for more than 15 seconds. If this condition is met, pause playback

**Issues**
* If the music player is uninitialized (this can happen when switching between playing music and video):
> * the now playing bug displayed a position from before the session ended instead of updating to 0.
> * the now playing activity buttons (play, pause, etc) would be in their default state until playback is started and the player is initialized.

* `onComplete()` in `MediaManager` didn't release the player after the last item in the queue completes
* if the device is put to sleep while music is playing, the server will continue to get progress reports infinitely until that specific item is reported as paused or stopped.
If that item is never reported as stopped, especially if new playback sessions are started afterward, I repeatedly experienced my server become unresponsive and needed to be restarted
