### PR TITLE
fixed playFrom() crash, support queueing entire row (eg: last played)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -140,14 +140,16 @@ public class ItemLauncher {
                         Timber.d("got pos %s", pos);
                         if (rowItem.getBaseItem() == null)
                             return;
+                        MediaManager mediaManager = KoinJavaComponent.<MediaManager>get(MediaManager.class);
+
                         // if the song currently playing is selected (and is the exact item - this only happens in the nowPlayingRow), open AudioNowPlayingActivity
-                        if (KoinJavaComponent.<MediaManager>get(MediaManager.class).hasAudioQueueItems() && rowItem.getBaseItem() == KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioItem()) {
+                        if (mediaManager.hasAudioQueueItems() && rowItem.getBaseItem() == mediaManager.getCurrentAudioItem()) {
                             // otherwise, open AudioNowPlayingActivity
                             Intent nowPlaying = new Intent(activity, AudioNowPlayingActivity.class);
                             activity.startActivity(nowPlaying);
-                        } else if (KoinJavaComponent.<MediaManager>get(MediaManager.class).hasAudioQueueItems() && rowItem instanceof AudioQueueItem && pos < KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueueSize()) {
+                        } else if (mediaManager.hasAudioQueueItems() && rowItem instanceof AudioQueueItem && pos < mediaManager.getCurrentAudioQueueSize()) {
                             Timber.d("playing audio queue item");
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playFrom(pos);
+                            mediaManager.playFrom(pos);
                         } else {
                             Timber.d("playing audio item");
                             List<BaseItemDto> audioItemsAsList = new ArrayList<>();
@@ -156,7 +158,7 @@ public class ItemLauncher {
                                 if (item instanceof BaseRowItem && ((BaseRowItem) item).getBaseItem() != null)
                                     audioItemsAsList.add(((BaseRowItem) item).getBaseItem());
                             }
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(activity, audioItemsAsList, pos, false);
+                            mediaManager.playNow(activity, audioItemsAsList, pos, false);
                         }
 
                         return;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -26,7 +26,6 @@ import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.ui.playback.AudioNowPlayingActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
-import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -139,17 +138,28 @@ public class ItemLauncher {
 
                     case Audio:
                         Timber.d("got pos %s", pos);
-                        // if a song isn't the first in the queue, play it
-                        if (rowItem.getIndex() > KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueuePosition() && rowItem.getIndex() < KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueueSize()) {
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playFrom(rowItem.getIndex());
-                        } else {
+                        if (rowItem.getBaseItem() == null)
+                            return;
+                        // if the song currently playing is selected (and is the exact item - this only happens in the nowPlayingRow), open AudioNowPlayingActivity
+                        if (KoinJavaComponent.<MediaManager>get(MediaManager.class).hasAudioQueueItems() && rowItem.getBaseItem() == KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioItem()) {
                             // otherwise, open AudioNowPlayingActivity
                             Intent nowPlaying = new Intent(activity, AudioNowPlayingActivity.class);
                             activity.startActivity(nowPlaying);
+                        } else if (KoinJavaComponent.<MediaManager>get(MediaManager.class).hasAudioQueueItems() && rowItem instanceof AudioQueueItem && pos < KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueueSize()) {
+                            Timber.d("playing audio queue item");
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playFrom(pos);
+                        } else {
+                            Timber.d("playing audio item");
+                            List<BaseItemDto> audioItemsAsList = new ArrayList<>();
+
+                            for (Object item : adapter.unmodifiableList()) {
+                                if (item instanceof BaseRowItem && ((BaseRowItem) item).getBaseItem() != null)
+                                    audioItemsAsList.add(((BaseRowItem) item).getBaseItem());
+                            }
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(activity, audioItemsAsList, pos, false);
                         }
 
                         return;
-
                     case Season:
                     case RecordingGroup:
                         //Start activity for enhanced browse

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -215,8 +215,8 @@ public class KeyProcessor {
 
         if (rowItem instanceof AudioQueueItem) {
             if (activity instanceof AudioNowPlayingActivity) {
-                if (rowItem.getIndex() > KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueuePosition() && rowItem.getIndex() < KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioQueueSize())
-                menu.getMenu().add(0, MENU_ADVANCE_QUEUE, order++, R.string.lbl_play_from_here);
+                if (rowItem.getBaseItem() != KoinJavaComponent.<MediaManager>get(MediaManager.class).getCurrentAudioItem())
+                    menu.getMenu().add(0, MENU_ADVANCE_QUEUE, order++, R.string.lbl_play_from_here);
             } else {
                 menu.getMenu().add(0, MENU_GOTO_NOW_PLAYING, order++, R.string.lbl_goto_now_playing);
 
@@ -422,8 +422,9 @@ public class KeyProcessor {
                     return true;
                 case MENU_ADVANCE_QUEUE:
                     KoinJavaComponent.<MediaManager>get(MediaManager.class).playFrom(mCurrentRowItemNdx);
+                    return true;
                 case MENU_CLEAR_QUEUE:
-                    KoinJavaComponent.<MediaManager>get(MediaManager.class).clearAudioQueue();
+                    KoinJavaComponent.<MediaManager>get(MediaManager.class).clearAudioQueue(true);
                     return true;
                 case MENU_INSTANT_MIX:
                     PlaybackHelper.playInstantMix(mCurrentActivity, mCurrentItem);


### PR DESCRIPTION
**Changes**
* fixed crash when calling playFrom() where the player was unintentionally released
* clicking on an audio item will now:
> * open NowPlayingActivity if it is the currently playing item
> * use `playFrom()` to skip within the queue (and not affect things like shufffle, etc) if the item belongs to the queue
> * otherwise, start a new session by adding the items in the row to the queue and playing from the selected item's index. This means we can easily play all "last played" songs

* `playNow()` will loop through its input list and create a new list of only audio items. This protects against accidentally adding video items if an entire row is added to the queue. I don't know of any rows that have mixed A/V items but better safe than sorry, and the methods for adding to the video queue already do this.

* changed deprecated `mExoPlayer.stop(boolean)` -> `mExoPlayer.stop()`

**Issues**
* the audio player was being released unintentionally
* playFrom() in the context menu was missing a return statement, which caused some weird behavior
