### PR TITLE
reverted VideoAdapter getDuration

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -59,7 +59,8 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     @Override
     public long getDuration() {
-        return playbackController.getDuration();
+        return getCurrentlyPlayingItem() != null && getCurrentlyPlayingItem().getRunTimeTicks() != null ?
+                getCurrentlyPlayingItem().getRunTimeTicks() / 10000 : -1;
     }
 
     @Override


### PR DESCRIPTION
**Changes**
* reverted the change to `VideoPlayerAdapter`'s `getDuration()` made in #1435 

**Issues**
* the change relied on getting the duration from the playback controller, which in turn got it from VideoManager. The duration is only used to update the UI in `VideoPlayerAdapter`'s updateDuration(). This is called in `LeanbackOverlayFragment`s `mediaInfoChanged()` when a new item is loaded. When this happens it is likely too early to reliably expect PlaybackController or VideoManager to provide the duration of the new item instead of the old one.

**Notes**
* another potential solution is to add `getCallback().onDurationChanged(this);` to `updateCurrentPosition()` and rework `mediaInfoChanged()`.