### PR TITLE
Fix a potential crash in VideoManager with invalid speed

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -644,9 +644,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
     public void setPlaybackSpeed(@NonNull Double speed) {
         if (speed < 0.25) {
-            Timber.w("Invalid playback speed requested: %d", speed);
+            Timber.w("Invalid playback speed requested: %f", speed);
             return;
         }
+        Timber.d("Setting playback speed: %f", speed);
 
         if (nativeMode) {
             mExoPlayer.setPlaybackParameters(new PlaybackParameters(speed.floatValue()));


### PR DESCRIPTION
We should never hit this, unless someone is manually tweaking values in
the debugger or there's a random cosmic bit flip.... but it still results in a hard 
crash as %d is for an `int`, not a `double`.

I've also added something to the debug logs for when a user changes playback speed, 
as there is currently no logging to indicate if someone is using a custom speed from the logs