### PR TITLE
Fix ApiBinder calling callback twice when the success callback fails

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/ApiBinder.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ApiBinder.kt
@@ -21,16 +21,17 @@ class ApiBinder(
 	private val device: IDevice,
 	private val authenticationStore: AuthenticationStore,
 ) {
-	fun updateSession(session: Session?, resultCallback: (Boolean) -> Unit) {
+	fun updateSession(session: Session?, resultCallback: ((Boolean) -> Unit)? = null) {
 		GlobalScope.launch(Dispatchers.IO) {
 			@Suppress("TooGenericExceptionCaught")
-			try {
-				val success = updateSessionInternal(session)
-				resultCallback(success)
+			val success = try {
+				updateSessionInternal(session)
 			} catch (throwable: Throwable) {
 				Timber.e(throwable, "Unable to update legacy API session.")
-				resultCallback(false)
+				false
 			}
+
+			resultCallback?.invoke(success)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -99,7 +99,7 @@ class SessionRepositoryImpl(
 
 		_currentSession.value = null
 		userApiClient.applySession(null)
-		apiBinder.updateSession(null) { }
+		apiBinder.updateSession(null)
 	}
 
 	private fun setCurrentSession(session: Session?, includeSystemUser: Boolean, callback: ((Boolean) -> Unit)? = null) {


### PR DESCRIPTION
**Changes**

- Fix ApiBinder calling callback twice when the success callback fails
- Make callback optional

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
