### PR TITLE
Fix preferences crashing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
@@ -10,7 +10,7 @@ import java.util.Locale
 class ButtonRemapPreference @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
-	defStyleAttr: Int = 0,
+	defStyleAttr: Int = androidx.preference.R.attr.dialogPreferenceStyle,
 	defStyleRes: Int = 0,
 ) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
 	override fun getDialogLayoutResource() = R.layout.preference_button_remap

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/DurationSeekBarPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/DurationSeekBarPreference.kt
@@ -13,7 +13,7 @@ import org.jellyfin.androidtv.R
 class DurationSeekBarPreference @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
-	defStyleAttr: Int = 0,
+	defStyleAttr: Int = androidx.preference.R.attr.seekBarPreferenceStyle,
 	defStyleRes: Int = 0,
 ) : SeekBarPreference(context, attrs, defStyleAttr, defStyleRes) {
 	var valueFormatter = ValueFormatter()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListPreference.kt
@@ -11,7 +11,7 @@ import org.jellyfin.androidtv.ui.preference.custom.RichListDialogFragment.RichLi
 class RichListPreference<K> @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
-	defStyleAttr: Int = 0,
+	defStyleAttr: Int = androidx.preference.R.attr.dialogPreferenceStyle,
 	defStyleRes: Int = 0,
 ) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
 	private var items: List<RichListItem<K>> = emptyList()


### PR DESCRIPTION
Fix regression from #1540. The preference views have default style attribute values which were accidentally removed causing the app to crash when a preference view was displayed.

**Changes**
- Set defStyleAttr for DurationSeekBarPreference, RichListPreference and ButtonRemapPreference

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
