### PR TITLE
patch for clicking on the playing item in the audio now playing row sometimes restarting the song

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -143,7 +143,7 @@ public class ItemLauncher {
                         MediaManager mediaManager = KoinJavaComponent.<MediaManager>get(MediaManager.class);
 
                         // if the song currently playing is selected (and is the exact item - this only happens in the nowPlayingRow), open AudioNowPlayingActivity
-                        if (mediaManager.hasAudioQueueItems() && rowItem.getBaseItem() == mediaManager.getCurrentAudioItem()) {
+                        if (mediaManager.hasAudioQueueItems() && rowItem instanceof AudioQueueItem && rowItem.getBaseItem().getId().equals(mediaManager.getCurrentAudioItem().getId())) {
                             // otherwise, open AudioNowPlayingActivity
                             Intent nowPlaying = new Intent(activity, AudioNowPlayingActivity.class);
                             activity.startActivity(nowPlaying);


### PR DESCRIPTION
**Changes**
* when checking if the chosen item is currently playing, compare item IDs and check if item is in the audio queue instead of comparing objects

**Issues**
* clicking on the currently playing item in the now playing row would often fail the condition that opens the audio now playing activity, and instead just play it (which makes it restart)

**Notes**
* patches code added in #1568 