### PR TITLE
simplified exoplayer code

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -148,7 +148,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 new DefaultRenderersFactory(context) {
                     @Override
                     protected void buildTextRenderers(Context context, TextOutput output,
-                                                      Looper outputLooper, int extensionRendeexrerMode,
+                                                      Looper outputLooper, int extensionRendererMode,
                                                       ArrayList<Renderer> out) {
                         // Do not add text renderers since we handle subtitles
                     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -93,10 +93,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         mSubtitlesSurface.setZOrderMediaOverlay(true);
         mSubtitlesSurface.getHolder().setFormat(PixelFormat.TRANSLUCENT);
 
-        ExoPlayer.Builder exoPlayerBuilder = new ExoPlayer.Builder(activity);
-        exoPlayerBuilder.setRenderersFactory(createExoplayerRenderersFactory(activity));
-        mExoPlayer = exoPlayerBuilder.build();
-
+        mExoPlayer = configureExoplayerBuilder(activity).build();
         mExoPlayerView = view.findViewById(R.id.exoPlayerView);
         mExoPlayerView.setPlayer(mExoPlayer);
         mExoPlayer.addListener(new Player.Listener() {
@@ -142,9 +139,11 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
      * ExoPlayer to silently fallback to software renderers.
      *
      * @param context The associated context
-     * @return A configured factory for Exoplayer
+     * @return A configured builder for Exoplayer
      */
-    private DefaultRenderersFactory createExoplayerRenderersFactory(Context context) {
+    private ExoPlayer.Builder configureExoplayerBuilder(Context context) {
+        ExoPlayer.Builder exoPlayerBuilder = new ExoPlayer.Builder(context);
+
         DefaultRenderersFactory defaultRendererFactory =
                 new DefaultRenderersFactory(context) {
                     @Override
@@ -156,7 +155,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 };
         defaultRendererFactory.setEnableDecoderFallback(true);
         defaultRendererFactory.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON);
-        return defaultRendererFactory;
+        exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
+
+        return exoPlayerBuilder;
     }
 
     public boolean isInitialized() {


### PR DESCRIPTION
**Changes**
* put all the factory-related code in one place
* Replaced deprecated `DefaultDataSourceFactory` with `DefaultHttpDataSource.Factory`
* Replaced deprecated `Player.EventListener` with `Player.Listener`
* cut out unnecessary steps in setting the media

**Notes**
The `MediaSourceFactory` is only used to add the user agent (via `DefaultHttpDataSource`). If the user agent isn't actually necessary, that can be removed too. Then it would be all defaults, and would be a simple:
1) make the player builder, set the renderer, and build
2) set the media item and prepare


This cleanup was done while trying to figure out why the last few seconds of hls streams repeat. I tested adding a `DefaultExtractorsFactory` and setting:
`extractorsFactory.setFragmentedMp4ExtractorFlags(FragmentedMp4Extractor.FLAG_WORKAROUND_IGNORE_EDIT_LISTS);`
This is what the exoplayer docs recommended for parts of the video repeating. It didn't work. Neither did the corresponding flag for the `Mp4Extractor` 

I also tested using an `HlsMediaSource` and setting:
`exoPlayerBuilder.setMediaSourceFactory(new HlsMediaSource.Factory(baseDataSourceFactory).setAllowChunklessPreparation(true));`
This sped up video loading. However, there wasn't a simple way do this only when transcoding, so I ditched it.