### PR TITLE
Fix app crash when switching users while music is playing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -70,6 +70,8 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 	}
 
 	override fun onQueueStatusChanged(hasQueue: Boolean) {
+		if (activity == null || requireActivity().isFinishing) return
+
 		Timber.i("Updating audio queue in HomeFragment (onQueueStatusChanged)")
 		nowPlaying.update(mRowsAdapter)
 	}


### PR DESCRIPTION
Ideally we'd stop the music too but calling the MediaManager.stopAudio function will crash the app because it still uses the API. Until we have the playback rewrite code, which uses coroutines that we can await, there is no simple solution. So audio will keep playing for now and the state gets a bit funky after signing in again. (the audio still plays but the UI Doesn't show anything as playing..)

**Changes**

- Fix app crash when switching users while music is playing

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
