### PR TITLE
Add handling for updating end time based on playback speed

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -88,7 +88,7 @@ public class PlaybackController {
     private int mDefaultSubIndex = -1;
     private int mDefaultAudioIndex = -1;
     private boolean burningSubs = false;
-    private double mRequestedPlaybackSpeed = -1.0;
+    private float mRequestedPlaybackSpeed = -1.0f;
 
     private PlayMethod mPlaybackMethod = PlayMethod.Transcode;
 
@@ -163,7 +163,13 @@ public class PlaybackController {
         mPlaybackMethod = value;
     }
 
-    public void setPlaybackSpeed(@NonNull Double speed) {
+    public float getPlaybackSpeed() {
+        // Actually poll the video manager, since exoplayer can revert back
+        // to 1x if it can't go faster, so we should check directly
+        return mVideoManager.getPlaybackSpeed();
+    }
+
+    public void setPlaybackSpeed(@NonNull float speed) {
         mRequestedPlaybackSpeed = speed;
         if (hasInitializedVideoManager()) {
             mVideoManager.setPlaybackSpeed(speed);
@@ -767,7 +773,7 @@ public class PlaybackController {
 
         // set playback speed to user selection, or 1 if we're watching live-tv
         if (mVideoManager != null)
-            mVideoManager.setPlaybackSpeed(isLiveTv() ? 1.0 : mRequestedPlaybackSpeed);
+            mVideoManager.setPlaybackSpeed(isLiveTv() ? 1.0f : mRequestedPlaybackSpeed);
 
         if (mFragment != null) mFragment.updateDisplay();
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -642,7 +642,17 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         return ndx;
     }
 
-    public void setPlaybackSpeed(@NonNull Double speed) {
+    public float getPlaybackSpeed(){
+        if (!isInitialized()) {
+            return 1.0f;
+        } else if (isNativeMode()){
+            return mExoPlayer.getPlaybackParameters().speed;
+        } else {
+            return mVlcPlayer.getRate();
+        }
+    }
+
+    public void setPlaybackSpeed(@NonNull float speed) {
         if (speed < 0.25) {
             Timber.w("Invalid playback speed requested: %f", speed);
             return;
@@ -650,9 +660,9 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         Timber.d("Setting playback speed: %f", speed);
 
         if (nativeMode) {
-            mExoPlayer.setPlaybackParameters(new PlaybackParameters(speed.floatValue()));
+            mExoPlayer.setPlaybackParameters(new PlaybackParameters(speed));
         } else {
-            mVlcPlayer.setRate(speed.floatValue());
+            mVlcPlayer.setRate(speed);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoSpeedController.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoSpeedController.kt
@@ -3,16 +3,16 @@ package org.jellyfin.androidtv.ui.playback
 class VideoSpeedController(
 	private val parentController: PlaybackController
 ) {
-	enum class SpeedSteps(val speed: Double) {
+	enum class SpeedSteps(val speed: Float) {
 		// Use named parameter so detekt knows these aren't magic values
-		SPEED_0_25(speed = 0.25),
-		SPEED_0_50(speed = 0.5),
-		SPEED_0_75(speed = 0.75),
-		SPEED_1_00(speed = 1.0),
-		SPEED_1_25(speed = 1.25),
-		SPEED_1_50(speed = 1.50),
-		SPEED_1_75(speed = 1.75),
-		SPEED_2_00(speed = 2.0),
+		SPEED_0_25(speed = 0.25f),
+		SPEED_0_50(speed = 0.5f),
+		SPEED_0_75(speed = 0.75f),
+		SPEED_1_00(speed = 1.0f),
+		SPEED_1_25(speed = 1.25f),
+		SPEED_1_50(speed = 1.50f),
+		SPEED_1_75(speed = 1.75f),
+		SPEED_2_00(speed = 2.0f),
 	}
 
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -158,6 +158,10 @@ public class VideoPlayerAdapter extends PlayerAdapter {
         return playbackController.getCurrentlyPlayingItem();
     }
 
+    public double getPlaybackSpeed() {
+        return playbackController.getPlaybackSpeed();
+    }
+
     boolean hasChapters() {
         BaseItemDto item = getCurrentlyPlayingItem();
         List<ChapterInfoDto> chapters = item.getChapters();

--- a/app/src/test/kotlin/ui/playback/VideoSpeedControllerTests.kt
+++ b/app/src/test/kotlin/ui/playback/VideoSpeedControllerTests.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.androidtv.ui.playback
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.floats.plusOrMinus
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.justRun
@@ -17,19 +17,19 @@ class VideoSpeedControllerTests : FunSpec({
 
 	test("VideoSpeedController.SpeedSteps uses intervals of 0.25") {
 		VideoSpeedController.SpeedSteps.values().forEachIndexed { i, v ->
-			v.speed.shouldBe((i + 1) * 0.25 plusOrMinus 0.0001)
+			v.speed.shouldBe((i + 1) * 0.25f plusOrMinus 1.0E-4F)
 		}
 	}
 
 	test("VideoSpeedController speed is 1 by default") {
 		val mockController = mockk<PlaybackController>(relaxed = true)
-		val slot = slot<Double>()
+		val slot = slot<Float>()
 		justRun { mockController.setPlaybackSpeed(capture(slot)) }
 
 		VideoSpeedController(mockController)
 
 		verify { mockController.setPlaybackSpeed(any()) }
-		slot.captured shouldBe (1.0 plusOrMinus 0.0001)
+		slot.captured shouldBe (1.0f plusOrMinus 1.0E-4F)
 	}
 
 	test("VideoSpeedController.currentSpeed getter returns set value") {
@@ -44,7 +44,7 @@ class VideoSpeedControllerTests : FunSpec({
 
 	test("VideoSpeedController.currentSpeed updates the speed in the controller") {
 		val mockController = mockk<PlaybackController>(relaxed = true)
-		val slot = slot<Double>()
+		val slot = slot<Float>()
 		justRun { mockController.setPlaybackSpeed(capture(slot)) }
 
 		val controller = VideoSpeedController(mockController)
@@ -52,7 +52,7 @@ class VideoSpeedControllerTests : FunSpec({
 		controller.currentSpeed = expected
 
 		verify { mockController.setPlaybackSpeed(any()) }
-		slot.captured shouldBe (expected.speed plusOrMinus 0.0001)
+		slot.captured shouldBe (expected.speed plusOrMinus 1.0E-4F)
 	}
 
 	test("VideoSpeedController.resetSpeedToDefault() works correctly") {
@@ -62,26 +62,26 @@ class VideoSpeedControllerTests : FunSpec({
 		videoController.currentSpeed = VideoSpeedController.SpeedSteps.SPEED_2_00
 		videoController.resetSpeedToDefault()
 
-		val slot = slot<Double>()
+		val slot = slot<Float>()
 		justRun { playbackController.setPlaybackSpeed(capture(slot)) }
 		VideoSpeedController(playbackController)
 
 		verify { playbackController.setPlaybackSpeed(any()) }
-		slot.captured shouldBe (VideoSpeedController.SpeedSteps.SPEED_1_00.speed plusOrMinus 0.0001)
+		slot.captured shouldBe (VideoSpeedController.SpeedSteps.SPEED_1_00.speed plusOrMinus 1.0E-4F)
 	}
 
 	test("VideoSpeedController remembers previous instance speed value") {
-		var lastSetSpeed = 1.0
+		var lastSetSpeed = 1.0f
 
 		VideoSpeedController.SpeedSteps.values().forEach { newSpeed ->
 			val mockController = mockk<PlaybackController>(relaxed = true)
-			val slot = slot<Double>()
+			val slot = slot<Float>()
 			justRun { mockController.setPlaybackSpeed(capture(slot)) }
 
 			val controller = VideoSpeedController(mockController)
 
 			verify { mockController.setPlaybackSpeed(any()) }
-			slot.captured shouldBe (lastSetSpeed plusOrMinus 0.0001)
+			slot.captured shouldBe (lastSetSpeed plusOrMinus 1.0E-4F)
 
 			controller.currentSpeed = newSpeed
 			lastSetSpeed = newSpeed.speed
@@ -101,13 +101,13 @@ class VideoSpeedControllerTests : FunSpec({
 		}
 		val speedController = VideoSpeedController(mockController)
 
-		verify { mockController.setPlaybackSpeed(1.0) }
+		verify { mockController.setPlaybackSpeed(1.0f) }
 		speedController.currentSpeed shouldBe VideoSpeedController.SpeedSteps.SPEED_1_00
 
 		// Try to set it back to other values should be ignored
 		speedController.currentSpeed = VideoSpeedController.SpeedSteps.SPEED_2_00
 
-		verify { mockController.setPlaybackSpeed(1.0) }
+		verify { mockController.setPlaybackSpeed(1.0f) }
 		speedController.currentSpeed shouldBe VideoSpeedController.SpeedSteps.SPEED_1_00
 	}
 
@@ -117,12 +117,12 @@ class VideoSpeedControllerTests : FunSpec({
 		}
 		val speedController = VideoSpeedController(mockController)
 
-		verify { mockController.setPlaybackSpeed(1.0) }
+		verify { mockController.setPlaybackSpeed(1.0f) }
 		speedController.currentSpeed shouldBe VideoSpeedController.SpeedSteps.SPEED_1_00
 
 		speedController.currentSpeed = VideoSpeedController.SpeedSteps.SPEED_2_00
 
-		verify { mockController.setPlaybackSpeed(2.0) }
+		verify { mockController.setPlaybackSpeed(2.0f) }
 		speedController.currentSpeed shouldBe VideoSpeedController.SpeedSteps.SPEED_2_00
 	}
 })


### PR DESCRIPTION
**Changes**
- Add handling for updating end time based on playback speed. This is a bit hacky due to the current architecture:
```
    Exoplayer is built on the assumption that we
    have bi-directional communication to our UI layer. Instead the
    CustomPlaybackTransportControlGlue is uni-directional polling the video
    manager.
    
    We unfortunately have to use hacky poll tricks to work-around the fact
    we can't wire up on the "onPlaybackParametersChanged" call to notify the
    glue class to update its value. However, in the short-term a 5s "delay" between setting 
    and updating is more favourable than setting up reverse listening support.
```

**Issues**
Fixes #1509 

**Testing**
- Play a video, check the finish time
- Change the speed to 0.25 and/or 2x
- Check the finish time updates accordingly (after 5s)
