### PR TITLE
Add app name and flavor to version in about section

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/about.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/category/about.kt
@@ -11,8 +11,9 @@ fun OptionsScreen.aboutCategory() = category {
 	setTitle(R.string.pref_about_title)
 
 	link {
+		// Hardcoded strings for troubleshooting purposes
 		title = "Jellyfin app version"
-		content = BuildConfig.VERSION_NAME
+		content = "jellyfin-androidtv ${BuildConfig.VERSION_NAME} ${BuildConfig.BUILD_TYPE}"
 		icon = R.drawable.ic_jellyfin
 	}
 


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/2305178/159332302-7822f0a5-6757-4496-816f-2020ba93ea4f.png)

After

![image](https://user-images.githubusercontent.com/2305178/159332506-bfa1c3dc-29b4-411b-8418-2864b6850ee8.png)


**Changes**

- Add app name and flavor to version in about section
  - This is now consistent with the version shown in the server selection screen

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
