### PR TITLE
Fix opening app via leanback channels not showing item

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -109,11 +109,13 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 	}
 
 	private suspend fun openNextActivity() {
-		val itemId = when (intent.action) {
-			Intent.ACTION_VIEW -> intent.data.toString()
+		val itemId = when {
+			intent.action == Intent.ACTION_VIEW && intent.data != null -> intent.data.toString()
 			else -> intent.getStringExtra(EXTRA_ITEM_ID)
 		}
 		val itemIsUserView = intent.getBooleanExtra(EXTRA_ITEM_IS_USER_VIEW, false)
+
+		Timber.d("Determining next activity (action=${intent.action}, itemId=$itemId, itemIsUserView=$itemIsUserView)")
 
 		// Start session
 		(application as? JellyfinApplication)?.onSessionStart()


### PR DESCRIPTION
After adding the search integration the app stopped showing item details when an item is opened from the leanback channels in the launcher. This was because the channels communicate the item id differently while also using the VIEW action in the intent. This PR changes that to check if the data is null and falling back to the extra. This way both ways of sending the item id work as expected.

**Changes**
- Fix opening app via leanback channels not showing the requested item
- Add debug log to show the data used to determine the next activity

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
