### PR TITLE
Close Home and Details activities when no active user found

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -87,9 +87,13 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 	}
 
 	override fun setupQueries(rowLoader: RowLoader) {
-		lifecycleScope.launch(Dispatchers.IO) {
-			val currentUser = TvApp.getApplication()!!.currentUser!!
+		val currentUser = TvApp.getApplication()?.currentUser
+		if (currentUser == null) {
+			activity?.finish()
+			return
+		}
 
+		lifecycleScope.launch(Dispatchers.IO) {
 			// Start out with default sections
 			val homesections = userSettingPreferences.homesections
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -154,6 +154,13 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Prevent activity from crashing after recovering from a crash
+        if (TvApp.getApplication().getCurrentUser() == null) {
+            finish();
+            return;
+        }
+
         setContentView(R.layout.activity_full_details);
 
         BUTTON_SIZE = Utils.convertDpToPixel(this, 40);


### PR DESCRIPTION
This prevents the app from crashing after recovering from a crash. It's a temporary solution until the current user data is moved to a repository and the activities are rewritten to make use of that.

**Changes**
- Add a check if the TvApp.currentUser value is null during onCreate() for home and details activities
  - This fixes 2 of our most common crashes, hopefully causing ACRA to now report the actual crash before the app tried to recover.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
