### PR TITLE
Fix default values for library sorting

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
@@ -24,7 +24,7 @@ class LibraryPreferences(
 		val filterUnwatchedOnly = Preference.boolean("FilterUnwatchedOnly", false)
 
 		// Item sorting
-		val sortBy = Preference.string("SortBy", "DateCreated,SortName")
-		val sortOrder = Preference.enum("SortOrder", SortOrder.Descending)
+		val sortBy = Preference.string("SortBy", "SortName")
+		val sortOrder = Preference.enum("SortOrder", SortOrder.Ascending)
 	}
 }


### PR DESCRIPTION
**Changes**
Fixes the default library sort options that were changed in #1011.

We use Name by default in all other clients, so it probably doesn't make sense to use something different here (although an app level settings for library options would probably be a good future enhancement).

**Issues**
N/A
