### PR TITLE
Migrate remaining image url building to SDK

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -86,7 +86,7 @@ val appModule = module {
 	single<UserViewsRepository> { UserViewsRepositoryImpl(get(userApiClient)) }
 
 	viewModel { LoginViewModel(get(), get(), get()) }
-	viewModel { NextUpViewModel(get(), get(), get(), get()) }
+	viewModel { NextUpViewModel(get(), get(), get(), get(), get()) }
 
 	single { BackgroundService(get(), get(userApiClient), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -88,5 +88,5 @@ val appModule = module {
 	viewModel { LoginViewModel(get(), get(), get()) }
 	viewModel { NextUpViewModel(get(), get(), get(), get()) }
 
-	single { BackgroundService(get(), get(), get()) }
+	single { BackgroundService(get(), get(userApiClient), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpViewModel.kt
@@ -13,16 +13,18 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
+import org.jellyfin.androidtv.util.ImageHelper
 import org.jellyfin.androidtv.util.apiclient.getDisplayName
 import org.jellyfin.androidtv.util.apiclient.getItem
+import org.jellyfin.androidtv.util.sdk.compat.asSdk
 import org.jellyfin.apiclient.interaction.ApiClient
-import org.jellyfin.apiclient.model.dto.ImageOptions
 
 class NextUpViewModel(
 	private val context: Context,
 	private val apiClient: ApiClient,
 	private val userPreferences: UserPreferences,
 	private val sessionRepository: SessionRepository,
+	private val imageHelper: ImageHelper,
 ) : ViewModel() {
 	private val _item = MutableLiveData<NextUpItemData?>()
 	val item: LiveData<NextUpItemData?> = _item
@@ -65,10 +67,10 @@ class NextUpViewModel(
 		val item = apiClient.getItem(id, userId) ?: return@withContext null
 
 		val thumbnail = when (userPreferences[UserPreferences.nextUpBehavior]) {
-			NextUpBehavior.EXTENDED -> apiClient.GetImageUrl(item, ImageOptions())
+			NextUpBehavior.EXTENDED -> imageHelper.getPrimaryImageUrl(item.asSdk())
 			else -> null
 		}
-		val logo = apiClient.GetLogoImageUrl(item, ImageOptions())
+		val logo = imageHelper.getLogoImageUrl(item.asSdk())
 		val title = item.getDisplayName(context)
 
 		NextUpItemData(

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -39,7 +39,7 @@ class ImageHelper(
 		}
 	}
 
-	fun getPrimaryImageUrl(item: BaseItemDto, width: Int?, height: Int?): String? {
+	fun getPrimaryImageUrl(item: BaseItemDto, width: Int? = null, height: Int? = null): String? {
 		val primaryImageTag = item.imageTags?.get(ImageType.PRIMARY) ?: return null
 
 		return api.imageApi.getItemImageUrl(
@@ -101,7 +101,7 @@ class ImageHelper(
 		)
 	}
 
-	fun getLogoImageUrl(item: BaseItemDto?, maxWidth: Int, useSeriesFallback: Boolean): String? {
+	fun getLogoImageUrl(item: BaseItemDto?, maxWidth: Int? = null, useSeriesFallback: Boolean = true): String? {
 		val logoTag = item?.imageTags?.get(ImageType.LOGO)
 		return when {
 			// No item


### PR DESCRIPTION
Part 2 of #1377 migrating all other usages of apiClient.GetImageUrl to the SDK. There are only 3 usages left in ImageUtils, all of them are used in Live TV code only and thus I cannot test my changes. **Feel free to finish the migration by converting those 3**.

**Changes**
- Migrate BackgroundService to use SDK for images
- Migrate BaseItemUtils.buildChapterItems to use SDK for images
- Migrate NextUpViewModel to use SDK for images

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
