### PR TITLE
Use Timber instead of (legacy) apiclient logger in StopTranscodingResponse

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -6,16 +6,12 @@ import org.jellyfin.androidtv.ui.playback.GarbagePlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.PlaybackManager
 import org.jellyfin.androidtv.ui.playback.RewritePlaybackLauncher
 import org.jellyfin.apiclient.interaction.AndroidDevice
-import org.jellyfin.apiclient.logging.AndroidLogger
 import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 
 val playbackModule = module {
 	single {
-		PlaybackManager(
-			AndroidDevice.fromContext(androidApplication()),
-			AndroidLogger("PlaybackManager")
-		)
+		PlaybackManager(AndroidDevice.fromContext(androidApplication()))
 	}
 
 	factory {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -8,7 +8,6 @@ import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.interaction.device.IDevice;
-import org.jellyfin.apiclient.logging.ILogger;
 import org.jellyfin.apiclient.model.dlna.PlaybackErrorCode;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.entities.MediaStream;
@@ -26,12 +25,10 @@ import java.util.ArrayList;
  */
 @Deprecated
 public class PlaybackManager {
-    private final ILogger logger;
     private final IDevice device;
 
-    public PlaybackManager(IDevice device, ILogger logger) {
+    public PlaybackManager(IDevice device) {
         this.device = device;
-        this.logger = logger;
     }
 
     public ArrayList<MediaStream> getInPlaybackSelectableAudioStreams(StreamInfo info) {
@@ -83,7 +80,7 @@ public class PlaybackManager {
     public void changeVideoStream(final StreamInfo currentStreamInfo, final String serverId, final VideoOptions options, Long startPositionTicks, ApiClient apiClient, final Response<StreamInfo> response) {
         String playSessionId = currentStreamInfo.getPlaySessionId();
 
-        apiClient.StopTranscodingProcesses(device.getDeviceId(), playSessionId, new StopTranscodingResponse(this, serverId, currentStreamInfo, options, logger, startPositionTicks, apiClient, response));
+        apiClient.StopTranscodingProcesses(device.getDeviceId(), playSessionId, new StopTranscodingResponse(this, serverId, currentStreamInfo, options, startPositionTicks, apiClient, response));
     }
 
     public void reportPlaybackStart(PlaybackStartInfo info, ApiClient apiClient, EmptyResponse response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
@@ -6,7 +6,8 @@ import org.jellyfin.androidtv.data.compat.VideoOptions;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
-import org.jellyfin.apiclient.logging.ILogger;
+
+import timber.log.Timber;
 
 @Deprecated
 public class StopTranscodingResponse extends EmptyResponse {
@@ -14,17 +15,15 @@ public class StopTranscodingResponse extends EmptyResponse {
     private String serverId;
     private StreamInfo currentStreamInfo;
     private AudioOptions options;
-    private ILogger logger;
     private Response<StreamInfo> response;
     private Long startPositionTicks;
     private ApiClient apiClient;
 
-    public StopTranscodingResponse(PlaybackManager playbackManager, String serverId, StreamInfo currentStreamInfo, AudioOptions options, ILogger logger, Long startPositionTicks, ApiClient apiClient, Response<StreamInfo> response) {
+    public StopTranscodingResponse(PlaybackManager playbackManager, String serverId, StreamInfo currentStreamInfo, AudioOptions options, Long startPositionTicks, ApiClient apiClient, Response<StreamInfo> response) {
         this.playbackManager = playbackManager;
         this.serverId = serverId;
         this.currentStreamInfo = currentStreamInfo;
         this.options = options;
-        this.logger = logger;
         this.response = response;
         this.startPositionTicks = startPositionTicks;
         this.apiClient = apiClient;
@@ -41,7 +40,7 @@ public class StopTranscodingResponse extends EmptyResponse {
 
     @Override
     public void onError(Exception ex) {
-        logger.error("Error in StopTranscodingProcesses", ex);
+        Timber.e(ex, "Error in StopTranscodingProcesses");
         onAny();
     }
 }


### PR DESCRIPTION
apiclient bad
timber good

**Changes**
- Use Timber instead of (legacy) apiclient logger in StopTranscodingResponse

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
