### PR TITLE
Fix ImageHelper returning wrong URL when preferParentThumb is true

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -65,7 +65,7 @@ class ImageHelper(
 		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
 		var imageType = ImageType.PRIMARY
 
-		if (preferParentThumb && item.type.equals(BaseItemType.Episode.toString(), ignoreCase = true) && imageTag == null) {
+		if (preferParentThumb && item.type.equals(BaseItemType.Episode.toString(), ignoreCase = true)) {
 			if (item.parentThumbItemId != null && item.parentThumbImageTag != null) {
 				itemId = item.parentThumbItemId!!.toUUID()
 				imageTag = item.parentThumbImageTag


### PR DESCRIPTION
Accidentally added a null check in #1377. It wasn't there in the previous ImageUtils implementation.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
