### PR TITLE
add mkv transcoding profile for explayer, use playerErrorEncountered for live-tv to avoid infinite retries

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -175,7 +175,7 @@ public class PlaybackController {
     }
 
     public boolean hasInitializedVideoManager() {
-        return mVideoManager != null && mVideoManager.isInitialized() ? true : false;
+        return mVideoManager != null && mVideoManager.isInitialized();
     }
 
     public MediaSourceInfo getCurrentMediaSource() {
@@ -270,7 +270,6 @@ public class PlaybackController {
             Timber.i("Player error encountered - retrying");
             stop();
             play(mCurrentPosition);
-
         } else {
             mPlaybackState = PlaybackState.ERROR;
             if (mFragment != null) {
@@ -322,7 +321,7 @@ public class PlaybackController {
 
     @TargetApi(23)
     private void setRefreshRate(MediaStream videoStream) {
-        if (videoStream == null) {
+        if (videoStream == null || mFragment == null) {
             Timber.e("Null video stream attempting to set refresh rate");
             return;
         }
@@ -1360,18 +1359,19 @@ public class PlaybackController {
 
             @Override
             public void onEvent() {
-                if (mFragment == null) return;
+                if (mFragment == null) {
+                    playerErrorEncountered();
+                    return;
+                }
+
                 if (isLiveTv && directStreamLiveTv) {
                     Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_error_live_stream));
                     directStreamLiveTv = false;
-                    PlaybackHelper.retrieveAndPlay(getCurrentlyPlayingItem().getId(), false, mFragment.getContext());
-                    mFragment.finish();
                 } else {
                     String msg = mFragment.getString(R.string.video_error_unknown_error);
                     Timber.e("Playback error - %s", msg);
-                    playerErrorEncountered();
                 }
-
+                playerErrorEncountered();
             }
         });
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -55,34 +55,51 @@ class ExoPlayerProfile(
 	init {
 		name = "AndroidTV-ExoPlayer"
 
-		if (isHlsSupported) {
-			transcodingProfiles = arrayOf(
-					// TS video profile
-					TranscodingProfile().apply {
-						type = DlnaProfileType.Video
-						context = EncodingContext.Streaming
-						container = ContainerTypes.TS
-						videoCodec = buildList {
-							if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.TS)) add(CodecTypes.HEVC)
-							add(CodecTypes.H264)
-						}.joinToString(",")
-						audioCodec = buildList {
-							if (isAC3Enabled) add(CodecTypes.AC3)
-							add(CodecTypes.AAC)
-							add(CodecTypes.MP3)
-						}.joinToString(",")
-						protocol = "hls"
-						copyTimestamps = false
-					},
-					// MP3 audio profile
-					TranscodingProfile().apply {
-						type = DlnaProfileType.Audio
-						context = EncodingContext.Streaming
-						container = CodecTypes.MP3
-						audioCodec = CodecTypes.MP3
-					}
-			)
-		}
+		transcodingProfiles = arrayOf(
+			when (isHlsSupported) {
+				// TS video profile
+				true -> TranscodingProfile().apply {
+					type = DlnaProfileType.Video
+					context = EncodingContext.Streaming
+					container = ContainerTypes.TS
+					videoCodec = buildList {
+						if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.TS)) add(CodecTypes.HEVC)
+						add(CodecTypes.H264)
+					}.joinToString(",")
+					audioCodec = buildList {
+						if (isAC3Enabled) add(CodecTypes.AC3)
+						add(CodecTypes.AAC)
+						add(CodecTypes.MP3)
+					}.joinToString(",")
+					protocol = "hls"
+					copyTimestamps = false
+				}
+				// MKV video profile
+				else -> TranscodingProfile().apply {
+					type = DlnaProfileType.Video
+					context = EncodingContext.Streaming
+					container = ContainerTypes.MKV
+					videoCodec = buildList {
+						if (deviceHevcCodecProfile.ContainsCodec(CodecTypes.HEVC, ContainerTypes.MKV)) add(CodecTypes.HEVC)
+						add(CodecTypes.H264)
+					}.joinToString(",")
+					audioCodec = buildList {
+						if (isAC3Enabled) add(CodecTypes.AC3)
+						add(CodecTypes.AAC)
+						add(CodecTypes.MP3)
+					}.joinToString(",")
+					protocol = "http"
+					copyTimestamps = true
+				}
+			},
+			// MP3 audio profile
+			TranscodingProfile().apply {
+				type = DlnaProfileType.Audio
+				context = EncodingContext.Streaming
+				container = CodecTypes.MP3
+				audioCodec = CodecTypes.MP3
+			}
+		)
 
 		directPlayProfiles = buildList {
 			// Video direct play


### PR DESCRIPTION
**Changes**
* added mkv transcoding profile for exoplayer so AC-3 audio can still be played when HLS is disabled
* use playerErrorEncountered for live-tv
* simplified a statement
* added a null check for mFragment

**Issues**
* likely fixes #1514
 > * playback failed due to a lack of AAC support. The user says they didn't have issues in beta 4 so it's likely that they 
       relied on AC-3 support.
 > * playback failing resulted in an infinite retry loop

* when live tv infinitely retries after errors, mfragment was used as context for the new session. I think this may have prevented the old instance from being GCd
