### PR TITLE
Refactor existing callbacks into interface

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -143,7 +143,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         return mFragment;
     }
 
-    public void init(VideoManager mgr, CustomPlaybackOverlayFragment fragment) {
+    public void init(@NonNull VideoManager mgr, @NonNull CustomPlaybackOverlayFragment fragment) {
         mVideoManager = mgr;
         mVideoManager.subscribe(this);
         mFragment = fragment;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerNotifiable.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerNotifiable.kt
@@ -1,0 +1,9 @@
+package org.jellyfin.androidtv.ui.playback
+
+interface PlaybackControllerNotifiable {
+	fun onCompletion()
+	fun onError()
+	fun onPrepared()
+	fun onProgress()
+	fun onPlaybackSpeedChange(newSpeed: Float)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -166,7 +166,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         });
     }
 
-    public void subscribe(PlaybackControllerNotifiable notifier){
+    public void subscribe(@NonNull PlaybackControllerNotifiable notifier){
         mPlaybackControllerNotifiable = notifier;
         setupVLCListeners();
     }


### PR DESCRIPTION
Builds on #1574 

**Changes**
  Many call-backs already exist between the VideoManager and
  PlaybackController. But they are created on an ad-hoc basis in various
  methods.
  
  By extracting these out to a method it means we can:
  - Remove the boilerplate of @Override methods in PlaybackController
  - Easily refactor these into a seperate class long-term
  - Add new handlers
  - Pass parameters around in the future
  - Not have everything dispatch to a simple onEvent.
  
  This also makes extending the interface easier where we have exoplayer
  only notifications (such as onPlaybackSpeedChanged). Since the VLC code
  can simply call the notifier without going through a PlaybackListener

--

I'm not super happy with `PlaybackControllerNotifiable` so I'm open to any/all suggestions on this front, maybe something along the lines of `VideoManagerSignals` (coming from a Qt background)