### PR TITLE
Fix an issue where long-touching can crash the app

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -43,6 +43,8 @@ public class LegacyImageCardView extends BaseCardView {
         setOnLongClickListener(v -> {
             Activity activity = ContextExtensionsKt.getActivity(getContext());
             if (activity == null) return false;
+            // Make sure the view is focused so the created menu uses it as anchor
+            if (!v.requestFocus()) return false;
             return activity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MENU));
         });
     }


### PR DESCRIPTION
oops

**Changes**
- Make sure the LegacyImageCardView is focused before triggering the menu keypress on it
  - If it's not focused the app can crash because `activity.getCurrentFocus()` returns null

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
