### PR TITLE
three crash fixes from tracepot issues

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1258,7 +1258,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     public void setCurrentTime(long time) {
-        leanbackOverlayFragment.updateCurrentPosition();
+        if (leanbackOverlayFragment != null)
+            leanbackOverlayFragment.updateCurrentPosition();
     }
 
     public void setSecondaryTime(long time) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -32,6 +32,8 @@ public class PlaybackManager {
     }
 
     public ArrayList<MediaStream> getInPlaybackSelectableAudioStreams(StreamInfo info) {
+        if (info == null)
+            return null;
         return info.GetSelectableAudioStreams();
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -211,8 +211,10 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     }
 
     void addMediaActions() {
-        primaryActionsAdapter.clear();
-        secondaryActionsAdapter.clear();
+        if (primaryActionsAdapter.size() > 0)
+            primaryActionsAdapter.clear();
+        if (secondaryActionsAdapter.size() > 0)
+            secondaryActionsAdapter.clear();
 
         // Primary Items
         primaryActionsAdapter.add(playPauseAction);
@@ -378,8 +380,10 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     }
 
     void invalidatePlaybackControls() {
-        primaryActionsAdapter.clear();
-        secondaryActionsAdapter.clear();
+        if (primaryActionsAdapter.size() > 0)
+            primaryActionsAdapter.clear();
+        if (secondaryActionsAdapter.size() > 0)
+            secondaryActionsAdapter.clear();
         addMediaActions();
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.java
@@ -27,6 +27,10 @@ public class SelectAudioAction extends CustomAction {
     public void handleClickAction(PlaybackController playbackController, LeanbackOverlayFragment leanbackOverlayFragment, Context context, View view) {
 
         List<MediaStream> audioTracks = KoinJavaComponent.<PlaybackManager>get(PlaybackManager.class).getInPlaybackSelectableAudioStreams(playbackController.getCurrentStreamInfo());
+
+        if (audioTracks == null)
+            return;
+
         int currentAudioIndex = playbackController.getAudioStreamIndex();
 
         PopupMenu audioMenu = new PopupMenu(context, view, Gravity.END);


### PR DESCRIPTION
**Changes**
* catch `leanbackOverlayFragment` being null in `setCurrentTime()`
* catch `StreamInfo info` being null in `getInPlaybackSelectableAudioStreams()`, and catch it then returning null in `SelectAudioAction`
* only clear `primaryActionsAdapter` and `secondaryActionsAdapter` if they are not empty

**Issues**
tracepot:
* https://app.tracepot.com/app/75387/release/1a07276a0001267b
  `java.lang.NullPointerException: Attempt to invoke virtual method 'void org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment.updateCurrentPosition()' on a null object reference`
* https://app.tracepot.com/app/75387/release/1d115b860001267b
  `java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.ArrayList org.jellyfin.androidtv.data.compat.StreamInfo.GetSelectableAudioStreams()' on a null object reference`
* https://app.tracepot.com/app/75387/release/a46fe8ca0001267b
  `java.lang.IndexOutOfBoundsException: Invalid index 0, size is 0`