### PR TITLE
Remove more TvApp.getApplication usages

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -21,7 +21,6 @@ import androidx.leanback.widget.RowPresenter;
 import androidx.leanback.widget.VerticalGridPresenter;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.model.FilterOptions;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
@@ -51,25 +50,25 @@ public class GridFragment extends Fragment {
     private int mSelectedPosition = -1;
     private int mCardHeight;
 
-    protected int SMALL_CARD = Utils.convertDpToPixel(TvApp.getApplication(), 116);
-    protected int MED_CARD = Utils.convertDpToPixel(TvApp.getApplication(), 175);
-    protected int LARGE_CARD = Utils.convertDpToPixel(TvApp.getApplication(), 210);
-    protected int SMALL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 58);
-    protected int MED_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 88);
-    protected int LARGE_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 105);
+    protected int SMALL_CARD = Utils.convertDpToPixel(getContext(), 116);
+    protected int MED_CARD = Utils.convertDpToPixel(getContext(), 175);
+    protected int LARGE_CARD = Utils.convertDpToPixel(getContext(), 210);
+    protected int SMALL_BANNER = Utils.convertDpToPixel(getContext(), 58);
+    protected int MED_BANNER = Utils.convertDpToPixel(getContext(), 88);
+    protected int LARGE_BANNER = Utils.convertDpToPixel(getContext(), 105);
 
-    protected int SMALL_VERTICAL_POSTER = Utils.convertDpToPixel(TvApp.getApplication(), 116);
-    protected int MED_VERTICAL_POSTER = Utils.convertDpToPixel(TvApp.getApplication(), 171);
-    protected int LARGE_VERTICAL_POSTER = Utils.convertDpToPixel(TvApp.getApplication(), 202);
-    protected int SMALL_VERTICAL_SQUARE = Utils.convertDpToPixel(TvApp.getApplication(), 114);
-    protected int MED_VERTICAL_SQUARE = Utils.convertDpToPixel(TvApp.getApplication(), 163);
-    protected int LARGE_VERTICAL_SQUARE = Utils.convertDpToPixel(TvApp.getApplication(), 206);
-    protected int SMALL_VERTICAL_THUMB = Utils.convertDpToPixel(TvApp.getApplication(), 116);
-    protected int MED_VERTICAL_THUMB = Utils.convertDpToPixel(TvApp.getApplication(), 155);
-    protected int LARGE_VERTICAL_THUMB = Utils.convertDpToPixel(TvApp.getApplication(), 210);
-    protected int SMALL_VERTICAL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 51);
-    protected int MED_VERTICAL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 77);
-    protected int LARGE_VERTICAL_BANNER = Utils.convertDpToPixel(TvApp.getApplication(), 118);
+    protected int SMALL_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 116);
+    protected int MED_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 171);
+    protected int LARGE_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 202);
+    protected int SMALL_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 114);
+    protected int MED_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 163);
+    protected int LARGE_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 206);
+    protected int SMALL_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 116);
+    protected int MED_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 155);
+    protected int LARGE_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 210);
+    protected int SMALL_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 51);
+    protected int MED_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 77);
+    protected int LARGE_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 118);
 
     /**
      * Sets the grid presenter.
@@ -149,13 +148,13 @@ public class GridFragment extends Fragment {
 
     protected Map<Integer, SortOption> sortOptions = new HashMap<>();
     {
-        sortOptions.put(0, new SortOption(TvApp.getApplication().getString(R.string.lbl_name), "SortName", SortOrder.Ascending));
-        sortOptions.put(1, new SortOption(TvApp.getApplication().getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
-        sortOptions.put(2, new SortOption(TvApp.getApplication().getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
-        sortOptions.put(3, new SortOption(TvApp.getApplication().getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
-        sortOptions.put(4, new SortOption(TvApp.getApplication().getString(R.string.lbl_community_rating), "CommunityRating,SortName", SortOrder.Descending));
-        sortOptions.put(5,new SortOption(TvApp.getApplication().getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
-        sortOptions.put(6, new SortOption(TvApp.getApplication().getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
+        sortOptions.put(0, new SortOption(getString(R.string.lbl_name), "SortName", SortOrder.Ascending));
+        sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
+        sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
+        sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
+        sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), "CommunityRating,SortName", SortOrder.Descending));
+        sortOptions.put(5,new SortOption(getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
+        sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
     }
 
     protected String getSortFriendlyName(String value) {
@@ -176,20 +175,20 @@ public class GridFragment extends Fragment {
     }
 
     public void setStatusText(String folderName) {
-        String text = TvApp.getApplication().getResources().getString(R.string.lbl_showing) + " ";
+        String text = getString(R.string.lbl_showing) + " ";
         FilterOptions filters = mAdapter.getFilters();
         if (filters == null || (!filters.isFavoriteOnly() && !filters.isUnwatchedOnly())) {
-            text += TvApp.getApplication().getResources().getString(R.string.lbl_all_items);
+            text += getString(R.string.lbl_all_items);
         } else {
-            text += (filters.isUnwatchedOnly() ? TvApp.getApplication().getResources().getString(R.string.lbl_unwatched) : "") + " " +
-                    (filters.isFavoriteOnly() ? TvApp.getApplication().getResources().getString(R.string.lbl_favorites) : "");
+            text += (filters.isUnwatchedOnly() ? getString(R.string.lbl_unwatched) : "") + " " +
+                    (filters.isFavoriteOnly() ? getString(R.string.lbl_favorites) : "");
         }
 
         if (mAdapter.getStartLetter() != null) {
-            text += " " + TvApp.getApplication().getResources().getString(R.string.lbl_starting_with) + " " + mAdapter.getStartLetter();
+            text += " " + getString(R.string.lbl_starting_with) + " " + mAdapter.getStartLetter();
         }
 
-        text += " " + TvApp.getApplication().getString(R.string.lbl_from) + " '" + folderName + "' " + TvApp.getApplication().getString(R.string.lbl_sorted_by) + " " + getSortFriendlyName(mAdapter.getSortBy());
+        text += " " + getString(R.string.lbl_from) + " '" + folderName + "' " + getString(R.string.lbl_sorted_by) + " " + getSortFriendlyName(mAdapter.getSortBy());
 
         mStatusText.setText(text);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -15,7 +15,6 @@ import com.bumptech.glide.Glide;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
-import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -41,7 +40,7 @@ public class GuideChannelHeader extends RelativeLayout {
         LayoutInflater inflater = LayoutInflater.from(context);
         View v = inflater.inflate(R.layout.channel_header, this, false);
         int headerWidth = Utils.convertDpToPixel(context, 160);
-        v.setLayoutParams(new AbsListView.LayoutParams(headerWidth, LiveTvGuideActivity.ROW_HEIGHT));
+        v.setLayoutParams(new AbsListView.LayoutParams(headerWidth, Utils.convertDpToPixel(context, 55)));
         this.addView(v);
         this.setFocusable(true);
         ((TextView) findViewById(R.id.channelName)).setText(channel.getName());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
+import org.jellyfin.androidtv.util.Utils;
 
 public class GuidePagingButton extends RelativeLayout {
 
@@ -34,7 +35,7 @@ public class GuidePagingButton extends RelativeLayout {
 
         setBackgroundResource(R.drawable.gray_gradient);
         TextView txtLabel = new TextView(activity);
-        txtLabel.setHeight(LiveTvGuideActivity.PAGEBUTTON_HEIGHT);
+        txtLabel.setHeight(Utils.convertDpToPixel(getContext(), 55));
         txtLabel.setTextColor(Color.BLACK);
         setPadding(100,0,0,0);
         txtLabel.setFocusable(true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
@@ -15,7 +15,6 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.preference.LiveTvPreferences;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
@@ -66,7 +65,7 @@ public class ProgramGridCell extends RelativeLayout implements RecordingIndicato
                 TextView time = new TextView(context);
                 time.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
                 time.setTextSize(12);
-                time.setText(android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(program.getStartDate())));
+                time.setText(android.text.format.DateFormat.getTimeFormat(getContext()).format(TimeUtils.convertToLocalDate(program.getStartDate())));
                 mInfoRow.addView(time);
             }
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
@@ -75,17 +75,17 @@ public class ProgramGridCell extends RelativeLayout implements RecordingIndicato
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowNewIndicator()) && BaseItemUtils.isNew(program) && (!liveTvPreferences.get(LiveTvPreferences.Companion.getShowPremiereIndicator()) || !Utils.isTrue(program.getIsPremiere()))) {
             InfoLayoutHelper.addSpacer(context, mInfoRow, "  ", 10);
-            InfoLayoutHelper.addBlockText(context, mInfoRow, TvApp.getApplication().getString(R.string.lbl_new), 10, Color.GRAY, R.drawable.dark_green_gradient);
+            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_new), 10, Color.GRAY, R.drawable.dark_green_gradient);
         }
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowPremiereIndicator()) && Utils.isTrue(program.getIsPremiere())) {
             InfoLayoutHelper.addSpacer(context, mInfoRow, "  ", 10);
-            InfoLayoutHelper.addBlockText(context, mInfoRow, TvApp.getApplication().getString(R.string.lbl_premiere), 10, Color.GRAY, R.drawable.dark_green_gradient);
+            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_premiere), 10, Color.GRAY, R.drawable.dark_green_gradient);
         }
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowRepeatIndicator()) && Utils.isTrue(program.getIsRepeat())) {
             InfoLayoutHelper.addSpacer(context, mInfoRow, "  ", 10);
-            InfoLayoutHelper.addBlockText(context, mInfoRow, TvApp.getApplication().getString(R.string.lbl_repeat), 10, Color.GRAY, R.color.lb_default_brand_color);
+            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_repeat), 10, Color.GRAY, R.color.lb_default_brand_color);
         }
 
         if (program.getOfficialRating() != null && !program.getOfficialRating().equals("0")) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
@@ -61,10 +61,10 @@ public class RecordPopup {
     Button mOkButton;
     Button mCancelButton;
 
-    String MINUTE = TvApp.getApplication().getString(R.string.lbl_minute);
-    String MINUTES = TvApp.getApplication().getString(R.string.lbl_minutes);
-    String HOURS = TvApp.getApplication().getString(R.string.lbl_hours);
-    ArrayList<String> mPaddingDisplayOptions = new ArrayList<>(Arrays.asList(TvApp.getApplication().getString(R.string.lbl_on_schedule),"1  "+MINUTE,"5  "+MINUTES,"15 "+MINUTES,"30 "+MINUTES,"60 "+MINUTES,"90 "+MINUTES,"2  "+HOURS,"3  "+HOURS));
+    String MINUTE = mActivity.getString(R.string.lbl_minute);
+    String MINUTES = mActivity.getString(R.string.lbl_minutes);
+    String HOURS = mActivity.getString(R.string.lbl_hours);
+    ArrayList<String> mPaddingDisplayOptions = new ArrayList<>(Arrays.asList(mActivity.getString(R.string.lbl_on_schedule),"1  "+MINUTE,"5  "+MINUTES,"15 "+MINUTES,"30 "+MINUTES,"60 "+MINUTES,"90 "+MINUTES,"2  "+HOURS,"3  "+HOURS));
     ArrayList<Integer> mPaddingValues = new ArrayList<>(Arrays.asList(0,60,300,900,1800,3600,5400,7200,10800));
 
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -40,7 +40,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
     @Override
     protected void setupQueries(final RowLoader rowLoader) {
         showViews = true;
-        mTitle.setText(TvApp.getApplication().getResources().getString(R.string.lbl_loading_elipses));
+        mTitle.setText(getString(R.string.lbl_loading_elipses));
         //Latest Recordings
         RecordingQuery recordings = new RecordingQuery();
         recordings.setFields(new ItemFields[]{
@@ -165,11 +165,11 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
     @Override
     protected void addAdditionalRows(ArrayObjectAdapter rowAdapter) {
-        HeaderItem gridHeader = new HeaderItem(rowAdapter.size(), TvApp.getApplication().getString(R.string.lbl_views));
+        HeaderItem gridHeader = new HeaderItem(rowAdapter.size(), getString(R.string.lbl_views));
 
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
         ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
-        gridRowAdapter.add(new GridButton(SCHEDULE, TvApp.getApplication().getString(R.string.lbl_schedule), R.drawable.tile_port_time, null));
+        gridRowAdapter.add(new GridButton(SCHEDULE, getString(R.string.lbl_schedule), R.drawable.tile_port_time, null));
         gridRowAdapter.add(new GridButton(SERIES, mActivity.getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer, null));
         rowAdapter.add(new ListRow(gridHeader, gridRowAdapter));
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -157,7 +157,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
             @Override
             public void onError(Exception exception) {
-                    Utils.showToast(TvApp.getApplication(), exception.getLocalizedMessage());
+                    Utils.showToast(getContext(), exception.getLocalizedMessage());
                     }
 
         });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -415,7 +415,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                     @Override
                     public void onError(Exception exception) {
-                        Utils.showToast(TvApp.getApplication(), exception.getLocalizedMessage());
+                        Utils.showToast(getContext(), exception.getLocalizedMessage());
                     }
                 });
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -78,7 +78,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 resumeMovies.setFilters(new ItemFilter[]{ItemFilter.IsResumable});
                 resumeMovies.setSortBy(new String[]{ItemSortBy.DatePlayed});
                 resumeMovies.setSortOrder(SortOrder.Descending);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_continue_watching), resumeMovies, 0, new ChangeTriggerType[]{ChangeTriggerType.MoviePlayback}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_continue_watching), resumeMovies, 0, new ChangeTriggerType[]{ChangeTriggerType.MoviePlayback}));
 
                 //Latest
                 LatestItemsQuery latestMovies = new LatestItemsQuery();
@@ -92,7 +92,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 latestMovies.setParentId(mFolder.getId());
                 latestMovies.setLimit(50);
                 latestMovies.setImageTypeLimit(1);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_latest), latestMovies, new ChangeTriggerType[]{ChangeTriggerType.MoviePlayback, ChangeTriggerType.LibraryUpdated}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_latest), latestMovies, new ChangeTriggerType[]{ChangeTriggerType.MoviePlayback, ChangeTriggerType.LibraryUpdated}));
 
                 //Favorites
                 StdItemQuery favorites = new StdItemQuery(new ItemFields[]{
@@ -110,7 +110,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 favorites.setImageTypeLimit(1);
                 favorites.setFilters(new ItemFilter[]{ItemFilter.IsFavorite});
                 favorites.setSortBy(new String[]{ItemSortBy.SortName});
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_favorites), favorites, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_favorites), favorites, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
 
                 //Collections
                 StdItemQuery collections = new StdItemQuery();
@@ -122,7 +122,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 collections.setImageTypeLimit(1);
                 //collections.setParentId(mFolder.getId());
                 collections.setSortBy(new String[]{ItemSortBy.SortName});
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_collections), collections, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_collections), collections, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
 
                 rowLoader.loadRows(mRows);
                 break;
@@ -142,7 +142,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                         ItemFields.MediaSources,
                         ItemFields.MediaStreams
                 });
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getResources().getString(R.string.lbl_next_up), nextUpQuery, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_next_up), nextUpQuery, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
 
                 //Premieres
                 if (KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getPremieresEnabled())) {
@@ -164,7 +164,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                     newQuery.setSortOrder(SortOrder.Descending);
                     newQuery.setEnableTotalRecordCount(false);
                     newQuery.setLimit(300);
-                    mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_new_premieres), newQuery, 0, true, true, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}, QueryType.Premieres));
+                    mRows.add(new BrowseRowDef(getString(R.string.lbl_new_premieres), newQuery, 0, true, true, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}, QueryType.Premieres));
                 }
 
                 //Latest content added
@@ -181,7 +181,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 latestSeries.setParentId(mFolder.getId());
                 latestSeries.setLimit(50);
                 latestSeries.setImageTypeLimit(1);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_latest), latestSeries, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_latest), latestSeries, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
 
                 //Favorites
                 StdItemQuery tvFavorites = new StdItemQuery();
@@ -191,7 +191,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 tvFavorites.setImageTypeLimit(1);
                 tvFavorites.setFilters(new ItemFilter[]{ItemFilter.IsFavorite});
                 tvFavorites.setSortBy(new String[]{ItemSortBy.SortName});
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_favorites), tvFavorites, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_favorites), tvFavorites, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
 
                 rowLoader.loadRows(mRows);
                 break;
@@ -209,7 +209,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 latestAlbums.setImageTypeLimit(1);
                 latestAlbums.setParentId(mFolder.getId());
                 latestAlbums.setLimit(50);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_latest), latestAlbums, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_latest), latestAlbums, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
 
                 //Last Played
                 StdItemQuery lastPlayed = new StdItemQuery();
@@ -222,7 +222,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 lastPlayed.setSortOrder(SortOrder.Descending);
                 lastPlayed.setEnableTotalRecordCount(false);
                 lastPlayed.setLimit(50);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_last_played), lastPlayed, 0, false, true, new ChangeTriggerType[]{ChangeTriggerType.MusicPlayback, ChangeTriggerType.LibraryUpdated}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_last_played), lastPlayed, 0, false, true, new ChangeTriggerType[]{ChangeTriggerType.MusicPlayback, ChangeTriggerType.LibraryUpdated}));
 
                 //Favorites
                 StdItemQuery favAlbums = new StdItemQuery();
@@ -232,7 +232,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 favAlbums.setImageTypeLimit(1);
                 favAlbums.setFilters(new ItemFilter[]{ItemFilter.IsFavorite});
                 favAlbums.setSortBy(new String[]{ItemSortBy.SortName});
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_favorites), favAlbums, 60, false, true, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_favorites), favAlbums, 60, false, true, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated, ChangeTriggerType.FavoriteUpdate}));
 
                 //AudioPlaylists
                 StdItemQuery playlists = new StdItemQuery(new ItemFields[]{
@@ -245,7 +245,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 playlists.setRecursive(true);
                 playlists.setSortBy(new String[]{ItemSortBy.DateCreated});
                 playlists.setSortOrder(SortOrder.Descending);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_playlists), playlists, 60, false, true, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}, QueryType.AudioPlaylists));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_playlists), playlists, 60, false, true, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}, QueryType.AudioPlaylists));
 
                 rowLoader.loadRows(mRows);
                 break;
@@ -266,7 +266,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 onNow.setImageTypeLimit(1);
                 onNow.setEnableTotalRecordCount(false);
                 onNow.setLimit(150);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_on_now), onNow));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_on_now), onNow));
 
                 //Upcoming
                 RecommendedProgramQuery upcomingTv = new RecommendedProgramQuery();
@@ -282,20 +282,20 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 upcomingTv.setImageTypeLimit(1);
                 upcomingTv.setEnableTotalRecordCount(false);
                 upcomingTv.setLimit(150);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_coming_up), upcomingTv));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_coming_up), upcomingTv));
 
                 //Fav Channels
                 LiveTvChannelQuery favTv = new LiveTvChannelQuery();
                 favTv.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 favTv.setEnableFavoriteSorting(true);
                 favTv.setIsFavorite(true);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_favorite_channels), favTv));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_favorite_channels), favTv));
 
                 //Other Channels
                 LiveTvChannelQuery otherTv = new LiveTvChannelQuery();
                 otherTv.setUserId(TvApp.getApplication().getCurrentUser().getId());
                 otherTv.setIsFavorite(false);
-                mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_other_channels), otherTv));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_other_channels), otherTv));
 
                 //Latest Recordings
                 RecordingQuery recordings = new RecordingQuery();
@@ -464,32 +464,32 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
     protected void addAdditionalRows(ArrayObjectAdapter rowAdapter) {
         if (isLiveTvLibrary) {
             //Views row
-            HeaderItem gridHeader = new HeaderItem(mRowsAdapter.size(), TvApp.getApplication().getString(R.string.lbl_views));
+            HeaderItem gridHeader = new HeaderItem(mRowsAdapter.size(), getString(R.string.lbl_views));
 
             GridButtonPresenter mGridPresenter = new GridButtonPresenter();
             ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
             gridRowAdapter.add(new GridButton(
                 TvApp.LIVE_TV_GUIDE_OPTION_ID,
-                TvApp.getApplication().getResources().getString(R.string.lbl_live_tv_guide),
+                getString(R.string.lbl_live_tv_guide),
                 R.drawable.tile_port_guide,
                 null
             ));
             gridRowAdapter.add(new GridButton(
                 TvApp.LIVE_TV_RECORDINGS_OPTION_ID,
-                TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv),
+                getString(R.string.lbl_recorded_tv),
                 R.drawable.tile_port_record,
                 null
             ));
             if (TvApp.getApplication().canManageRecordings()) {
                 gridRowAdapter.add(new GridButton(
                     TvApp.LIVE_TV_SCHEDULE_OPTION_ID,
-                    TvApp.getApplication().getResources().getString(R.string.lbl_schedule),
+                    getString(R.string.lbl_schedule),
                     R.drawable.tile_port_time,
                     null
                 ));
                 gridRowAdapter.add(new GridButton(
                     TvApp.LIVE_TV_SERIES_OPTION_ID,
-                    TvApp.getApplication().getResources().getString(R.string.lbl_series),
+                    getString(R.string.lbl_series),
                     R.drawable.tile_port_series_timer,
                     null
                 ));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.java
@@ -1,16 +1,15 @@
 package org.jellyfin.androidtv.ui.browsing;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
 
 public class ByLetterFragment extends BrowseFolderFragment {
-    private static String letters = TvApp.getApplication().getResources().getString(R.string.byletter_letters);
 
     @Override
     protected void setupQueries(RowLoader rowLoader) {
+        String letters = getString(R.string.byletter_letters);
         if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
             //First add a '#' item
             StdItemQuery numbers = new StdItemQuery();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.ui.browsing;
 import android.os.Bundle;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemFields;
@@ -30,17 +29,17 @@ public class CollectionFragment extends EnhancedBrowseFragment {
             });
             movies.setParentId(mFolder.getId());
             movies.setIncludeItemTypes(new String[]{"Movie"});
-            mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_movies), movies, 100));
+            mRows.add(new BrowseRowDef(getString(R.string.lbl_movies), movies, 100));
 
             StdItemQuery series = new StdItemQuery();
             series.setParentId(mFolder.getId());
             series.setIncludeItemTypes(new String[]{"Series"});
-            mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_tv_series), series, 100));
+            mRows.add(new BrowseRowDef(getString(R.string.lbl_tv_series), series, 100));
 
             StdItemQuery others = new StdItemQuery();
             others.setParentId(mFolder.getId());
             others.setExcludeItemTypes(new String[]{"Movie", "Series"});
-            mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_other), others, 100));
+            mRows.add(new BrowseRowDef(getString(R.string.lbl_other), others, 100));
 
 
             rowLoader.loadRows(mRows);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -286,20 +286,20 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
     protected void addAdditionalRows(ArrayObjectAdapter rowAdapter) {
         if (!showViews) return;
 
-        HeaderItem gridHeader = new HeaderItem(rowAdapter.size(), TvApp.getApplication().getString(R.string.lbl_views));
+        HeaderItem gridHeader = new HeaderItem(rowAdapter.size(), getString(R.string.lbl_views));
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
         ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
 
         switch (itemTypeString) {
             case "Movie":
-                gridRowAdapter.add(new GridButton(SUGGESTED, TvApp.getApplication().getString(R.string.lbl_suggested), R.drawable.tile_suggestions, null));
+                gridRowAdapter.add(new GridButton(SUGGESTED, getString(R.string.lbl_suggested), R.drawable.tile_suggestions, null));
                 addStandardViewButtons(gridRowAdapter);
                 break;
 
             case "MusicAlbum":
-                gridRowAdapter.add(new GridButton(ALBUMS, TvApp.getApplication().getString(R.string.lbl_albums), R.drawable.tile_audio, null));
-                gridRowAdapter.add(new GridButton(ARTISTS, TvApp.getApplication().getString(R.string.lbl_artists), R.drawable.tile_artists, null));
-                gridRowAdapter.add(new GridButton(GENRES, TvApp.getApplication().getString(R.string.lbl_genres), R.drawable.tile_genres, null));
+                gridRowAdapter.add(new GridButton(ALBUMS, getString(R.string.lbl_albums), R.drawable.tile_audio, null));
+                gridRowAdapter.add(new GridButton(ARTISTS, getString(R.string.lbl_artists), R.drawable.tile_artists, null));
+                gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres, null));
                 break;
 
             default:
@@ -311,11 +311,11 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
     }
 
     protected void addStandardViewButtons(ArrayObjectAdapter gridRowAdapter) {
-        gridRowAdapter.add(new GridButton(GRID, TvApp.getApplication().getString(R.string.lbl_all_items), R.drawable.tile_port_grid, null));
-        gridRowAdapter.add(new GridButton(BY_LETTER, TvApp.getApplication().getString(R.string.lbl_by_letter), R.drawable.tile_letters, null));
-        gridRowAdapter.add(new GridButton(GENRES, TvApp.getApplication().getString(R.string.lbl_genres), R.drawable.tile_genres, null));
+        gridRowAdapter.add(new GridButton(GRID, getString(R.string.lbl_all_items), R.drawable.tile_port_grid, null));
+        gridRowAdapter.add(new GridButton(BY_LETTER, getString(R.string.lbl_by_letter), R.drawable.tile_letters, null));
+        gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres, null));
         // Disabled because the screen doesn't behave properly
-        // gridRowAdapter.add(new GridButton(PERSONS, TvApp.getApplication().getString(R.string.lbl_performers), R.drawable.tile_actors));
+        // gridRowAdapter.add(new GridButton(PERSONS, getString(R.string.lbl_performers), R.drawable.tile_actors));
     }
 
     protected void setupEventListeners() {
@@ -448,7 +448,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
                         Intent recordings = new Intent(mActivity, BrowseRecordingsActivity.class);
                         BaseItemDto folder = new BaseItemDto();
                         folder.setId("");
-                        folder.setName(TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv));
+                        folder.setName(getString(R.string.lbl_recorded_tv));
                         recordings.putExtra(Extras.Folder, serializer.getValue().SerializeToString(folder));
                         mActivity.startActivity(recordings);
                         break;
@@ -459,7 +459,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
                         break;
 
                     default:
-                        Toast.makeText(getActivity(), item.toString() + TvApp.getApplication().getString(R.string.msg_not_implemented), Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getActivity(), item.toString() + getString(R.string.msg_not_implemented), Toast.LENGTH_SHORT).show();
                         break;
                 }
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
@@ -36,7 +36,7 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
                     ItemFields.PrimaryImageAspectRatio,
                     ItemFields.ChildCount
             });
-            mRows.add(new BrowseRowDef(TvApp.getApplication().getResources().getString(R.string.lbl_all_items), query));
+            mRows.add(new BrowseRowDef(getString(R.string.lbl_all_items), query));
             rowLoader.loadRows(mRows);
         } else {
 
@@ -55,7 +55,7 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
                         resume.setFilters(new ItemFilter[]{ItemFilter.IsResumable});
                         resume.setSortBy(new String[]{ItemSortBy.DatePlayed});
                         resume.setSortOrder(SortOrder.Descending);
-                        mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_continue_watching), resume, 0));
+                        mRows.add(new BrowseRowDef(getString(R.string.lbl_continue_watching), resume, 0));
                     }
 
                     StdItemQuery latest = new StdItemQuery();
@@ -64,14 +64,14 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
                     latest.setFilters(new ItemFilter[]{ItemFilter.IsUnplayed});
                     latest.setSortBy(new String[]{ItemSortBy.DateCreated});
                     latest.setSortOrder(SortOrder.Descending);
-                    mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_latest_additions), latest, 0));
+                    mRows.add(new BrowseRowDef(getString(R.string.lbl_latest_additions), latest, 0));
 
                 }
 
 
                 StdItemQuery byName = new StdItemQuery();
                 byName.setParentId(mFolder.getId());
-                String header = (mFolder.getBaseItemType() == BaseItemType.Season) ? mFolder.getName() : TvApp.getApplication().getString(R.string.lbl_by_name);
+                String header = (mFolder.getBaseItemType() == BaseItemType.Season) ? mFolder.getName() : getString(R.string.lbl_by_name);
                 mRows.add(new BrowseRowDef(header, byName, 100));
 
                 rowLoader.loadRows(mRows);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
@@ -48,7 +48,7 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
                             ItemFields.MediaSources
                     });
                     similar.setLimit(7);
-                    mRows.add(new BrowseRowDef(TvApp.getApplication().getString(R.string.lbl_because_you_watched)+item.getName(), similar, QueryType.SimilarMovies));
+                    mRows.add(new BrowseRowDef(getString(R.string.lbl_because_you_watched)+item.getName(), similar, QueryType.SimilarMovies));
                 }
 
                 rowLoader.loadRows(mRows);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
@@ -49,8 +49,8 @@ public class ChannelCardView extends FrameLayout {
     private void updateDisplay(BaseItemDto program) {
         binding.program.setText(program.getName());
         if (program.getStartDate() != null && program.getEndDate() != null) {
-            binding.time.setText(android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(program.getStartDate()))
-                    + "-" + android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(program.getEndDate())));
+            binding.time.setText(android.text.format.DateFormat.getTimeFormat(getContext()).format(TimeUtils.convertToLocalDate(program.getStartDate()))
+                    + "-" + android.text.format.DateFormat.getTimeFormat(getContext()).format(TimeUtils.convertToLocalDate(program.getEndDate())));
             long start = TimeUtils.convertToLocalDate(program.getStartDate()).getTime();
             long current = System.currentTimeMillis() - start;
             if (current > 0) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -12,7 +12,6 @@ import android.widget.RelativeLayout;
 import androidx.leanback.widget.BaseCardView;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.databinding.ViewCardLegacyImageBinding;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.TimeUtils;
@@ -100,7 +99,7 @@ public class LegacyImageCardView extends BaseCardView {
         if (getCardType() == BaseCardView.CARD_TYPE_MAIN_ONLY && item.showCardInfoOverlay()) {
             switch (item.getBaseItemType()) {
                 case Photo:
-                    binding.overlayText.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(item.getBaseItem().getPremiereDate())) : item.getFullName(getContext()));
+                    binding.overlayText.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(getContext()).format(TimeUtils.convertToLocalDate(item.getBaseItem().getPremiereDate())) : item.getFullName(getContext()));
                     binding.icon.setImageResource(R.drawable.ic_camera);
                     break;
                 case PhotoAlbum:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -904,14 +904,14 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                             if (response.getItems().length > 0) {
                                 play(response.getItems()[0], 0 , false);
                             } else {
-                                Utils.showToast(TvApp.getApplication(), "Unable to find next up episode");
+                                Utils.showToast(FullDetailsActivity.this, "Unable to find next up episode");
                             }
                         }
 
                         @Override
                         public void onError(Exception exception) {
                             Timber.e(exception, "Error playing next up episode");
-                            Utils.showToast(TvApp.getApplication(), getString(R.string.msg_video_playback_error));
+                            Utils.showToast(FullDetailsActivity.this, getString(R.string.msg_video_playback_error));
                         }
                     });
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -590,7 +590,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 personMovies.setIncludeItemTypes(new String[] {"Movie"});
                 personMovies.setSortBy(new String[] {ItemSortBy.SortName});
                 ItemRowAdapter personMoviesAdapter = new ItemRowAdapter(personMovies, 100, false, new CardPresenter(), adapter);
-                addItemRow(adapter, personMoviesAdapter, 0, TvApp.getApplication().getString(R.string.lbl_movies));
+                addItemRow(adapter, personMoviesAdapter, 0, getString(R.string.lbl_movies));
 
                 ItemQuery personSeries = new ItemQuery();
                 personSeries.setFields(new ItemFields[]{
@@ -604,7 +604,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 personSeries.setIncludeItemTypes(new String[] {"Series"});
                 personSeries.setSortBy(new String[] {ItemSortBy.SortName});
                 ItemRowAdapter personSeriesAdapter = new ItemRowAdapter(personSeries, 100, false, new CardPresenter(), adapter);
-                addItemRow(adapter, personSeriesAdapter, 1, TvApp.getApplication().getString(R.string.lbl_tv_series));
+                addItemRow(adapter, personSeriesAdapter, 1, getString(R.string.lbl_tv_series));
 
                 ItemQuery personEpisodes = new ItemQuery();
                 personEpisodes.setFields(new ItemFields[]{
@@ -618,7 +618,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 personEpisodes.setIncludeItemTypes(new String[] {"Episode"});
                 personEpisodes.setSortBy(new String[] {ItemSortBy.SeriesSortName, ItemSortBy.SortName});
                 ItemRowAdapter personEpisodesAdapter = new ItemRowAdapter(personEpisodes, 100, false, new CardPresenter(), adapter);
-                addItemRow(adapter, personEpisodesAdapter, 2, TvApp.getApplication().getString(R.string.lbl_episodes));
+                addItemRow(adapter, personEpisodesAdapter, 2, getString(R.string.lbl_episodes));
 
                 break;
             case MusicArtist:
@@ -633,7 +633,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 artistAlbums.setRecursive(true);
                 artistAlbums.setIncludeItemTypes(new String[]{"MusicAlbum"});
                 ItemRowAdapter artistAlbumsAdapter = new ItemRowAdapter(artistAlbums, 100, false, new CardPresenter(), adapter);
-                addItemRow(adapter, artistAlbumsAdapter, 0, TvApp.getApplication().getString(R.string.lbl_albums));
+                addItemRow(adapter, artistAlbumsAdapter, 0, getString(R.string.lbl_albums));
 
                 break;
             case Series:
@@ -645,7 +645,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.ChildCount
                 });
                 ItemRowAdapter nextUpAdapter = new ItemRowAdapter(nextUpQuery, false, new CardPresenter(true, 260), adapter);
-                addItemRow(adapter, nextUpAdapter, 0, TvApp.getApplication().getString(R.string.lbl_next_up));
+                addItemRow(adapter, nextUpAdapter, 0, getString(R.string.lbl_next_up));
 
                 SeasonQuery seasons = new SeasonQuery();
                 seasons.setSeriesId(mBaseItem.getId());
@@ -670,7 +670,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
 
                 if (mBaseItem.getPeople() != null && mBaseItem.getPeople().length > 0) {
                     ItemRowAdapter seriesCastAdapter = new ItemRowAdapter(mBaseItem.getPeople(), new CardPresenter(true, 260), adapter);
-                    addItemRow(adapter, seriesCastAdapter, 3, TvApp.getApplication().getString(R.string.lbl_cast_crew));
+                    addItemRow(adapter, seriesCastAdapter, 3, getString(R.string.lbl_cast_crew));
 
                 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -509,13 +509,13 @@ public class BaseRowItem {
         }
     }
 
-    public Drawable getBadgeImage() {
+    public Drawable getBadgeImage(Context context) {
         switch (type) {
             case BaseItem:
                 if (baseItem.getBaseItemType() == BaseItemType.Movie && baseItem.getCriticRating() != null) {
-                    return baseItem.getCriticRating() > 59 ? ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_rt_fresh) : ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_rt_rotten);
+                    return baseItem.getCriticRating() > 59 ? ContextCompat.getDrawable(context, R.drawable.ic_rt_fresh) : ContextCompat.getDrawable(context, R.drawable.ic_rt_rotten);
                 } else if (baseItem.getBaseItemType() == BaseItemType.Program && baseItem.getTimerId() != null) {
-                    return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_record_series_red) : ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_record_red);
+                    return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(context, R.drawable.ic_record_series_red) : ContextCompat.getDrawable(context, R.drawable.ic_record_red);
                 }
                 break;
             case Person:
@@ -523,18 +523,18 @@ public class BaseRowItem {
                 break;
             case User:
                 if (user.getHasPassword()) {
-                    return ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_lock);
+                    return ContextCompat.getDrawable(context, R.drawable.ic_lock);
                 }
                 break;
             case LiveTvProgram:
                 if (baseItem.getTimerId() != null) {
-                    return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_record_series_red) : ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.ic_record_red);
+                    return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(context, R.drawable.ic_record_series_red) : ContextCompat.getDrawable(context, R.drawable.ic_record_red);
                 }
             case Chapter:
                 break;
         }
 
-        return ContextCompat.getDrawable(TvApp.getApplication(), R.drawable.blank10x10);
+        return ContextCompat.getDrawable(context, R.drawable.blank10x10);
     }
 
     public void refresh(final EmptyResponse outerResponse) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -419,8 +419,8 @@ public class BaseRowItem {
             case LiveTvRecording:
                 return (baseItem.getChannelName() != null ? baseItem.getChannelName() + " - " : "") + (baseItem.getEpisodeTitle() != null ? baseItem.getEpisodeTitle() : "") + " " +
                         new SimpleDateFormat("d MMM").format(TimeUtils.convertToLocalDate(baseItem.getStartDate())) + " " +
-                        (android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(baseItem.getStartDate())) + "-"
-                                + android.text.format.DateFormat.getTimeFormat(TvApp.getApplication()).format(TimeUtils.convertToLocalDate(baseItem.getEndDate())));
+                        (android.text.format.DateFormat.getTimeFormat(context).format(TimeUtils.convertToLocalDate(baseItem.getStartDate())) + "-"
+                                + android.text.format.DateFormat.getTimeFormat(context).format(TimeUtils.convertToLocalDate(baseItem.getEndDate())));
             case User:
                 Date date = user.getLastActivityDate();
                 return date != null ? DateUtils.getRelativeTimeSpanString(TimeUtils.convertToLocalDate(date).getTime()).toString() : context.getString(R.string.lbl_never);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -408,7 +408,7 @@ public class ItemLauncher {
                         Intent recordings = new Intent(activity, BrowseRecordingsActivity.class);
                         BaseItemDto folder = new BaseItemDto();
                         folder.setId("");
-                        folder.setName(TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv));
+                        folder.setName(activity.getString(R.string.lbl_recorded_tv));
                         recordings.putExtra(Extras.Folder, KoinJavaComponent.<GsonJsonSerializer>get(GsonJsonSerializer.class).SerializeToString(folder));
                         activity.startActivity(recordings);
                         break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -1309,14 +1309,14 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     int prevItems = adapter.size() > 0 ? adapter.size() : 0;
                     if (adapter.chunkSize == 0) {
                         // and recordings as first item if showing all
-                        adapter.add(new BaseRowItem(new GridButton(TvApp.LIVE_TV_RECORDINGS_OPTION_ID, TvApp.getApplication().getResources().getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record, null)));
+                        adapter.add(new BaseRowItem(new GridButton(TvApp.LIVE_TV_RECORDINGS_OPTION_ID, TvApp.getApplication().getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record, null)));
                         i++;
                         if (TvApp.getApplication().canManageRecordings()) {
                             // and schedule
-                            adapter.add(new BaseRowItem(new GridButton(TvApp.LIVE_TV_SCHEDULE_OPTION_ID, TvApp.getApplication().getResources().getString(R.string.lbl_schedule), R.drawable.tile_port_time, null)));
+                            adapter.add(new BaseRowItem(new GridButton(TvApp.LIVE_TV_SCHEDULE_OPTION_ID, TvApp.getApplication().getString(R.string.lbl_schedule), R.drawable.tile_port_time, null)));
                             i++;
                             // and series
-                            adapter.add(new BaseRowItem(new GridButton(TvApp.LIVE_TV_SERIES_OPTION_ID, TvApp.getApplication().getResources().getString(R.string.lbl_series), R.drawable.tile_port_series_timer, null)));
+                            adapter.add(new BaseRowItem(new GridButton(TvApp.LIVE_TV_SERIES_OPTION_ID, TvApp.getApplication().getString(R.string.lbl_series), R.drawable.tile_port_series_timer, null)));
                             i++;
                         }
                     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -69,10 +69,10 @@ import kotlin.Lazy;
 import timber.log.Timber;
 
 public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
-    public static final int ROW_HEIGHT = Utils.convertDpToPixel(TvApp.getApplication(),55);
-    public static final int PIXELS_PER_MINUTE = Utils.convertDpToPixel(TvApp.getApplication(),7);
-    public static final int PAGEBUTTON_HEIGHT = Utils.convertDpToPixel(TvApp.getApplication(), 20);
-    public static final int PAGEBUTTON_WIDTH = 120 * PIXELS_PER_MINUTE;
+    public final int ROW_HEIGHT = Utils.convertDpToPixel(this, 55);
+    public final int PIXELS_PER_MINUTE = Utils.convertDpToPixel(this,7);
+    public final int PAGEBUTTON_HEIGHT = Utils.convertDpToPixel(this, 20);
+    public final int PAGEBUTTON_WIDTH = 120 * PIXELS_PER_MINUTE;
     public static final int PAGE_SIZE = 75;
     public static final int NORMAL_HOURS = 9;
     public static final int FILTERED_HOURS = 4;
@@ -742,7 +742,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
                 }
 
                 TextView placeHolder = new TextView(mActivity);
-                placeHolder.setHeight(LiveTvGuideActivity.PAGEBUTTON_HEIGHT);
+                placeHolder.setHeight(PAGEBUTTON_HEIGHT);
                 mChannels.addView(placeHolder);
                 displayedChannels = 0;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -373,7 +373,7 @@ public class TvManager {
 
             @Override
             public void onError(Exception exception) {
-                Utils.showToast(TvApp.getApplication(), exception.getLocalizedMessage());
+                Utils.showToast(context, exception.getLocalizedMessage());
                 outerResponse.onError(exception);
             }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -61,7 +61,6 @@ import org.jellyfin.androidtv.ui.ScrollViewListener;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
-import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpActivity;
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
@@ -106,7 +105,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private PositionableListRowPresenter mPopupRowPresenter;
 
     //Live guide items
-    private static final int PIXELS_PER_MINUTE = Utils.convertDpToPixel(TvApp.getApplication(), 7);
+    private final int PIXELS_PER_MINUTE = Utils.convertDpToPixel(getContext(), 7);
     private static final int PAGE_SIZE = 75;
     private static final int GUIDE_HOURS = 9;
 
@@ -160,7 +159,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // stop any audio that may be playing
         mediaManager.getValue().stopAudio(true);
 
-        mAudioManager = (AudioManager) TvApp.getApplication().getSystemService(Context.AUDIO_SERVICE);
+        mAudioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
         if (mAudioManager == null) {
             Timber.e("Unable to get audio manager");
             Utils.showToast(getActivity(), R.string.msg_cannot_play_time);
@@ -172,7 +171,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         mItemsToPlay = mediaManager.getValue().getCurrentVideoQueue();
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
-            Utils.showToast(TvApp.getApplication(), getString(R.string.msg_no_playable_items));
+            Utils.showToast(getContext(), getString(R.string.msg_no_playable_items));
             requireActivity().finish();
             return;
         }
@@ -632,7 +631,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                 @Override
                 public void onError(Exception exception) {
-                    Utils.showToast(TvApp.getApplication(), R.string.msg_video_playback_error);
+                    Utils.showToast(getContext(), R.string.msg_video_playback_error);
                     finish();
                 }
             });
@@ -814,7 +813,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 if (pageUpStart < 0) pageUpStart = 0;
 
                 TextView placeHolder = new TextView(requireContext());
-                placeHolder.setHeight(LiveTvGuideActivity.PAGEBUTTON_HEIGHT);
+                placeHolder.setHeight(Utils.convertDpToPixel(getContext(), 20));
                 tvGuideBinding.channels.addView(placeHolder);
                 displayedChannels = 0;
 
@@ -876,7 +875,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 if (pageDnEnd >= mAllChannels.size()) pageDnEnd = mAllChannels.size() - 1;
 
                 TextView placeHolder = new TextView(requireContext());
-                placeHolder.setHeight(LiveTvGuideActivity.PAGEBUTTON_HEIGHT);
+                placeHolder.setHeight(Utils.convertDpToPixel(getContext(), 20));
                 tvGuideBinding.channels.addView(placeHolder);
 
                 tvGuideBinding.programRows.addView(new GuidePagingButton(requireActivity(), guide, mCurrentDisplayChannelEndNdx + 1, getString(R.string.lbl_load_channels) + mAllChannels.get(mCurrentDisplayChannelEndNdx + 1).getNumber() + " - " + mAllChannels.get(pageDnEnd).getNumber()));
@@ -912,7 +911,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
                 ProgramGridCell cell = new ProgramGridCell(requireContext(), this, empty, false);
                 cell.setId(currentCellId++);
-                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
+                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, Utils.convertDpToPixel(getContext(), 55)));
                 cell.setFocusable(true);
                 programRow.addView(cell);
                 if (slot == 0)
@@ -942,7 +941,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(prevEnd + duration)));
                 ProgramGridCell cell = new ProgramGridCell(requireContext(), this, empty, false);
                 cell.setId(currentCellId++);
-                cell.setLayoutParams(new ViewGroup.LayoutParams(((Long) (duration / 60000)).intValue() * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
+                cell.setLayoutParams(new ViewGroup.LayoutParams(((Long) (duration / 60000)).intValue() * PIXELS_PER_MINUTE, Utils.convertDpToPixel(getContext(), 55)));
                 cell.setFocusable(true);
                 programRow.addView(cell);
             }
@@ -953,7 +952,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             if (duration > 0) {
                 ProgramGridCell program = new ProgramGridCell(requireContext(), this, item, false);
                 program.setId(currentCellId++);
-                program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * PIXELS_PER_MINUTE, LiveTvGuideActivity.ROW_HEIGHT));
+                program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * PIXELS_PER_MINUTE, Utils.convertDpToPixel(getContext(), 55)));
                 program.setFocusable(true);
 
                 if (start == getCurrentLocalStartDate())

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -172,7 +172,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         mItemsToPlay = mediaManager.getValue().getCurrentVideoQueue();
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_no_playable_items));
+            Utils.showToast(TvApp.getApplication(), getString(R.string.msg_no_playable_items));
             requireActivity().finish();
             return;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -68,7 +68,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
         mItemsToPlay = mediaManager.getValue().getCurrentVideoQueue();
 
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_no_playable_items));
+            Utils.showToast(TvApp.getApplication(), getString(R.string.msg_no_playable_items));
             finish();
             return;
         }
@@ -257,13 +257,13 @@ public class ExternalPlayerActivity extends FragmentActivity {
                             PlaybackException ex = (PlaybackException) exception;
                             switch (ex.getErrorCode()) {
                                 case NotAllowed:
-                                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_playback_not_allowed));
+                                    Utils.showToast(TvApp.getApplication(), getString(R.string.msg_playback_not_allowed));
                                     break;
                                 case NoCompatibleStream:
-                                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_playback_incompatible));
+                                    Utils.showToast(TvApp.getApplication(), getString(R.string.msg_playback_incompatible));
                                     break;
                                 case RateLimitExceeded:
-                                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_playback_restricted));
+                                    Utils.showToast(TvApp.getApplication(), getString(R.string.msg_playback_restricted));
                                     break;
                             }
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -68,7 +68,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
         mItemsToPlay = mediaManager.getValue().getCurrentVideoQueue();
 
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
-            Utils.showToast(TvApp.getApplication(), getString(R.string.msg_no_playable_items));
+            Utils.showToast(this, getString(R.string.msg_no_playable_items));
             finish();
             return;
         }
@@ -257,13 +257,13 @@ public class ExternalPlayerActivity extends FragmentActivity {
                             PlaybackException ex = (PlaybackException) exception;
                             switch (ex.getErrorCode()) {
                                 case NotAllowed:
-                                    Utils.showToast(TvApp.getApplication(), getString(R.string.msg_playback_not_allowed));
+                                    Utils.showToast(ExternalPlayerActivity.this, getString(R.string.msg_playback_not_allowed));
                                     break;
                                 case NoCompatibleStream:
-                                    Utils.showToast(TvApp.getApplication(), getString(R.string.msg_playback_incompatible));
+                                    Utils.showToast(ExternalPlayerActivity.this, getString(R.string.msg_playback_incompatible));
                                     break;
                                 case RateLimitExceeded:
-                                    Utils.showToast(TvApp.getApplication(), getString(R.string.msg_playback_restricted));
+                                    Utils.showToast(ExternalPlayerActivity.this, getString(R.string.msg_playback_restricted));
                                     break;
                             }
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -40,7 +40,6 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dlna.DeviceProfile;
-import org.jellyfin.apiclient.model.dlna.DirectPlayProfile;
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -269,13 +268,13 @@ public class PlaybackController {
         lastPlaybackError = System.currentTimeMillis();
 
         if (playbackRetries < 3) {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.player_error));
+            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.player_error));
             Timber.i("Player error encountered - retrying");
             stop();
             play(mCurrentPosition);
 
         } else {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.too_many_errors));
+            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.too_many_errors));
             mPlaybackState = PlaybackState.ERROR;
             if (mFragment != null) mFragment.finish();
         }
@@ -427,13 +426,13 @@ public class PlaybackController {
                         new AlertDialog.Builder(mFragment.getContext())
                                 .setTitle(R.string.episode_missing)
                                 .setMessage(R.string.episode_missing_message)
-                                .setPositiveButton(TvApp.getApplication().getResources().getString(R.string.lbl_yes), new DialogInterface.OnClickListener() {
+                                .setPositiveButton(R.string.lbl_yes, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
                                         next();
                                     }
                                 })
-                                .setNegativeButton(TvApp.getApplication().getResources().getString(R.string.lbl_no), new DialogInterface.OnClickListener() {
+                                .setNegativeButton(R.string.lbl_no, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
                                         mFragment.requireActivity().finish();
@@ -445,7 +444,7 @@ public class PlaybackController {
                         new AlertDialog.Builder(mFragment.getContext())
                                 .setTitle(R.string.episode_missing)
                                 .setMessage(R.string.episode_missing_message_2)
-                                .setPositiveButton(TvApp.getApplication().getResources().getString(R.string.lbl_ok), new DialogInterface.OnClickListener() {
+                                .setPositiveButton(R.string.lbl_ok, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
                                         mFragment.requireActivity().finish();
@@ -459,7 +458,7 @@ public class PlaybackController {
 
                 // confirm we actually can play
                 if (item.getPlayAccess() != PlayAccess.Full) {
-                    String msg = item.getIsPlaceHolder() ? TvApp.getApplication().getString(R.string.msg_cannot_play) : TvApp.getApplication().getString(R.string.msg_cannot_play_time);
+                    String msg = item.getIsPlaceHolder() ? mFragment.getString(R.string.msg_cannot_play) : mFragment.getString(R.string.msg_cannot_play_time);
                     Utils.showToast(TvApp.getApplication(), msg);
                     return;
                 }
@@ -662,17 +661,17 @@ public class PlaybackController {
             PlaybackException ex = (PlaybackException) exception;
             switch (ex.getErrorCode()) {
                 case NotAllowed:
-                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_playback_not_allowed));
+                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_playback_not_allowed));
                     break;
                 case NoCompatibleStream:
-                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_playback_incompatible));
+                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_playback_incompatible));
                     break;
                 case RateLimitExceeded:
-                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_playback_restricted));
+                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_playback_restricted));
                     break;
             }
         } else {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_cannot_play));
+            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_cannot_play));
         }
         // give the user a second to read the error message
         try {
@@ -883,7 +882,7 @@ public class PlaybackController {
 
         MediaStream stream = StreamHelper.getMediaStream(getCurrentMediaSource(), index);
         if (stream == null) {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.subtitle_error));
+            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.subtitle_error));
             return;
         }
 
@@ -891,7 +890,7 @@ public class PlaybackController {
         // handle according to delivery method
         SubtitleStreamInfo streamInfo = getSubtitleStreamInfo(index);
         if (streamInfo == null) {
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getResources().getString(R.string.msg_unable_load_subs));
+            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
         } else {
             switch (streamInfo.getDeliveryMethod()) {
 
@@ -899,7 +898,7 @@ public class PlaybackController {
                     // Gonna need to burn in so start a transcode with the sub index
                     stop();
                     if (!mVideoManager.isNativeMode()) {
-                        Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getResources().getString(R.string.msg_burn_sub_warning));
+                        Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_burn_sub_warning));
                     }
                     play(mCurrentPosition, index);
                     break;
@@ -909,7 +908,7 @@ public class PlaybackController {
                             mFragment.addManualSubtitles(null); // in case these were on
                         if (!mVideoManager.setSubtitleTrack(index, getCurrentlyPlayingItem().getMediaStreams())) {
                             // error selecting internal subs
-                            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getResources().getString(R.string.msg_unable_load_subs));
+                            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
                         }
                         break;
                     }
@@ -930,7 +929,7 @@ public class PlaybackController {
                                 if (mFragment != null) mFragment.addManualSubtitles(info);
                             } else {
                                 Timber.e("Empty subtitle result");
-                                Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getResources().getString(R.string.msg_unable_load_subs));
+                                Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
                                 if (mFragment != null) mFragment.showSubLoadingMsg(false);
                             }
                         }
@@ -938,7 +937,7 @@ public class PlaybackController {
                         @Override
                         public void onError(Exception ex) {
                             Timber.e(ex, "Error downloading subtitles");
-                            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getResources().getString(R.string.msg_unable_load_subs));
+                            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
                             if (mFragment != null) mFragment.showSubLoadingMsg(false);
                         }
 
@@ -1122,7 +1121,7 @@ public class PlaybackController {
         } else {
             if (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer())) {
                 //Exo does not support seeking in .ts
-                Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
+                Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.seek_error));
             } else {
                 // use the same approach to directplay seeking as setOnProgressListener
                 // set state to SEEKING
@@ -1132,7 +1131,7 @@ public class PlaybackController {
                 Timber.d("Seek method - native");
                 mPlaybackState = PlaybackState.SEEKING;
                 if (mVideoManager.seekTo(pos) < 0) {
-                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.seek_error));
+                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.seek_error));
                     pause();
                 } else {
                     mVideoManager.play();
@@ -1338,12 +1337,12 @@ public class PlaybackController {
             @Override
             public void onEvent() {
                 if (isLiveTv && directStreamLiveTv) {
-                    Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_error_live_stream));
+                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_error_live_stream));
                     directStreamLiveTv = false;
                     PlaybackHelper.retrieveAndPlay(getCurrentlyPlayingItem().getId(), false, TvApp.getApplication());
                     if (mFragment != null) mFragment.finish();
                 } else {
-                    String msg = TvApp.getApplication().getString(R.string.video_error_unknown_error);
+                    String msg = mFragment.getString(R.string.video_error_unknown_error);
                     Timber.e("Playback error - %s", msg);
                     playerErrorEncountered();
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -268,13 +268,13 @@ public class PlaybackController {
         lastPlaybackError = System.currentTimeMillis();
 
         if (playbackRetries < 3) {
-            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.player_error));
+            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.player_error));
             Timber.i("Player error encountered - retrying");
             stop();
             play(mCurrentPosition);
 
         } else {
-            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.too_many_errors));
+            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.too_many_errors));
             mPlaybackState = PlaybackState.ERROR;
             if (mFragment != null) mFragment.finish();
         }
@@ -459,7 +459,7 @@ public class PlaybackController {
                 // confirm we actually can play
                 if (item.getPlayAccess() != PlayAccess.Full) {
                     String msg = item.getIsPlaceHolder() ? mFragment.getString(R.string.msg_cannot_play) : mFragment.getString(R.string.msg_cannot_play_time);
-                    Utils.showToast(TvApp.getApplication(), msg);
+                    Utils.showToast(mFragment.getContext(), msg);
                     return;
                 }
 
@@ -661,17 +661,17 @@ public class PlaybackController {
             PlaybackException ex = (PlaybackException) exception;
             switch (ex.getErrorCode()) {
                 case NotAllowed:
-                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_playback_not_allowed));
+                    Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_playback_not_allowed));
                     break;
                 case NoCompatibleStream:
-                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_playback_incompatible));
+                    Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_playback_incompatible));
                     break;
                 case RateLimitExceeded:
-                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_playback_restricted));
+                    Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_playback_restricted));
                     break;
             }
         } else {
-            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_cannot_play));
+            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_cannot_play));
         }
         // give the user a second to read the error message
         try {
@@ -882,7 +882,7 @@ public class PlaybackController {
 
         MediaStream stream = StreamHelper.getMediaStream(getCurrentMediaSource(), index);
         if (stream == null) {
-            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.subtitle_error));
+            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.subtitle_error));
             return;
         }
 
@@ -890,7 +890,7 @@ public class PlaybackController {
         // handle according to delivery method
         SubtitleStreamInfo streamInfo = getSubtitleStreamInfo(index);
         if (streamInfo == null) {
-            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
+            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
         } else {
             switch (streamInfo.getDeliveryMethod()) {
 
@@ -898,7 +898,7 @@ public class PlaybackController {
                     // Gonna need to burn in so start a transcode with the sub index
                     stop();
                     if (!mVideoManager.isNativeMode()) {
-                        Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_burn_sub_warning));
+                        Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_burn_sub_warning));
                     }
                     play(mCurrentPosition, index);
                     break;
@@ -908,7 +908,7 @@ public class PlaybackController {
                             mFragment.addManualSubtitles(null); // in case these were on
                         if (!mVideoManager.setSubtitleTrack(index, getCurrentlyPlayingItem().getMediaStreams())) {
                             // error selecting internal subs
-                            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
+                            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
                         }
                         break;
                     }
@@ -929,7 +929,7 @@ public class PlaybackController {
                                 if (mFragment != null) mFragment.addManualSubtitles(info);
                             } else {
                                 Timber.e("Empty subtitle result");
-                                Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
+                                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
                                 if (mFragment != null) mFragment.showSubLoadingMsg(false);
                             }
                         }
@@ -937,7 +937,7 @@ public class PlaybackController {
                         @Override
                         public void onError(Exception ex) {
                             Timber.e(ex, "Error downloading subtitles");
-                            Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_unable_load_subs));
+                            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
                             if (mFragment != null) mFragment.showSubLoadingMsg(false);
                         }
 
@@ -1121,7 +1121,7 @@ public class PlaybackController {
         } else {
             if (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer())) {
                 //Exo does not support seeking in .ts
-                Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.seek_error));
+                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.seek_error));
             } else {
                 // use the same approach to directplay seeking as setOnProgressListener
                 // set state to SEEKING
@@ -1131,7 +1131,7 @@ public class PlaybackController {
                 Timber.d("Seek method - native");
                 mPlaybackState = PlaybackState.SEEKING;
                 if (mVideoManager.seekTo(pos) < 0) {
-                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.seek_error));
+                    Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.seek_error));
                     pause();
                 } else {
                     mVideoManager.play();
@@ -1337,9 +1337,9 @@ public class PlaybackController {
             @Override
             public void onEvent() {
                 if (isLiveTv && directStreamLiveTv) {
-                    Utils.showToast(TvApp.getApplication(), mFragment.getString(R.string.msg_error_live_stream));
+                    Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_error_live_stream));
                     directStreamLiveTv = false;
-                    PlaybackHelper.retrieveAndPlay(getCurrentlyPlayingItem().getId(), false, TvApp.getApplication());
+                    PlaybackHelper.retrieveAndPlay(getCurrentlyPlayingItem().getId(), false, mFragment.getContext());
                     if (mFragment != null) mFragment.finish();
                 } else {
                     String msg = mFragment.getString(R.string.video_error_unknown_error);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.java
@@ -7,7 +7,6 @@ import android.view.View;
 import android.widget.PopupMenu;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.compat.SubtitleStreamInfo;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue;
@@ -29,7 +28,7 @@ public class ClosedCaptionsAction extends CustomAction {
     public void handleClickAction(PlaybackController playbackController, LeanbackOverlayFragment leanbackOverlayFragment, Context context, View view) {
         if (playbackController.getCurrentStreamInfo() == null) {
             Timber.w("StreamInfo null trying to obtain subtitles");
-            Utils.showToast(TvApp.getApplication(), "Unable to obtain subtitle info");
+            Utils.showToast(context, "Unable to obtain subtitle info");
             return;
         }
         List<SubtitleStreamInfo> subtitles = playbackController.getSubtitleStreams();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -427,7 +427,7 @@ public class CardPresenter extends Presenter {
             if (holder.getItem().getBaseItemType() != BaseItemType.UserView) {
                 RatingType ratingType = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getDefaultRatingType());
                 if (ratingType == RatingType.RATING_TOMATOES) {
-                    Drawable badge = rowItem.getBadgeImage();
+                    Drawable badge = rowItem.getBadgeImage(holder.view.getContext());
                     holder.mCardView.setRating(null);
                     if (badge != null) {
                         holder.mCardView.setBadgeImage(badge);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
@@ -13,7 +13,6 @@ import android.widget.TextView;
 import androidx.leanback.widget.RowPresenter;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.data.model.InfoItem;
 import org.jellyfin.androidtv.ui.TextUnderButton;
 import org.jellyfin.androidtv.ui.itemdetail.MyDetailsOverviewRow;
@@ -71,7 +70,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
 
         public void collapseLeftFrame() {
             ViewGroup.LayoutParams params = mLeftFrame.getLayoutParams();
-            params.width = Utils.convertDpToPixel(TvApp.getApplication(), 100);
+            params.width = Utils.convertDpToPixel(view.getContext(), 100);
         }
     }
 
@@ -114,7 +113,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
             case Person:
                 RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) vh.mSummary.getLayoutParams();
                 params.topMargin = 10;
-                params.height = Utils.convertDpToPixel(TvApp.getApplication(), 185);
+                params.height = Utils.convertDpToPixel(vh.view.getContext(), 185);
                 vh.mSummary.setMaxLines(9);
                 vh.mGenreRow.setVisibility(View.GONE);
                 vh.mInfoRow.setVisibility(View.GONE);
@@ -137,7 +136,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
         viewHolder.mTitle.setText(text);
         if (text.length() > 28) {
             // raise it up a bit
-            ((RelativeLayout.LayoutParams) viewHolder.mTitle.getLayoutParams()).topMargin = Utils.convertDpToPixel(TvApp.getApplication(), 55);
+            ((RelativeLayout.LayoutParams) viewHolder.mTitle.getLayoutParams()).topMargin = Utils.convertDpToPixel(viewHolder.view.getContext(), 55);
         }
     }
 


### PR DESCRIPTION
Went from 313 to ~~180~~ 172 usages of TvApp.getApplication(). Most left now are to get the current user or to do other fancy stuff like storing the playbackcontroller etc.

**Changes**
- use getString from current context or closest context when possible
- use self or closest context as context parameter when possible

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
