### PR TITLE
fix getSubtitleStreamIndex returning the wrong index

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -213,7 +213,7 @@ public class PlaybackController {
     }
 
     public int getSubtitleStreamIndex() {
-        return (mCurrentOptions != null && mCurrentOptions.getSubtitleStreamIndex() != null) ? mCurrentOptions.getSubtitleStreamIndex() : mDefaultSubIndex;
+        return (mCurrentOptions != null && mCurrentOptions.getSubtitleStreamIndex() != null) ? mCurrentOptions.getSubtitleStreamIndex() : -1;
     }
 
     public List<SubtitleStreamInfo> getSubtitleStreams() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -942,10 +942,8 @@ public class PlaybackController {
             return;
         }
 
-        // when burnt-in subtitles are selected, these values are set in startItem() as soon as playback starts
+        // when burnt-in subtitles are selected, mCurrentOptions SubtitleStreamIndex is set in startItem() as soon as playback starts
         // otherwise mCurrentOptions SubtitleStreamIndex is kept null until now so we knew subtitles needed to be enabled but weren't already
-        mCurrentOptions.setSubtitleStreamIndex(index);
-        mDefaultSubIndex = index;
 
         switch (streamInfo.getDeliveryMethod()) {
             case Embed:
@@ -954,6 +952,9 @@ public class PlaybackController {
                         // error selecting internal subs
                         if (mFragment != null)
                             Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
+                    } else {
+                        mCurrentOptions.setSubtitleStreamIndex(index);
+                        mDefaultSubIndex = index;
                     }
                     break;
                 }
@@ -970,6 +971,8 @@ public class PlaybackController {
                         if (info != null) {
                             Timber.d("Adding json subtitle track to player");
                             if (mFragment != null) mFragment.addManualSubtitles(info);
+                            mCurrentOptions.setSubtitleStreamIndex(index);
+                            mDefaultSubIndex = index;
                         } else {
                             Timber.e("Empty subtitle result");
                             if (mFragment != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -907,6 +907,8 @@ public class PlaybackController {
         // clear subtitles first
         if (mFragment != null) mFragment.addManualSubtitles(null);
         mVideoManager.disableSubs();
+        // clear the default in case there's an error loading the subtitles
+        mDefaultSubIndex = -1;
 
         // handle setting subtitles as disabled
         // restart playback if turning off burnt-in subtitles


### PR DESCRIPTION
**Changes**
* in `getSubtitleStreamIndex()`, use index from `mCurrentOptions` if valid and -1 otherwise. Following the changes in #1571 mDefaultSubStreamIndex isn't used to determine what's actually being used.
* in `switchSubtitleStream()` only modify `mCurrentOptions SubtitleStreamIndex` and `mDefaultSubIndex` if the subtitles loaded without errors

**Issues**
* if subtitles failed to load, the popup menu for choosing subtitles would show the wrong value/not have "none" selected. I assume reports to the server also used the index for the subtitles that failed to load.