### PR TITLE
Add 10.8 home section types

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/HomeSectionType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/HomeSectionType.kt
@@ -25,11 +25,17 @@ enum class HomeSectionType(
 	@EnumDisplayOptions(R.string.home_section_resume_audio)
 	RESUME_AUDIO("resumeaudio"),
 
+	@EnumDisplayOptions(R.string.home_section_resume_book)
+	RESUME_BOOK("resumebook"),
+
 	@EnumDisplayOptions(R.string.home_section_active_recordings)
 	ACTIVE_RECORDINGS("activerecordings"),
 
 	@EnumDisplayOptions(R.string.home_section_next_up)
 	NEXT_UP("nextup"),
+
+	@EnumDisplayOptions(R.string.home_section_rewatching)
+	REWATCHING("rewatching"),
 
 	@EnumDisplayOptions(R.string.home_section_livetv)
 	LIVE_TV("livetv"),

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -147,8 +147,10 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 			HomeSectionType.LIBRARY_BUTTONS -> rows.add(helper.loadLibraryTiles())
 			HomeSectionType.RESUME -> rows.add(helper.loadResumeVideo())
 			HomeSectionType.RESUME_AUDIO -> rows.add(helper.loadResumeAudio())
+			HomeSectionType.RESUME_BOOK -> Unit // Books are not (yet) supported
 			HomeSectionType.ACTIVE_RECORDINGS -> rows.add(helper.loadLatestLiveTvRecordings())
 			HomeSectionType.NEXT_UP -> rows.add(helper.loadNextUp())
+			HomeSectionType.REWATCHING -> Unit // FIXME: Similar to next up but with rewatching=true parameter
 			HomeSectionType.LIVE_TV -> if (includeLiveTvRows) {
 				rows.add(liveTVRow)
 				rows.add(helper.loadOnNow())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,4 +491,6 @@
     <string name="pref_audio">Audio</string>
     <string name="pref_direct_stream_live_off">Transcoding is used when necessary</string>
     <string name="pref_direct_stream_live_on">Transcoding is disabled</string>
+    <string name="home_section_resume_book">Continue reading</string>
+    <string name="home_section_rewatching">Rewatching</string>
 </resources>


### PR DESCRIPTION
The webui (jellyfin-web) added new section types to 10.8. This PR adds them to the app. Without this change the preferences and shown section will behave weirdly (using a new (unknown) section type will show the default value instead)

**Changes**
- Add RESUME_BOOK(resumebook)
- Add REWATCHING(rewatching)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

**Dependencies**

Depends on jellyfin/jellyfin-web#3451