### PR TITLE
fixes for crashes from subtitle rendering and audio track selection

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1388,6 +1388,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         if (subtitleTrackInfo == null
                 || subtitleTrackInfo.getTrackEvents() == null
+                || subtitleTrackInfo.getTrackEvents().size() < 1
                 || currentSubtitleIndex >= subtitleTrackInfo.getTrackEvents().size()) {
             return;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -464,7 +464,13 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 if (trackType == chosenTrackType) {
                     if (groupInfo.isTrackSelected(i)) {
                         if (trackFormat.id != null) {
-                            int id = Integer.parseInt(trackFormat.id) - 1;
+                            int id;
+                            try {
+                                id = Integer.parseInt(trackFormat.id) - 1;
+                            } catch (NumberFormatException e) {
+                                Timber.d("failed to parse track ID [%s]", trackFormat.id);
+                                return -1;
+                            }
                             if (id >= 0 && id < allStreams.size())
                                 return id;
                         }
@@ -535,7 +541,14 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
                 if (trackType != chosenTrackType || trackFormat.id == null)
                     continue;
-                if (Integer.parseInt(trackFormat.id) != exoTrackID) {
+
+                int id;
+                try {
+                    id = Integer.parseInt(trackFormat.id);
+                    if (id != exoTrackID)
+                        continue;
+                } catch (NumberFormatException e) {
+                    Timber.d("failed to parse track ID [%s]", trackFormat.id);
                     continue;
                 }
 


### PR DESCRIPTION
**Changes**
* catch subtitle track events size being < 1
* catch `NumberFormatException` if an exoplayer track ID isn't/can't be parsed to an integer, and return -1 so another method is used to get the current track, and to switch tracks (transcoding).

**Issues**
* potentially fixes #1488 
* https://github.com/jellyfin/jellyfin-androidtv/pull/1469#issuecomment-1058027334
* https://github.com/jellyfin/jellyfin-androidtv/pull/1465#issuecomment-1058029794
