### PR TITLE
Migrate NextUp code to Kotlin flows

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
@@ -3,6 +3,9 @@ package org.jellyfin.androidtv.ui.playback.nextup
 import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity
@@ -24,20 +27,24 @@ class NextUpActivity : FragmentActivity() {
 		val useExternalPlayer = intent.getBooleanExtra(EXTRA_USE_EXTERNAL_PLAYER, false)
 
 		// Observe state
-		viewModel.state.observe(this) { state ->
-			when (state) {
-				// Open next item
-				NextUpState.PLAY_NEXT -> {
-					when (useExternalPlayer) {
-						true -> startActivity(Intent(this, ExternalPlayerActivity::class.java))
-						false -> startActivity(Intent(this, PlaybackOverlayActivity::class.java))
+		lifecycleScope.launchWhenCreated {
+			repeatOnLifecycle(Lifecycle.State.STARTED) {
+				viewModel.state.collect { state ->
+					when (state) {
+						// Open next item
+						NextUpState.PLAY_NEXT -> {
+							when (useExternalPlayer) {
+								true -> startActivity(Intent(this@NextUpActivity, ExternalPlayerActivity::class.java))
+								false -> startActivity(Intent(this@NextUpActivity, PlaybackOverlayActivity::class.java))
+							}
+							finish()
+						}
+						// Close activity
+						NextUpState.CLOSE -> finish()
+						// Unknown state
+						else -> Unit
 					}
-					finish()
 				}
-				// Close activity
-				NextUpState.CLOSE -> finish()
-				// Unknown state
-				else -> Unit
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -5,6 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.databinding.FragmentNextUpBinding
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -22,15 +26,19 @@ class NextUpFragment : Fragment() {
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
 		binding = FragmentNextUpBinding.inflate(inflater, container, false)
 
-		viewModel.item.observe(viewLifecycleOwner) { data ->
-			// No data, keep current
-			if (data == null) return@observe
+		viewLifecycleOwner.lifecycleScope.launch {
+			viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+				viewModel.item.collect { data ->
+					// No data, keep current
+					if (data == null) return@collect
 
-			backgroundService.setBackground(data.baseItem)
+					backgroundService.setBackground(data.baseItem)
 
-			binding.logo.setImageBitmap(data.logo)
-			binding.image.setImageBitmap(data.thumbnail)
-			binding.title.text = data.title
+					binding.logo.setImageBitmap(data.logo)
+					binding.image.setImageBitmap(data.thumbnail)
+					binding.title.text = data.title
+				}
+			}
 		}
 
 		binding.fragmentNextUpButtons.apply {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpViewModel.kt
@@ -2,12 +2,12 @@ package org.jellyfin.androidtv.ui.playback.nextup
 
 import android.content.Context
 import android.graphics.Bitmap
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -24,27 +24,26 @@ class NextUpViewModel(
 	private val userPreferences: UserPreferences,
 	private val imageHelper: ImageHelper,
 ) : ViewModel() {
-	private val _item = MutableLiveData<NextUpItemData?>()
-	val item: LiveData<NextUpItemData?> = _item
-	private val _state = MutableLiveData(NextUpState.INITIALIZED)
-	val state: LiveData<NextUpState> = _state
+	private val _item = MutableStateFlow<NextUpItemData?>(null)
+	val item: StateFlow<NextUpItemData?> = _item
+	private val _state = MutableStateFlow(NextUpState.INITIALIZED)
+	val state: StateFlow<NextUpState> = _state
 
 	fun setItemId(id: UUID?) = viewModelScope.launch {
 		if (id == null) {
-			_item.postValue(null)
-			_state.postValue(NextUpState.NO_DATA)
+			_item.value = null
+			_state.value = NextUpState.NO_DATA
 		} else {
-			val item = loadItemData(id)
-			_item.postValue(item)
+			_item.value = loadItemData(id)
 		}
 	}
 
 	fun playNext() {
-		_state.postValue(NextUpState.PLAY_NEXT)
+		_state.value = NextUpState.PLAY_NEXT
 	}
 
 	fun close() {
-		_state.postValue(NextUpState.CLOSE)
+		_state.value = NextUpState.CLOSE
 	}
 
 	@Suppress("TooGenericExceptionCaught", "SwallowedException")


### PR DESCRIPTION
LiveData is no longer the recommended way for live updates in UI. The kotlinx.coroutine flow API is the way to go. Fortunately we already have a bunch of flows in our code (SDK/some repositories) so the migration should be relatively easy.

Some resources:
- https://medium.com/androiddevelopers/migrating-from-livedata-to-kotlins-flow-379292f419fb
- https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
- https://developer.android.com/kotlin/flow
- https://developer.android.com/kotlin/flow/stateflow-and-sharedflow

This PR migrates the next up code.

**Changes**
- Migrate NextUp code to Kotlin flows

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
