### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Jellyfin documentation
     url:  https://jellyfin.org/docs/general/getting-help.html


### PR DESCRIPTION
We get too much useless issues from people that refuse to provide proper information about their bugs. This PR disables blank issues to prevent this from happening. I'd rather not disable blank issues as I  use them myself for roadmap issues and I believe there are people that wouldn't abuse blank issues. But unfortunately the issues are just unmanageable right now.

**Changes**
- Disable blank issues

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

_note: do not add to a project_