### PR TITLE
reworked context menu for audio queue, removed buttons for video queue

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -965,7 +965,12 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                     playButton.requestFocus();
                 }
 
-                if (!mBaseItem.getIsFolderItem() && !BaseItemUtils.isLiveTv(mBaseItem)) {
+                boolean isMusic = mBaseItem.getBaseItemType() == BaseItemType.MusicAlbum
+                        || mBaseItem.getBaseItemType() == BaseItemType.MusicArtist
+                        || mBaseItem.getBaseItemType() == BaseItemType.Audio
+                        || (mBaseItem.getBaseItemType() == BaseItemType.Playlist && "Audio".equals(mBaseItem.getMediaType()));
+
+                if (isMusic) {
                     queueButton = new TextUnderButton(this, R.drawable.ic_add, buttonSize, 2, getString(R.string.lbl_add_to_queue), new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -23,6 +23,7 @@ import org.jellyfin.androidtv.ui.itemdetail.FullDetailsActivity;
 import org.jellyfin.androidtv.ui.itemdetail.ItemListActivity;
 import org.jellyfin.androidtv.ui.itemdetail.PhotoPlayerActivity;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
+import org.jellyfin.androidtv.ui.playback.AudioNowPlayingActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.util.KeyProcessor;
@@ -137,8 +138,16 @@ public class ItemLauncher {
                         return;
 
                     case Audio:
-                        //produce item menu
-                        KeyProcessor.HandleKey(KeyEvent.KEYCODE_MENU, rowItem, activity);
+                        Timber.d("got pos %s", pos);
+                        // if a song isn't the first in the queue, play it
+                        if (rowItem.getIndex() > KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueuePosition() && rowItem.getIndex() < KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueueSize()) {
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playFrom(rowItem.getIndex());
+                        } else {
+                            // otherwise, open AudioNowPlayingActivity
+                            Intent nowPlaying = new Intent(activity, AudioNowPlayingActivity.class);
+                            activity.startActivity(nowPlaying);
+                        }
+
                         return;
 
                     case Season:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -207,7 +207,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
         mSaveButton.setOnFocusChangeListener(mainAreaFocusListener);
 
         mShuffleButton = binding.shuffleBtn;
-        mShuffleButton.setContentDescription(getString(R.string.lbl_reshuffle_queue));
+        mShuffleButton.setContentDescription(getString(R.string.lbl_shuffle_queue));
         mShuffleButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -514,6 +514,7 @@ public class MediaManager {
     }
 
     public void clearAudioQueue() {
+        stopAudio(true);
         clearUnShuffledQueue();
         if (mCurrentAudioQueue == null) {
             createAudioQueue(new ArrayList<BaseItemDto>());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="lbl_add_to_queue">Add to Queue</string>
     <string name="lbl_open_artist">Open Artist</string>
     <string name="lbl_open_album">Open Album</string>
-    <string name="lbl_reshuffle_queue">Re-Shuffle Queue</string>
+    <string name="lbl_shuffle_queue">Toggle Shuffle</string>
     <string name="lbl_next_item">Next Item</string>
     <string name="lbl_prev_item">Previous Item</string>
     <string name="lbl_up_next_colon">"Up Next: "</string>


### PR DESCRIPTION
**Changes**
* clicking on an item in the audio queue on the home screen now either:
  (for other actions, long click on the item to open the context menu)
> * opens the `NowPlayingActivity` if it's the first item in the row
> * otherwise, plays the item without opening `NowPlayingActivity`



* changed the buttons in the context menu for audio items:
> * only show 'play from here' if:
>> * if not in `NowPlayingActivity` since a single click on an item will play it
>> * the item isn't the currently playing one (the previous code didn't properly do this)
> * added a 'toggle shuffle' button
> * moved the 'favorite' button closer to the top
> * added a 'clear queue' button since we can now do this without crashing the app

* changed the values in `KeyProcessor` for MENU_MARK_FAVORITE, MENU_PLAY, etc. If there's a reason why they were numbered how they were I couldn't figure it out.
* in `FullDetailsActivity`, removed both the button and menu item for "add to queue" for video items since the video queue doesn't work properly

**Notes**
* I'll work on the context menu for video items next