### PR TITLE
show buffered position in seekbar for exoplayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1458,6 +1458,27 @@ public class PlaybackController {
         });
     }
 
+    public long getDuration() {
+        if (hasInitializedVideoManager()) {
+            return mVideoManager.getDuration();
+        } else if (getCurrentlyPlayingItem() != null && getCurrentlyPlayingItem().getRunTimeTicks() != null) {
+            return getCurrentlyPlayingItem().getRunTimeTicks() / 10000;
+        }
+        return -1;
+    }
+
+    public long getBufferedPosition() {
+        long bufferedPosition = -1;
+
+        if (hasInitializedVideoManager() && mVideoManager.getBufferedPosition() > -1) {
+            bufferedPosition = mVideoManager.getBufferedPosition();
+        } else {
+            bufferedPosition = getDuration();
+        }
+
+        return bufferedPosition;
+    }
+
     public long getCurrentPosition() {
         // don't report the real position if seeking
         return !isPlaying() && mSeekPosition != -1 ? mSeekPosition : mCurrentPosition;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1441,7 +1441,7 @@ public class PlaybackController {
                     if (mFragment != null)
                         mFragment.updateSubtitles(mCurrentPosition);
                 }
-                if (mFragment != null && finishedInitialSeek)
+                if (mFragment != null)
                     mFragment.setCurrentTime(mCurrentPosition);
             }
         });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1087,7 +1087,7 @@ public class PlaybackController {
     }
 
     public void seek(long pos) {
-        pos = Utils.getSafePosition(pos, getDuration());
+        pos = Utils.getSafeSeekPosition(pos, getDuration());
 
         Timber.d("Trying to seek from %s to %d", mCurrentPosition, pos);
         Timber.d("Container: %s", mCurrentStreamInfo == null ? "unknown" : mCurrentStreamInfo.getContainer());
@@ -1178,7 +1178,7 @@ public class PlaybackController {
             mHandler.removeCallbacks(skipRunnable);
             stopReportLoop();
             refreshCurrentPosition();
-            currentSkipPos = Utils.getSafePosition((currentSkipPos == 0 ? mCurrentPosition : currentSkipPos) + msec, getDuration());
+            currentSkipPos = Utils.getSafeSeekPosition((currentSkipPos == 0 ? mCurrentPosition : currentSkipPos) + msec, getDuration());
 
             Timber.d("Skip amount requested was %s. Calculated position is %s", msec, currentSkipPos);
             Timber.d("Duration reported as: %s current pos: %s", getDuration(), mCurrentPosition);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1086,7 +1086,9 @@ public class PlaybackController {
         skip(-prefs.get(UserSettingPreferences.Companion.getSkipBackLength()));
     }
 
-    public void seek(final long pos) {
+    public void seek(long pos) {
+        pos = Utils.getSafePosition(pos, getDuration());
+
         Timber.d("Trying to seek from %s to %d", mCurrentPosition, pos);
         Timber.d("Container: %s", mCurrentStreamInfo == null ? "unknown" : mCurrentStreamInfo.getContainer());
 
@@ -1176,16 +1178,10 @@ public class PlaybackController {
             mHandler.removeCallbacks(skipRunnable);
             stopReportLoop();
             refreshCurrentPosition();
-            currentSkipPos = (currentSkipPos == 0 ? mCurrentPosition : currentSkipPos) + msec;
-
-            if (currentSkipPos < 0) {
-                currentSkipPos = 0;
-            } else if (currentSkipPos > mVideoManager.getDuration()) {
-                currentSkipPos = mVideoManager.getDuration() - 1000;
-            }
+            currentSkipPos = Utils.getSafePosition((currentSkipPos == 0 ? mCurrentPosition : currentSkipPos) + msec, getDuration());
 
             Timber.d("Skip amount requested was %s. Calculated position is %s", msec, currentSkipPos);
-            Timber.d("Duration reported as: %s current pos: %s", mVideoManager.getDuration(), mCurrentPosition);
+            Timber.d("Duration reported as: %s current pos: %s", getDuration(), mCurrentPosition);
 
             mSeekPosition = currentSkipPos;
             mHandler.postDelayed(skipRunnable, 800);
@@ -1290,6 +1286,7 @@ public class PlaybackController {
                 if (mVideoManager == null)
                     return;
                 if (mVideoManager.getDuration() <= 0) {
+                    // use mVideoManager.getDuration here for accurate results
                     // wait until we have valid duration
                     mHandler.postDelayed(this, 25);
                 } else if (mVideoManager.isSeekable()) {
@@ -1459,22 +1456,24 @@ public class PlaybackController {
     }
 
     public long getDuration() {
+        long duration = 0;
+
         if (hasInitializedVideoManager()) {
-            return mVideoManager.getDuration();
+            duration = mVideoManager.getDuration();
         } else if (getCurrentlyPlayingItem() != null && getCurrentlyPlayingItem().getRunTimeTicks() != null) {
-            return getCurrentlyPlayingItem().getRunTimeTicks() / 10000;
+            duration = getCurrentlyPlayingItem().getRunTimeTicks() / 10000;
         }
-        return -1;
+        return duration > 0 ? duration : 0;
     }
 
     public long getBufferedPosition() {
         long bufferedPosition = -1;
 
-        if (hasInitializedVideoManager() && mVideoManager.getBufferedPosition() > -1) {
+        if (hasInitializedVideoManager())
             bufferedPosition = mVideoManager.getBufferedPosition();
-        } else {
+
+        if (bufferedPosition < 0)
             bufferedPosition = getDuration();
-        }
 
         return bufferedPosition;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -221,6 +221,24 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
     }
 
+    public long getBufferedPosition() {
+        if (!isInitialized())
+            return -1;
+
+        // to do: add libVLC support
+        if (!isNativeMode())
+            return -1;
+
+        long bufferedPosition = mExoPlayer.getBufferedPosition();
+
+        Timber.d("exoplayer got buffered position %s", bufferedPosition);
+
+        if (bufferedPosition > -1 && bufferedPosition < getDuration()) {
+            return bufferedPosition;
+        }
+        return -1;
+    }
+
     public long getCurrentPosition() {
         if (nativeMode) {
             if (mExoPlayer == null || !isPlaying()) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -225,7 +225,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         if (!isInitialized())
             return -1;
 
-        // to do: add libVLC support
+        // only exoplayer supports reporting buffered position
         if (!isNativeMode())
             return -1;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -231,8 +231,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
         long bufferedPosition = mExoPlayer.getBufferedPosition();
 
-        Timber.d("exoplayer got buffered position %s", bufferedPosition);
-
         if (bufferedPosition > -1 && bufferedPosition < getDuration()) {
             return bufferedPosition;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -59,8 +59,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     @Override
     public long getDuration() {
-        return getCurrentlyPlayingItem() != null && getCurrentlyPlayingItem().getRunTimeTicks() != null ?
-                getCurrentlyPlayingItem().getRunTimeTicks() / 10000 : -1;
+        return playbackController.getDuration();
     }
 
     @Override
@@ -75,11 +74,15 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     @Override
     public long getBufferedPosition() {
-        return getDuration();
+        return playbackController.getBufferedPosition();
     }
 
     void updateCurrentPosition() {
         getCallback().onCurrentPositionChanged(this);
+
+        // only exoplayer supports reporting buffered position
+        if (isNativeMode())
+            getCallback().onBufferedPositionChanged(this);
     }
 
     void updatePlayState() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -133,4 +133,12 @@ public class Utils {
 
         return KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
     }
+
+    public static long getSafePosition(long position, long duration) {
+        if (position < 0 || duration < 0)
+            return 0;
+        if (position >= duration)
+            return Math.max(duration - 1000, 0);
+        return position;
+    }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -134,7 +134,7 @@ public class Utils {
         return KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO;
     }
 
-    public static long getSafePosition(long position, long duration) {
+    public static long getSafeSeekPosition(long position, long duration) {
         if (position < 0 || duration < 0)
             return 0;
         if (position >= duration)


### PR DESCRIPTION
**Changes**
* get the buffered position from exoplayer and use it to update the overlay's seekbar
  this is disabled for libVLC since afaik it can't report buffered position.
* move getDuration from the VideoAdapter to PlaybackController
* removed check for finishedInitialSeek when setting mFragment.setCurrentTime. I think this was left in by mistake, and leaving it in causes the seekbar to show 0 until playback starts.

![20220210_185612.jpg](https://user-images.githubusercontent.com/28824542/153530903-5ba8248d-668c-48a6-85f1-ab97e668bbf0.jpg)