### PR TITLE
Fix AutoBitrate causing an app crash when switching users while detecting bitrate

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/AutoBitrate.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/AutoBitrate.kt
@@ -22,6 +22,9 @@ class AutoBitrate(
 			Timber.i("Auto bitrate set to: %d", bitrate)
 		} catch (err: ApiClientException) {
 			Timber.e(err, "Failed to detect bitrate")
+		} catch (err: IllegalArgumentException) {
+			// Session probably ended before the detection completed
+			Timber.e(err, "Failed to detect bitrate")
 		}
 	}
 }


### PR DESCRIPTION
Ideally we'd create a coroutine scope for a user session so we can cancel all api calls connected to it but this will do for now.

**Changes**

- Fix AutoBitrate causing an app crash when switching users while detecting bitrate

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
