### PR TITLE
fix crashes from changing audio tracks, fix exoplayer not using default audio track

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -659,8 +659,8 @@ public class PlaybackController {
                             Integer defaultAudioIndex = internalResponse.getMediaSource().getDefaultAudioStreamIndex();
                             Integer firstAudioIndex = bestGuessAudioTrack(internalResponse.getMediaSource());
 
-                                            // if an audio index is specified but is not the default or inferred first
-                            if (!useVlc && (currAudioIndex != null && ((defaultAudioIndex != null && !currAudioIndex.equals(defaultAudioIndex)) || (firstAudioIndex != null && !currAudioIndex.equals(firstAudioIndex)))) ||
+                                            // if an audio index is specified but is not the inferred first
+                            if (!useVlc && (currAudioIndex != null && firstAudioIndex != null && !currAudioIndex.equals(firstAudioIndex)) ||
                                             // if an audio index is not specified but the default is not the inferred first
                                             (currAudioIndex == null && firstAudioIndex != null && defaultAudioIndex != null && !firstAudioIndex.equals(defaultAudioIndex))) {
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -875,6 +875,7 @@ public class PlaybackController {
             mPlaybackState = PlaybackState.BUFFERING;
         } else if (mVideoManager.setAudioTrack(index) == index) {
             // if setAudioTrack succeeded it will return the requested index
+            mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
             mCurrentOptions.setAudioStreamIndex(index);
             mVideoManager.setAudioMode();
         }
@@ -1156,6 +1157,7 @@ public class PlaybackController {
                     mVideoManager.play();
                     mPlaybackState = PlaybackState.PLAYING;
                     if (mFragment != null) mFragment.setFadingEnabled(true);
+                    startReportLoop();
                 }
             }
         }
@@ -1406,13 +1408,20 @@ public class PlaybackController {
                         Timber.i("Turning off subs by default");
                         mVideoManager.disableSubs();
                     }
-                    int eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex() != null ? getCurrentMediaSource().getDefaultAudioStreamIndex() : mDefaultAudioIndex;
+                    int eligibleAudioTrack = mDefaultAudioIndex;
+                    if (mCurrentOptions.getAudioStreamIndex() != null) {
+                        eligibleAudioTrack = mCurrentOptions.getAudioStreamIndex();
+                        Timber.d("switching AudioStream to index: %d - using mCurrentOptions index", eligibleAudioTrack);
+                    } else if (getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
+                        eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex();
+                        Timber.d("switching AudioStream to index: %d - using getDefaultAudioStreamIndex", eligibleAudioTrack);
+                    } else {
+                        Timber.d("switching AudioStream to index: %d - using mDefaultAudioIndex", eligibleAudioTrack);
+                    }
                     if (!mVideoManager.isNativeMode()) {
-                        Timber.i("switching AudioStream to index: %d", eligibleAudioTrack);
                         switchAudioStream(eligibleAudioTrack);
                     }
                 }
-
             }
         });
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -659,7 +659,7 @@ public class PlaybackController {
                             Integer defaultAudioIndex = internalResponse.getMediaSource().getDefaultAudioStreamIndex();
                             Integer firstAudioIndex = bestGuessAudioTrack(internalResponse.getMediaSource());
 
-                                            // if an audio index is specified but in not the default or inferred first
+                                            // if an audio index is specified but is not the default or inferred first
                             if (!useVlc && (currAudioIndex != null && (!currAudioIndex.equals(defaultAudioIndex) || !currAudioIndex.equals(firstAudioIndex))) ||
                                             // if an audio index is not specified but the default is not the inferred first
                                             (currAudioIndex == null && firstAudioIndex != null && !firstAudioIndex.equals(defaultAudioIndex))) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -653,16 +653,16 @@ public class PlaybackController {
                                 return;
                             mVideoManager.init(getBufferAmount(), useDeinterlacing);
 
-                            Timber.d("internal audio index %s response default %s", internalOptions.getAudioStreamIndex(), internalResponse.getMediaSource().getDefaultAudioStreamIndex());
+                            Timber.d("current selected audio index: %s server default: %s inferred first track: %s", internalOptions.getAudioStreamIndex(), internalResponse.getMediaSource().getDefaultAudioStreamIndex(), bestGuessAudioTrack(internalResponse.getMediaSource()));
 
                             Integer currAudioIndex = internalOptions.getAudioStreamIndex();
                             Integer defaultAudioIndex = internalResponse.getMediaSource().getDefaultAudioStreamIndex();
                             Integer firstAudioIndex = bestGuessAudioTrack(internalResponse.getMediaSource());
 
                                             // if an audio index is specified but is not the default or inferred first
-                            if (!useVlc && (currAudioIndex != null && (!currAudioIndex.equals(defaultAudioIndex) || !currAudioIndex.equals(firstAudioIndex))) ||
+                            if (!useVlc && (currAudioIndex != null && ((defaultAudioIndex != null && !currAudioIndex.equals(defaultAudioIndex)) || (firstAudioIndex != null && !currAudioIndex.equals(firstAudioIndex)))) ||
                                             // if an audio index is not specified but the default is not the inferred first
-                                            (currAudioIndex == null && firstAudioIndex != null && !firstAudioIndex.equals(defaultAudioIndex))) {
+                                            (currAudioIndex == null && firstAudioIndex != null && defaultAudioIndex != null && !firstAudioIndex.equals(defaultAudioIndex))) {
 
                                 // requested specific audio stream that is different from default so we need to force a transcode to get it (ExoMedia currently cannot switch)
                                 // remove direct play profiles to force the transcode

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1408,17 +1408,17 @@ public class PlaybackController {
                         Timber.i("Turning off subs by default");
                         mVideoManager.disableSubs();
                     }
-                    int eligibleAudioTrack = mDefaultAudioIndex;
-                    if (mCurrentOptions.getAudioStreamIndex() != null) {
-                        eligibleAudioTrack = mCurrentOptions.getAudioStreamIndex();
-                        Timber.d("switching AudioStream to index: %d - using mCurrentOptions index", eligibleAudioTrack);
-                    } else if (getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
-                        eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex();
-                        Timber.d("switching AudioStream to index: %d - using getDefaultAudioStreamIndex", eligibleAudioTrack);
-                    } else {
-                        Timber.d("switching AudioStream to index: %d - using mDefaultAudioIndex", eligibleAudioTrack);
-                    }
                     if (!mVideoManager.isNativeMode()) {
+                        int eligibleAudioTrack = mDefaultAudioIndex;
+                        if (mCurrentOptions.getAudioStreamIndex() != null) {
+                            eligibleAudioTrack = mCurrentOptions.getAudioStreamIndex();
+                            Timber.d("switching AudioStream to index: %d - using mCurrentOptions index", eligibleAudioTrack);
+                        } else if (getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
+                            eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex();
+                            Timber.d("switching AudioStream to index: %d - using getDefaultAudioStreamIndex", eligibleAudioTrack);
+                        } else {
+                            Timber.d("switching AudioStream to index: %d - using mDefaultAudioIndex", eligibleAudioTrack);
+                        }
                         switchAudioStream(eligibleAudioTrack);
                     }
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1451,7 +1451,6 @@ public class PlaybackController {
                 itemComplete();
             }
         });
-
     }
 
     public long getCurrentPosition() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -360,20 +360,16 @@ public class PlaybackController {
             if (!isPlaying() && mSeekPosition != -1) {
                 newPos = mSeekPosition;
                 // use seekPosition until playback starts
-                Timber.d("using seekPosition %s", newPos);
             } else if (isPlaying()) {
                 if (finishedInitialSeek) {
                     // playback has started - get current position and reset seekPosition
                     newPos = mVideoManager.getCurrentPosition();
                     mSeekPosition = -1;
-                    Timber.d("using real position %s", newPos);
                 } else if (wasSeeking) {
                     finishedInitialSeek = true;
-                    Timber.d("finished initial seek %s", newPos);
                 } else if (mSeekPosition != -1) {
                     newPos = mSeekPosition;
                     // use seekPosition until initial seek is done
-                    Timber.d("using seekPosition %s", newPos);
                 }
                 wasSeeking = false;
             }
@@ -409,10 +405,8 @@ public class PlaybackController {
                 mVideoManager.play();
                 if (mVideoManager.isNativeMode())
                     mPlaybackState = PlaybackState.PLAYING; //won't get another onprepared call
-                if (mFragment != null) {
+                if (mFragment != null)
                     mFragment.setFadingEnabled(true);
-                    mFragment.setPlayPauseActionState(0);
-                }
                 startReportLoop();
                 break;
             case BUFFERING:
@@ -1160,6 +1154,8 @@ public class PlaybackController {
                     pause();
                 } else {
                     mVideoManager.play();
+                    mPlaybackState = PlaybackState.PLAYING;
+                    if (mFragment != null) mFragment.setFadingEnabled(true);
                 }
             }
         }
@@ -1382,7 +1378,7 @@ public class PlaybackController {
         mVideoManager.setOnPreparedListener(new PlaybackListener() {
             @Override
             public void onEvent() {
-                if (mPlaybackState == PlaybackState.BUFFERING || mPlaybackState == PlaybackState.SEEKING) {
+                if (mPlaybackState == PlaybackState.BUFFERING) {
                     if (mFragment != null) mFragment.setFadingEnabled(true);
 
                     mPlaybackState = PlaybackState.PLAYING;
@@ -1424,7 +1420,6 @@ public class PlaybackController {
         mVideoManager.setOnProgressListener(new PlaybackListener() {
             @Override
             public void onEvent() {
-                Timber.d("on progress event");
                 refreshCurrentPosition();
                 if (isPlaying()) {
                     if (!spinnerOff) {
@@ -1432,6 +1427,7 @@ public class PlaybackController {
                             initialSeek(mStartPosition);
                             mStartPosition = 0;
                         } else {
+                            finishedInitialSeek = true;
                             stopSpinner();
                         }
                     }
@@ -1443,7 +1439,7 @@ public class PlaybackController {
                     if (mFragment != null)
                         mFragment.updateSubtitles(mCurrentPosition);
                 }
-                if (mFragment != null)
+                if (mFragment != null && finishedInitialSeek)
                     mFragment.setCurrentTime(mCurrentPosition);
             }
         });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -183,8 +183,10 @@ public class PlaybackController {
 
     public MediaSourceInfo getCurrentMediaSource() {
         if (mCurrentStreamInfo != null && mCurrentStreamInfo.getMediaSource() != null) {
+            Timber.d("using media source from current stream info");
             return mCurrentStreamInfo.getMediaSource();
         } else {
+            Timber.d("using media source from media sources list");
             ArrayList<MediaSourceInfo> mediaSources = getCurrentlyPlayingItem().getMediaSources();
 
             if (mediaSources == null || mediaSources.isEmpty()) {
@@ -732,6 +734,9 @@ public class PlaybackController {
             return;
         }
         mCurrentStreamInfo = response;
+        mCurrentOptions.setAudioStreamIndex(response.getMediaSource().getDefaultAudioStreamIndex());
+        mCurrentOptions.setMediaSourceId(response.getMediaSource().getId());
+
         Long mbPos = position * 10000;
 
         setPlaybackMethod(response.getPlayMethod());
@@ -1123,6 +1128,7 @@ public class PlaybackController {
                 @Override
                 public void onResponse(StreamInfo response) {
                     mCurrentStreamInfo = response;
+                    Timber.d("after seek - current audio index %s default index %s", mCurrentOptions.getAudioStreamIndex(), mCurrentStreamInfo == null ? -1 : mCurrentStreamInfo.getMediaSource().getDefaultAudioStreamIndex());
                     if (mVideoManager != null) {
                         mVideoManager.setVideoPath(response.getMediaUrl());
                         mVideoManager.start();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
@@ -14,12 +14,12 @@ import timber.log.Timber;
 public class StopTranscodingResponse extends EmptyResponse {
     private PlaybackManager playbackManager;
     private final DeviceInfo deviceInfo;
-    private AudioOptions options;
+    private VideoOptions options;
     private Response<StreamInfo> response;
     private Long startPositionTicks;
     private ApiClient apiClient;
 
-    public StopTranscodingResponse(PlaybackManager playbackManager, DeviceInfo deviceInfo, AudioOptions options, Long startPositionTicks, ApiClient apiClient, Response<StreamInfo> response) {
+    public StopTranscodingResponse(PlaybackManager playbackManager, DeviceInfo deviceInfo, VideoOptions options, Long startPositionTicks, ApiClient apiClient, Response<StreamInfo> response) {
         this.playbackManager = playbackManager;
         this.deviceInfo = deviceInfo;
         this.options = options;
@@ -29,7 +29,7 @@ public class StopTranscodingResponse extends EmptyResponse {
     }
 
     private void onAny() {
-        playbackManager.getVideoStreamInfo(deviceInfo, (VideoOptions) options, startPositionTicks, apiClient, response);
+        playbackManager.getVideoStreamInfo(deviceInfo, options, startPositionTicks, apiClient, response);
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -407,6 +407,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     public int getAudioTrack() {
         if (!isInitialized() || nativeMode)
             return -1;
+
         Timber.d("vlc audio track is %s", mVlcPlayer.getAudioTrack());
         return mVlcPlayer.getAudioTrack();
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -306,6 +306,18 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         stopProgressLoop();
     }
 
+    public boolean isSeekable() {
+        if (!isInitialized())
+            return false;
+        boolean canSeek = false;
+        if (isNativeMode())
+            canSeek = mExoPlayer.isCurrentMediaItemSeekable();
+        else
+            canSeek = mVlcPlayer.isSeekable();
+        Timber.d("current media item is%s seekable", canSeek ? "" : " not");
+        return canSeek;
+    }
+
     public long seekTo(long pos) {
         if (!isInitialized())
             return -1;
@@ -393,50 +405,63 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     public int getAudioTrack() {
-        return nativeMode ? -1 : mVlcPlayer.getAudioTrack();
+        if (!isInitialized() || nativeMode)
+            return -1;
+        Timber.d("vlc audio track is %s", mVlcPlayer.getAudioTrack());
+        return mVlcPlayer.getAudioTrack();
     }
 
-    public void setAudioTrack(int ndx, List<MediaStream> allStreams) {
-        if (!nativeMode) {
-            //find the relative order of our audio index within the audio tracks in VLC
-            int vlcIndex = 1; // start at 1 to account for "disabled"
-            for (MediaStream stream : allStreams) {
-                if (stream.getType() == MediaStreamType.Audio && !stream.getIsExternal()) {
-                    if (stream.getIndex() == ndx) {
-                        break;
-                    }
-                    vlcIndex++;
-                }
+    public int setAudioTrack(int ndx) {
+        if (!isInitialized() || ndx < 0)
+            return -1;
+
+        if (isNativeMode()) {
+            Timber.e("Cannot set audio track in native mode");
+            return -1;
+        }
+
+        boolean matched = false;
+        for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
+            if (track.id == ndx) {
+                matched = true;
+                break;
             }
+        }
 
-            org.videolan.libvlc.MediaPlayer.TrackDescription vlcTrack;
+        org.videolan.libvlc.MediaPlayer.TrackDescription vlcTrack = null;
+
+        if (matched) {
             try {
-                vlcTrack = mVlcPlayer.getAudioTracks()[vlcIndex];
-
+                vlcTrack = mVlcPlayer.getAudioTracks()[ndx];
             } catch (IndexOutOfBoundsException e) {
                 Timber.e("Could not locate audio with index %s in vlc track info", ndx);
-                mVlcPlayer.setAudioTrack(ndx);
-                return;
+                return -1;
             } catch (NullPointerException e) {
-                Timber.e("No subtitle tracks found in player trying to set subtitle with index %s in vlc track info", ndx);
-                mVlcPlayer.setAudioTrack(vlcIndex);
-                return;
+                Timber.e("Could not locate audio track with index %s in vlc, null exception", ndx);
+                return -1;
             }
-            //debug
-            Timber.d("Setting VLC audio track index to: %d / %d", vlcIndex, vlcTrack.id);
-            for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
-                Timber.d("VLC Audio Track: %s / %d", track.name, track.id);
-            }
-            //
-            if (mVlcPlayer.setAudioTrack(vlcTrack.id)) {
-                Timber.i("Setting by ID was successful");
-            } else {
-                Timber.i("Setting by ID not succesful, trying index");
-                mVlcPlayer.setAudioTrack(vlcIndex);
-            }
-        } else {
-            Timber.e("Cannot set audio track in native mode");
         }
+
+        if (!matched || vlcTrack == null) {
+            Timber.e("Could not locate audio track with index %s in vlc", ndx);
+        } else if (mVlcPlayer.getAudioTrack() == ndx) {
+            Timber.d("provided index points to the audio track already in use, aborting");
+        }
+
+        //debug
+        Timber.d("Setting VLC audio track index to: %d / %d", ndx, vlcTrack.id);
+        for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
+            Timber.d("VLC Audio Track: %s / %d", track.name, track.id);
+        }
+        //
+
+        if (mVlcPlayer.setAudioTrack(vlcTrack.id)) {
+            Timber.i("Setting by ID was successful");
+        } else {
+            Timber.i("Setting by ID not successful, trying index");
+            mVlcPlayer.setAudioTrack(ndx);
+        }
+        return ndx;
     }
 
     public void setPlaybackSpeed(@NonNull Double speed) {
@@ -776,14 +801,5 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 changeSurfaceLayout(mVideoWidth, mVideoHeight, mVideoVisibleWidth, mVideoVisibleHeight, mSarNum, mSarDen);
             }
         });
-    }
-
-    public Integer translateVlcAudioId(Integer vlcId) {
-        Integer ourIndex = 0;
-        for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
-            if (track.id == vlcId) return ourIndex - 1; // Vlc has 'disabled' as first
-            ourIndex++;
-        }
-        return ourIndex;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -405,15 +405,13 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         return false;
     }
 
-    public int getAudioTrack() {
+    public int getVLCAudioTrack() {
         if (!isInitialized() || nativeMode)
             return -1;
-
-        Timber.d("vlc audio track is %s", mVlcPlayer.getAudioTrack());
         return mVlcPlayer.getAudioTrack();
     }
 
-    public int setAudioTrack(int ndx) {
+    public int setVLCAudioTrack(int ndx) {
         if (!isInitialized() || ndx < 0)
             return -1;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -312,8 +312,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         boolean canSeek = false;
         if (isNativeMode())
             canSeek = mExoPlayer.isCurrentMediaItemSeekable();
-        else
-            canSeek = mVlcPlayer.isSeekable();
+        else {
+            canSeek = mVlcPlayer.isSeekable() && mVlcPlayer.getLength() > 0;
+        }
         Timber.d("current media item is%s seekable", canSeek ? "" : " not");
         return canSeek;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -420,6 +420,13 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             return -1;
         }
 
+        //debug
+        Timber.d("Setting VLC audio track index to: %d", ndx);
+        for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
+            Timber.d("VLC Audio Track: %s / %d", track.name, track.id);
+        }
+        //
+
         boolean matched = false;
         for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
             if (track.id == ndx) {
@@ -444,16 +451,11 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
         if (!matched || vlcTrack == null) {
             Timber.e("Could not locate audio track with index %s in vlc", ndx);
+            return -1;
         } else if (mVlcPlayer.getAudioTrack() == ndx) {
             Timber.d("provided index points to the audio track already in use, aborting");
+            return -1;
         }
-
-        //debug
-        Timber.d("Setting VLC audio track index to: %d / %d", ndx, vlcTrack.id);
-        for (org.videolan.libvlc.MediaPlayer.TrackDescription track : mVlcPlayer.getAudioTracks()) {
-            Timber.d("VLC Audio Track: %s / %d", track.name, track.id);
-        }
-        //
 
         if (mVlcPlayer.setAudioTrack(vlcTrack.id)) {
             Timber.i("Setting by ID was successful");

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.java
@@ -27,16 +27,12 @@ public class SelectAudioAction extends CustomAction {
     public void handleClickAction(PlaybackController playbackController, LeanbackOverlayFragment leanbackOverlayFragment, Context context, View view) {
 
         List<MediaStream> audioTracks = KoinJavaComponent.<PlaybackManager>get(PlaybackManager.class).getInPlaybackSelectableAudioStreams(playbackController.getCurrentStreamInfo());
-        Integer currentAudioIndex = playbackController.getAudioStreamIndex();
-        if (!playbackController.isNativeMode() && currentAudioIndex != null && currentAudioIndex > audioTracks.size()) {
-            //VLC has translated this to an ID - we need to translate back to our index positionally
-            currentAudioIndex = playbackController.translateVlcAudioId(currentAudioIndex);
-        }
+        int currentAudioIndex = playbackController.getAudioStreamIndex();
 
         PopupMenu audioMenu = new PopupMenu(context, view, Gravity.END);
         for (MediaStream audio : audioTracks) {
             MenuItem item = audioMenu.getMenu().add(0, audio.getIndex(), audio.getIndex(), audio.getDisplayTitle());
-            if (currentAudioIndex != null && currentAudioIndex == audio.getIndex())
+            if (currentAudioIndex == audio.getIndex())
                 item.setChecked(true);
         }
         audioMenu.getMenu().setGroupCheckable(0, true, false);


### PR DESCRIPTION
**Changes**
* reformatted several methods so they are easier to read by converting ternary statements into if/else blocks
* removed libVLC ID <- -> Stream info ID conversion
* reworked the `VideoManager` `setVLCAudioTrack()` to only handle verifying the specified track index could be passed to the player
* in `PlaybackController` `getAudioStreamIndex()`, prioritize `mVideoManager.getAudioTrack()` before other methods for finding the current audio track. Its value is only used when direct playback first starts and libVLC defaults to an audio track that isn't known elsewhere, and in turn this allows it to be changed.
* rewrote the conditions to force transcoding for exoplayer in order to start playback with an audio track which isn't the first one
* update `mCurrentOptions` to keep track of the selected audio index locally, and to report to the server when a new track has been selected.
* use `VideoOptions` in `StopTranscodingResponse` instead of casting from `AudioOptions`. Using AudioOptions likely discarded the audio and subtitles index when seeking was done, and resulted in the index being reset.
* reworked and simplified the seeking logic to prevent issues from double seeking, and to allow identifying the initial seek for direct streams and hls transcodes

**Issues**
* when using libVLC the app could crash if `mVlcPlayer.setAudioTrack()` was called and the specified track was already the one used.
* when using libVLC the audio track would reset to the default after seeking
* Converting the libVLC ID <- -> Stream info ID was no longer needed since libVLC uses the same ID now, and because of that the conversion was reporting an incorrect value.
* added `resetPlaybackStats()` to `PlaybackController` to clear stuff like sub  & audio index, stream info
* #1403 

**Testing**
* change audio tracks while playing, close the player, and then:
> * start playback again and it should play the audio track you just selected
> * switch to a different player backend and it should play the audio track you just selected
> * with exoplayer chosen, it should transcode if an audio track other than the first is chosen, and switch back to direct play if you choose the first audio track
* seeking should work normally and never change or reset the audio track selection
* the popup menu for audio track selection should always have the correct track selected

* **Testing with videos that have external audio tracks is needed**