### PR TITLE
Make cancel default on delete/clear

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -851,9 +851,8 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
         new AlertDialog.Builder(mActivity)
                 .setTitle(R.string.lbl_delete)
                 .setMessage("This will PERMANENTLY DELETE " + mBaseItem.getName() + " from your library.  Are you VERY sure?")
-                .setPositiveButton("Delete", new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        apiClient.getValue().DeleteItem(mBaseItem.getId(), new EmptyResponse() {
+                .setPositiveButton("Delete",
+                        (dialog, whichButton) -> apiClient.getValue().DeleteItem(mBaseItem.getId(), new EmptyResponse() {
                             @Override
                             public void onResponse() {
                                 Utils.showToast(mActivity, mBaseItem.getName() + " Deleted");
@@ -865,19 +864,10 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                             public void onError(Exception ex) {
                                 Utils.showToast(mActivity, ex.getLocalizedMessage());
                             }
-                        });
-                    }
-                })
-                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        Utils.showToast(mActivity, "Item NOT Deleted");
-                    }
-                })
+                        }))
+                .setNegativeButton("Cancel", (dialog, which) -> Utils.showToast(mActivity, "Item NOT Deleted"))
                 .show()
                 .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
-
-
     }
 
     private TextUnderButton favButton = null;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -874,7 +874,8 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         Utils.showToast(mActivity, "Item NOT Deleted");
                     }
                 })
-                .show();
+                .show()
+                .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
 
 
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -651,28 +651,20 @@ public class ItemListActivity extends FragmentActivity {
                             new AlertDialog.Builder(mActivity)
                                     .setTitle(R.string.lbl_clear_queue)
                                     .setMessage(R.string.clear_expanded)
-                                    .setPositiveButton(R.string.lbl_clear, new DialogInterface.OnClickListener() {
-                                        public void onClick(DialogInterface dialog, int whichButton) {
-                                            mediaManager.getValue().setCurrentVideoQueue(new ArrayList<BaseItemDto>());
-                                            dataRefreshService.getValue().setLastVideoQueueChange(System.currentTimeMillis());
-                                            finish();
-                                        }
+                                    .setPositiveButton(R.string.lbl_clear, (dialog, whichButton) -> {
+                                        mediaManager.getValue().setCurrentVideoQueue(new ArrayList<BaseItemDto>());
+                                        dataRefreshService.getValue().setLastVideoQueueChange(System.currentTimeMillis());
+                                        finish();
                                     })
-                                    .setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(DialogInterface dialog, int which) {
-                                        }
-                                    })
+                                    .setNegativeButton(R.string.btn_cancel, (dialog, which) -> {})
                                     .show()
                                     .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
-
                         } else {
                             new AlertDialog.Builder(mActivity)
                                     .setTitle(R.string.lbl_delete)
                                     .setMessage(getString(R.string.delete_warning, mBaseItem.getName()))
-                                    .setPositiveButton(R.string.lbl_delete, new DialogInterface.OnClickListener() {
-                                        public void onClick(DialogInterface dialog, int whichButton) {
-                                            apiClient.getValue().DeleteItem(mBaseItem.getId(), new EmptyResponse() {
+                                    .setPositiveButton(R.string.lbl_delete,
+                                            (dialog, whichButton) -> apiClient.getValue().DeleteItem(mBaseItem.getId(), new EmptyResponse() {
                                                 @Override
                                                 public void onResponse() {
                                                     Utils.showToast(mActivity, getString(R.string.lbl_deleted, mBaseItem.getName()));
@@ -684,15 +676,9 @@ public class ItemListActivity extends FragmentActivity {
                                                 public void onError(Exception ex) {
                                                     Utils.showToast(mActivity, ex.getLocalizedMessage());
                                                 }
-                                            });
-                                        }
-                                    })
-                                    .setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(DialogInterface dialog, int which) {
-                                            Utils.showToast(mActivity, R.string.not_deleted);
-                                        }
-                                    })
+                                            }))
+                                    .setNegativeButton(R.string.btn_cancel,
+                                            (dialog, which) -> Utils.showToast(mActivity, R.string.not_deleted))
                                     .show()
                                     .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -663,7 +663,8 @@ public class ItemListActivity extends FragmentActivity {
                                         public void onClick(DialogInterface dialog, int which) {
                                         }
                                     })
-                                    .show();
+                                    .show()
+                                    .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
 
                         } else {
                             new AlertDialog.Builder(mActivity)
@@ -692,7 +693,8 @@ public class ItemListActivity extends FragmentActivity {
                                             Utils.showToast(mActivity, R.string.not_deleted);
                                         }
                                     })
-                                    .show();
+                                    .show()
+                                    .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
 
 
                         }


### PR DESCRIPTION
**Changes**
Select cancel by default on confirmation dialog
    
Select cancel so a user doesn't accidentally delete media by hitting
delete twice. Since we ask it's worth adding this extra step, if we need
to remove the extra step it's arguable we can completely remove alert
dialog all-together

**Testing**
Ensure that the user account can delete media
- Go to a random video
- Attempt to delete
- Ensure cancel is selected by default
