### PR TITLE
Remove 10.8 check for HLS support

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -46,9 +46,7 @@ import com.bumptech.glide.request.target.Target;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.auth.AuthenticationRepository;
-import org.jellyfin.androidtv.auth.Session;
 import org.jellyfin.androidtv.auth.SessionRepository;
-import org.jellyfin.androidtv.auth.model.Server;
 import org.jellyfin.androidtv.constant.CustomMessage;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
 import org.jellyfin.androidtv.databinding.OverlayTvGuideBinding;
@@ -89,7 +87,6 @@ import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
 import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackEvent;
 import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackInfo;
-import org.jellyfin.sdk.model.ServerVersion;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
@@ -1495,24 +1492,5 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             binding.subtitlesText.setText(span);
             binding.subtitlesText.setVisibility(View.VISIBLE);
         });
-    }
-
-    public boolean getServerVersionEqualOrGreater(@NonNull ServerVersion minServerVersion) {
-        Session session = sessionRepository.getValue().getCurrentSession().getValue();
-        if (session == null) {
-            Timber.d("couldn't compare server versions - session is null");
-            return false;
-        }
-
-        Server server = authenticationRepository.getValue().getServer(session.getServerId());
-        if (server == null) {
-            Timber.d("couldn't compare server versions - server is null");
-            return false;
-        }
-
-        boolean result = server.compareTo(minServerVersion) >= 0;
-        Timber.d("current server version [%s] is %s [%s]", server.getVersion(), result ? ">=" : "<", minServerVersion.toString());
-
-        return result;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -48,7 +48,6 @@ import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackInfo;
 import org.jellyfin.apiclient.model.session.PlayMethod;
-import org.jellyfin.sdk.model.ServerVersion;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
@@ -530,16 +529,10 @@ public class PlaybackController {
                 internalOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
                 DeviceProfile internalProfile = new BaseProfile();
                 if (DeviceUtils.is60() || userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())) {
-                    boolean hlsSupported = false;
-                    if (mFragment != null)
-                        hlsSupported = mFragment.getServerVersionEqualOrGreater(new ServerVersion(10, 8, 0, null));
-                    Timber.d("HLS is %s", hlsSupported ? "allowed" : "disabled");
-
                     internalProfile = new ExoPlayerProfile(
                             isLiveTv,
                             userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                            userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
-                            hlsSupported
+                            userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
                     );
                     Timber.i("*** Using extended Exoplayer profile options");
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -26,7 +26,6 @@ class ExoPlayerProfile(
 	isLiveTV: Boolean = false,
 	isLiveTVDirectPlayEnabled: Boolean = false,
 	isAC3Enabled: Boolean = false,
-	isHlsSupported: Boolean = false,
 ) : BaseProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		Codec.Audio.AAC,
@@ -55,41 +54,22 @@ class ExoPlayerProfile(
 		name = "AndroidTV-ExoPlayer"
 
 		transcodingProfiles = arrayOf(
-			when (isHlsSupported) {
-				// TS video profile
-				true -> TranscodingProfile().apply {
-					type = DlnaProfileType.Video
-					context = EncodingContext.Streaming
-					container = Codec.Container.TS
-					videoCodec = buildList {
-						if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
-						add(Codec.Video.H264)
-					}.joinToString(",")
-					audioCodec = buildList {
-						if (isAC3Enabled) add(Codec.Audio.AC3)
-						add(Codec.Audio.AAC)
-						add(Codec.Audio.MP3)
-					}.joinToString(",")
-					protocol = "hls"
-					copyTimestamps = false
-				}
-				// MKV video profile
-				else -> TranscodingProfile().apply {
-					type = DlnaProfileType.Video
-					context = EncodingContext.Streaming
-					container = Codec.Container.MKV
-					videoCodec = buildList {
-						if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.MKV)) add(Codec.Video.HEVC)
-						add(Codec.Video.H264)
-					}.joinToString(",")
-					audioCodec = buildList {
-						if (isAC3Enabled) add(Codec.Audio.AC3)
-						add(Codec.Audio.AAC)
-						add(Codec.Audio.MP3)
-					}.joinToString(",")
-					protocol = "http"
-					copyTimestamps = true
-				}
+			// TS video profile
+			TranscodingProfile().apply {
+				type = DlnaProfileType.Video
+				context = EncodingContext.Streaming
+				container = Codec.Container.TS
+				videoCodec = buildList {
+					if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
+					add(Codec.Video.H264)
+				}.joinToString(",")
+				audioCodec = buildList {
+					if (isAC3Enabled) add(Codec.Audio.AC3)
+					add(Codec.Audio.AAC)
+					add(Codec.Audio.MP3)
+				}.joinToString(",")
+				protocol = "hls"
+				copyTimestamps = false
 			},
 			// MP3 audio profile
 			TranscodingProfile().apply {


### PR DESCRIPTION
0.14 will only support Jellyfin 10.8 >=. This will be enforced via the SDK (version 1.3).

**Changes**
- Remove 10.8 check for HLS support
  - Partially reverts #1501

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
