### PR TITLE
libVLC: Switch to using audio time stretching by default

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -753,7 +753,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
             // Create a new media player
             ArrayList<String> options = new ArrayList<>(20);
             options.add("--network-caching=" + buffer);
-            options.add("--no-audio-time-stretch");
+            options.add("--audio-time-stretch");
             options.add("--avcodec-skiploopfilter");
             options.add("1");
             options.add("--avcodec-skip-frame");


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
This matches libVLC's normal default. Looking back in the project
history this was set to no stretching from the very start @commit
9528b9a3eef1244e32a7f54ed603b2c063bc5981

Since libVLC uses it by default and this wasn't a bug fix I propose we
can opt in the audio stretching by default. This should only trigger when
a user selects a playback speed that isn't 1x anyway.

For future reference, the original changeset was here:
https://github.com/jellyfin/jellyfin-androidtv/commit/9528b9a3eef1244e32a7f54ed603b2c063bc5981#diff-226bb739f67bb7dbde6485e2433c55b1cc25fff3fea24029e5344b0c396657b6R232

**Issues**
None on GitHub, but I have seen it mentioned on Reddit and I was planning on doing this anyway so...

**Testing**
- Ensure libVLC is forced
- Change the speed to 2x 
- It should sound normal. Some cracks and pops are expected when the content and audio rate start to become CPU bound (such as using software emulation)