### PR TITLE
only use HLS for live tv - otherwise use progressive mkv

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1448,7 +1448,8 @@ public class PlaybackController {
     public long getBufferedPosition() {
         long bufferedPosition = -1;
 
-        if (hasInitializedVideoManager())
+        // FIXME handle live tv buffered position and position while paused
+        if (!isLiveTv() && hasInitializedVideoManager())
             bufferedPosition = mVideoManager.getBufferedPosition();
 
         if (bufferedPosition < 0)


### PR DESCRIPTION
**Changes**
* revert to using progressive mkv for everything but live tv which will still use HLS
* added a condition to `getBufferedPosition()` that excludes live-tv. The logic for getting the current position when playing live tv is kinda broken, especially if the player is paused and then resumed.

**Issues**
* using mkv again should resolve #1410 though I'm not sure about live-tv contexts
* after seeking using HLS, the video would be slightly early but the timestamp wouldn't reflect it.
  This caused:
  * subtitles to be out of sync
  * the last few seconds of a video looping

  According to ffmpeg docs, the flag `-noaccurate_seek`, which jellyfin uses, supplies a stream starting at the key-frame prior to the requested timestamp. This is incompatible with exoplayer's frame-accurate seeking.
The ffmpeg docs (https://trac.ffmpeg.org/wiki/Seeking):
  > -ss is now also "frame-accurate" even when used as an input option. Previous behavior (seeking only to the nearest 
     preceding keyframe, even if not precisely accurate) can be restored with the -noaccurate_seek option

  To resolve this and use HLS in contexts that allow seeking, the version of exoplayer we use will need to support `SeekParameters` for HLS. As far as I can tell, the flag we'd use is ``SeekParameters.PREVIOUS_SYNC``
  The relevant issue is here:
  https://github.com/google/ExoPlayer/issues/2882
  And here is the merged PR that _should_ allow this once the next exoplayer release comes out:
  https://github.com/google/ExoPlayer/pull/9536

**Notes**
* using HLS has made the player **far** more stable. If there's a way to synchronize the subtitles despite the player being unaware of the desync then that would be much better than abandoning HLS.
