### PR TITLE
Receive context in MediaManager.playNowInternal

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/TvApiEventListener.java
@@ -4,8 +4,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
-import android.widget.Toast;
 import android.os.Looper;
+import android.widget.Toast;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
@@ -194,7 +194,7 @@ public class TvApiEventListener extends ApiEventListener {
                                     TvApp.getApplication().getCurrentActivity().startActivity(intent);
                                     break;
                                 case "Audio":
-                                    mediaManager.playNow(Arrays.asList(response.getItems()), startIndex, false);
+                                    mediaManager.playNow(TvApp.getApplication().getCurrentActivity(), Arrays.asList(response.getItems()), startIndex, false);
                                     break;
                             }
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -1455,7 +1455,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         @Override
                         public void onResponse(List<BaseItemDto> response) {
                             if (mBaseItem.getBaseItemType() == BaseItemType.MusicArtist) {
-                                mediaManager.getValue().playNow(response, false);
+                                mediaManager.getValue().playNow(FullDetailsActivity.this, response, false);
                             } else {
                                 Intent intent = new Intent(FullDetailsActivity.this, ExternalPlayerActivity.class);
                                 mediaManager.getValue().setCurrentVideoQueue(response);
@@ -1613,7 +1613,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 if (playbackLauncher.interceptPlayRequest(FullDetailsActivity.this, item)) return;
 
                 if (item.getBaseItemType() == BaseItemType.MusicArtist) {
-                    mediaManager.getValue().playNow(response, shuffle);
+                    mediaManager.getValue().playNow(FullDetailsActivity.this, response, shuffle);
                 } else {
                     Class activity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(item.getBaseItemType());
                     Intent intent = new Intent(FullDetailsActivity.this, activity);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -63,7 +63,6 @@ import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.List;
 
 import kotlin.Lazy;
@@ -530,7 +529,7 @@ public class ItemListActivity extends FragmentActivity {
             mediaManager.getValue().setCurrentVideoQueue(items);
             startActivity(intent);
         } else {
-            mediaManager.getValue().playNow(items, ndx, shuffle);
+            mediaManager.getValue().playNow(this, items, ndx, shuffle);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -31,6 +31,7 @@ import org.jellyfin.androidtv.ui.itemhandling.AudioQueueItem;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
+import org.jellyfin.androidtv.util.ContextExtensionsKt;
 import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
@@ -595,30 +596,30 @@ public class MediaManager {
         return audioInitialized;
     }
 
-    public void playNow(final List<BaseItemDto> items, int position, boolean shuffle) {
+    public void playNow(Context context, final List<BaseItemDto> items, int position, boolean shuffle) {
         if (!ensureInitialized()) return;
 
         boolean fireQueueReplaceEvent = hasAudioQueueItems();
 
-        playNowInternal(items, position, shuffle);
+        playNowInternal(context, items, position, shuffle);
 
         if (fireQueueReplaceEvent)
             fireQueueReplaced();
     }
 
-    public void playNow(final List<BaseItemDto> items, boolean shuffle) {
-        playNow(items, 0, shuffle);
+    public void playNow(Context context, final List<BaseItemDto> items, boolean shuffle) {
+        playNow(context, items, 0, shuffle);
     }
 
-    public void playNow(final BaseItemDto item) {
+    public void playNow(Context context, final BaseItemDto item) {
         if (!ensureInitialized()) return;
 
         List<BaseItemDto> list = new ArrayList<BaseItemDto>();
         list.add(item);
-        playNow(list, false);
+        playNow(context, list, false);
     }
 
-    private void playNowInternal(List<BaseItemDto> items, int position, boolean shuffle) {
+    private void playNowInternal(Context context, List<BaseItemDto> items, int position, boolean shuffle) {
         if (items == null || items.size() == 0) return;
         if (position < 0 || position >= items.size()) position = 0;
         // stop current item before queue is cleared so it can still be referenced
@@ -632,11 +633,12 @@ public class MediaManager {
 
         if (shuffle) shuffleAudioQueue();
         playFrom(position);
-        if (TvApp.getApplication().getCurrentActivity().getClass() != AudioNowPlayingActivity.class) {
-            Intent nowPlaying = new Intent(TvApp.getApplication(), AudioNowPlayingActivity.class);
-            TvApp.getApplication().getCurrentActivity().startActivity(nowPlaying);
+
+        if (ContextExtensionsKt.getActivity(context).getClass() != AudioNowPlayingActivity.class) {
+            Intent nowPlaying = new Intent(context, AudioNowPlayingActivity.class);
+            context.startActivity(nowPlaying);
         } else {
-            Toast.makeText(TvApp.getApplication(),items.size() + (items.size() > 1 ? TvApp.getApplication().getString(R.string.msg_items_added) : TvApp.getApplication().getString(R.string.msg_item_added)), Toast.LENGTH_LONG).show();
+            Toast.makeText(context,items.size() + (items.size() > 1 ? context.getString(R.string.msg_items_added) : context.getString(R.string.msg_item_added)), Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -266,11 +266,11 @@ public class PlaybackHelper {
                 switch (item.getBaseItemType()) {
                     case MusicAlbum:
                     case MusicArtist:
-                        KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response, shuffle);
+                        KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(activity, response, shuffle);
                         break;
                     case Playlist:
                         if ("Audio".equals(item.getMediaType())) {
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response, shuffle);
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(activity, response, shuffle);
 
                         } else {
                             BaseItemType itemType = response.size() > 0 ? response.get(0).getBaseItemType() : null;
@@ -285,7 +285,7 @@ public class PlaybackHelper {
                         break;
                     case Audio:
                         if (response.size() > 0) {
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(response.get(0));
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(activity, response.get(0));
                         }
                         break;
 
@@ -341,7 +341,7 @@ public class PlaybackHelper {
             @Override
             public void onResponse(BaseItemDto[] response) {
                 if (response.length > 0) {
-                    KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(Arrays.asList(response), false);
+                    KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(context, Arrays.asList(response), false);
                 } else {
                     Utils.showToast(context, R.string.msg_no_playable_items);
                 }


### PR DESCRIPTION
With this change the only usages left of TvApp.getCurrentActivity() are in the TvApiEventListener, which will soon be replaced with the SDK (0.14 probably).

**Changes**
- Receive context in MediaManager.playNowInternal

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
