### PR TITLE
Open context menu on long press

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -1,8 +1,10 @@
 package org.jellyfin.androidtv.ui.card;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +16,7 @@ import androidx.leanback.widget.BaseCardView;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.databinding.ViewCardLegacyImageBinding;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
+import org.jellyfin.androidtv.util.ContextExtensionsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 
@@ -35,6 +38,13 @@ public class LegacyImageCardView extends BaseCardView {
         }
 
         binding.mainImage.setClipToOutline(true);
+
+        // "hack" to trigger KeyProcessor to open the menu for this item on long press
+        setOnLongClickListener(v -> {
+            Activity activity = ContextExtensionsKt.getActivity(getContext());
+            if (activity == null) return false;
+            return activity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MENU));
+        });
     }
 
     public void setBanner(int bannerResource) {


### PR DESCRIPTION
_technically a feature but let's sneak it in for 0.13..._

This is a bit of a hack, but it will do for now.

**Changes**
- Emit a "menu" key press when long pressing an LegacyImageCardView
  - This causes the context menu to show for most cards
  - Enables a feature previously unusable on remotes without a dedicated menu buttons (like the Nvidia Shield)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
