### PR TITLE
Migrate LoginViewModel and ServerRepository to Kotlin flow

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/ServerRepository.kt
@@ -1,7 +1,5 @@
 package org.jellyfin.androidtv.auth
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.liveData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
@@ -37,7 +35,7 @@ interface ServerRepository {
 	fun getStoredServers(): List<Server>
 	fun getDiscoveryServers(): Flow<Server>
 
-	fun getServerUsers(server: Server): LiveData<List<User>>
+	fun getServerUsers(server: Server): Flow<List<User>>
 	fun removeServer(serverId: UUID): Boolean
 	fun addServer(address: String): Flow<ServerAdditionState>
 	suspend fun refreshServerInfo(server: Server): Boolean
@@ -103,7 +101,7 @@ class ServerRepositoryImpl(
 		.getUsers(server.id)
 		.orEmpty()
 
-	override fun getServerUsers(server: Server): LiveData<List<User>> = liveData {
+	override fun getServerUsers(server: Server): Flow<List<User>> = flow {
 		val users = mutableListOf<User>()
 
 		users.addAll(getServerStoredUsers(server))


### PR DESCRIPTION
LiveData is no longer the recommended way for live updates in UI. The kotlinx.coroutine flow API is the way to go. Fortunately we already have a bunch of flows in our code (SDK/some repositories) so the migration should be relatively easy.

Some resources:
- https://medium.com/androiddevelopers/migrating-from-livedata-to-kotlins-flow-379292f419fb
- https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
- https://developer.android.com/kotlin/flow
- https://developer.android.com/kotlin/flow/stateflow-and-sharedflow

This PR migrates the login view model and server repository code.

**Changes**
- Migrate LoginViewModel and ServerRepository to Kotlin flow

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
