### PR TITLE
fixed screensaver background cycling in music player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -45,7 +45,7 @@ class BackgroundService(
 ) {
 	companion object {
 		const val TRANSITION_DURATION = 400L // 0.4 seconds
-		const val SLIDESHOW_DURATION = 10000L // 10 seconds
+		const val SLIDESHOW_DURATION = 30000L // 30 seconds
 		const val UPDATE_INTERVAL = 500L // 0.5 seconds
 		val FRAGMENT_TAG = BackgroundServiceFragment::class.qualifiedName!!
 	}


### PR DESCRIPTION
**Changes**
* Implemented fix suggested by @nielsvanvelzen in [#1290](https://github.com/jellyfin/jellyfin-androidtv/pull/1290#issuecomment-1054665937): 
  removed `rotateBackdrops` loop because it conflicted with the app's background service. Starting the screensaver is handled in `onProgress()`

* increased `SLIDESHOW_DURATION` from 10 seconds to 30 seconds

* made some linter-suggested changes:
> * made `PositionableListRowPresenter` non static
> * made `mLoopHandler` final

**Issues**
* https://www.reddit.com/r/jellyfin/comments/t3k3to/android_tv_beta_artist_background_bug_wmult/
  discussed in [#1290](https://github.com/jellyfin/jellyfin-androidtv/pull/1290#issuecomment-1054665937)

**Notes**
* I was able to reproduce the issue and test that this resolves it.
   To reproduce I added a few background images to an artist, and restarted the app to force a reload before playing music.