### PR TITLE
require at least server version 10.8.0 to use HLS

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -114,8 +114,6 @@ public class PlaybackController {
     private int playbackRetries = 0;
     private long lastPlaybackError = 0;
 
-    private boolean updateProgress = true;
-
     private Display.Mode[] mDisplayModes;
     private boolean refreshRateSwitchingEnabled;
 
@@ -498,10 +496,16 @@ public class PlaybackController {
                 internalOptions.setMediaSourceId(transcodedSubtitle != null ? getCurrentMediaSource().getId() : null);
                 DeviceProfile internalProfile = new BaseProfile();
                 if (DeviceUtils.is60() || userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())) {
+                    boolean hlsSupported = false;
+                    if (mFragment != null)
+                        hlsSupported = mFragment.getServerMeetsMinimumVersion("10.8.0");
+                    Timber.d("HLS is %s", hlsSupported ? "allowed" : "disabled");
+
                     internalProfile = new ExoPlayerProfile(
                             isLiveTv,
                             userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                            userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
+                            userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
+                            hlsSupported
                     );
                     Timber.i("*** Using extended Exoplayer profile options");
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -27,6 +27,7 @@ class ExoPlayerProfile(
 	isLiveTV: Boolean = false,
 	isLiveTVDirectPlayEnabled: Boolean = false,
 	isAC3Enabled: Boolean = false,
+	isHlsSupported: Boolean = false,
 ) : BaseProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		CodecTypes.AAC,
@@ -54,32 +55,34 @@ class ExoPlayerProfile(
 	init {
 		name = "AndroidTV-ExoPlayer"
 
-		transcodingProfiles = arrayOf(
-			// TS video profile
-			TranscodingProfile().apply {
-				type = DlnaProfileType.Video
-				context = EncodingContext.Streaming
-				container = ContainerTypes.TS
-				videoCodec = buildList {
-					if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.MP4)) add(CodecTypes.HEVC)
-					add(CodecTypes.H264)
-				}.joinToString(",")
-				audioCodec = buildList {
-					if (isAC3Enabled) add(CodecTypes.AC3)
-					add(CodecTypes.AAC)
-					add(CodecTypes.MP3)
-				}.joinToString(",")
-				protocol = "hls"
-				copyTimestamps = false
-			},
-			// MP3 audio profile
-			TranscodingProfile().apply {
-				type = DlnaProfileType.Audio
-				context = EncodingContext.Streaming
-				container = CodecTypes.MP3
-				audioCodec = CodecTypes.MP3
-			}
-		)
+		if (isHlsSupported) {
+			transcodingProfiles = arrayOf(
+					// TS video profile
+					TranscodingProfile().apply {
+						type = DlnaProfileType.Video
+						context = EncodingContext.Streaming
+						container = ContainerTypes.TS
+						videoCodec = buildList {
+							if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.TS)) add(CodecTypes.HEVC)
+							add(CodecTypes.H264)
+						}.joinToString(",")
+						audioCodec = buildList {
+							if (isAC3Enabled) add(CodecTypes.AC3)
+							add(CodecTypes.AAC)
+							add(CodecTypes.MP3)
+						}.joinToString(",")
+						protocol = "hls"
+						copyTimestamps = false
+					},
+					// MP3 audio profile
+					TranscodingProfile().apply {
+						type = DlnaProfileType.Audio
+						context = EncodingContext.Streaming
+						container = CodecTypes.MP3
+						audioCodec = CodecTypes.MP3
+					}
+			)
+		}
 
 		directPlayProfiles = buildList {
 			// Video direct play


### PR DESCRIPTION
**Changes**
* added a method to return whether the current server meets a given minimum version requirement
  _it should probably be moved somewhere more suitable_
* exoplayer profile only adds its transcoding profile if HLS is enabled

* fixed transcoding profile still using `ContainsCodec(CodecTypes.HEVC, ContainerTypes.MP4)` instead of `ContainsCodec(CodecTypes.HEVC, ContainerTypes.TS)`
* removed unused variable in playback controller

**Issues**
* HLS transcoding is partially broken prior to 10.8.0 PR:
  https://github.com/jellyfin/jellyfin/pull/7338
  prior to that PR, HLS transcode streams may repeat the last few seconds of a video or not seek accurately
  
  **Notes**
Please suggest a better place to store the `getServerMeetsMinimumVersion()` method
