### PR TITLE
only parse exoplayer TracksInfo when needed - instead of once every 0.5-2 seconds

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -460,7 +460,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         if (streamType != MediaStreamType.Subtitle && streamType != MediaStreamType.Audio)
             return -1;
 
-        if (exoplayerAudioIndex != null)
+        if (exoplayerAudioIndex != null && streamType == MediaStreamType.Audio)
             return exoplayerAudioIndex;
 
         int chosenTrackType = streamType == MediaStreamType.Subtitle ? C.TRACK_TYPE_TEXT : C.TRACK_TYPE_AUDIO;
@@ -485,7 +485,8 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                             }
                             if (id >= 0 && id < allStreams.size()) {
                                 Timber.d("re-retrieved exoplayer track index %s", id);
-                                exoplayerAudioIndex = id;
+                                if (streamType == MediaStreamType.Audio)
+                                    exoplayerAudioIndex = id;
                                 return id;
                             }
                         }


### PR DESCRIPTION
**Changes**
* store the current exoplayer audio track index/id and reuse it instead of parsing `TracksInfo` every time `getExoPlayerTrack()` is called

**Issues**
* every time `reportProgress()` runs it gets the current audio index (calls `getExoPlayerTrack()`), which currently parses `TracksInfo`. I'm not sure how expensive this is but some users have reported worse performance in 0.13 specifically with exoplayer. This may be contributing to that.
