### PR TITLE
subtitle fixes for PR 1455

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -208,7 +208,7 @@ public class PlaybackController {
     }
 
     public int getSubtitleStreamIndex() {
-        return (mCurrentOptions != null && mCurrentOptions.getSubtitleStreamIndex() != null) ? mCurrentOptions.getSubtitleStreamIndex() : -1;
+        return (mCurrentOptions != null && mCurrentOptions.getSubtitleStreamIndex() != null) ? mCurrentOptions.getSubtitleStreamIndex() : mDefaultSubIndex;
     }
 
     public List<SubtitleStreamInfo> getSubtitleStreams() {
@@ -867,7 +867,8 @@ public class PlaybackController {
         // get current timestamp first
         refreshCurrentPosition();
         Timber.d("Setting subtitle index to: %d", index);
-        mCurrentOptions.setSubtitleStreamIndex(index >= 0 ? index : null);
+        mCurrentOptions.setSubtitleStreamIndex(index);
+        mDefaultSubIndex = index;
 
         if (index < 0) {
             if (burningSubs) {


### PR DESCRIPTION
**Changes**
* set `mDefaultSubIndex` when a subtitle track is selected/cleared
* don't search for subtitle events if the current position is before the start of the first event
* clear subtitles  after seeking

**Issues**
* if subtitles were enabled and then disabled, they would be re-enabled after seeking
* a subtitle event might not clear after seeking, and would stay on screen until a new event is ready (new from #1455)
* if playback starts at the beginning/before the start of the first subtitle event, each call to `updateSubtitles()` would search through the whole list of events without doing anything (new from #1455)
