### PR TITLE
reset vlc meta position in clearPlaybackSessionOptions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1048,6 +1048,8 @@ public class PlaybackController {
         mDefaultAudioIndex = -1;
         finishedInitialSeek = false;
         wasSeeking = false;
+        if (mVideoManager != null)
+            mVideoManager.setMetaVLCStreamStartPosition(-1);
     }
 
     public void next() {


### PR DESCRIPTION
**Changes**
* reset vlc meta position in clearPlaybackSessionOptions

**Issues**
* if the stream goes from transcoding -> direct without ending the session, and vlc is used, the timestamp will be current pos + meta pos
* needed for #1406 
