### PR TITLE
Login screen bugfixes while testing for release

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -79,17 +79,20 @@ class AuthPreferencesScreen : OptionsFragment() {
 			}
 		}
 
-		category {
-			setTitle(R.string.lbl_manage_servers)
+		val servers = authenticationRepository.getServers()
+		if (servers.isNotEmpty()) {
+			category {
+				setTitle(R.string.lbl_manage_servers)
 
-			authenticationRepository.getServers().forEach { server ->
-				link {
-					title = server.name
-					icon = R.drawable.ic_house
-					content = server.address
-					withFragment<EditServerScreen>(bundleOf(
-						EditServerScreen.ARG_SERVER_UUID to server.id
-					))
+				servers.forEach { server ->
+					link {
+						title = server.name
+						icon = R.drawable.ic_house
+						content = server.address
+						withFragment<EditServerScreen>(bundleOf(
+							EditServerScreen.ARG_SERVER_UUID to server.id
+						))
+					}
 				}
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -145,6 +145,7 @@ class ServerFragment : Fragment() {
 
 		val server = serverIdArgument?.let(loginViewModel::getServer)
 		if (server != null) loginViewModel.loadUsers(server)
+		else navigateFragment<SelectServerFragment>(keepToolbar = true)
 	}
 
 	private class UserAdapter(


### PR DESCRIPTION
I was testing some things and taking screenshots for the blog post when I encountered some issues.

**Changes**

- Hide "manage servers" in preferences when there are no servers
  - Looked really stupid when opening the settings on first use of the app
- Close ServerFragment when the server is removed from preferences
  - So this probably never happens for anyone (why would you remove a server you just opened?) but still a bug

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
