### PR TITLE
Fix ASPECT_RATIO_BANNER

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import timber.log.Timber;
 
 public class CardPresenter extends Presenter {
-    private static final double ASPECT_RATIO_BANNER = 434 / 79;
+    private static final double ASPECT_RATIO_BANNER = 1000 / 185;
 
     private int mStaticHeight = 300;
     private ImageType mImageType = ImageType.DEFAULT;


### PR DESCRIPTION
In #1377 I changed the value from `5.414` to `434 / 79` (`5.4936708861`) because I couldn't find the original values used to calculate the ratio. I've now found the values in jellyfin-web to be `1000 / 185` (`5.4054054054`).

**Changes**
- Change value of ASPECT_RATIO_BANNER to match jellyfin-web (and it's value before #1377)

**Issues**

Should fix #1548 but unable to test as I don't have any banner images.