### PR TITLE
Migrate UserViewsRepository to Kotlin flow

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
@@ -1,14 +1,14 @@
 package org.jellyfin.androidtv.data.repository
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.liveData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import org.jellyfin.apiclient.model.entities.CollectionType
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 
 interface UserViewsRepository {
-	val views: LiveData<Collection<BaseItemDto>>
+	val views: Flow<Collection<BaseItemDto>>
 
 	fun isSupported(collectionType: String?): Boolean
 	fun allowViewSelection(collectionType: String?): Boolean
@@ -17,7 +17,7 @@ interface UserViewsRepository {
 class UserViewsRepositoryImpl(
 	private val api: ApiClient,
 ) : UserViewsRepository {
-	override val views: LiveData<Collection<BaseItemDto>> = liveData {
+	override val views = flow {
 		val views by api.userViewsApi.getUserViews()
 		val filteredViews = views.items
 			.orEmpty()


### PR DESCRIPTION
LiveData is no longer the recommended way for live updates in UI. The kotlinx.coroutine flow API is the way to go. Fortunately we already have a bunch of flows in our code (SDK/some repositories) so the migration should be relatively easy.

Some resources:
- https://medium.com/androiddevelopers/migrating-from-livedata-to-kotlins-flow-379292f419fb
- https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
- https://developer.android.com/kotlin/flow
- https://developer.android.com/kotlin/flow/stateflow-and-sharedflow

This PR migrates the user views repository code. I'm probably redoing this one at some point to make it use a websocket listener (update the value when the server tells us the libraries have changed).

**Changes**
- Migrate UserViewsRepository to Kotlin flow

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
