### PR TITLE
Use ItemSortBy constants instead of hardcoded strings

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/LibraryDreamService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/LibraryDreamService.kt
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.databinding.DreamLibraryBinding
 import org.jellyfin.androidtv.di.systemApiClient
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
+import org.jellyfin.apiclient.model.querying.ItemSortBy
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.imageApi
@@ -78,7 +79,7 @@ class LibraryDreamService : DreamService() {
 		val response by api.itemsApi.getItemsByUserId(
 			includeItemTypes = listOf("Movie", "Series"),
 			recursive = true,
-			sortBy = listOf("Random"),
+			sortBy = listOf(ItemSortBy.Random),
 			limit = 1,
 			imageTypes = listOf(ImageType.BACKDROP)
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
@@ -4,6 +4,7 @@ import org.jellyfin.androidtv.constant.GridDirection
 import org.jellyfin.androidtv.constant.ImageType
 import org.jellyfin.androidtv.constant.PosterSize
 import org.jellyfin.apiclient.model.entities.SortOrder
+import org.jellyfin.apiclient.model.querying.ItemSortBy
 import org.jellyfin.sdk.api.client.ApiClient
 
 class LibraryPreferences(
@@ -24,7 +25,7 @@ class LibraryPreferences(
 		val filterUnwatchedOnly = Preference.boolean("FilterUnwatchedOnly", false)
 
 		// Item sorting
-		val sortBy = Preference.string("SortBy", "SortName")
+		val sortBy = Preference.string("SortBy", ItemSortBy.SortName)
 		val sortOrder = Preference.enum("SortOrder", SortOrder.Ascending)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/LiveTvPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LiveTvPreferences.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.preference
 
+import org.jellyfin.apiclient.model.querying.ItemSortBy
 import org.jellyfin.sdk.api.client.ApiClient
 
 class LiveTvPreferences(
@@ -9,7 +10,7 @@ class LiveTvPreferences(
 	api = api,
 ) {
 	companion object {
-		val channelOrder = Preference.string("livetv-channelorder", "DatePlayed")
+		val channelOrder = Preference.string("livetv-channelorder", ItemSortBy.DatePlayed)
 		val colorCodeGuide = Preference.boolean("guide-colorcodedbackgrounds", false)
 		val favsAtTop = Preference.boolean("livetv-favoritechannelsattop", true)
 		val showHDIndicator = Preference.boolean("guide-indicator-hd", false)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridFragment.java
@@ -29,6 +29,7 @@ import org.jellyfin.androidtv.ui.presentation.HorizontalGridPresenter;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.entities.SortOrder;
+import org.jellyfin.apiclient.model.querying.ItemSortBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -95,13 +96,13 @@ public class GridFragment extends Fragment {
 
         sortOptions = new HashMap<>();
         {
-            sortOptions.put(0, new SortOption(getString(R.string.lbl_name), "SortName", SortOrder.Ascending));
-            sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), "DateCreated,SortName", SortOrder.Descending));
-            sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), "PremiereDate,SortName", SortOrder.Descending));
-            sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), "OfficialRating,SortName", SortOrder.Ascending));
-            sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), "CommunityRating,SortName", SortOrder.Descending));
-            sortOptions.put(5,new SortOption(getString(R.string.lbl_critic_rating), "CriticRating,SortName", SortOrder.Descending));
-            sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), "DatePlayed,SortName", SortOrder.Descending));
+            sortOptions.put(0, new SortOption(getString(R.string.lbl_name), ItemSortBy.SortName, SortOrder.Ascending));
+            sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), ItemSortBy.DateCreated + "," + ItemSortBy.SortName, SortOrder.Descending));
+            sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), ItemSortBy.PremiereDate + "," + ItemSortBy.SortName, SortOrder.Descending));
+            sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), ItemSortBy.OfficialRating + "," + ItemSortBy.SortName, SortOrder.Ascending));
+            sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), ItemSortBy.CommunityRating + "," + ItemSortBy.SortName, SortOrder.Descending));
+            sortOptions.put(5,new SortOption(getString(R.string.lbl_critic_rating), ItemSortBy.CriticRating + "," + ItemSortBy.SortName, SortOrder.Descending));
+            sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), ItemSortBy.DatePlayed + "," + ItemSortBy.SortName, SortOrder.Descending));
         };
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -55,6 +55,7 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.CollectionType;
+import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 
 import java.util.UUID;
@@ -558,7 +559,7 @@ public class StdGridFragment extends GridFragment {
             public void onResponse() {
                 setStatusText(mFolder.getName());
                 updateCounter(mGridAdapter.getTotalItems() > 0 ? 1 : 0);
-                mLetterButton.setVisibility("SortName".equals(mGridAdapter.getSortBy()) ? View.VISIBLE : View.GONE);
+                mLetterButton.setVisibility(ItemSortBy.SortName.equals(mGridAdapter.getSortBy()) ? View.VISIBLE : View.GONE);
                 setItem(null);
                 if (mGridAdapter.getTotalItems() == 0) {
                     mToolBar.requestFocus();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -46,6 +46,7 @@ import org.jellyfin.apiclient.model.livetv.SeriesTimerQuery;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
+import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.querying.LatestItemsQuery;
 import org.jellyfin.apiclient.model.querying.NextUpQuery;
@@ -397,7 +398,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     mQuery.setSortOrder(option.order);
                     break;
             }
-            if (!"SortName".equals(option.value)) {
+            if (!ItemSortBy.SortName.equals(option.value)) {
                 setStartLetter(null);
             }
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -57,6 +57,7 @@ import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
+import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
@@ -615,7 +616,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
             mSortBy.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
                 public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                    mCurrentSort = position == 0 ? "DatePlayed" : "Number";
+                    mCurrentSort = position == 0 ? ItemSortBy.DatePlayed : ItemSortBy.SortName;
                 }
 
                 @Override
@@ -641,7 +642,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
             mRepeat.setChecked(prefs.get(LiveTvPreferences.Companion.getShowRepeatIndicator()));
             mColorCode.setChecked(prefs.get(LiveTvPreferences.Companion.getColorCodeGuide()));
             mPremiere.setChecked(prefs.get(LiveTvPreferences.Companion.getShowPremiereIndicator()));
-            mSortBy.setSelection(prefs.get(LiveTvPreferences.Companion.getChannelOrder()).equals("DatePlayed") ? 0 : 1);
+            mSortBy.setSelection(prefs.get(LiveTvPreferences.Companion.getChannelOrder()).equals(ItemSortBy.DatePlayed) ? 0 : 1);
 
             mPopup.showAtLocation(mTimelineScroller, Gravity.NO_GRAVITY, mTimelineScroller.getRight(), mSummary.getTop()-20);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -34,6 +34,7 @@ import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
 import org.jellyfin.apiclient.model.livetv.ProgramQuery;
 import org.jellyfin.apiclient.model.livetv.TimerInfoDto;
 import org.jellyfin.apiclient.model.livetv.TimerQuery;
+import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.results.ChannelInfoDtoResult;
 import org.jellyfin.apiclient.model.results.TimerInfoDtoResult;
@@ -130,8 +131,8 @@ public class TvManager {
         query.setUserId(TvApp.getApplication().getCurrentUser().getId());
         query.setAddCurrentProgram(true);
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getFavsAtTop())) query.setEnableFavoriteSorting(true);
-        query.setSortOrder("DatePlayed".equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder())) ? SortOrder.Descending : null);
-        query.setSortBy(new String[] {"DatePlayed".equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder())) ? "DatePlayed" : "SortName"});
+        query.setSortOrder(ItemSortBy.DatePlayed.equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder())) ? SortOrder.Descending : null);
+        query.setSortBy(new String[] {ItemSortBy.DatePlayed.equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder())) ? ItemSortBy.DatePlayed : ItemSortBy.SortName});
         Timber.d("*** About to load channels");
         KoinJavaComponent.<ApiClient>get(ApiClient.class).GetLiveTvChannelsAsync(query, new Response<ChannelInfoDtoResult>() {
             @Override
@@ -169,7 +170,7 @@ public class TvManager {
         int ndx = 0;
         if (allChannels != null) {
             //Sort by last played - if selected
-            if ("DatePlayed".equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder()))) {
+            if (ItemSortBy.DatePlayed.equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder()))) {
                 Collections.sort(allChannels, Collections.reverseOrder(new Comparator<ChannelInfoDto>() {
                     @Override
                     public int compare(ChannelInfoDto lhs, ChannelInfoDto rhs) {
@@ -210,7 +211,7 @@ public class TvManager {
             endNdx = endNdx > channelIds.length ? channelIds.length : endNdx+1; //array copy range final ndx is exclusive
             query.setChannelIds(Arrays.copyOfRange(channelIds, startNdx, endNdx));
             query.setEnableImages(false);
-            query.setSortBy(new String[] {"StartDate"});
+            query.setSortBy(new String[] {ItemSortBy.StartDate});
             Calendar end = (Calendar) endTime.clone();
             end.setTimeZone(TimeZone.getTimeZone("Z"));
             end.add(Calendar.SECOND, -1);

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -29,6 +29,7 @@ import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
+import org.jellyfin.apiclient.model.querying.ItemSortBy;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.koin.java.KoinJavaComponent;
 
@@ -375,7 +376,7 @@ public class KeyProcessor {
                     query.setRecursive(true);
                     query.setIsVirtualUnaired(false);
                     query.setIsMissing(false);
-                    query.setSortBy(new String[]{"SortName"});
+                    query.setSortBy(new String[]{ItemSortBy.SortName});
                     query.setSortOrder(SortOrder.Ascending);
                     query.setLimit(1);
                     query.setExcludeItemTypes(new String[] {"Series","Season","Folder","MusicAlbum","Playlist","BoxSet"});


### PR DESCRIPTION
I wanted to check if all sort fields we use in the app were added in https://github.com/jellyfin/jellyfin/pull/7492. Noticed that we don't always use the constants from the apiclient (yeah sorry SDK doesn't have them :p).

**Changes**
- Use ItemSortBy constants instead of hardcoded strings
- Use "SortName" instead of non-existing "Number" sort field in Live TV
  - I looked at the usages of the value and it's actually always compared with the DatePlayed value, so we could even put gibberish in here. I chose SortName because there is one place where it uses SortName if the value is not DatePlayed

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
