### PR TITLE
Refactor play logic in PlaybackController

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -174,7 +174,7 @@ public class PlaybackController {
         }
     }
 
-    public void setPlaybackSpeed(@NonNull float speed) {
+    public void setPlaybackSpeed(float speed) {
         mRequestedPlaybackSpeed = speed;
         if (hasInitializedVideoManager()) {
             mVideoManager.setPlaybackSpeed(speed);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -506,10 +506,10 @@ public class PlaybackController {
                 // undo setting mSeekPosition for liveTV
                 if (isLiveTv) mSeekPosition = -1;
 
-                //Build options for each player
-                VideoOptions vlcOptions = buildVLCOptions(forcedSubtitleIndex, item);
-                VideoOptions internalOptions = buildExoPlayerOptions(forcedSubtitleIndex, item);
-                Timber.d("Max bitrate is: %d", Utils.getMaxBitrate());
+                int maxBitrate = Utils.getMaxBitrate();
+                Timber.d("Max bitrate is: %d", maxBitrate);
+                VideoOptions vlcOptions = buildVLCOptions(forcedSubtitleIndex, item, maxBitrate);
+                VideoOptions internalOptions = buildExoPlayerOptions(forcedSubtitleIndex, item, maxBitrate);
 
                 playInternal(getCurrentlyPlayingItem(), position, vlcOptions, internalOptions);
                 mPlaybackState = PlaybackState.BUFFERING;
@@ -527,11 +527,11 @@ public class PlaybackController {
     }
 
     @NonNull
-    private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item) {
+    private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item, int maxBitrate) {
         VideoOptions internalOptions = new VideoOptions();
         internalOptions.setItemId(item.getId());
         internalOptions.setMediaSources(item.getMediaSources());
-        internalOptions.setMaxBitrate(Utils.getMaxBitrate());
+        internalOptions.setMaxBitrate(maxBitrate);
         if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
             internalOptions.setEnableDirectStream(false);
         internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
@@ -554,11 +554,11 @@ public class PlaybackController {
     }
 
     @NonNull
-    private VideoOptions buildVLCOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item) {
+    private VideoOptions buildVLCOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item, int maxBitrate) {
         VideoOptions vlcOptions = new VideoOptions();
         vlcOptions.setItemId(item.getId());
         vlcOptions.setMediaSources(item.getMediaSources());
-        vlcOptions.setMaxBitrate(Utils.getMaxBitrate());
+        vlcOptions.setMaxBitrate(maxBitrate);
         if (vlcErrorEncountered) {
             Timber.i("*** Disabling direct play/stream due to previous error");
             vlcOptions.setEnableDirectStream(false);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -507,43 +507,8 @@ public class PlaybackController {
                 if (isLiveTv) mSeekPosition = -1;
 
                 //Build options for each player
-                VideoOptions vlcOptions = new VideoOptions();
-                vlcOptions.setItemId(item.getId());
-                vlcOptions.setMediaSources(item.getMediaSources());
-                vlcOptions.setMaxBitrate(Utils.getMaxBitrate());
-                if (vlcErrorEncountered) {
-                    Timber.i("*** Disabling direct play/stream due to previous error");
-                    vlcOptions.setEnableDirectStream(false);
-                    vlcOptions.setEnableDirectPlay(false);
-                }
-                vlcOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
-                vlcOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
-                DeviceProfile vlcProfile = new LibVlcProfile(mFragment.getContext(), isLiveTv);
-                vlcOptions.setProfile(vlcProfile);
-
-                VideoOptions internalOptions = new VideoOptions();
-                internalOptions.setItemId(item.getId());
-                internalOptions.setMediaSources(item.getMediaSources());
-                internalOptions.setMaxBitrate(Utils.getMaxBitrate());
-                if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
-                    internalOptions.setEnableDirectStream(false);
-                internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
-                internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
-                internalOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
-                DeviceProfile internalProfile = new BaseProfile();
-                if (DeviceUtils.is60() || userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())) {
-                    internalProfile = new ExoPlayerProfile(
-                            mFragment.getContext(),
-                            isLiveTv,
-                            userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                            userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
-                    );
-                    Timber.i("*** Using extended Exoplayer profile options");
-                } else {
-                    Timber.i("*** Using default android profile");
-                }
-                internalOptions.setProfile(internalProfile);
-
+                VideoOptions vlcOptions = buildVLCOptions(forcedSubtitleIndex, item);
+                VideoOptions internalOptions = buildExoPlayerOptions(forcedSubtitleIndex, item);
                 Timber.d("Max bitrate is: %d", Utils.getMaxBitrate());
 
                 playInternal(getCurrentlyPlayingItem(), position, vlcOptions, internalOptions);
@@ -559,6 +524,51 @@ public class PlaybackController {
 
                 break;
         }
+    }
+
+    @NonNull
+    private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item) {
+        VideoOptions internalOptions = new VideoOptions();
+        internalOptions.setItemId(item.getId());
+        internalOptions.setMediaSources(item.getMediaSources());
+        internalOptions.setMaxBitrate(Utils.getMaxBitrate());
+        if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
+            internalOptions.setEnableDirectStream(false);
+        internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
+        internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
+        internalOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
+        DeviceProfile internalProfile = new BaseProfile();
+        if (DeviceUtils.is60() || userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())) {
+            internalProfile = new ExoPlayerProfile(
+                    mFragment.getContext(),
+                    isLiveTv,
+                    userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
+                    userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
+            );
+            Timber.i("*** Using extended Exoplayer profile options");
+        } else {
+            Timber.i("*** Using default android profile");
+        }
+        internalOptions.setProfile(internalProfile);
+        return internalOptions;
+    }
+
+    @NonNull
+    private VideoOptions buildVLCOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item) {
+        VideoOptions vlcOptions = new VideoOptions();
+        vlcOptions.setItemId(item.getId());
+        vlcOptions.setMediaSources(item.getMediaSources());
+        vlcOptions.setMaxBitrate(Utils.getMaxBitrate());
+        if (vlcErrorEncountered) {
+            Timber.i("*** Disabling direct play/stream due to previous error");
+            vlcOptions.setEnableDirectStream(false);
+            vlcOptions.setEnableDirectPlay(false);
+        }
+        vlcOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
+        vlcOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
+        DeviceProfile vlcProfile = new LibVlcProfile(mFragment.getContext(), isLiveTv);
+        vlcOptions.setProfile(vlcProfile);
+        return vlcOptions;
     }
 
     public int getBufferAmount() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -675,7 +675,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
     }
 
-    public void setPlaybackSpeed(@NonNull float speed) {
+    public void setPlaybackSpeed(float speed) {
         if (speed < 0.25) {
             Timber.w("Invalid playback speed requested: %f", speed);
             return;


### PR DESCRIPTION
**Changes**
- Refactors the video option building from `PlaybackController:play` into private methods. This first step was done as-is so no modifications were made to the actual methods
- Removes the three call sites to `Utils.getMaxBitrate` to a single location

This is a precursor to #1569 and should allow us to:
- Make sense of the diff in the next PR
- Allow us to easily refactor away deprecated `VideoOptions` when the replacement
- Makes the code more readable

**Testing**
- Try to play a video with libVLC and ExoPlayer
