### PR TITLE
use ts for exoplayer transcodes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -497,9 +497,9 @@ public class PlaybackController {
                 if (DeviceUtils.is60() || userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())) {
                     internalProfile = new ExoPlayerProfile(
                             isLiveTv,
-                            userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled())
+                            userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
+                            userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
                     );
-                    ProfileHelper.addAc3Streaming(internalProfile, true);
                     Timber.i("*** Using extended Exoplayer profile options");
                 } else {
                     Timber.i("*** Using default android profile");

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1119,26 +1119,21 @@ public class PlaybackController {
                 }
             });
         } else {
-            if (mVideoManager.isNativeMode() && !isLiveTv && ContainerTypes.TS.equals(mCurrentStreamInfo.getContainer())) {
-                //Exo does not support seeking in .ts
+            // use the same approach to directplay seeking as setOnProgressListener
+            // set state to SEEKING
+            // if seek succeeds call play and mirror the logic in play() for unpausing. if fails call pause()
+            // stopProgressLoop() being called at the beginning of startProgressLoop keeps this from breaking. otherwise it would start twice
+            // if seek() is called from skip()
+            Timber.d("Seek method - native");
+            mPlaybackState = PlaybackState.SEEKING;
+            if (mVideoManager.seekTo(pos) < 0) {
                 Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.seek_error));
+                pause();
             } else {
-                // use the same approach to directplay seeking as setOnProgressListener
-                // set state to SEEKING
-                // if seek succeeds call play and mirror the logic in play() for unpausing. if fails call pause()
-                // stopProgressLoop() being called at the beginning of startProgressLoop keeps this from breaking. otherwise it would start twice
-                // if seek() is called from skip()
-                Timber.d("Seek method - native");
-                mPlaybackState = PlaybackState.SEEKING;
-                if (mVideoManager.seekTo(pos) < 0) {
-                    Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.seek_error));
-                    pause();
-                } else {
-                    mVideoManager.play();
-                    mPlaybackState = PlaybackState.PLAYING;
-                    if (mFragment != null) mFragment.setFadingEnabled(true);
-                    startReportLoop();
-                }
+                mVideoManager.play();
+                mPlaybackState = PlaybackState.PLAYING;
+                if (mFragment != null) mFragment.setFadingEnabled(true);
+                startReportLoop();
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -24,6 +24,9 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.TracksInfo;
+import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
+import com.google.android.exoplayer2.extractor.ts.TsExtractor;
+import com.google.android.exoplayer2.source.DefaultMediaSourceFactory;
 import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.trackselection.TrackSelectionOverrides;
 import com.google.android.exoplayer2.trackselection.TrackSelectionParameters;
@@ -157,6 +160,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         defaultRendererFactory.setEnableDecoderFallback(true);
         defaultRendererFactory.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON);
         exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
+
+        DefaultExtractorsFactory defaultExtractorsFactory = new DefaultExtractorsFactory().setTsExtractorTimestampSearchBytes(TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES * 3);
+        exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(context, defaultExtractorsFactory));
 
         return exoPlayerBuilder;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -18,6 +18,7 @@ import org.jellyfin.apiclient.model.dlna.*
 class ExoPlayerProfile(
 	isLiveTV: Boolean = false,
 	isLiveTVDirectPlayEnabled: Boolean = false,
+	isAC3Enabled: Boolean = false,
 ) : BaseProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		CodecTypes.AAC,
@@ -55,7 +56,11 @@ class ExoPlayerProfile(
 					if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.MP4)) add(CodecTypes.HEVC)
 					add(CodecTypes.H264)
 				}.joinToString(",")
-				audioCodec = arrayOf(CodecTypes.AAC, CodecTypes.MP3).joinToString(",")
+				audioCodec = buildList {
+					if (isAC3Enabled) add(CodecTypes.AC3)
+					add(CodecTypes.AAC)
+					add(CodecTypes.MP3)
+				}.joinToString(",")
 				protocol = "hls"
 				copyTimestamps = false
 			},

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -46,18 +46,17 @@ class ExoPlayerProfile(
 		name = "AndroidTV-ExoPlayer"
 
 		transcodingProfiles = arrayOf(
-			// MP4 video profile
+			// TS video profile
 			TranscodingProfile().apply {
 				type = DlnaProfileType.Video
 				context = EncodingContext.Streaming
-				container = ContainerTypes.MP4
+				container = ContainerTypes.TS
 				videoCodec = buildList {
 					if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.MP4)) add(CodecTypes.HEVC)
 					add(CodecTypes.H264)
 				}.joinToString(",")
 				audioCodec = arrayOf(CodecTypes.AAC, CodecTypes.MP3).joinToString(",")
 				protocol = "hls"
-				minSegments = 1
 				copyTimestamps = false
 			},
 			// MP3 audio profile

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -139,11 +139,6 @@ object ProfileHelper {
 			)
 		}
 
-	private fun findTranscodingProfile(
-		deviceProfile: DeviceProfile,
-		container: String
-	) = deviceProfile.transcodingProfiles.find { it.container == container }
-
 	internal fun subtitleProfile(
 		format: String,
 		method: SubtitleDeliveryMethod

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -143,12 +143,16 @@ object ProfileHelper {
 	fun addAc3Streaming(profile: DeviceProfile, primary: Boolean) {
 		if (Utils.downMixAudio()) return
 
-		val mkvProfile = findTranscodingProfile(profile, ContainerTypes.MKV) ?: return
+		val containers = arrayOf(ContainerTypes.MKV, ContainerTypes.TS)
+		containers.forEach { c ->
+			Timber.d("trying to match transcoding profile for %s", c)
+			val transcodingProfile = findTranscodingProfile(profile, c) ?: return@forEach
 
-		Timber.i("*** Adding AC3 as supported transcoded audio")
-		mkvProfile.audioCodec = when (primary) {
-			true -> "${CodecTypes.AC3},${mkvProfile.audioCodec}"
-			false -> "${mkvProfile.audioCodec},${CodecTypes.AC3}"
+			Timber.i("*** Adding AC3 as supported transcoded audio for %s", c)
+			transcodingProfile.audioCodec = when (primary) {
+				true -> "${CodecTypes.AC3},${transcodingProfile.audioCodec}"
+				false -> "${transcodingProfile.audioCodec},${CodecTypes.AC3}"
+			}
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -139,23 +139,6 @@ object ProfileHelper {
 			)
 		}
 
-	@JvmStatic
-	fun addAc3Streaming(profile: DeviceProfile, primary: Boolean) {
-		if (Utils.downMixAudio()) return
-
-		val containers = arrayOf(ContainerTypes.MKV, ContainerTypes.TS)
-		containers.forEach { c ->
-			Timber.d("trying to match transcoding profile for %s", c)
-			val transcodingProfile = findTranscodingProfile(profile, c) ?: return@forEach
-
-			Timber.i("*** Adding AC3 as supported transcoded audio for %s", c)
-			transcodingProfile.audioCodec = when (primary) {
-				true -> "${CodecTypes.AC3},${transcodingProfile.audioCodec}"
-				false -> "${transcodingProfile.audioCodec},${CodecTypes.AC3}"
-			}
-		}
-	}
-
 	private fun findTranscodingProfile(
 		deviceProfile: DeviceProfile,
 		container: String


### PR DESCRIPTION
**Changes**
* remove the code that prevents seeking when the container is TS
* replaced MP4 with TS (still uses HLS) in `ExoplayerProfile`
* modify the TS search bytes to match what jellyfin-android does:
  https://github.com/jellyfin/jellyfin-android/blob/6d42621e16bc38d805cf2861a6a10f65ca2d626c/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt#L77
* update `addAc3Streaming` so it can enable AC3 for more than one container (mkv, ts)

**Issues**
* fixes #1410 
