### PR TITLE
Use consistent naming & constructors in custom views

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/AlphaPickerView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AlphaPickerView.kt
@@ -10,10 +10,12 @@ import androidx.core.view.children
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.ViewButtonAlphaPickerBinding
 
-class AlphaPicker(
+class AlphaPickerView @JvmOverloads constructor(
 	context: Context,
-	attrs: AttributeSet? = null
-) : HorizontalScrollView(context, attrs) {
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+	defStyleRes: Int = 0,
+) : HorizontalScrollView(context, attrs, defStyleAttr, defStyleRes) {
 	var onAlphaSelected: (letter: Char) -> Unit = {}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
@@ -21,7 +21,7 @@ class ClockUserView @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
 	defStyleAttr: Int = 0,
-	defStyleRes: Int = 0
+	defStyleRes: Int = 0,
 ) : RelativeLayout(context, attrs, defStyleAttr, defStyleRes), KoinComponent {
 	private val binding: ClockUserBugBinding = ClockUserBugBinding.inflate(LayoutInflater.from(context), this, true)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ExpandableTextView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ExpandableTextView.kt
@@ -11,7 +11,11 @@ import androidx.core.content.ContextCompat
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.PopupExpandableTextViewBinding
 
-class ExpandableTextView(context: Context, attrs: AttributeSet?) : AppCompatTextView(context, attrs) {
+class ExpandableTextView @JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+) : AppCompatTextView(context, attrs, defStyleAttr) {
 	private val popupContentBinding = PopupExpandableTextViewBinding.inflate(
 		LayoutInflater.from(context),
 		null,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/FadeViewSwitcherLayout.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/FadeViewSwitcherLayout.kt
@@ -8,7 +8,7 @@ import android.widget.FrameLayout
 import androidx.annotation.IntRange
 import org.jellyfin.androidtv.integration.dream.LibraryDreamService
 
-class FadeViewSwitcher @JvmOverloads constructor(
+class FadeViewSwitcherLayout @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
 	defStyleAttr: Int = 0,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -38,7 +38,7 @@ import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.databinding.PopupEmptyBinding;
 import org.jellyfin.androidtv.preference.LibraryPreferences;
 import org.jellyfin.androidtv.preference.PreferencesRepository;
-import org.jellyfin.androidtv.ui.AlphaPicker;
+import org.jellyfin.androidtv.ui.AlphaPickerView;
 import org.jellyfin.androidtv.ui.GridFragment;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
@@ -482,7 +482,7 @@ public class StdGridFragment extends GridFragment {
         private final int HEIGHT = Utils.convertDpToPixel(requireContext(), 55);
 
         private final PopupWindow popupWindow;
-        private final AlphaPicker alphaPicker;
+        private final AlphaPickerView alphaPicker;
 
         JumplistPopup() {
             LayoutInflater inflater = LayoutInflater.from(requireContext());
@@ -492,7 +492,7 @@ public class StdGridFragment extends GridFragment {
             popupWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT)); // necessary for popup to dismiss
             popupWindow.setAnimationStyle(R.style.WindowAnimation_SlideTop);
 
-            alphaPicker = new AlphaPicker(requireContext(), null);
+            alphaPicker = new AlphaPickerView(requireContext(), null);
             alphaPicker.setOnAlphaSelected(letter -> {
                 mGridAdapter.setStartLetter(letter.toString());
                 loadGrid(mRowDef);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtonsView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpButtonsView.kt
@@ -7,14 +7,12 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import org.jellyfin.androidtv.databinding.FragmentNextUpButtonsBinding
 
-class NextUpButtons(
+class NextUpButtonsView @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
 	defStyleAttr: Int = 0,
-	defStyle: Int = 0
-) : FrameLayout(context, attrs, defStyleAttr, defStyle) {
-	constructor(context: Context, attrs: AttributeSet) : this(context, attrs, 0, 0)
-
+	defStyleRes: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 	private var countdownTimer: CountDownTimer? = null
 	private val view = FragmentNextUpButtonsBinding.inflate(LayoutInflater.from(context), this, true)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
@@ -7,10 +7,12 @@ import androidx.preference.DialogPreference
 import org.jellyfin.androidtv.R
 import java.util.Locale
 
-class ButtonRemapPreference(
+class ButtonRemapPreference @JvmOverloads constructor(
 	context: Context,
-	attrs: AttributeSet? = null
-) : DialogPreference(context, attrs) {
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+	defStyleRes: Int = 0,
+) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
 	override fun getDialogLayoutResource() = R.layout.preference_button_remap
 
 	private var innerKeyCode: Int = -1

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/DurationSeekBarPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/DurationSeekBarPreference.kt
@@ -10,10 +10,12 @@ import androidx.preference.PreferenceViewHolder
 import androidx.preference.SeekBarPreference
 import org.jellyfin.androidtv.R
 
-class DurationSeekBarPreference(
+class DurationSeekBarPreference @JvmOverloads constructor(
 	context: Context,
-	attrs: AttributeSet? = null
-) : SeekBarPreference(context, attrs) {
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+	defStyleRes: Int = 0,
+) : SeekBarPreference(context, attrs, defStyleAttr, defStyleRes) {
 	var valueFormatter = ValueFormatter()
 
 	override fun onBindViewHolder(view: PreferenceViewHolder) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListPreference.kt
@@ -8,10 +8,12 @@ import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment.RichLi
 import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment.RichListItem.RichListOption
 import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment.RichListItem.RichListSection
 
-class RichListPreference<K>(
+class RichListPreference<K> @JvmOverloads constructor(
 	context: Context,
-	attrs: AttributeSet? = null
-) : DialogPreference(context, attrs) {
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+	defStyleRes: Int = 0,
+) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
 	private var items: List<RichListItem<K>> = emptyList()
 	var value: K? = null
 

--- a/app/src/main/res/layout/dream_library.xml
+++ b/app/src/main/res/layout/dream_library.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <org.jellyfin.androidtv.ui.FadeViewSwitcher
+    <org.jellyfin.androidtv.ui.FadeViewSwitcherLayout
         android:id="@+id/item_switcher"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -33,7 +33,7 @@
         <org.jellyfin.androidtv.integration.dream.LibraryDreamItemView
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
-    </org.jellyfin.androidtv.ui.FadeViewSwitcher>
+    </org.jellyfin.androidtv.ui.FadeViewSwitcherLayout>
 
     <TextClock
         android:id="@+id/clock"

--- a/app/src/main/res/layout/fragment_next_up.xml
+++ b/app/src/main/res/layout/fragment_next_up.xml
@@ -78,7 +78,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             tools:text="Episode title" />
 
-        <org.jellyfin.androidtv.ui.playback.nextup.NextUpButtons
+        <org.jellyfin.androidtv.ui.playback.nextup.NextUpButtonsView
             android:id="@+id/fragment_next_up_buttons"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
We have quite a bit custom views. A lot of them, unfortunately, still written in Java. This PR only focusses on the Kotlin based views.

**Changes**
- Use consistent naming for custom views
  - End with "Layout" for layouting (FadeViewSwitcherLayout)
  - End with "Preference" for preferences
  - End with "View" for all other views
- Always use this particular constructor, with defStyleRes omitted if the extended view does not support it (like AppCompatTextView)
  ```kotlin
   class MyAwesomeCustomView @JvmOverloads constructor(
  	context: Context,
  	attrs: AttributeSet? = null,
  	defStyleAttr: Int = 0,
  	defStyleRes: Int = 0,
  ) : View(context, attrs, defStyleAttr, defStyleRes)
  ```

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
