### PR TITLE
Remove "i" prefix from interfaces

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -14,7 +14,7 @@ import androidx.core.content.ContextCompat;
 import com.bumptech.glide.Glide;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.ui.livetv.ILiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.Utils;
@@ -27,14 +27,14 @@ public class GuideChannelHeader extends RelativeLayout {
     private ImageView mFavImage;
     private ChannelInfoDto mChannel;
     private Context mContext;
-    private ILiveTvGuide mTvGuide;
+    private LiveTvGuide mTvGuide;
 
-    public GuideChannelHeader(Context context, ILiveTvGuide tvGuide, ChannelInfoDto channel) {
+    public GuideChannelHeader(Context context, LiveTvGuide tvGuide, ChannelInfoDto channel) {
         super(context);
         initComponent(context, tvGuide, channel);
     }
 
-    private void initComponent(Context context, ILiveTvGuide tvGuide, ChannelInfoDto channel) {
+    private void initComponent(Context context, LiveTvGuide tvGuide, ChannelInfoDto channel) {
         mContext = context;
         mChannel = channel;
         mTvGuide = tvGuide;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
@@ -9,7 +9,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.ui.livetv.ILiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 
 public class GuidePagingButton extends RelativeLayout {
@@ -26,7 +26,7 @@ public class GuidePagingButton extends RelativeLayout {
         super(context, attrs);
     }
 
-    public GuidePagingButton(final Activity activity, final ILiveTvGuide guide, int start, String label) {
+    public GuidePagingButton(final Activity activity, final LiveTvGuide guide, int start, String label) {
         super(activity);
 
         us = this;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopup.java
@@ -20,7 +20,7 @@ import androidx.core.content.ContextCompat;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
-import org.jellyfin.androidtv.ui.livetv.ILiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
@@ -45,7 +45,7 @@ public class LiveProgramDetailPopup {
     private BaseItemDto mProgram;
     private ProgramGridCell mSelectedProgramView;
     private BaseActivity mActivity;
-    private ILiveTvGuide mTvGuide;
+    private LiveTvGuide mTvGuide;
     private TextView mDTitle;
     private TextView mDSummary;
     private TextView mDRecordInfo;
@@ -64,7 +64,7 @@ public class LiveProgramDetailPopup {
 
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);
 
-    public LiveProgramDetailPopup(BaseActivity activity, ILiveTvGuide tvGuide, int width, EmptyResponse tuneAction) {
+    public LiveProgramDetailPopup(BaseActivity activity, LiveTvGuide tvGuide, int width, EmptyResponse tuneAction) {
         mActivity = activity;
         mTvGuide = tvGuide;
         mTuneAction = tuneAction;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
@@ -17,7 +17,7 @@ import android.widget.TextView;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.preference.LiveTvPreferences;
-import org.jellyfin.androidtv.ui.livetv.ILiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
@@ -26,9 +26,9 @@ import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
 import java.util.Date;
 
-public class ProgramGridCell extends RelativeLayout implements IRecordingIndicatorView {
+public class ProgramGridCell extends RelativeLayout implements RecordingIndicatorView {
 
-    private ILiveTvGuide mActivity;
+    private LiveTvGuide mActivity;
     private TextView mProgramName;
     private LinearLayout mInfoRow;
     private BaseItemDto mProgram;
@@ -37,12 +37,12 @@ public class ProgramGridCell extends RelativeLayout implements IRecordingIndicat
     private boolean isLast;
     private boolean isFirst;
 
-    public ProgramGridCell(Context context, ILiveTvGuide activity, BaseItemDto program, boolean keyListen) {
+    public ProgramGridCell(Context context, LiveTvGuide activity, BaseItemDto program, boolean keyListen) {
         super(context);
         initComponent((Activity) context, activity, program, keyListen);
     }
 
-    private void initComponent(Activity context, ILiveTvGuide activity, BaseItemDto program, boolean keyListen) {
+    private void initComponent(Activity context, LiveTvGuide activity, BaseItemDto program, boolean keyListen) {
         mActivity = activity;
 
         LayoutInflater inflater = LayoutInflater.from(context);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
@@ -42,7 +42,7 @@ public class RecordPopup {
     PopupWindow mPopup;
     String mProgramId;
     SeriesTimerInfoDto mCurrentOptions;
-    IRecordingIndicatorView mSelectedView;
+    RecordingIndicatorView mSelectedView;
     View mAnchorView;
     int mPosLeft;
     int mPosTop;
@@ -188,7 +188,7 @@ public class RecordPopup {
         return (mPopup != null && mPopup.isShowing());
     }
 
-    public void setContent(Context context, BaseItemDto program, SeriesTimerInfoDto current, IRecordingIndicatorView selectedView, boolean recordSeries) {
+    public void setContent(Context context, BaseItemDto program, SeriesTimerInfoDto current, RecordingIndicatorView selectedView, boolean recordSeries) {
         mProgramId = program.getId();
         mCurrentOptions = current;
         mRecordSeries = recordSeries;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordingIndicatorView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordingIndicatorView.java
@@ -1,6 +1,6 @@
 package org.jellyfin.androidtv.ui;
 
-public interface IRecordingIndicatorView {
+public interface RecordingIndicatorView {
     public void setRecTimer(String id);
     public void setRecSeriesTimer(String id);
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -24,7 +24,7 @@ public class BrowseGridFragment extends StdGridFragment {
     }
 
     @Override
-    protected void setupQueries(IGridLoader gridLoader) {
+    protected void setupQueries(GridLoader gridLoader) {
         StdItemQuery query = new StdItemQuery(new ItemFields[] {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -24,7 +24,7 @@ public class BrowseGridFragment extends StdGridFragment {
     }
 
     @Override
-    protected void setupQueries(GridLoader gridLoader) {
+    protected void setupQueries() {
         StdItemQuery query = new StdItemQuery(new ItemFields[] {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount,
@@ -62,7 +62,7 @@ public class BrowseGridFragment extends StdGridFragment {
                         });
                         albumArtists.setParentId(mParentId.toString());
                         mRowDef = new BrowseRowDef("", albumArtists, CHUNK_SIZE, new ChangeTriggerType[] {});
-                        gridLoader.loadGrid(mRowDef);
+                        loadGrid(mRowDef);
                         return;
                     }
                     query.setIncludeItemTypes(new String[]{includeType != null ? includeType : "MusicAlbum"});
@@ -73,6 +73,6 @@ public class BrowseGridFragment extends StdGridFragment {
 
         mRowDef = new BrowseRowDef("", query, CHUNK_SIZE, false, true);
 
-        gridLoader.loadGrid(mRowDef);
+        loadGrid(mRowDef);
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -38,7 +38,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
     }
 
     @Override
-    protected void setupQueries(final IRowLoader rowLoader) {
+    protected void setupQueries(final RowLoader rowLoader) {
         showViews = true;
         mTitle.setText(TvApp.getApplication().getResources().getString(R.string.lbl_loading_elipses));
         //Latest Recordings

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleFragment.java
@@ -13,7 +13,7 @@ public class BrowseScheduleFragment extends EnhancedBrowseFragment {
     }
 
     @Override
-    protected void setupQueries(final IRowLoader rowLoader) {
+    protected void setupQueries(final RowLoader rowLoader) {
         TvManager.getScheduleRowsAsync(requireContext(), new TimerQuery(), new CardPresenter(true), mRowsAdapter, new Response<Integer>() {
             @Override
             public void onResponse(Integer response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -52,7 +52,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);
 
     @Override
-    protected void setupQueries(final IRowLoader rowLoader) {
+    protected void setupQueries(final RowLoader rowLoader) {
         String type = mFolder.getCollectionType() != null ? mFolder.getCollectionType().toLowerCase() : "";
         switch (type) {
             case "movies":

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.java
@@ -13,7 +13,7 @@ import org.koin.java.KoinJavaComponent;
 
 public class ByGenreFragment extends BrowseFolderFragment {
     @Override
-    protected void setupQueries(final IRowLoader rowLoader) {
+    protected void setupQueries(final RowLoader rowLoader) {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //Get all genres for this folder
             ItemsByNameQuery genres = new ItemsByNameQuery();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.java
@@ -10,7 +10,7 @@ public class ByLetterFragment extends BrowseFolderFragment {
     private static String letters = TvApp.getApplication().getResources().getString(R.string.byletter_letters);
 
     @Override
-    protected void setupQueries(IRowLoader rowLoader) {
+    protected void setupQueries(RowLoader rowLoader) {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //First add a '#' item
             StdItemQuery numbers = new StdItemQuery();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
@@ -17,7 +17,7 @@ public class CollectionFragment extends EnhancedBrowseFragment {
     }
 
     @Override
-    protected void setupQueries(IRowLoader rowLoader) {
+    protected void setupQueries(RowLoader rowLoader) {
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             StdItemQuery movies = new StdItemQuery(new ItemFields[]{
                     ItemFields.PrimaryImageAspectRatio,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -46,8 +46,8 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IKeyListener;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
+import org.jellyfin.androidtv.ui.shared.KeyListener;
+import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TextUtilsKt;
@@ -62,7 +62,7 @@ import java.util.List;
 
 import kotlin.Lazy;
 
-public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
+public class EnhancedBrowseFragment extends Fragment implements RowLoader {
     protected FragmentActivity mActivity;
 
     protected TextView mTitle;
@@ -148,7 +148,7 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
         setupEventListeners();
     }
 
-    protected void setupQueries(IRowLoader rowLoader) {
+    protected void setupQueries(RowLoader rowLoader) {
         rowLoader.loadRows(mRows);
     }
 
@@ -326,14 +326,14 @@ public class EnhancedBrowseFragment extends Fragment implements IRowLoader {
         mRowsFragment.setOnItemViewSelectedListener(mSelectedListener);
         mSelectedListener.registerListener(new ItemViewSelectedListener());
         if (mActivity != null && mActivity instanceof BaseActivity) {
-            ((BaseActivity) mActivity).registerKeyListener(new IKeyListener() {
+            ((BaseActivity) mActivity).registerKeyListener(new KeyListener() {
                 @Override
                 public boolean onKeyUp(int key, KeyEvent event) {
                     return KeyProcessor.HandleKey(key, mCurrentItem, ((BaseActivity) mActivity));
                 }
             });
 
-            ((BaseActivity) mActivity).registerMessageListener(new IMessageListener() {
+            ((BaseActivity) mActivity).registerMessageListener(new MessageListener() {
                 @Override
                 public void onMessageReceived(CustomMessage message) {
                     switch (message) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
@@ -26,7 +26,7 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
     private static BaseItemType[] showSpecialViewTypes = new BaseItemType[] {BaseItemType.CollectionFolder, BaseItemType.Folder, BaseItemType.UserView, BaseItemType.ChannelFolderItem };
 
     @Override
-    protected void setupQueries(IRowLoader rowLoader) {
+    protected void setupQueries(RowLoader rowLoader) {
 
         if (mFolder.getBaseItemType() == BaseItemType.RecordingGroup){
             RecordingQuery query = new RecordingQuery();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GridLoader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GridLoader.java
@@ -1,5 +1,0 @@
-package org.jellyfin.androidtv.ui.browsing;
-
-public interface GridLoader {
-    void loadGrid(BrowseRowDef rowDef);
-}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GridLoader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GridLoader.java
@@ -1,5 +1,5 @@
 package org.jellyfin.androidtv.ui.browsing;
 
-public interface IGridLoader {
+public interface GridLoader {
     void loadGrid(BrowseRowDef rowDef);
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/RowLoader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/RowLoader.java
@@ -2,6 +2,6 @@ package org.jellyfin.androidtv.ui.browsing;
 
 import java.util.List;
 
-public interface IRowLoader {
+public interface RowLoader {
     void loadRows(List<BrowseRowDef> rows);
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
@@ -46,7 +46,7 @@ import java.util.List;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoader {
+public class StdBrowseFragment extends BrowseSupportFragment implements RowLoader {
     protected String MainTitle;
     protected boolean ShowBadge = true;
     protected BaseRowItem mCurrentItem;
@@ -75,7 +75,7 @@ public class StdBrowseFragment extends BrowseSupportFragment implements IRowLoad
         setupEventListeners();
     }
 
-    protected void setupQueries(IRowLoader rowLoader) {
+    protected void setupQueries(RowLoader rowLoader) {
         rowLoader.loadRows(mRows);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -48,8 +48,8 @@ import org.jellyfin.androidtv.ui.preference.PreferencesActivity;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.HorizontalGridPresenter;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IKeyListener;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
+import org.jellyfin.androidtv.ui.shared.KeyListener;
+import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
@@ -63,7 +63,7 @@ import kotlin.Lazy;
 import kotlinx.serialization.json.Json;
 import timber.log.Timber;
 
-public class StdGridFragment extends GridFragment implements IGridLoader {
+public class StdGridFragment extends GridFragment implements GridLoader {
     protected String MainTitle;
     protected BaseActivity mActivity;
     protected BaseRowItem mCurrentItem;
@@ -181,7 +181,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
         setupEventListeners();
     }
 
-    protected void setupQueries(IGridLoader gridLoader) {
+    protected void setupQueries(GridLoader gridLoader) {
     }
 
     @Override
@@ -527,7 +527,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
         mSelectedListener.registerListener(new ItemViewSelectedListener());
 
         if (mActivity != null) {
-            mActivity.registerKeyListener(new IKeyListener() {
+            mActivity.registerKeyListener(new KeyListener() {
                 @Override
                 public boolean onKeyUp(int key, KeyEvent event) {
                     if (key == KeyEvent.KEYCODE_MEDIA_PLAY || key == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE) {
@@ -539,7 +539,7 @@ public class StdGridFragment extends GridFragment implements IGridLoader {
                 }
             });
 
-            mActivity.registerMessageListener(new IMessageListener() {
+            mActivity.registerMessageListener(new MessageListener() {
                 @Override
                 public void onMessageReceived(CustomMessage message) {
                     switch (message) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -63,7 +63,7 @@ import kotlin.Lazy;
 import kotlinx.serialization.json.Json;
 import timber.log.Timber;
 
-public class StdGridFragment extends GridFragment implements GridLoader {
+public class StdGridFragment extends GridFragment {
     protected String MainTitle;
     protected BaseActivity mActivity;
     protected BaseRowItem mCurrentItem;
@@ -174,14 +174,14 @@ public class StdGridFragment extends GridFragment implements GridLoader {
 
         backgroundService.getValue().attach(requireActivity());
 
-        setupQueries(this);
+        setupQueries();
 
         addTools();
 
         setupEventListeners();
     }
 
-    protected void setupQueries(GridLoader gridLoader) {
+    protected void setupQueries() {
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdRowsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdRowsFragment.java
@@ -27,8 +27,8 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IKeyListener;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
+import org.jellyfin.androidtv.ui.shared.KeyListener;
+import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -40,7 +40,7 @@ import java.util.List;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class StdRowsFragment extends RowsSupportFragment implements IRowLoader {
+public class StdRowsFragment extends RowsSupportFragment implements RowLoader {
     protected BaseActivity mActivity;
     protected BaseRowItem mCurrentItem;
     protected ListRow mCurrentRow;
@@ -68,7 +68,7 @@ public class StdRowsFragment extends RowsSupportFragment implements IRowLoader {
         setupEventListeners();
     }
 
-    protected void setupQueries(IRowLoader rowLoader) {
+    protected void setupQueries(RowLoader rowLoader) {
         rowLoader.loadRows(mRows);
     }
 
@@ -189,14 +189,14 @@ public class StdRowsFragment extends RowsSupportFragment implements IRowLoader {
         mSelectedListener.registerListener(new ItemViewSelectedListener());
 
         if (mActivity != null) {
-            mActivity.registerKeyListener(new IKeyListener() {
+            mActivity.registerKeyListener(new KeyListener() {
                 @Override
                 public boolean onKeyUp(int key, KeyEvent event) {
                     return KeyProcessor.HandleKey(key, mCurrentItem, mActivity);
                 }
             });
 
-            mActivity.registerMessageListener(new IMessageListener() {
+            mActivity.registerMessageListener(new MessageListener() {
                 @Override
                 public void onMessageReceived(CustomMessage message) {
                     switch (message) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
@@ -24,7 +24,7 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
     }
 
     @Override
-    protected void setupQueries(final IRowLoader rowLoader) {
+    protected void setupQueries(final RowLoader rowLoader) {
         StdItemQuery lastPlayed = new StdItemQuery();
         lastPlayed.setParentId(mFolder.getId());
         lastPlayed.setIncludeItemTypes(new String[]{"Movie"});

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -14,7 +14,7 @@ import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.constant.HomeSectionType
 import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
-import org.jellyfin.androidtv.ui.browsing.IRowLoader
+import org.jellyfin.androidtv.ui.browsing.RowLoader
 import org.jellyfin.androidtv.ui.browsing.StdRowsFragment
 import org.jellyfin.androidtv.ui.playback.AudioEventListener
 import org.jellyfin.androidtv.ui.playback.MediaManager
@@ -86,7 +86,7 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 		mClickedListener.registerListener(liveTVRow::onItemClicked)
 	}
 
-	override fun setupQueries(rowLoader: IRowLoader) {
+	override fun setupQueries(rowLoader: RowLoader) {
 		lifecycleScope.launch(Dispatchers.IO) {
 			val currentUser = TvApp.getApplication()!!.currentUser!!
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -48,8 +48,8 @@ import org.jellyfin.androidtv.preference.SystemPreferences;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.ClockBehavior;
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer;
-import org.jellyfin.androidtv.ui.IRecordingIndicatorView;
 import org.jellyfin.androidtv.ui.RecordPopup;
+import org.jellyfin.androidtv.ui.RecordingIndicatorView;
 import org.jellyfin.androidtv.ui.TextUnderButton;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
@@ -63,7 +63,7 @@ import org.jellyfin.androidtv.ui.presentation.CustomListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.InfoCardPresenter;
 import org.jellyfin.androidtv.ui.presentation.MyDetailsOverviewRowPresenter;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
+import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
@@ -106,7 +106,7 @@ import java.util.concurrent.ExecutionException;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class FullDetailsActivity extends BaseActivity implements IRecordingIndicatorView {
+public class FullDetailsActivity extends BaseActivity implements RecordingIndicatorView {
 
     private int BUTTON_SIZE;
 
@@ -182,7 +182,7 @@ public class FullDetailsActivity extends BaseActivity implements IRecordingIndic
             mSeriesTimerInfo = serializer.getValue().DeserializeFromString(timerJson, SeriesTimerInfoDto.class);
         }
 
-        registerMessageListener(new IMessageListener() {
+        registerMessageListener(new MessageListener() {
             @Override
             public void onMessageReceived(CustomMessage message) {
                 if (message == CustomMessage.ActionComplete && mSeriesTimerInfo != null && mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuide.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuide.java
@@ -2,7 +2,7 @@ package org.jellyfin.androidtv.ui.livetv;
 
 import android.widget.RelativeLayout;
 
-public interface ILiveTvGuide {
+public interface LiveTvGuide {
     public void displayChannels(int start, int max);
     public long getCurrentLocalStartDate();
     public void showProgramOptions();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -45,7 +45,7 @@ import org.jellyfin.androidtv.ui.ObservableScrollView;
 import org.jellyfin.androidtv.ui.ProgramGridCell;
 import org.jellyfin.androidtv.ui.ScrollViewListener;
 import org.jellyfin.androidtv.ui.shared.BaseActivity;
-import org.jellyfin.androidtv.ui.shared.IMessageListener;
+import org.jellyfin.androidtv.ui.shared.MessageListener;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TimeUtils;
@@ -68,7 +68,7 @@ import java.util.List;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
+public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
     public static final int ROW_HEIGHT = Utils.convertDpToPixel(TvApp.getApplication(),55);
     public static final int PIXELS_PER_MINUTE = Utils.convertDpToPixel(TvApp.getApplication(),7);
     public static final int PAGEBUTTON_HEIGHT = Utils.convertDpToPixel(TvApp.getApplication(), 20);
@@ -213,7 +213,7 @@ public class LiveTvGuideActivity extends BaseActivity implements ILiveTvGuide {
         mChannelScroller.setFocusable(false);
 
         //Register to receive message from popup
-        registerMessageListener(new IMessageListener() {
+        registerMessageListener(new MessageListener() {
             @Override
             public void onMessageReceived(CustomMessage message) {
                 if (message.equals(CustomMessage.ActionComplete)) dismissProgramOptions();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -60,7 +60,7 @@ import org.jellyfin.androidtv.ui.ProgramGridCell;
 import org.jellyfin.androidtv.ui.ScrollViewListener;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
-import org.jellyfin.androidtv.ui.livetv.ILiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpActivity;
@@ -96,7 +96,7 @@ import java.util.List;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class CustomPlaybackOverlayFragment extends Fragment implements IPlaybackOverlayFragment, ILiveTvGuide {
+public class CustomPlaybackOverlayFragment extends Fragment implements PlaybackOverlayFragment, LiveTvGuide {
     private VlcPlayerInterfaceBinding binding;
     private OverlayTvGuideBinding tvGuideBinding;
 
@@ -794,9 +794,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements IPlayback
     class DisplayProgramsTask extends AsyncTask<Integer, Integer, Void> {
         private View firstRow;
         private int displayedChannels = 0;
-        private final ILiveTvGuide guide;
+        private final LiveTvGuide guide;
 
-        DisplayProgramsTask(ILiveTvGuide guide) {
+        DisplayProgramsTask(LiveTvGuide guide) {
             super();
             this.guide = guide;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -20,7 +20,6 @@ import org.jellyfin.androidtv.data.compat.StreamInfo;
 import org.jellyfin.androidtv.data.compat.SubtitleStreamInfo;
 import org.jellyfin.androidtv.data.compat.VideoOptions;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
-import org.jellyfin.androidtv.preference.PreferenceStore;
 import org.jellyfin.androidtv.preference.SystemPreferences;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.UserSettingPreferences;
@@ -82,7 +81,7 @@ public class PlaybackController {
     private List<SubtitleStreamInfo> mSubtitleStreams;
 
     @Nullable
-    private IPlaybackOverlayFragment mFragment;
+    private PlaybackOverlayFragment mFragment;
     private Boolean spinnerOff = false;
 
     private VideoOptions mCurrentOptions;
@@ -117,7 +116,7 @@ public class PlaybackController {
     private Display.Mode[] mDisplayModes;
     private boolean refreshRateSwitchingEnabled;
 
-    public PlaybackController(List<BaseItemDto> items, IPlaybackOverlayFragment fragment) {
+    public PlaybackController(List<BaseItemDto> items, PlaybackOverlayFragment fragment) {
         mItems = items;
         mFragment = fragment;
         mHandler = new Handler();
@@ -138,11 +137,11 @@ public class PlaybackController {
         return mFragment != null;
     }
 
-    public IPlaybackOverlayFragment getFragment() {
+    public PlaybackOverlayFragment getFragment() {
         return mFragment;
     }
 
-    public void init(VideoManager mgr, IPlaybackOverlayFragment fragment) {
+    public void init(VideoManager mgr, PlaybackOverlayFragment fragment) {
         mVideoManager = mgr;
         mFragment = fragment;
         directStreamLiveTv = userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayFragment.java
@@ -2,7 +2,7 @@ package org.jellyfin.androidtv.ui.playback;
 
 import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackInfo;
 
-public interface IPlaybackOverlayFragment {
+public interface PlaybackOverlayFragment {
     void setCurrentTime(long time);
     void setSecondaryTime(long time);
     void setFadingEnabled(boolean value);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/BaseActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/BaseActivity.java
@@ -11,8 +11,8 @@ import kotlin.ReplaceWith;
 
 @Deprecated(message = "Use FragmentActivity instead", replaceWith = @ReplaceWith(expression = "FragmentActivity", imports = {}))
 public abstract class BaseActivity extends FragmentActivity {
-    private IKeyListener keyListener;
-    private IMessageListener messageListener;
+    private KeyListener keyListener;
+    private MessageListener messageListener;
 
     public BaseActivity() {
         super();
@@ -22,11 +22,11 @@ public abstract class BaseActivity extends FragmentActivity {
         super(fragmentContentView);
     }
 
-    public void registerKeyListener(IKeyListener listener) {
+    public void registerKeyListener(KeyListener listener) {
         keyListener = listener;
     }
 
-    public void registerMessageListener(IMessageListener listener) {
+    public void registerMessageListener(MessageListener listener) {
         messageListener = listener;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/KeyListener.java
@@ -2,6 +2,6 @@ package org.jellyfin.androidtv.ui.shared;
 
 import android.view.KeyEvent;
 
-public interface IKeyListener {
+public interface KeyListener {
     public boolean onKeyUp(int key, KeyEvent event);
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/MessageListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/MessageListener.java
@@ -2,6 +2,6 @@ package org.jellyfin.androidtv.ui.shared;
 
 import org.jellyfin.androidtv.constant.CustomMessage;
 
-public interface IMessageListener {
+public interface MessageListener {
     public void onMessageReceived(CustomMessage message);
 }


### PR DESCRIPTION
Consistency stuff. A bunch of interfaces used the prefix and a bunch don't. Now they all don't.

**Changes**
- Remove "I" prefix from interfaces (so IGridLoader becomes GridLoader)
- Remove GridLoader interface (unnecessary)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
