### PR TITLE
Add ripple effect to DefaultCardView and fix the one in LegacyImageCardView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -47,6 +47,8 @@ public class LegacyImageCardView extends BaseCardView {
             if (!v.requestFocus()) return false;
             return activity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MENU));
         });
+
+        setForeground(null);
     }
 
     public void setBanner(int bannerResource) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.java
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.presentation;
 
-import android.graphics.drawable.Drawable;
 import android.view.View;
 
 import androidx.leanback.widget.ListRowPresenter;
@@ -9,7 +8,6 @@ import androidx.leanback.widget.RowPresenter;
 public class CustomListRowPresenter extends ListRowPresenter {
     private View viewHolder;
     private Integer topPadding;
-    private Drawable backgroundDrawable;
 
     public CustomListRowPresenter() {
         super();
@@ -20,14 +18,6 @@ public class CustomListRowPresenter extends ListRowPresenter {
     public CustomListRowPresenter(Integer topPadding) {
         super();
         this.topPadding = topPadding;
-
-        setHeaderPresenter(new CustomRowHeaderPresenter());
-    }
-
-    public CustomListRowPresenter(Drawable drawable, Integer topPadding) {
-        super();
-        this.topPadding = topPadding;
-        this.backgroundDrawable = drawable;
 
         setHeaderPresenter(new CustomRowHeaderPresenter());
     }
@@ -50,10 +40,6 @@ public class CustomListRowPresenter extends ListRowPresenter {
 
         if (topPadding != null) {
             viewHolder.setPadding(viewHolder.getPaddingLeft(), topPadding, viewHolder.getPaddingRight(), viewHolder.getPaddingBottom());
-        }
-
-        if (backgroundDrawable != null) {
-            viewHolder.setBackground(backgroundDrawable);
         }
     }
 }

--- a/app/src/main/res/drawable/ripple.xml
+++ b/app/src/main/res/drawable/ripple.xml
@@ -1,0 +1,2 @@
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:attr/colorControlHighlight" />

--- a/app/src/main/res/layout/view_card_default.xml
+++ b/app/src/main/res/layout/view_card_default.xml
@@ -15,6 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="110dp"
         android:duplicateParentState="true"
+        android:foreground="@drawable/ripple"
         app:cardCornerRadius="?attr/cardRounding">
 
         <ImageView

--- a/app/src/main/res/layout/view_card_legacy_image.xml
+++ b/app/src/main/res/layout/view_card_legacy_image.xml
@@ -19,8 +19,11 @@
     <RelativeLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:duplicateParentState="true"
+        android:foreground="@drawable/ripple"
         android:gravity="end"
         android:visibility="gone"
+        tools:ignore="UnusedAttribute"
         tools:visibility="visible">
 
         <ImageView


### PR DESCRIPTION
**Changes**
- Fix ripple effect in LegacyImageCardView
  - (used pretty much everywhere in the app)
  - Previously, the effect would go over the text underneath the image. This looked off.
  - Now it only shows on top of the image part
- Add ripple effect to DefaultCardView
  - (used for users in the login screen)
  - Show ripple on top of the image part
- Remove some unused stuff from CustomListRowPresenter

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
