### PR TITLE
Update Android Gradle Plugin to 7.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 android {
+	namespace = "org.jellyfin.androidtv"
 	compileSdk = 31
 
 	defaultConfig {
@@ -14,6 +15,7 @@ android {
 		targetSdk = 31
 
 		// Release version
+		applicationId = namespace
 		versionName = project.getVersionName()
 		versionCode = getVersionCode(versionName!!)
 		setProperty("archivesBaseName", "jellyfin-androidtv-v$versionName")
@@ -35,9 +37,9 @@ android {
 			isMinifyEnabled = false
 
 			// Set package names used in various XML files
-			resValue("string", "app_id", "org.jellyfin.androidtv")
-			resValue("string", "app_search_suggest_authority", "org.jellyfin.androidtv.content")
-			resValue("string", "app_search_suggest_intent_data", "content://org.jellyfin.androidtv.content/intent")
+			resValue("string", "app_id", namespace!!)
+			resValue("string", "app_search_suggest_authority", "${namespace}.content")
+			resValue("string", "app_search_suggest_intent_data", "content://${namespace}.content/intent")
 
 			// Set flavored application name
 			resValue("string", "app_name", "@string/app_name_release")
@@ -50,9 +52,9 @@ android {
 			applicationIdSuffix = ".debug"
 
 			// Set package names used in various XML files
-			resValue("string", "app_id", "org.jellyfin.androidtv.debug")
-			resValue("string", "app_search_suggest_authority", "org.jellyfin.androidtv.debug.content")
-			resValue("string", "app_search_suggest_intent_data", "content://org.jellyfin.androidtv.debug.content/intent")
+			resValue("string", "app_id", namespace + applicationIdSuffix)
+			resValue("string", "app_search_suggest_authority", "${namespace + applicationIdSuffix}.content")
+			resValue("string", "app_search_suggest_intent_data", "content://${namespace + applicationIdSuffix}.content/intent")
 
 			// Set flavored application name
 			resValue("string", "app_name", "@string/app_name_debug")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 aboutlibraries = "8.9.4"
 acra = "5.8.4"
 android-desugar = "1.1.5"
-android-gradle = "7.1.1"
+android-gradle = "7.1.2"
 androidx-activity = "1.4.0"
 androidx-appcompat = "1.4.0"
 androidx-cardview = "1.0.0"


### PR DESCRIPTION

**Changes**
- Update Android Gradle Plugin to 7.1.2
  - https://androidstudio.googleblog.com/2022/02/android-studio-bumblebee-202111-patch-2.html
  - Notable fix: "Android Studio BumbleBee does not always deploy latest changes"
- Update app/build.gradle.kts to include the namespace and applicationId
  - This _should_ allow us to remove the package attribute in the manifest but due too some bug it doesn't work for debug builds (appends the applicationIdSuffix to the namespace which shouldn't happen)
  - According to Android Studio Chipmunk (beta) the package attribute in the manifest is being deprecated

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
