### PR TITLE
Fix remaining context used before initialization crashes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -50,25 +50,59 @@ public class GridFragment extends Fragment {
     private int mSelectedPosition = -1;
     private int mCardHeight;
 
-    protected int SMALL_CARD = Utils.convertDpToPixel(getContext(), 116);
-    protected int MED_CARD = Utils.convertDpToPixel(getContext(), 175);
-    protected int LARGE_CARD = Utils.convertDpToPixel(getContext(), 210);
-    protected int SMALL_BANNER = Utils.convertDpToPixel(getContext(), 58);
-    protected int MED_BANNER = Utils.convertDpToPixel(getContext(), 88);
-    protected int LARGE_BANNER = Utils.convertDpToPixel(getContext(), 105);
+    protected int SMALL_CARD;
+    protected int MED_CARD;
+    protected int LARGE_CARD;
+    protected int SMALL_BANNER;
+    protected int MED_BANNER;
+    protected int LARGE_BANNER;
+    protected int SMALL_VERTICAL_POSTER;
+    protected int MED_VERTICAL_POSTER;
+    protected int LARGE_VERTICAL_POSTER;
+    protected int SMALL_VERTICAL_SQUARE;
+    protected int MED_VERTICAL_SQUARE;
+    protected int LARGE_VERTICAL_SQUARE;
+    protected int SMALL_VERTICAL_THUMB;
+    protected int MED_VERTICAL_THUMB;
+    protected int LARGE_VERTICAL_THUMB;
+    protected int SMALL_VERTICAL_BANNER;
+    protected int MED_VERTICAL_BANNER;
+    protected int LARGE_VERTICAL_BANNER;
 
-    protected int SMALL_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 116);
-    protected int MED_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 171);
-    protected int LARGE_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 202);
-    protected int SMALL_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 114);
-    protected int MED_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 163);
-    protected int LARGE_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 206);
-    protected int SMALL_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 116);
-    protected int MED_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 155);
-    protected int LARGE_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 210);
-    protected int SMALL_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 51);
-    protected int MED_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 77);
-    protected int LARGE_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 118);
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        SMALL_CARD = Utils.convertDpToPixel(getContext(), 116);
+        MED_CARD = Utils.convertDpToPixel(getContext(), 175);
+        LARGE_CARD = Utils.convertDpToPixel(getContext(), 210);
+        SMALL_BANNER = Utils.convertDpToPixel(getContext(), 58);
+        MED_BANNER = Utils.convertDpToPixel(getContext(), 88);
+        LARGE_BANNER = Utils.convertDpToPixel(getContext(), 105);
+        SMALL_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 116);
+        MED_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 171);
+        LARGE_VERTICAL_POSTER = Utils.convertDpToPixel(getContext(), 202);
+        SMALL_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 114);
+        MED_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 163);
+        LARGE_VERTICAL_SQUARE = Utils.convertDpToPixel(getContext(), 206);
+        SMALL_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 116);
+        MED_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 155);
+        LARGE_VERTICAL_THUMB = Utils.convertDpToPixel(getContext(), 210);
+        SMALL_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 51);
+        MED_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 77);
+        LARGE_VERTICAL_BANNER = Utils.convertDpToPixel(getContext(), 118);
+
+        sortOptions = new HashMap<>();
+        {
+            sortOptions.put(0, new SortOption(getString(R.string.lbl_name), "SortName", SortOrder.Ascending));
+            sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
+            sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
+            sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
+            sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), "CommunityRating,SortName", SortOrder.Descending));
+            sortOptions.put(5,new SortOption(getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
+            sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
+        };
+    }
 
     /**
      * Sets the grid presenter.
@@ -146,16 +180,7 @@ public class GridFragment extends Fragment {
         }
     }
 
-    protected Map<Integer, SortOption> sortOptions = new HashMap<>();
-    {
-        sortOptions.put(0, new SortOption(getString(R.string.lbl_name), "SortName", SortOrder.Ascending));
-        sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
-        sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
-        sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
-        sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), "CommunityRating,SortName", SortOrder.Descending));
-        sortOptions.put(5,new SortOption(getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
-        sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
-    }
+    protected Map<Integer, SortOption> sortOptions;
 
     protected String getSortFriendlyName(String value) {
         return getSortOption(value).name;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
@@ -61,10 +61,7 @@ public class RecordPopup {
     Button mOkButton;
     Button mCancelButton;
 
-    String MINUTE = mActivity.getString(R.string.lbl_minute);
-    String MINUTES = mActivity.getString(R.string.lbl_minutes);
-    String HOURS = mActivity.getString(R.string.lbl_hours);
-    ArrayList<String> mPaddingDisplayOptions = new ArrayList<>(Arrays.asList(mActivity.getString(R.string.lbl_on_schedule),"1  "+MINUTE,"5  "+MINUTES,"15 "+MINUTES,"30 "+MINUTES,"60 "+MINUTES,"90 "+MINUTES,"2  "+HOURS,"3  "+HOURS));
+    ArrayList<String> mPaddingDisplayOptions;
     ArrayList<Integer> mPaddingValues = new ArrayList<>(Arrays.asList(0,60,300,900,1800,3600,5400,7200,10800));
 
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);
@@ -74,6 +71,19 @@ public class RecordPopup {
         mAnchorView = anchorView;
         mPosLeft = left;
         mPosTop = top;
+
+        mPaddingDisplayOptions = new ArrayList<>(Arrays.asList(
+                mActivity.getString(R.string.lbl_on_schedule),
+                "1  " + mActivity.getString(R.string.lbl_minute),
+                "5  " + mActivity.getString(R.string.lbl_minutes),
+                "15 " + mActivity.getString(R.string.lbl_minutes),
+                "30 " + mActivity.getString(R.string.lbl_minutes),
+                "60 " + mActivity.getString(R.string.lbl_minutes),
+                "90 " + mActivity.getString(R.string.lbl_minutes),
+                "2  " + mActivity.getString(R.string.lbl_hours),
+                "3  " + mActivity.getString(R.string.lbl_hours)
+        ));
+
         LayoutInflater inflater = (LayoutInflater) mActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View layout = inflater.inflate(R.layout.new_program_record_popup, null);
         int popupHeight = Utils.convertDpToPixel(activity, 330);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -69,10 +69,9 @@ import kotlin.Lazy;
 import timber.log.Timber;
 
 public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
-    public final int ROW_HEIGHT = Utils.convertDpToPixel(this, 55);
-    public final int PIXELS_PER_MINUTE = Utils.convertDpToPixel(this,7);
-    public final int PAGEBUTTON_HEIGHT = Utils.convertDpToPixel(this, 20);
-    public final int PAGEBUTTON_WIDTH = 120 * PIXELS_PER_MINUTE;
+    public int ROW_HEIGHT;
+    public int PIXELS_PER_MINUTE;
+    public int PAGEBUTTON_HEIGHT;
     public static final int PAGE_SIZE = 75;
     public static final int NORMAL_HOURS = 9;
     public static final int FILTERED_HOURS = 4;
@@ -121,6 +120,10 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
         super.onCreate(savedInstanceState);
 
         mActivity = this;
+
+        ROW_HEIGHT = Utils.convertDpToPixel(this, 55);
+        PIXELS_PER_MINUTE = Utils.convertDpToPixel(this,7);
+        PAGEBUTTON_HEIGHT = Utils.convertDpToPixel(this, 20);
 
         setContentView(R.layout.live_tv_guide);
 


### PR DESCRIPTION
More fixes just like in #1457. This time setting the vars from onCreate instead of inlining the values. I went trough all changes of #1453 to find the usages of getContext() in properties and updated those. Most of the issues were in the live tv code.

**Changes**
- Fix remaining context used before initialization crashes

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
