### PR TITLE
Disable wildcard imports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,16 @@ root = true
 
 [*]
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [{*.kts, *.kt}]
 charset = utf-8
 indent_style = tab
 tab_width = 4
+# Disable wildcard imports in IntelliJ/Android Studio
+ij_kotlin_name_count_to_use_star_import = 1000
+ij_kotlin_name_count_to_use_star_import_for_members = 1000
+ij_kotlin_packages_to_use_import_on_demand =
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -5,7 +5,11 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.*
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.await
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope

--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv;
 import android.app.Activity;
 import android.app.Application;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MediatorLiveData;

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AccountManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AccountManagerHelper.kt
@@ -7,7 +7,7 @@ import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.auth.model.AccountManagerAccount
 import org.jellyfin.sdk.model.serializer.toUUID
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
-import java.util.*
+import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationRepository.kt
@@ -4,7 +4,17 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import org.jellyfin.androidtv.auth.model.*
+import org.jellyfin.androidtv.auth.model.AccountManagerAccount
+import org.jellyfin.androidtv.auth.model.AuthenticatedState
+import org.jellyfin.androidtv.auth.model.AuthenticatingState
+import org.jellyfin.androidtv.auth.model.AuthenticationStoreServer
+import org.jellyfin.androidtv.auth.model.AuthenticationStoreUser
+import org.jellyfin.androidtv.auth.model.LoginState
+import org.jellyfin.androidtv.auth.model.PrivateUser
+import org.jellyfin.androidtv.auth.model.RequireSignInState
+import org.jellyfin.androidtv.auth.model.Server
+import org.jellyfin.androidtv.auth.model.ServerVersionNotSupported
+import org.jellyfin.androidtv.auth.model.User
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.sdk.forUser
@@ -17,7 +27,8 @@ import org.jellyfin.sdk.api.client.extensions.userApi
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.api.ImageType
 import timber.log.Timber
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 interface AuthenticationRepository {
 	fun getServers(): List<Server>

--- a/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationStore.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/AuthenticationStore.kt
@@ -2,14 +2,21 @@ package org.jellyfin.androidtv.auth
 
 import android.content.Context
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import org.jellyfin.androidtv.auth.model.AuthenticationStoreServer
 import org.jellyfin.androidtv.auth.model.AuthenticationStoreUser
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 import timber.log.Timber
-import java.util.*
+import java.util.UUID
 
 /**
  * Storage for authentication related entities. Stores servers with users inside. Should be used in

--- a/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
@@ -3,8 +3,20 @@ package org.jellyfin.androidtv.auth
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.liveData
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
-import org.jellyfin.androidtv.auth.model.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapNotNull
+import org.jellyfin.androidtv.auth.model.ConnectedState
+import org.jellyfin.androidtv.auth.model.ConnectingState
+import org.jellyfin.androidtv.auth.model.PrivateUser
+import org.jellyfin.androidtv.auth.model.PublicUser
+import org.jellyfin.androidtv.auth.model.Server
+import org.jellyfin.androidtv.auth.model.ServerAdditionState
+import org.jellyfin.androidtv.auth.model.UnableToConnectState
+import org.jellyfin.androidtv.auth.model.User
 import org.jellyfin.androidtv.util.sdk.toPublicUser
 import org.jellyfin.androidtv.util.sdk.toServer
 import org.jellyfin.sdk.Jellyfin
@@ -18,7 +30,8 @@ import org.jellyfin.sdk.model.api.ServerDiscoveryInfo
 import org.jellyfin.sdk.model.api.UserDto
 import org.jellyfin.sdk.model.serializer.toUUID
 import timber.log.Timber
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 interface ServerRepository {
 	fun getStoredServers(): List<Server>

--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -5,13 +5,15 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.runBlocking
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.preference.PreferencesRepository
-import org.jellyfin.androidtv.preference.constant.UserSelectBehavior.*
+import org.jellyfin.androidtv.preference.constant.UserSelectBehavior.DISABLED
+import org.jellyfin.androidtv.preference.constant.UserSelectBehavior.LAST_USER
+import org.jellyfin.androidtv.preference.constant.UserSelectBehavior.SPECIFIC_USER
 import org.jellyfin.androidtv.util.sdk.forUser
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
-import java.util.*
+import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/AccountManagerAccount.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/AccountManagerAccount.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.androidtv.auth.model
 
-import java.util.*
+import java.util.UUID
 
 data class AccountManagerAccount(
 	val id: UUID,

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreServer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreServer.kt
@@ -6,7 +6,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 /**
  * Locally stored server information. New properties require default values or deserialization will fail.

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreUser.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreUser.kt
@@ -2,7 +2,7 @@ package org.jellyfin.androidtv.auth.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Locally stored user information. New properties require default values or deserialization will fail.

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
@@ -2,7 +2,8 @@ package org.jellyfin.androidtv.auth.model
 
 import org.jellyfin.androidtv.auth.ServerRepository
 import org.jellyfin.sdk.model.ServerVersion
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 /**
  * Server model to use locally in place of ServerInfo model in ApiClient.

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/ServerAdditionState.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/ServerAdditionState.kt
@@ -2,7 +2,7 @@ package org.jellyfin.androidtv.auth.model
 
 import org.jellyfin.sdk.discovery.RecommendedServerIssue
 import org.jellyfin.sdk.model.api.PublicSystemInfo
-import java.util.*
+import java.util.UUID
 
 sealed class ServerAdditionState
 data class ConnectingState(val address: String) : ServerAdditionState()

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/User.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/User.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.androidtv.auth.model
 
-import java.util.*
+import java.util.UUID
 
 /**
  * User model used locally.

--- a/app/src/main/java/org/jellyfin/androidtv/data/model/FilterOptions.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/model/FilterOptions.java
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.data.model;
 
+import org.jellyfin.apiclient.model.querying.ItemFilter;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jellyfin.apiclient.model.querying.ItemFilter;
 
 public class FilterOptions {
     private boolean favoriteOnly;

--- a/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.data.querying;
 
 import org.jellyfin.androidtv.TvApp;
-
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -19,7 +19,14 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.add
 import androidx.window.layout.WindowMetricsCalculator
 import com.bumptech.glide.Glide
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.apiclient.model.dto.BaseItemDto

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -2,7 +2,14 @@ package org.jellyfin.androidtv.di
 
 import androidx.core.content.getSystemService
 import org.jellyfin.androidtv.JellyfinApplication
-import org.jellyfin.androidtv.auth.*
+import org.jellyfin.androidtv.auth.AccountManagerHelper
+import org.jellyfin.androidtv.auth.ApiBinder
+import org.jellyfin.androidtv.auth.AuthenticationRepository
+import org.jellyfin.androidtv.auth.AuthenticationRepositoryImpl
+import org.jellyfin.androidtv.auth.AuthenticationStore
+import org.jellyfin.androidtv.auth.LegacyAccountMigration
+import org.jellyfin.androidtv.auth.SessionRepository
+import org.jellyfin.androidtv.auth.SessionRepositoryImpl
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module

--- a/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
@@ -1,6 +1,11 @@
 package org.jellyfin.androidtv.di
 
-import org.jellyfin.androidtv.preference.*
+import org.jellyfin.androidtv.preference.AuthenticationPreferences
+import org.jellyfin.androidtv.preference.LiveTvPreferences
+import org.jellyfin.androidtv.preference.PreferencesRepository
+import org.jellyfin.androidtv.preference.SystemPreferences
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -8,8 +8,12 @@ import android.os.Build
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
-import androidx.tvprovider.media.tv.*
+import androidx.tvprovider.media.tv.Channel
+import androidx.tvprovider.media.tv.ChannelLogoUtils
+import androidx.tvprovider.media.tv.PreviewProgram
+import androidx.tvprovider.media.tv.TvContractCompat
 import androidx.tvprovider.media.tv.TvContractCompat.WatchNextPrograms
+import androidx.tvprovider.media.tv.WatchNextProgram
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/LibraryDreamService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/LibraryDreamService.kt
@@ -5,7 +5,14 @@ import android.service.dreams.DreamService
 import android.view.LayoutInflater
 import androidx.core.view.isVisible
 import com.bumptech.glide.Glide
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.databinding.DreamLibraryBinding
 import org.jellyfin.androidtv.di.systemApiClient
 import org.jellyfin.androidtv.preference.UserPreferences

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -4,7 +4,14 @@ import android.content.Context
 import android.view.KeyEvent
 import androidx.preference.PreferenceManager
 import org.acra.ACRA
-import org.jellyfin.androidtv.preference.constant.*
+import org.jellyfin.androidtv.preference.constant.AppTheme
+import org.jellyfin.androidtv.preference.constant.AudioBehavior
+import org.jellyfin.androidtv.preference.constant.ClockBehavior
+import org.jellyfin.androidtv.preference.constant.NextUpBehavior
+import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
+import org.jellyfin.androidtv.preference.constant.RatingType
+import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
+import org.jellyfin.androidtv.preference.constant.defaultAudioBehavior
 import org.jellyfin.androidtv.util.DeviceUtils
 
 /**
@@ -180,7 +187,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Enable series thumbnails in home screen rows
 		 */
 		var seriesThumbnailsEnabled = Preference.boolean("pref_enable_series_thumbnails", true)
-			
+
 		/**
 		 * Enable subtitles background
 		 */

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -11,7 +11,11 @@ import org.jellyfin.apiclient.model.entities.LocationType
 import org.jellyfin.apiclient.model.entities.MediaType
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery
 import org.jellyfin.apiclient.model.livetv.RecordingQuery
-import org.jellyfin.apiclient.model.querying.*
+import org.jellyfin.apiclient.model.querying.ItemFields
+import org.jellyfin.apiclient.model.querying.ItemFilter
+import org.jellyfin.apiclient.model.querying.ItemSortBy
+import org.jellyfin.apiclient.model.querying.ItemsResult
+import org.jellyfin.apiclient.model.querying.NextUpQuery
 
 class HomeFragmentHelper(
 	private val context: Context

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
@@ -2,7 +2,13 @@ package org.jellyfin.androidtv.ui.home
 
 import android.app.Activity
 import android.content.Intent
-import androidx.leanback.widget.*
+import androidx.leanback.widget.ArrayObjectAdapter
+import androidx.leanback.widget.HeaderItem
+import androidx.leanback.widget.ListRow
+import androidx.leanback.widget.OnItemViewClickedListener
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.Row
+import androidx.leanback.widget.RowPresenter
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.R
@@ -16,7 +22,7 @@ import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter
 import org.jellyfin.sdk.model.api.BaseItemDto
-import java.util.*
+import java.util.UUID
 
 class HomeFragmentLiveTVRow(
 	private val activity: Activity,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.playback;
 
-import org.jellyfin.androidtv.data.compat.AudioOptions;
 import org.jellyfin.androidtv.data.compat.StreamInfo;
 import org.jellyfin.androidtv.data.compat.VideoOptions;
 import org.jellyfin.apiclient.interaction.ApiClient;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -3,10 +3,8 @@ package org.jellyfin.androidtv.ui.playback.overlay;
 import androidx.leanback.media.PlayerAdapter;
 
 import org.jellyfin.androidtv.TvApp;
-import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
-import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.apiclient.StreamHelper;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.ChapterInfoDto;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/AdjustAudioDelayAction.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/AdjustAudioDelayAction.java
@@ -5,11 +5,11 @@ import android.view.View;
 import android.widget.PopupWindow;
 
 import org.jellyfin.androidtv.R;
+import org.jellyfin.androidtv.ui.AudioDelayPopup;
+import org.jellyfin.androidtv.ui.ValueChangedListener;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue;
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
-import org.jellyfin.androidtv.ui.AudioDelayPopup;
-import org.jellyfin.androidtv.ui.ValueChangedListener;
 
 public class AdjustAudioDelayAction extends CustomAction {
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
@@ -9,7 +9,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.VideoSpeedController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
-import java.util.*
+import java.util.Locale
 
 class PlaybackSpeedAction(
 	context: Context,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -13,7 +13,7 @@ import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 import timber.log.Timber
-import java.util.*
+import java.util.UUID
 
 class PlaybackForwardingActivity : FragmentActivity() {
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesFragment.kt
@@ -5,7 +5,12 @@ import androidx.core.os.bundleOf
 import androidx.leanback.preference.LeanbackEditTextPreferenceDialogFragmentCompat
 import androidx.leanback.preference.LeanbackListPreferenceDialogFragmentCompat
 import androidx.leanback.preference.LeanbackSettingsFragmentCompat
-import androidx.preference.*
+import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
+import androidx.preference.MultiSelectListPreference
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceScreen
 import org.jellyfin.androidtv.ui.preference.custom.ButtonRemapDialogFragment
 import org.jellyfin.androidtv.ui.preference.custom.ButtonRemapPreference
 import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
@@ -1,7 +1,11 @@
 package org.jellyfin.androidtv.ui.preference.custom
 
 import android.os.Bundle
-import android.view.*
+import android.view.ContextThemeWrapper
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.leanback.preference.LeanbackPreferenceDialogFragmentCompat
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.PreferenceButtonRemapBinding

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
@@ -5,7 +5,7 @@ import android.util.AttributeSet
 import android.view.KeyEvent
 import androidx.preference.DialogPreference
 import org.jellyfin.androidtv.R
-import java.util.*
+import java.util.Locale
 
 class ButtonRemapPreference(
 	context: Context,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsAction.kt
@@ -5,7 +5,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
-import java.util.*
+import java.util.UUID
 
 /**
  * Perform a custom action when activated.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemCheckbox.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemCheckbox.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import androidx.preference.CheckBoxPreference
 import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
-import java.util.*
+import java.util.UUID
 
 class OptionsItemCheckbox(
 	private val context: Context

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemEnum.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemEnum.kt
@@ -6,7 +6,7 @@ import androidx.preference.PreferenceCategory
 import org.jellyfin.androidtv.preference.Preference
 import org.jellyfin.androidtv.preference.PreferenceStore
 import org.jellyfin.androidtv.ui.preference.custom.RichListPreference
-import java.util.*
+import java.util.UUID
 
 class OptionsItemEnum<T : Enum<T>>(
 	private val context: Context,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemInfo.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemInfo.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceCategory
-import java.util.*
+import java.util.UUID
 
 class OptionsItemInfo(
 	private val context: Context

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemList.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemList.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceCategory
-import java.util.*
+import java.util.UUID
 
 class OptionsItemList(
 	private val context: Context

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemSeekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemSeekbar.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import androidx.preference.PreferenceCategory
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
-import java.util.*
+import java.util.UUID
 
 class OptionsItemSeekbar(
 	private val context: Context

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemShortcut.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemShortcut.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import androidx.preference.PreferenceCategory
 import org.jellyfin.androidtv.ui.preference.custom.ButtonRemapPreference
-import java.util.*
+import java.util.UUID
 
 class OptionsItemShortcut(
 	private val context: Context

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemUserPicker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemUserPicker.kt
@@ -11,7 +11,7 @@ import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment.RichLi
 import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment.RichListItem.RichListSection
 import org.jellyfin.androidtv.ui.preference.custom.RichListPreference
 import java.text.DateFormat
-import java.util.*
+import java.util.UUID
 
 class OptionsItemUserPicker(
 	private val context: Context,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsLink.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsLink.kt
@@ -6,7 +6,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
-import java.util.*
+import java.util.UUID
 import kotlin.reflect.KClass
 
 /**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -9,7 +9,14 @@ import org.jellyfin.androidtv.preference.AuthenticationPreferences
 import org.jellyfin.androidtv.preference.Preference
 import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
 import org.jellyfin.androidtv.ui.preference.category.aboutCategory
-import org.jellyfin.androidtv.ui.preference.dsl.*
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsBinder
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsItemUserPicker
+import org.jellyfin.androidtv.ui.preference.dsl.checkbox
+import org.jellyfin.androidtv.ui.preference.dsl.enum
+import org.jellyfin.androidtv.ui.preference.dsl.link
+import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.androidtv.ui.preference.dsl.userPicker
 import org.jellyfin.androidtv.ui.startup.preference.EditServerScreen
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -6,7 +6,12 @@ import org.jellyfin.androidtv.preference.constant.AppTheme
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
-import org.jellyfin.androidtv.ui.preference.dsl.*
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.checkbox
+import org.jellyfin.androidtv.ui.preference.dsl.enum
+import org.jellyfin.androidtv.ui.preference.dsl.link
+import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.androidtv.ui.preference.dsl.shortcut
 import org.koin.android.ext.android.inject
 
 class CustomizationPreferencesScreen : OptionsFragment() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -8,7 +8,12 @@ import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
-import org.jellyfin.androidtv.ui.preference.dsl.*
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.checkbox
+import org.jellyfin.androidtv.ui.preference.dsl.enum
+import org.jellyfin.androidtv.ui.preference.dsl.list
+import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.androidtv.ui.preference.dsl.seekbar
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.TimeUtils
 import org.koin.android.ext.android.inject

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.java
@@ -1,11 +1,10 @@
 package org.jellyfin.androidtv.ui.presentation;
 
 import android.graphics.drawable.Drawable;
+import android.view.View;
 
 import androidx.leanback.widget.ListRowPresenter;
 import androidx.leanback.widget.RowPresenter;
-
-import android.view.View;
 
 public class CustomListRowPresenter extends ListRowPresenter {
     private View viewHolder;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/TextItemPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/TextItemPresenter.java
@@ -1,10 +1,11 @@
 package org.jellyfin.androidtv.ui.presentation;
 
 import android.graphics.Color;
-import androidx.leanback.widget.Presenter;
 import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import androidx.leanback.widget.Presenter;
 
 public class TextItemPresenter extends Presenter {
     private static final int ITEM_WIDTH = 400;
@@ -21,7 +22,7 @@ public class TextItemPresenter extends Presenter {
         view.setTextSize(32);
         return new ViewHolder(view);
     }
-    
+
     @Override
     public void onBindViewHolder(ViewHolder viewHolder, Object item) {
         ((TextView) viewHolder.view).setText(item.toString());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/ThemeManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/ThemeManager.kt
@@ -6,7 +6,8 @@ import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AppTheme
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.koin.android.ext.android.get
-import java.util.*
+import java.util.Calendar
+import java.util.GregorianCalendar
 
 object ThemeManager {
 	private fun showAprilFools(userPreferences: UserPreferences): Boolean {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/LoginViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/LoginViewModel.kt
@@ -1,6 +1,12 @@
 package org.jellyfin.androidtv.ui.startup
 
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.liveData
+import androidx.lifecycle.map
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
@@ -12,7 +18,7 @@ import org.jellyfin.androidtv.auth.model.LoginState
 import org.jellyfin.androidtv.auth.model.Server
 import org.jellyfin.androidtv.auth.model.User
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
-import java.util.*
+import java.util.UUID
 
 class LoginViewModel(
 	private val serverRepository: ServerRepository,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -33,7 +33,7 @@ import org.jellyfin.apiclient.model.dto.BaseItemDto
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
-import java.util.*
+import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -16,7 +16,11 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.flow.collect
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.auth.model.*
+import org.jellyfin.androidtv.auth.model.ConnectedState
+import org.jellyfin.androidtv.auth.model.ConnectingState
+import org.jellyfin.androidtv.auth.model.Server
+import org.jellyfin.androidtv.auth.model.ServerAdditionState
+import org.jellyfin.androidtv.auth.model.UnableToConnectState
 import org.jellyfin.androidtv.databinding.FragmentSelectServerBinding
 import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.SpacingItemDecoration

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -16,7 +16,13 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.ServerRepository
-import org.jellyfin.androidtv.auth.model.*
+import org.jellyfin.androidtv.auth.model.AuthenticatedState
+import org.jellyfin.androidtv.auth.model.AuthenticatingState
+import org.jellyfin.androidtv.auth.model.RequireSignInState
+import org.jellyfin.androidtv.auth.model.Server
+import org.jellyfin.androidtv.auth.model.ServerUnavailableState
+import org.jellyfin.androidtv.auth.model.ServerVersionNotSupported
+import org.jellyfin.androidtv.auth.model.User
 import org.jellyfin.androidtv.databinding.FragmentServerBinding
 import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.card.DefaultCardView

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginAlertFragment.kt
@@ -7,7 +7,11 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.ServerRepository
-import org.jellyfin.androidtv.auth.model.*
+import org.jellyfin.androidtv.auth.model.AuthenticatedState
+import org.jellyfin.androidtv.auth.model.AuthenticatingState
+import org.jellyfin.androidtv.auth.model.RequireSignInState
+import org.jellyfin.androidtv.auth.model.ServerUnavailableState
+import org.jellyfin.androidtv.auth.model.ServerVersionNotSupported
 import org.jellyfin.androidtv.databinding.FragmentAlertUserLoginBinding
 import org.jellyfin.androidtv.ui.shared.AlertFragment
 import org.jellyfin.androidtv.ui.shared.KeyboardFocusChangeListener

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditServerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditServerScreen.kt
@@ -11,7 +11,8 @@ import org.jellyfin.androidtv.ui.startup.LoginViewModel
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import java.text.DateFormat
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 class EditServerScreen : OptionsFragment() {
 	private val loginViewModel: LoginViewModel by sharedViewModel()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditUserScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditUserScreen.kt
@@ -8,7 +8,7 @@ import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.startup.LoginViewModel
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
-import java.util.*
+import java.util.UUID
 
 class EditUserScreen : OptionsFragment() {
 	private val loginViewModel: LoginViewModel by sharedViewModel()

--- a/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
@@ -2,9 +2,8 @@ package org.jellyfin.androidtv.util
 
 import android.text.Spanned
 import androidx.core.text.HtmlCompat
-import java.util.*
 
 /**
- * Convert string with HTML to a [Spanned]. Uses the [FROM_HTML_MODE_COMPACT] flag.
+ * Convert string with HTML to a [Spanned]. Uses the [HtmlCompat.FROM_HTML_MODE_COMPACT] flag.
  */
 fun String.toHtmlSpanned(): Spanned = HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ApiClientExtensions.kt
@@ -5,7 +5,7 @@ import org.jellyfin.apiclient.interaction.EmptyResponse
 import org.jellyfin.apiclient.interaction.Response
 import org.jellyfin.apiclient.model.dto.BaseItemDto
 import org.jellyfin.apiclient.model.querying.ItemsResult
-import java.util.*
+import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/BaseItemUtils.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.toUUID
 import org.koin.java.KoinJavaComponent.inject
-import java.util.*
+import java.util.Calendar
 
 // TODO Feature Envy!!! Wants to live in BaseItemDto.
 fun BaseItemDto.isLiveTv() =

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -12,7 +12,16 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditio
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
-import org.jellyfin.apiclient.model.dlna.*
+import org.jellyfin.apiclient.model.dlna.CodecProfile
+import org.jellyfin.apiclient.model.dlna.CodecType
+import org.jellyfin.apiclient.model.dlna.DirectPlayProfile
+import org.jellyfin.apiclient.model.dlna.DlnaProfileType
+import org.jellyfin.apiclient.model.dlna.EncodingContext
+import org.jellyfin.apiclient.model.dlna.ProfileCondition
+import org.jellyfin.apiclient.model.dlna.ProfileConditionType
+import org.jellyfin.apiclient.model.dlna.ProfileConditionValue
+import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod
+import org.jellyfin.apiclient.model.dlna.TranscodingProfile
 
 @OptIn(ExperimentalStdlibApi::class)
 class ExoPlayerProfile(

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
@@ -7,7 +7,7 @@ import org.jellyfin.sdk.model.extensions.toNameGuidPair
 import org.jellyfin.sdk.model.serializer.toUUID
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.*
+import java.util.Date
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod as LegacySubtitleDeliveryMethod
 import org.jellyfin.apiclient.model.drawing.ImageOrientation as LegacyImageOrientation
 import org.jellyfin.apiclient.model.dto.BaseItemDto as LegacyBaseItemDto

--- a/app/src/test/.editorconfig
+++ b/app/src/test/.editorconfig
@@ -1,8 +1,0 @@
-# Note: This file is temporarily, these settings should be moved to the top-level editorconfig to
-# affect the complete project.
-
-[{*.kts,*.kt}]
-# Disable wildcard imports in IntelliJ/Android Studio
-ij_kotlin_name_count_to_use_star_import = 1000
-ij_kotlin_name_count_to_use_star_import_for_members = 1000
-ij_kotlin_packages_to_use_import_on_demand =

--- a/detekt.yaml
+++ b/detekt.yaml
@@ -20,5 +20,3 @@ style:
     values: [ 'STOPSHIP:' ]
   ReturnCount:
     max: 6
-  WildcardImport:
-    active: false


### PR DESCRIPTION
This one is going to create some conflicts...

**Changes**
- Disable wildcard imports in IntelliJ/Android Studio via editorconfig
  - Previously added in #1436 for unit tests, now for everything
- Re-enable WildcardImport rule in Detekt
- Optimize all imports in all files
  - Mostly converts java.util.* and apiclient/sdk model imports
  - This also removed some unused imports

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
