### PR TITLE
Remove srt as external from ExoPlayer subtitle profiles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -217,7 +217,6 @@ class ExoPlayerProfile(
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(
-			subtitleProfile("srt", SubtitleDeliveryMethod.External),
 			subtitleProfile("srt", SubtitleDeliveryMethod.Embed),
 			subtitleProfile("subrip", SubtitleDeliveryMethod.Embed),
 			subtitleProfile("ass", SubtitleDeliveryMethod.Encode),

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -120,7 +120,6 @@ class LibVlcProfile(
 		)
 
 		subtitleProfiles = arrayOf(
-			subtitleProfile("srt", SubtitleDeliveryMethod.External),
 			subtitleProfile("srt", SubtitleDeliveryMethod.Embed),
 			subtitleProfile("subrip", SubtitleDeliveryMethod.Embed),
 			subtitleProfile("ass", SubtitleDeliveryMethod.Embed),


### PR DESCRIPTION
We had 2 separate entries for srt: external and embed. I guess the server just used the first entry (external). It doesn't really do much because we don't support embedded subs in ExoPlayer anyway.

**Changes**
- Remove srt as external from ExoPlayer subtitle profiles
- Remove srt as external from libVLC subtitle profiles
