### PR TITLE
Add markdown support for item descriptions and server disclaimer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,6 +131,9 @@ dependencies {
 	implementation(libs.jellyfin.exoplayer.ffmpegextension)
 	implementation(libs.libvlc)
 
+	// Markdown
+	implementation(libs.bundles.markwon)
+
 	// Image utility
 	implementation(libs.glide.core)
 	kapt(libs.glide.compiler)

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -12,6 +12,7 @@ import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
 import org.jellyfin.androidtv.ui.startup.LoginViewModel
+import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.androidtv.util.sdk.legacy
 import org.jellyfin.apiclient.AppInfo
 import org.jellyfin.apiclient.android
@@ -88,4 +89,6 @@ val appModule = module {
 	viewModel { NextUpViewModel(get(), get(userApiClient), get(), get()) }
 
 	single { BackgroundService(get(), get(userApiClient), get()) }
+
+	single { MarkdownRenderer(get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -51,7 +51,7 @@ import org.jellyfin.androidtv.ui.shared.KeyListener;
 import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
-import org.jellyfin.androidtv.util.TextUtilsKt;
+import org.jellyfin.androidtv.util.MarkdownRenderer;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -98,6 +98,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
     private Lazy<GsonJsonSerializer> serializer = inject(GsonJsonSerializer.class);
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -504,7 +505,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
             mTitle.setText(rowItem.getName(requireContext()));
 
             String summary = rowItem.getSummary(requireContext());
-            if (summary != null) mSummary.setText(TextUtilsKt.toHtmlSpanned(summary));
+            if (summary != null) mSummary.setText(markdownRenderer.getValue().toMarkdownSpanned(summary));
             else mSummary.setText(null);
 
             InfoLayoutHelper.addInfoRow(requireContext(), rowItem, mInfoRow, true, true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -68,6 +68,7 @@ import org.jellyfin.androidtv.ui.shared.BaseActivity;
 import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.KeyProcessor;
+import org.jellyfin.androidtv.util.MarkdownRenderer;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
@@ -152,6 +153,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     private Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -179,7 +181,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
         mRowsFragment.setOnItemViewClickedListener(new ItemViewClickedListener());
         mRowsFragment.setOnItemViewSelectedListener(new ItemViewSelectedListener());
 
-        mDorPresenter = new MyDetailsOverviewRowPresenter();
+        mDorPresenter = new MyDetailsOverviewRowPresenter(markdownRenderer.getValue());
 
         mItemId = getIntent().getStringExtra("ItemId");
         mChannelId = getIntent().getStringExtra("ChannelId");

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
@@ -17,15 +17,19 @@ import org.jellyfin.androidtv.ui.DetailRowView;
 import org.jellyfin.androidtv.ui.TextUnderButton;
 import org.jellyfin.androidtv.ui.itemdetail.MyDetailsOverviewRow;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
-import org.jellyfin.androidtv.util.TextUtilsKt;
+import org.jellyfin.androidtv.util.MarkdownRenderer;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
 public class MyDetailsOverviewRowPresenter extends RowPresenter {
+    private final MarkdownRenderer markdownRenderer;
     private ViewHolder viewHolder;
 
-    public MyDetailsOverviewRowPresenter() {
+    public MyDetailsOverviewRowPresenter(MarkdownRenderer markdownRenderer) {
         super();
+
+        this.markdownRenderer = markdownRenderer;
+
         // Don't call setActivated() on views
         setSyncActivatePolicy(SYNC_ACTIVATED_CUSTOM);
     }
@@ -112,10 +116,9 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
             vh.mProgress.setVisibility(View.VISIBLE);
         }
 
-        // Support simple HTML elements
         String summaryRaw = row.getSummary();
         if (summaryRaw != null)
-            vh.mSummary.setText(TextUtilsKt.toHtmlSpanned(summaryRaw));
+            vh.mSummary.setText(markdownRenderer.toMarkdownSpanned(summaryRaw));
 
         switch (row.getItem().getBaseItemType()) {
             case Person:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -28,8 +28,9 @@ import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.card.DefaultCardView
 import org.jellyfin.androidtv.ui.startup.LoginViewModel
 import org.jellyfin.androidtv.util.ListAdapter
-import org.jellyfin.androidtv.util.toHtmlSpanned
+import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class ServerFragment : Fragment() {
@@ -38,6 +39,7 @@ class ServerFragment : Fragment() {
 	}
 
 	private val loginViewModel: LoginViewModel by sharedViewModel()
+	private val markdownRenderer: MarkdownRenderer by inject()
 	private lateinit var binding: FragmentServerBinding
 
 	private val serverIdArgument get() = arguments?.getString(ARG_SERVER_ID)?.ifBlank { null }?.toUUIDOrNull()
@@ -96,7 +98,7 @@ class ServerFragment : Fragment() {
 	}
 
 	private fun onServerChange(server: Server) {
-		binding.loginDisclaimer.text = server.loginDisclaimer?.toHtmlSpanned()
+		binding.loginDisclaimer.text = server.loginDisclaimer?.let { markdownRenderer.toMarkdownSpanned(it) }
 
 		binding.serverButton.apply {
 			state = ServerButtonView.State.EDIT

--- a/app/src/main/java/org/jellyfin/androidtv/util/MarkdownRenderer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/MarkdownRenderer.kt
@@ -1,0 +1,17 @@
+package org.jellyfin.androidtv.util
+
+import android.content.Context
+import android.text.Spanned
+import io.noties.markwon.Markwon
+import io.noties.markwon.html.HtmlPlugin
+
+class MarkdownRenderer(context: Context) {
+	private val markwon = Markwon.builder(context)
+		.usePlugin(HtmlPlugin.create())
+		.build()
+
+	/**
+	 * Convert string with markdown and HTML to a [Spanned].
+	 */
+	fun toMarkdownSpanned(input: String): Spanned = markwon.toMarkdown(input)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlinx-coroutines = "1.5.2"
 kotlinx-serialization = "1.3.1"
 leakcanary = "2.7"
 libvlc = "3.4.7"
+markwon = "4.6.2"
 mockk = "1.12.1"
 slf4j-timber = "3.1"
 timber = "5.0.1"
@@ -87,6 +88,10 @@ exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "
 jellyfin-exoplayer-ffmpegextension = { group = "org.jellyfin.exoplayer", name = "exoplayer-ffmpeg-extension", version.ref = "jellyfin-exoplayer-ffmpegextension" }
 libvlc = { module = "org.videolan.android:libvlc-all", version.ref = "libvlc" }
 
+# Markwon
+markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }
+markwon-html = { module = "io.noties.markwon:html", version.ref = "markwon" }
+
 # Image utility
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
 glide-core = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
@@ -132,4 +137,8 @@ koin = [
     "koin-android-compat",
     "koin-android-core",
     "koin-androidx-workmanager",
+]
+markwon = [
+    "markwon-core",
+    "markwon-html",
 ]


### PR DESCRIPTION
This pull request adds Markdown support for item descriptions and the server disclaimer (on the login screen). The renderSubtitles function in the PlaybackOverlay still uses HTML.

**Changes**
- Add Markwon dependency
- Add `MarkdownRenderer` class to create Markdown
- Support markdown (+basic HTML) for server disclaimer
- Support markdown (+basic HTML) for item overviews (descriptions)

**Issues**

- related: jellyfin/jellyfin-web#3355
