### PR TITLE
Fix ASPECT_RATIO_BANNER again

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import timber.log.Timber;
 
 public class CardPresenter extends Presenter {
-    private static final double ASPECT_RATIO_BANNER = 1000 / 185;
+    private static final double ASPECT_RATIO_BANNER = 1000.0 / 185.0;
 
     private int mStaticHeight = 300;
     private ImageType mImageType = ImageType.DEFAULT;


### PR DESCRIPTION
This is the banner I used:

![image](https://user-images.githubusercontent.com/2305178/161136605-1eddcf6d-b141-4f44-90df-4272179cd5ff.png)

This is how it looked in 0.13.2

![image](https://user-images.githubusercontent.com/2305178/161136650-c9c211c6-de24-40d3-b26a-b4020ffae5a6.png)

And this is how it looks after my new fix:

![image](https://user-images.githubusercontent.com/2305178/161136684-aa0f7d33-7b44-47b3-8f80-45fd5aae7c66.png)


**Changes**
- Fix ASPECT_RATIO_BANNER again
  - 1000/185=5
  - 1000.0/185.0=5.4054054054-ish

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- Fixes #1589