### PR TITLE
Prevent DreamActivity (screensaver) from opening login screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/ActivityLifecycleCallbacksModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/ActivityLifecycleCallbacksModule.kt
@@ -8,7 +8,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val activityLifecycleCallbacksModule = module {
-	single { AuthenticatedUserCallbacks() } bind Application.ActivityLifecycleCallbacks::class
+	single { AuthenticatedUserCallbacks(get()) } bind Application.ActivityLifecycleCallbacks::class
 	single { AppThemeCallbacks(get()) } bind Application.ActivityLifecycleCallbacks::class
 	single { CurrentActivityCallbacks() } bind Application.ActivityLifecycleCallbacks::class
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
@@ -3,7 +3,7 @@ package org.jellyfin.androidtv.ui.shared
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import org.jellyfin.androidtv.TvApp
+import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import timber.log.Timber
@@ -12,7 +12,9 @@ import timber.log.Timber
  * ActivityLifecycleCallback that bounces to the StartupActivity if an Activity is created and
  * the currentUser is null.
  */
-class AuthenticatedUserCallbacks : AbstractActivityLifecycleCallbacks() {
+class AuthenticatedUserCallbacks(
+	private val sessionRepository: SessionRepository,
+) : AbstractActivityLifecycleCallbacks() {
 	companion object {
 		val ignoredClassNames = arrayOf(
 			// Startup activities
@@ -30,15 +32,10 @@ class AuthenticatedUserCallbacks : AbstractActivityLifecycleCallbacks() {
 
 		if (name in ignoredClassNames) {
 			Timber.i("Activity $name is ignored")
-			return
-		}
-
-		TvApp.getApplication()?.apply {
-			if (currentUser == null) {
-				Timber.w("Current user is null, bouncing to StartupActivity")
-				activity.startActivity(Intent(this, StartupActivity::class.java))
-				activity.finish()
-			}
+		} else if (sessionRepository.currentSession.value == null) {
+			Timber.w("Activity $name started without a session, bouncing to StartupActivity")
+			activity.startActivity(Intent(activity, StartupActivity::class.java))
+			activity.finish()
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
@@ -13,21 +13,31 @@ import timber.log.Timber
  * the currentUser is null.
  */
 class AuthenticatedUserCallbacks : AbstractActivityLifecycleCallbacks() {
+	companion object {
+		val ignoredClassNames = arrayOf(
+			// Startup activities
+			StartupActivity::class.qualifiedName,
+			PreferencesActivity::class.qualifiedName,
+			// Third party
+			org.acra.dialog.CrashReportDialog::class.qualifiedName,
+			// Screensaver activity is not exposed in Android SDK
+			"android.service.dreams.DreamActivity"
+		)
+	}
+
 	override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-		when (activity) {
-			// Ignore startup activities
-			is StartupActivity -> return
-			is PreferencesActivity -> return
-			is org.acra.dialog.CrashReportDialog -> return
-			// All other activities should have a current user
-			else -> {
-				TvApp.getApplication()?.apply {
-					if (currentUser == null) {
-						Timber.w("Current user is null, bouncing to StartupActivity")
-						activity.startActivity(Intent(this, StartupActivity::class.java))
-						activity.finish()
-					}
-				}
+		val name = activity::class.qualifiedName
+
+		if (name in ignoredClassNames) {
+			Timber.i("Activity $name is ignored")
+			return
+		}
+
+		TvApp.getApplication()?.apply {
+			if (currentUser == null) {
+				Timber.w("Current user is null, bouncing to StartupActivity")
+				activity.startActivity(Intent(this, StartupActivity::class.java))
+				activity.finish()
 			}
 		}
 	}


### PR DESCRIPTION
The app would open the home screen after closing the screensaver when it caused the app to start. This fixes that. Unfortunately the Android SDK does not expose the DreamActivity so we need to hardcode the string to match with.

I've changed the when statement to an array of strings with the names of all ignored activities.

**Changes**

- Ignore DreamActivity in AuthenticatedUserCallbacks
- Check active user from sessionRepository in AuthenticatedUserCallbacks

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
