### PR TITLE
Fix crash getting badge image with null base item

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -467,21 +467,23 @@ public class BaseRowItem {
     }
 
     public Drawable getBadgeImage(Context context) {
-        switch (type) {
-            case BaseItem:
-                if (baseItem.getBaseItemType() == BaseItemType.Movie && baseItem.getCriticRating() != null) {
-                    return baseItem.getCriticRating() > 59 ? ContextCompat.getDrawable(context, R.drawable.ic_rt_fresh) : ContextCompat.getDrawable(context, R.drawable.ic_rt_rotten);
-                } else if (baseItem.getBaseItemType() == BaseItemType.Program && baseItem.getTimerId() != null) {
-                    return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(context, R.drawable.ic_record_series_red) : ContextCompat.getDrawable(context, R.drawable.ic_record_red);
-                }
-                break;
-            case Person:
-            case LiveTvProgram:
-                if (baseItem.getTimerId() != null) {
-                    return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(context, R.drawable.ic_record_series_red) : ContextCompat.getDrawable(context, R.drawable.ic_record_red);
-                }
-            case Chapter:
-                break;
+        if (baseItem != null) {
+            switch (type) {
+                case BaseItem:
+                    if (baseItem.getBaseItemType() == BaseItemType.Movie && baseItem.getCriticRating() != null) {
+                        return baseItem.getCriticRating() > 59 ? ContextCompat.getDrawable(context, R.drawable.ic_rt_fresh) : ContextCompat.getDrawable(context, R.drawable.ic_rt_rotten);
+                    } else if (baseItem.getBaseItemType() == BaseItemType.Program && baseItem.getTimerId() != null) {
+                        return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(context, R.drawable.ic_record_series_red) : ContextCompat.getDrawable(context, R.drawable.ic_record_red);
+                    }
+                    break;
+                case Person:
+                case LiveTvProgram:
+                    if (baseItem.getTimerId() != null) {
+                        return baseItem.getSeriesTimerId() != null ? ContextCompat.getDrawable(context, R.drawable.ic_record_series_red) : ContextCompat.getDrawable(context, R.drawable.ic_record_red);
+                    }
+                case Chapter:
+                    break;
+            }
         }
 
         return ContextCompat.getDrawable(context, R.drawable.blank10x10);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -414,7 +414,7 @@ public class CardPresenter extends Presenter {
         } else {
             holder.mCardView.setPlayingIndicator(false);
 
-            if (holder.getItem().getBaseItemType() != BaseItemType.UserView) {
+            if (rowItem.getBaseItem() != null && rowItem.getBaseItemType() != BaseItemType.UserView) {
                 RatingType ratingType = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getDefaultRatingType());
                 if (ratingType == RatingType.RATING_TOMATOES) {
                     Drawable badge = rowItem.getBadgeImage(holder.view.getContext());
@@ -423,7 +423,7 @@ public class CardPresenter extends Presenter {
                         holder.mCardView.setBadgeImage(badge);
                     }
                 } else if (ratingType == RatingType.RATING_STARS &&
-                        rowItem.getBaseItem() != null && rowItem.getBaseItem().getCommunityRating() != null) {
+                        rowItem.getBaseItem().getCommunityRating() != null) {
                     holder.mCardView.setBadgeImage(ContextCompat.getDrawable(viewHolder.view.getContext(), R.drawable.ic_star));
                     holder.mCardView.setRating(rowItem.getBaseItem().getCommunityRating().toString());
                 }


### PR DESCRIPTION
**Changes**
Fixes a crash on the item details screen trying to get a badge image when the base item is null

(I really have no idea _why_ it is null in some cases)

**Issues**
N/A
