### PR TITLE
Add UserRepository to replace TvApp.getCurrentUserLiveData()

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/TvApp.java
+++ b/app/src/main/java/org/jellyfin/androidtv/TvApp.java
@@ -3,13 +3,15 @@ package org.jellyfin.androidtv;
 import android.app.Application;
 
 import androidx.annotation.Nullable;
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MediatorLiveData;
 
-import org.jellyfin.androidtv.ui.livetv.TvManager;
+import org.jellyfin.androidtv.auth.UserRepository;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.UserDto;
+import org.jellyfin.sdk.model.api.UserDto;
+import org.koin.java.KoinJavaComponent;
+
+import kotlin.Deprecated;
+import kotlin.ReplaceWith;
 
 public class TvApp extends Application {
     public static final int LIVE_TV_GUIDE_OPTION_ID = 1000;
@@ -19,7 +21,6 @@ public class TvApp extends Application {
     public static final int LIVE_TV_SERIES_OPTION_ID = 5000;
 
     private static TvApp app;
-    private MediatorLiveData<UserDto> currentUser = new MediatorLiveData<UserDto>();
     private BaseItemDto lastPlayedItem;
     private PlaybackController playbackController;
 
@@ -35,21 +36,10 @@ public class TvApp extends Application {
         return app;
     }
 
-    @Deprecated
+    @Deprecated(message = "Use UserRepository", replaceWith = @ReplaceWith(expression = "KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue()", imports = {}))
     @Nullable
     public UserDto getCurrentUser() {
-        return currentUser.getValue();
-    }
-
-    @Deprecated
-    public LiveData<UserDto> getCurrentUserLiveData() {
-        return currentUser;
-    }
-
-    @Deprecated
-    public void setCurrentUser(UserDto currentUser) {
-        this.currentUser.postValue(currentUser);
-        TvManager.clearCache();
+        return KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue();
     }
 
     @Nullable

--- a/app/src/main/java/org/jellyfin/androidtv/auth/UserRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/UserRepository.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.androidtv.auth
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.jellyfin.sdk.model.api.UserDto
+
+interface UserRepository {
+	val currentUser: StateFlow<UserDto?>
+
+	fun updateCurrentUser(user: UserDto?)
+}
+
+class UserRepositoryImpl : UserRepository {
+	override val currentUser = MutableStateFlow<UserDto?>(null)
+
+	override fun updateCurrentUser(user: UserDto?) {
+		if (currentUser.value !== user) currentUser.value = user
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/querying/StdItemQuery.java
@@ -15,7 +15,7 @@ public class StdItemQuery extends ItemQuery {
                     ItemFields.ChildCount
             };
         }
-        setUserId(TvApp.getApplication().getCurrentUser().getId());
+        setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         setFields(fields);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -4,6 +4,8 @@ import androidx.work.WorkManager
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.auth.ServerRepository
 import org.jellyfin.androidtv.auth.ServerRepositoryImpl
+import org.jellyfin.androidtv.auth.UserRepository
+import org.jellyfin.androidtv.auth.UserRepositoryImpl
 import org.jellyfin.androidtv.data.eventhandling.SocketHandler
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
@@ -86,6 +88,7 @@ val appModule = module {
 	factory { WorkManager.getInstance(androidContext()) }
 
 	single<ServerRepository> { ServerRepositoryImpl(get(), get(), get()) }
+	single<UserRepository> { UserRepositoryImpl() }
 	single<UserViewsRepository> { UserViewsRepositoryImpl(get(userApiClient)) }
 
 	viewModel { LoginViewModel(get(), get(), get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.di
 
 import androidx.core.content.getSystemService
-import org.jellyfin.androidtv.JellyfinApplication
 import org.jellyfin.androidtv.auth.AccountManagerHelper
 import org.jellyfin.androidtv.auth.ApiBinder
 import org.jellyfin.androidtv.auth.AuthenticationRepository
@@ -9,7 +8,6 @@ import org.jellyfin.androidtv.auth.AuthenticationRepositoryImpl
 import org.jellyfin.androidtv.auth.AuthenticationStore
 import org.jellyfin.androidtv.auth.SessionRepository
 import org.jellyfin.androidtv.auth.SessionRepositoryImpl
-import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -20,7 +18,7 @@ val authModule = module {
 		AuthenticationRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(), get(defaultDeviceInfo))
 	}
 	single<SessionRepository> {
-		SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient), get(), get(defaultDeviceInfo))
+		SessionRepositoryImpl(get(), get(), get(), get(), get(userApiClient), get(systemApiClient), get(), get(defaultDeviceInfo), get())
 	}
-	single { ApiBinder(androidApplication() as JellyfinApplication, get(), get()) }
+	single { ApiBinder(get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
@@ -7,7 +7,7 @@ import android.widget.RelativeLayout
 import androidx.core.view.isVisible
 import com.bumptech.glide.Glide
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.TvApp
+import org.jellyfin.androidtv.auth.UserRepository
 import org.jellyfin.androidtv.databinding.ClockUserBugBinding
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
@@ -15,7 +15,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.getActivity
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
+import org.koin.core.component.inject
 
 class ClockUserView @JvmOverloads constructor(
 	context: Context,
@@ -24,9 +24,11 @@ class ClockUserView @JvmOverloads constructor(
 	defStyleRes: Int = 0,
 ) : RelativeLayout(context, attrs, defStyleAttr, defStyleRes), KoinComponent {
 	private val binding: ClockUserBugBinding = ClockUserBugBinding.inflate(LayoutInflater.from(context), this, true)
+	private val userPreferences by inject<UserPreferences>()
+	private val userRepository by inject<UserRepository>()
 
 	init {
-		val showClock = get<UserPreferences>()[UserPreferences.clockBehavior]
+		val showClock = userPreferences[UserPreferences.clockBehavior]
 
 		binding.clock.isVisible = when (showClock) {
 			ClockBehavior.ALWAYS -> true
@@ -35,9 +37,9 @@ class ClockUserView @JvmOverloads constructor(
 			ClockBehavior.IN_MENUS -> context.getActivity() !is PlaybackOverlayActivity
 		}
 
-		val currentUser = TvApp.getApplication()?.currentUser
+		val currentUser = userRepository.currentUser.value
 
-		if (currentUser != null && !isInEditMode) {
+		if (currentUser != null) {
 			if (currentUser.primaryImageTag != null) {
 				Glide.with(context)
 					.load(ImageUtils.getPrimaryImageUrl(currentUser))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemListView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemListView.java
@@ -84,7 +84,7 @@ public class ItemListView extends FrameLayout {
                 ItemFields.MediaSources,
                 ItemFields.ChildCount
         });
-        query.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        query.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         String[] ids = new String[mItemIds.size()];
         query.setIds(mItemIds.toArray(ids));
         KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemsAsync(query, new Response<ItemsResult>() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopup.java
@@ -175,7 +175,7 @@ public class LiveProgramDetailPopup {
                                         @Override
                                         public void onResponse() {
                                             // we have to re-retrieve the program to get the timer id
-                                            apiClient.getValue().GetLiveTvProgramAsync(mProgram.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                                            apiClient.getValue().GetLiveTvProgramAsync(mProgram.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                                 @Override
                                                 public void onResponse(BaseItemDto response) {
                                                     mProgram = response;
@@ -261,7 +261,7 @@ public class LiveProgramDetailPopup {
                                             @Override
                                             public void onResponse() {
                                                 // we have to re-retrieve the program to get the timer id
-                                                apiClient.getValue().GetLiveTvProgramAsync(mProgram.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                                                apiClient.getValue().GetLiveTvProgramAsync(mProgram.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                                     @Override
                                                     public void onResponse(BaseItemDto response) {
                                                         mProgram = response;
@@ -355,7 +355,7 @@ public class LiveProgramDetailPopup {
         fave.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                apiClient.getValue().UpdateFavoriteStatusAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId(), !channel.getUserData().getIsFavorite(), new Response<UserItemDataDto>() {
+                apiClient.getValue().UpdateFavoriteStatusAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), !channel.getUserData().getIsFavorite(), new Response<UserItemDataDto>() {
                     @Override
                     public void onResponse(UserItemDataDto response) {
                         channel.setUserData(response);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
@@ -164,7 +164,7 @@ public class RecordPopup {
                             mPopup.dismiss();
                             mActivity.sendMessage(CustomMessage.ActionComplete);
                             // we have to re-retrieve the program to get the timer id
-                            apiClient.getValue().GetLiveTvProgramAsync(mProgramId, TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                            apiClient.getValue().GetLiveTvProgramAsync(mProgramId, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
                                     mSelectedView.setRecTimer(response.getTimerId());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -54,7 +54,7 @@ public class BrowseGridFragment extends StdGridFragment {
                     String includeType = getActivity().getIntent().getStringExtra(Extras.IncludeType);
                     if ("AlbumArtist".equals(includeType)) {
                         ArtistsQuery albumArtists = new ArtistsQuery();
-                        albumArtists.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                        albumArtists.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                         albumArtists.setFields(new ItemFields[]{
                                 ItemFields.PrimaryImageAspectRatio,
                                 ItemFields.ItemCounts,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -48,7 +48,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount
         });
-        recordings.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        recordings.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         recordings.setEnableImages(true);
         recordings.setLimit(40);
         mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_recent_recordings), recordings, 40));
@@ -60,7 +60,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount
         });
-        movies.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        movies.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         movies.setEnableImages(true);
         movies.setIsMovie(true);
         BrowseRowDef moviesDef = new BrowseRowDef(mActivity.getString(R.string.lbl_movies), movies, 60);
@@ -72,7 +72,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount
         });
-        shows.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        shows.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         shows.setEnableImages(true);
         shows.setIsSeries(true);
         BrowseRowDef showsDef = new BrowseRowDef(mActivity.getString(R.string.lbl_tv_series), shows, 60);
@@ -87,7 +87,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount
         });
-        sports.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        sports.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         sports.setEnableImages(true);
         sports.setIsSports(true);
         mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_sports), sports, 60));
@@ -99,14 +99,14 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
                 ItemFields.PrimaryImageAspectRatio,
                 ItemFields.ChildCount
         });
-        kids.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        kids.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         kids.setEnableImages(true);
         kids.setIsKids(true);
         mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_kids), kids, 60));
 
         //All Recordings by group - will only be there for non-internal TV
         RecordingGroupQuery recordingGroups = new RecordingGroupQuery();
-        recordingGroups.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        recordingGroups.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_all_recordings), recordingGroups));
 
         rowLoader.loadRows(mRows);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -42,6 +42,7 @@ import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import kotlin.Lazy;
 import timber.log.Timber;
@@ -131,7 +132,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Next up
                 NextUpQuery nextUpQuery = new NextUpQuery();
-                nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 nextUpQuery.setLimit(50);
                 nextUpQuery.setParentId(mFolder.getId());
                 nextUpQuery.setImageTypeLimit(1);
@@ -152,7 +153,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                             ItemFields.Overview,
                             ItemFields.ChildCount
                     });
-                    newQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                    newQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                     newQuery.setIncludeItemTypes(new String[]{"Episode"});
                     newQuery.setParentId(mFolder.getId());
                     newQuery.setRecursive(true);
@@ -262,7 +263,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                         ItemFields.ChannelInfo,
                         ItemFields.ChildCount
                 });
-                onNow.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                onNow.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 onNow.setImageTypeLimit(1);
                 onNow.setEnableTotalRecordCount(false);
                 onNow.setLimit(150);
@@ -270,7 +271,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Upcoming
                 RecommendedProgramQuery upcomingTv = new RecommendedProgramQuery();
-                upcomingTv.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                upcomingTv.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 upcomingTv.setFields(new ItemFields[]{
                         ItemFields.Overview,
                         ItemFields.PrimaryImageAspectRatio,
@@ -286,14 +287,14 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                 //Fav Channels
                 LiveTvChannelQuery favTv = new LiveTvChannelQuery();
-                favTv.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                favTv.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 favTv.setEnableFavoriteSorting(true);
                 favTv.setIsFavorite(true);
                 mRows.add(new BrowseRowDef(getString(R.string.lbl_favorite_channels), favTv));
 
                 //Other Channels
                 LiveTvChannelQuery otherTv = new LiveTvChannelQuery();
-                otherTv.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                otherTv.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 otherTv.setIsFavorite(false);
                 mRows.add(new BrowseRowDef(getString(R.string.lbl_other_channels), otherTv));
 
@@ -304,7 +305,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                recordings.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                recordings.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 recordings.setEnableImages(true);
                 recordings.setLimit(40);
 
@@ -367,12 +368,12 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                                             ItemFields.PrimaryImageAspectRatio,
                                             ItemFields.ChildCount
                                     });
-                                    recordings.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                                    recordings.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                                     recordings.setEnableImages(true);
                                     mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_recent_recordings), recordings, 50));
                                     //All Recordings by group - will only be there for non-internal TV
                                     RecordingGroupQuery recordingGroups = new RecordingGroupQuery();
-                                    recordingGroups.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                                    recordingGroups.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                                     mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_all_recordings), recordingGroups));
                                     rowLoader.loadRows(mRows);
 
@@ -428,11 +429,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
             default:
                 // Fall back to rows defined by the view children
                 final List<BrowseRowDef> rows = new ArrayList<>();
-                final String userId = TvApp.getApplication().getCurrentUser().getId();
+                final UUID userId = TvApp.getApplication().getCurrentUser().getId();
 
                 ItemQuery query = new ItemQuery();
                 query.setParentId(mFolder.getId());
-                query.setUserId(userId);
+                query.setUserId(userId.toString());
                 query.setImageTypeLimit(1);
                 query.setSortBy(new String[]{ItemSortBy.SortName});
 
@@ -443,7 +444,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                             for (BaseItemDto item : response.getItems()) {
                                 ItemQuery rowQuery = new StdItemQuery();
                                 rowQuery.setParentId(item.getId());
-                                rowQuery.setUserId(userId);
+                                rowQuery.setUserId(userId.toString());
                                 rows.add(new BrowseRowDef(item.getName(), rowQuery, 60, new ChangeTriggerType[]{ChangeTriggerType.LibraryUpdated}));
                             }
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.java
@@ -21,7 +21,7 @@ public class ByGenreFragment extends BrowseFolderFragment {
             genres.setSortBy(new String[]{ItemSortBy.SortName});
             if (includeType != null) genres.setIncludeItemTypes(new String[]{includeType});
             genres.setRecursive(true);
-            genres.setUserId(TvApp.getApplication().getCurrentUser().getId());
+            genres.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
             KoinJavaComponent.<ApiClient>get(ApiClient.class).GetGenresAsync(genres, new Response<ItemsResult>() {
                 @Override
                 public void onResponse(ItemsResult response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
@@ -30,7 +30,7 @@ public class GenericFolderFragment extends EnhancedBrowseFragment {
 
         if (mFolder.getBaseItemType() == BaseItemType.RecordingGroup){
             RecordingQuery query = new RecordingQuery();
-            query.setUserId(TvApp.getApplication().getCurrentUser().getId());
+            query.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
             query.setGroupId(mFolder.getId());
             query.setFields(new ItemFields[] {
                     ItemFields.PrimaryImageAspectRatio,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
@@ -28,7 +28,7 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
         StdItemQuery lastPlayed = new StdItemQuery();
         lastPlayed.setParentId(mFolder.getId());
         lastPlayed.setIncludeItemTypes(new String[]{"Movie"});
-        lastPlayed.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        lastPlayed.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         lastPlayed.setSortOrder(SortOrder.Descending);
         lastPlayed.setSortBy(new String[]{ItemSortBy.DatePlayed});
         lastPlayed.setLimit(8);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
@@ -27,7 +27,7 @@ public class ChannelCardView extends FrameLayout {
         if (program != null) {
             if (program.getEndDate() != null && System.currentTimeMillis() > TimeUtils.convertToLocalDate(program.getEndDate()).getTime()) {
                 //need to update program
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         if (response.getCurrentProgram() != null)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -100,13 +100,13 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 			val homesections = userSettingPreferences.homesections
 
 			// Check for live TV support
-			if (homesections.contains(HomeSectionType.LIVE_TV) && currentUser.policy.enableLiveTvAccess) {
+			if (homesections.contains(HomeSectionType.LIVE_TV) && currentUser.policy?.enableLiveTvAccess == true) {
 				// This is kind of ugly, but it mirrors how web handles the live TV rows on the home screen
 				// If we can retrieve one live TV recommendation, then we should display the rows
 				callApi<ItemsResult> {
 					apiClient.GetRecommendedLiveTvProgramsAsync(
 						RecommendedProgramQuery().apply {
-							userId = currentUser.id
+							userId = currentUser.id.toString()
 							enableTotalRecordCount = false
 							imageTypeLimit = 1
 							isAiring = true
@@ -118,7 +118,7 @@ class HomeFragment : StdRowsFragment(), AudioEventListener {
 			}
 
 			if (homesections.contains(HomeSectionType.LATEST_MEDIA)) {
-				views = callApi<ItemsResult> { apiClient.GetUserViews(currentUser.id, it) }
+				views = callApi<ItemsResult> { apiClient.GetUserViews(currentUser.id.toString(), it) }
 			}
 
 			// Make sure the rows are empty

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -62,7 +62,7 @@ class HomeFragmentHelper(
 				ItemFields.ChildCount
 			)
 
-			userId = TvApp.getApplication()!!.currentUser!!.id
+			userId = TvApp.getApplication()!!.currentUser!!.id.toString()
 			enableImages = true
 			limit = ITEM_LIMIT_RECORDINGS
 		}
@@ -72,7 +72,7 @@ class HomeFragmentHelper(
 
 	fun loadNextUp(): HomeFragmentRow {
 		val query = NextUpQuery().apply {
-			userId = TvApp.getApplication()!!.currentUser!!.id
+			userId = TvApp.getApplication()!!.currentUser!!.id.toString()
 			imageTypeLimit = 1
 			limit = ITEM_LIMIT_NEXT_UP
 			fields = arrayOf(
@@ -94,7 +94,7 @@ class HomeFragmentHelper(
 				ItemFields.ChannelInfo,
 				ItemFields.ChildCount
 			)
-			userId = TvApp.getApplication()!!.currentUser!!.id
+			userId = TvApp.getApplication()!!.currentUser!!.id.toString()
 			imageTypeLimit = 1
 			enableTotalRecordCount = false
 			limit = ITEM_LIMIT_ON_NOW

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.kt
@@ -20,7 +20,7 @@ class HomeFragmentLatestRow(
 		val configuration = TvApp.getApplication()!!.currentUser!!.configuration
 
 		// Create a list of views to include
-		val latestItemsExcludes = configuration.latestItemsExcludes
+		val latestItemsExcludes = configuration?.latestItemsExcludes.orEmpty()
 		views.items
 			.filterNot { item -> item.collectionType in EXCLUDED_COLLECTION_TYPES || item.id in latestItemsExcludes }
 			.map { item ->

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -259,7 +259,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         TvApp.getApplication().setLastPlayedItem(null); //blank this out so a detail screen we back up to doesn't also do this
                     } else {
                         Timber.d("Updating info after playback");
-                        apiClient.getValue().GetItemAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                        apiClient.getValue().GetItemAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                             @Override
                             public void onResponse(BaseItemDto response) {
                                 if (!isFinishing()) {
@@ -367,12 +367,12 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
         if (mChannelId != null && mProgramInfo == null) {
             // if we are displaying a live tv channel - we want to get whatever is showing now on that channel
             final FullDetailsActivity us = this;
-            apiClient.getValue().GetLiveTvChannelAsync(mChannelId, TvApp.getApplication().getCurrentUser().getId(), new Response<ChannelInfoDto>() {
+            apiClient.getValue().GetLiveTvChannelAsync(mChannelId, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<ChannelInfoDto>() {
                 @Override
                 public void onResponse(ChannelInfoDto response) {
                     mProgramInfo = response.getCurrentProgram();
                     mItemId = mProgramInfo.getId();
-                    apiClient.getValue().GetItemAsync(mItemId, TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                    apiClient.getValue().GetItemAsync(mItemId, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                         @Override
                         public void onResponse(BaseItemDto response) {
                             setBaseItem(response);
@@ -391,7 +391,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
 
             setBaseItem(item);
         } else {
-            apiClient.getValue().GetItemAsync(id, TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+            apiClient.getValue().GetItemAsync(id, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                 @Override
                 public void onResponse(BaseItemDto response) {
                     setBaseItem(response);
@@ -566,7 +566,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                similar.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                similar.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 similar.setId(mBaseItem.getId());
                 similar.setLimit(10);
 
@@ -589,7 +589,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                similarTrailer.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                similarTrailer.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 similarTrailer.setId(mBaseItem.getId());
                 similarTrailer.setLimit(10);
 
@@ -604,7 +604,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                personMovies.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                personMovies.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 personMovies.setPersonIds(new String[] {mBaseItem.getId()});
                 personMovies.setRecursive(true);
                 personMovies.setIncludeItemTypes(new String[] {"Movie"});
@@ -618,7 +618,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.DisplayPreferencesId,
                         ItemFields.ChildCount
                 });
-                personSeries.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                personSeries.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 personSeries.setPersonIds(new String[] {mBaseItem.getId()});
                 personSeries.setRecursive(true);
                 personSeries.setIncludeItemTypes(new String[] {"Series"});
@@ -632,7 +632,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.DisplayPreferencesId,
                         ItemFields.ChildCount
                 });
-                personEpisodes.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                personEpisodes.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 personEpisodes.setPersonIds(new String[] {mBaseItem.getId()});
                 personEpisodes.setRecursive(true);
                 personEpisodes.setIncludeItemTypes(new String[] {"Episode"});
@@ -648,7 +648,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                artistAlbums.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                artistAlbums.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 artistAlbums.setArtistIds(new String[]{mBaseItem.getId()});
                 artistAlbums.setRecursive(true);
                 artistAlbums.setIncludeItemTypes(new String[]{"MusicAlbum"});
@@ -658,7 +658,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 break;
             case Series:
                 NextUpQuery nextUpQuery = new NextUpQuery();
-                nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 nextUpQuery.setSeriesId(mBaseItem.getId());
                 nextUpQuery.setFields(new ItemFields[]{
                         ItemFields.PrimaryImageAspectRatio,
@@ -669,7 +669,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
 
                 SeasonQuery seasons = new SeasonQuery();
                 seasons.setSeriesId(mBaseItem.getId());
-                seasons.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                seasons.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 seasons.setFields(new ItemFields[] {
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.DisplayPreferencesId,
@@ -679,7 +679,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 addItemRow(adapter, seasonsAdapter, 1, getString(R.string.lbl_seasons));
 
                 UpcomingEpisodesQuery upcoming = new UpcomingEpisodesQuery();
-                upcoming.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                upcoming.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 upcoming.setParentId(mBaseItem.getId());
                 upcoming.setFields(new ItemFields[]{
                         ItemFields.PrimaryImageAspectRatio,
@@ -700,7 +700,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         ItemFields.DisplayPreferencesId,
                         ItemFields.ChildCount
                 });
-                similarSeries.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                similarSeries.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                 similarSeries.setId(mBaseItem.getId());
                 similarSeries.setLimit(20);
                 ItemRowAdapter similarAdapter = new ItemRowAdapter(similarSeries, QueryType.SimilarSeries, new CardPresenter(), adapter);
@@ -789,7 +789,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     }
 
     private void playTrailers() {
-        apiClient.getValue().GetLocalTrailersAsync(TvApp.getApplication().getCurrentUser().getId(), mBaseItem.getId(), new Response<BaseItemDto[]>() {
+        apiClient.getValue().GetLocalTrailersAsync(TvApp.getApplication().getCurrentUser().getId().toString(), mBaseItem.getId(), new Response<BaseItemDto[]>() {
             @Override
             public void onResponse(BaseItemDto[] response) {
                 play(response, 0, false);
@@ -842,7 +842,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
 
     private void toggleFavorite() {
         UserItemDataDto data = mBaseItem.getUserData();
-        apiClient.getValue().UpdateFavoriteStatusAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
+        apiClient.getValue().UpdateFavoriteStatusAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
             @Override
             public void onResponse(UserItemDataDto response) {
                 mBaseItem.setUserData(response);
@@ -907,7 +907,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                 if (mBaseItem.getBaseItemType() == BaseItemType.Series) {
                     //play next up
                     NextUpQuery nextUpQuery = new NextUpQuery();
-                    nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                    nextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                     nextUpQuery.setSeriesId(mBaseItem.getId());
                     apiClient.getValue().GetNextUpEpisodesAsync(nextUpQuery, new Response<ItemsResult>() {
                         @Override
@@ -1047,7 +1047,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                                         @Override
                                         public void onResponse() {
                                             // we have to re-retrieve the program to get the timer id
-                                            apiClient.getValue().GetLiveTvProgramAsync(mProgramInfo.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                                            apiClient.getValue().GetLiveTvProgramAsync(mProgramInfo.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                                 @Override
                                                 public void onResponse(BaseItemDto response) {
                                                     mProgramInfo = response;
@@ -1109,7 +1109,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                                         @Override
                                         public void onResponse() {
                                             // we have to re-retrieve the program to get the timer id
-                                            apiClient.getValue().GetLiveTvProgramAsync(mProgramInfo.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                                            apiClient.getValue().GetLiveTvProgramAsync(mProgramInfo.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                                 @Override
                                                 public void onResponse(BaseItemDto response) {
                                                     mProgramInfo = response;
@@ -1216,7 +1216,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
 
             //now go get our prev episode id
             EpisodeQuery adjacent = new EpisodeQuery();
-            adjacent.setUserId(TvApp.getApplication().getCurrentUser().getId());
+            adjacent.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
             adjacent.setSeriesId(mBaseItem.getSeriesId());
             adjacent.setAdjacentTo(mBaseItem.getId());
             apiClient.getValue().GetEpisodesAsync(adjacent, new Response<ItemsResult>() {
@@ -1374,7 +1374,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
             @Override
             public boolean onMenuItemClick(MenuItem menuItem) {
                 selectedVersionPopupIndex = menuItem.getItemId();
-                apiClient.getValue().GetItemAsync(versions.get(selectedVersionPopupIndex).getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                apiClient.getValue().GetItemAsync(versions.get(selectedVersionPopupIndex).getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         mBaseItem = response;
@@ -1504,7 +1504,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                         @Override
                         public void onResponse() {
                             // we have to re-retrieve the program to get the timer id
-                            apiClient.getValue().GetLiveTvProgramAsync(mProgramInfo.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                            apiClient.getValue().GetLiveTvProgramAsync(mProgramInfo.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
                                     setRecTimer(response.getTimerId());
@@ -1569,7 +1569,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     };
 
     private void markPlayed() {
-        apiClient.getValue().MarkPlayedAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId(), null, new Response<UserItemDataDto>() {
+        apiClient.getValue().MarkPlayedAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), null, new Response<UserItemDataDto>() {
             @Override
             public void onResponse(UserItemDataDto response) {
                 mBaseItem.setUserData(response);
@@ -1594,7 +1594,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     }
 
     private void markUnPlayed() {
-        apiClient.getValue().MarkUnplayedAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<UserItemDataDto>() {
+        apiClient.getValue().MarkUnplayedAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<UserItemDataDto>() {
             @Override
             public void onResponse(UserItemDataDto response) {
                 mBaseItem.setUserData(response);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -360,7 +360,7 @@ public class ItemListActivity extends FragmentActivity {
                 setBaseItem(queue);
                 break;
             default:
-                apiClient.getValue().GetItemAsync(id, TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                apiClient.getValue().GetItemAsync(id, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         setBaseItem(response);
@@ -411,7 +411,7 @@ public class ItemListActivity extends FragmentActivity {
                 default:
                     PlaylistItemQuery playlistSongs = new PlaylistItemQuery();
                     playlistSongs.setId(mBaseItem.getId());
-                    playlistSongs.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                    playlistSongs.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                     playlistSongs.setFields(new ItemFields[]{
                             ItemFields.PrimaryImageAspectRatio,
                             ItemFields.Genres,
@@ -616,7 +616,7 @@ public class ItemListActivity extends FragmentActivity {
                     @Override
                     public void onClick(final View v) {
                         UserItemDataDto data = mBaseItem.getUserData();
-                        apiClient.getValue().UpdateFavoriteStatusAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
+                        apiClient.getValue().UpdateFavoriteStatusAsync(mBaseItem.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
                             @Override
                             public void onResponse(UserItemDataDto response) {
                                 mBaseItem.setUserData(response);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -22,11 +22,11 @@ import org.jellyfin.apiclient.model.apiclient.ServerInfo;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
-import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
 import org.jellyfin.apiclient.model.search.SearchHint;
+import org.jellyfin.sdk.model.api.UserDto;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -492,7 +492,7 @@ public class BaseRowItem {
     public void refresh(final EmptyResponse outerResponse) {
         switch (type) {
             case BaseItem:
-                apiClient.getValue().GetItemAsync(getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                apiClient.getValue().GetItemAsync(getItemId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         baseItem = response;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.ui.itemhandling;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.view.KeyEvent;
 
 import androidx.core.util.Consumer;
 
@@ -258,7 +257,7 @@ public class ItemLauncher {
             case Chapter:
                 final ChapterItemInfo chapter = rowItem.getChapterInfo();
                 //Start playback of the item at the chapter point
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(chapter.getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(chapter.getItemId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         List<BaseItemDto> items = new ArrayList<>();
@@ -277,7 +276,7 @@ public class ItemLauncher {
             case SearchHint:
                 final SearchHint hint = rowItem.getSearchHint();
                 //Retrieve full item for display and playback
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(hint.getItemId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(hint.getItemId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         if (response.getIsFolderItem() && response.getBaseItemType() != BaseItemType.Series) {
@@ -334,7 +333,7 @@ public class ItemLauncher {
                     case Play:
                         if (program.getPlayAccess() == PlayAccess.Full) {
                             //Just play it directly - need to retrieve program channel via items api to convert to BaseItem
-                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(program.getChannelId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(program.getChannelId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
                                     List<BaseItemDto> items = new ArrayList<>();
@@ -356,7 +355,7 @@ public class ItemLauncher {
             case LiveTvChannel:
                 //Just tune to it by playing
                 final ChannelInfoDto channel = rowItem.getChannelInfo();
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         PlaybackHelper.getItemsToPlay(response, false, false, new Response<List<BaseItemDto>>() {
@@ -388,7 +387,7 @@ public class ItemLauncher {
                     case Play:
                         if (rowItem.getRecordingInfo().getPlayAccess() == PlayAccess.Full) {
                             //Just play it directly but need to retrieve as base item
-                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(rowItem.getRecordingInfo().getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(rowItem.getRecordingInfo().getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
                                     Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(rowItem.getBaseItemType());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -35,7 +35,6 @@ import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
-import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery;
@@ -59,6 +58,7 @@ import org.jellyfin.apiclient.model.results.SeriesTimerInfoDtoResult;
 import org.jellyfin.apiclient.model.search.SearchHint;
 import org.jellyfin.apiclient.model.search.SearchHintResult;
 import org.jellyfin.apiclient.model.search.SearchQuery;
+import org.jellyfin.sdk.model.api.UserDto;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.Calendar;
@@ -163,7 +163,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mQuery = query;
-        mQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         this.chunkSize = chunkSize;
         this.preferParentThumb = preferParentThumb;
         this.staticHeight = staticHeight;
@@ -177,7 +177,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mQuery = query;
-        mQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         this.chunkSize = chunkSize;
         this.preferParentThumb = preferParentThumb;
         this.staticHeight = staticHeight;
@@ -195,7 +195,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mArtistsQuery = query;
-        mArtistsQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mArtistsQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         staticHeight = true;
         this.chunkSize = chunkSize;
         if (chunkSize > 0) {
@@ -208,7 +208,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mNextUpQuery = query;
-        mNextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mNextUpQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         queryType = QueryType.NextUp;
         this.preferParentThumb = preferParentThumb;
         this.staticHeight = true;
@@ -225,7 +225,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mLatestQuery = query;
-        mLatestQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mLatestQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         queryType = QueryType.LatestItems;
         this.preferParentThumb = preferParentThumb;
         staticHeight = true;
@@ -314,7 +314,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mSimilarQuery = query;
-        mSimilarQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mSimilarQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         this.queryType = queryType;
     }
 
@@ -322,7 +322,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mUpcomingQuery = query;
-        mUpcomingQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mUpcomingQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         queryType = QueryType.Upcoming;
     }
 
@@ -330,7 +330,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mSeasonQuery = query;
-        mSeasonQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mSeasonQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         queryType = QueryType.Season;
     }
 
@@ -339,7 +339,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         mParent = parent;
         this.chunkSize = chunkSize;
         mPersonsQuery = query;
-        mPersonsQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mPersonsQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         if (chunkSize > 0) {
             mPersonsQuery.setLimit(chunkSize);
         }
@@ -350,7 +350,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
         super(presenter);
         mParent = parent;
         mSearchQuery = query;
-        mSearchQuery.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        mSearchQuery.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         mSearchQuery.setLimit(50);
         queryType = QueryType.Search;
     }
@@ -736,7 +736,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
     private void retrieveViews() {
         final ItemRowAdapter adapter = this;
         final UserDto user = TvApp.getApplication().getCurrentUser();
-        apiClient.getValue().GetUserViews(user.getId(), new Response<ItemsResult>() {
+        apiClient.getValue().GetUserViews(user.getId().toString(), new Response<ItemsResult>() {
             @Override
             public void onResponse(ItemsResult response) {
                 if (response.getTotalRecordCount() > 0) {
@@ -1335,7 +1335,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
 
     private void retrieve(final SpecialsQuery query) {
         final ItemRowAdapter adapter = this;
-        apiClient.getValue().GetSpecialFeaturesAsync(TvApp.getApplication().getCurrentUser().getId(), query.getItemId(), new Response<BaseItemDto[]>() {
+        apiClient.getValue().GetSpecialFeaturesAsync(TvApp.getApplication().getCurrentUser().getId().toString(), query.getItemId(), new Response<BaseItemDto[]>() {
             @Override
             public void onResponse(BaseItemDto[] response) {
                 if (response.length > 0) {
@@ -1372,7 +1372,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
 
     private void retrieve(final TrailersQuery query) {
         final ItemRowAdapter adapter = this;
-        apiClient.getValue().GetLocalTrailersAsync(TvApp.getApplication().getCurrentUser().getId(), query.getItemId(), new Response<BaseItemDto[]>() {
+        apiClient.getValue().GetLocalTrailersAsync(TvApp.getApplication().getCurrentUser().getId().toString(), query.getItemId(), new Response<BaseItemDto[]>() {
             @Override
             public void onResponse(BaseItemDto[] response) {
                 if (response.length > 0) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -402,7 +402,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
         GuideChannelHeader header = (GuideChannelHeader)mSelectedProgramView;
         UserItemDataDto data = header.getChannel().getUserData();
         if (data != null) {
-            apiClient.getValue().UpdateFavoriteStatusAsync(header.getChannel().getId(), TvApp.getApplication().getCurrentUser().getId(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
+            apiClient.getValue().UpdateFavoriteStatusAsync(header.getChannel().getId(), TvApp.getApplication().getCurrentUser().getId().toString(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
                 @Override
                 public void onResponse(UserItemDataDto response) {
                     header.getChannel().setUserData(response);
@@ -969,7 +969,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
         @Override
         public void run() {
             if (mSelectedProgram.getOverview() == null && mSelectedProgram.getId() != null) {
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(mSelectedProgram.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(mSelectedProgram.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         mSelectedProgram = response;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -128,7 +128,7 @@ public class TvManager {
         LiveTvPreferences liveTvPreferences = get(LiveTvPreferences.class);
 
         LiveTvChannelQuery query = new LiveTvChannelQuery();
-        query.setUserId(TvApp.getApplication().getCurrentUser().getId());
+        query.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
         query.setAddCurrentProgram(true);
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getFavsAtTop())) query.setEnableFavoriteSorting(true);
         query.setSortOrder(ItemSortBy.DatePlayed.equals(liveTvPreferences.get(LiveTvPreferences.Companion.getChannelOrder())) ? SortOrder.Descending : null);
@@ -207,7 +207,7 @@ public class TvManager {
         if (forceReload || needLoadTime == null || start.after(needLoadTime) || !mProgramsDict.containsKey(channelIds[startNdx]) || !mProgramsDict.containsKey(channelIds[endNdx])) {
             forceReload = false;
             ProgramQuery query = new ProgramQuery();
-            query.setUserId(TvApp.getApplication().getCurrentUser().getId());
+            query.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
             endNdx = endNdx > channelIds.length ? channelIds.length : endNdx+1; //array copy range final ndx is exclusive
             query.setChannelIds(Arrays.copyOfRange(channelIds, startNdx, endNdx));
             query.setEnableImages(false);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -452,7 +452,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         GuideChannelHeader header = (GuideChannelHeader)mSelectedProgramView;
         UserItemDataDto data = header.getChannel().getUserData();
         if (data != null) {
-            apiClient.getValue().UpdateFavoriteStatusAsync(header.getChannel().getId(), TvApp.getApplication().getCurrentUser().getId(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
+            apiClient.getValue().UpdateFavoriteStatusAsync(header.getChannel().getId(), TvApp.getApplication().getCurrentUser().getId().toString(), !data.getIsFavorite(), new Response<UserItemDataDto>() {
                 @Override
                 public void onResponse(UserItemDataDto response) {
                     header.getChannel().setUserData(response);
@@ -623,7 +623,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             mPlaybackController.stop();
             if (hideGuide)
                 hideGuide();
-            apiClient.getValue().GetItemAsync(id, TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+            apiClient.getValue().GetItemAsync(id, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                 @Override
                 public void onResponse(BaseItemDto response) {
                     List<BaseItemDto> items = new ArrayList<BaseItemDto>();
@@ -1001,7 +1001,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         @Override
         public void run() {
             if (mSelectedProgram.getOverview() == null && mSelectedProgram.getId() != null) {
-                apiClient.getValue().GetItemAsync(mSelectedProgram.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                apiClient.getValue().GetItemAsync(mSelectedProgram.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         mSelectedProgram = response;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -191,7 +191,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
     }
 
     protected void markPlayed(String itemId) {
-        apiClient.getValue().MarkPlayedAsync(itemId, TvApp.getApplication().getCurrentUser().getId(), null, new Response<UserItemDataDto>());
+        apiClient.getValue().MarkPlayedAsync(itemId, TvApp.getApplication().getCurrentUser().getId().toString(), null, new Response<UserItemDataDto>());
     }
 
     protected void playNext() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -440,7 +440,7 @@ public class MediaManager {
                     public void onClick(DialogInterface dialog, int which) {
                         final String text = name.getText().toString();
                         PlaylistCreationRequest request = new PlaylistCreationRequest();
-                        request.setUserId(TvApp.getApplication().getCurrentUser().getId());
+                        request.setUserId(TvApp.getApplication().getCurrentUser().getId().toString());
                         request.setMediaType(type == TYPE_AUDIO ? "Audio" : "Video");
                         request.setName(text);
                         request.setItemIdList(type == TYPE_AUDIO ? getCurrentAudioQueueItemIds() : getCurrentVideoQueueItemIds());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1224,7 +1224,7 @@ public class PlaybackController {
         // Get the current program info when playing a live TV channel
         final BaseItemDto channel = getCurrentlyPlayingItem();
         if (channel.getBaseItemType() == BaseItemType.TvChannel) {
-            apiClient.getValue().GetLiveTvChannelAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId(), new Response<ChannelInfoDto>() {
+            apiClient.getValue().GetLiveTvChannelAsync(channel.getId(), TvApp.getApplication().getCurrentUser().getId().toString(), new Response<ChannelInfoDto>() {
                 @Override
                 public void onResponse(ChannelInfoDto response) {
                     BaseItemDto program = response.getCurrentProgram();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -11,11 +11,12 @@ import androidx.fragment.app.add
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.JellyfinApplication
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.TvApp
 import org.jellyfin.androidtv.auth.SessionRepository
+import org.jellyfin.androidtv.auth.UserRepository
 import org.jellyfin.androidtv.ui.browsing.MainActivity
 import org.jellyfin.androidtv.ui.itemdetail.FullDetailsActivity
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher
@@ -46,6 +47,7 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 	private val apiClient: ApiClient by inject()
 	private val mediaManager: MediaManager by inject()
 	private val sessionRepository: SessionRepository by inject()
+	private val userRepository: UserRepository by inject()
 
 	private val networkPermissionsRequester = registerForActivityResult(
 		ActivityResultContracts.RequestMultiplePermissions()
@@ -79,12 +81,11 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 
 					showSplash()
 
-					(application as? TvApp)?.currentUserLiveData?.observe(this@StartupActivity) { currentUser ->
-						Timber.i("CurrentUser changed to ${currentUser?.id} while waiting for startup.")
+					val currentUser = userRepository.currentUser.first { it != null }
+					Timber.i("CurrentUser changed to ${currentUser?.id} while waiting for startup.")
 
-						if (currentUser != null) lifecycleScope.launch {
-							openNextActivity()
-						}
+					lifecycleScope.launch {
+						openNextActivity()
 					}
 				} else if (!isLoaded) {
 					// Clear audio queue in case left over from last run

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -6,9 +6,9 @@ import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemPerson
 import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.UserDto
 import org.jellyfin.sdk.model.serializer.toUUID
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
-import org.jellyfin.apiclient.model.dto.UserDto as LegacyUserDto
 
 class ImageHelper(
 	private val api: ApiClient,
@@ -26,17 +26,15 @@ class ImageHelper(
 		}
 	}
 
-	fun getPrimaryImageUrl(item: LegacyUserDto): String? {
+	fun getPrimaryImageUrl(item: UserDto): String? {
 		if (item.primaryImageTag == null) return null
 
-		return item.id?.toUUIDOrNull()?.let { userId ->
-			api.imageApi.getUserImageUrl(
-				userId = userId,
-				imageType = ImageType.PRIMARY,
-				tag = item.primaryImageTag,
-				maxHeight = ImageUtils.MAX_PRIMARY_IMAGE_HEIGHT,
-			)
-		}
+		return api.imageApi.getUserImageUrl(
+			userId = item.id,
+			imageType = ImageType.PRIMARY,
+			tag = item.primaryImageTag,
+			maxHeight = ImageUtils.MAX_PRIMARY_IMAGE_HEIGHT,
+		)
 	}
 
 	fun getPrimaryImageUrl(item: BaseItemDto, width: Int? = null, height: Int? = null): String? {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -15,10 +15,10 @@ import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemPerson;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
-import org.jellyfin.apiclient.model.dto.UserDto;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
+import org.jellyfin.sdk.model.api.UserDto;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.Arrays;

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -357,7 +357,7 @@ public class KeyProcessor {
                         });
 
                     } else {
-                        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId(), new Response<BaseItemDto>() {
+                        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<BaseItemDto>() {
                             @Override
                             public void onResponse(BaseItemDto response) {
                                 KoinJavaComponent.<MediaManager>get(MediaManager.class).addToVideoQueue(response);
@@ -436,7 +436,7 @@ public class KeyProcessor {
     };
 
     private static void markPlayed() {
-        KoinJavaComponent.<ApiClient>get(ApiClient.class).MarkPlayedAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId(), null, new Response<UserItemDataDto>() {
+        KoinJavaComponent.<ApiClient>get(ApiClient.class).MarkPlayedAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId().toString(), null, new Response<UserItemDataDto>() {
             @Override
             public void onResponse(UserItemDataDto response) {
                 if (mCurrentActivity instanceof BaseActivity)
@@ -453,7 +453,7 @@ public class KeyProcessor {
     }
 
     private static void markUnplayed() {
-        KoinJavaComponent.<ApiClient>get(ApiClient.class).MarkUnplayedAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId(), new Response<UserItemDataDto>() {
+        KoinJavaComponent.<ApiClient>get(ApiClient.class).MarkUnplayedAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId().toString(), new Response<UserItemDataDto>() {
             @Override
             public void onResponse(UserItemDataDto response) {
                 if (mCurrentActivity instanceof BaseActivity)
@@ -470,7 +470,7 @@ public class KeyProcessor {
     }
 
     private static void toggleFavorite(boolean fav) {
-        KoinJavaComponent.<ApiClient>get(ApiClient.class).UpdateFavoriteStatusAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId(), fav, new Response<UserItemDataDto>() {
+        KoinJavaComponent.<ApiClient>get(ApiClient.class).UpdateFavoriteStatusAsync(mCurrentItemId, TvApp.getApplication().getCurrentUser().getId().toString(), fav, new Response<UserItemDataDto>() {
             @Override
             public void onResponse(UserItemDataDto response) {
                 if (mCurrentActivity instanceof BaseActivity)

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -10,7 +10,7 @@ import androidx.annotation.NonNull;
 import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.AudioBehavior;
-import org.jellyfin.apiclient.model.dto.UserDto;
+import org.jellyfin.sdk.model.api.UserDto;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.Arrays;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,6 @@ androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-cor
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-leanback-core = { module = "androidx.leanback:leanback", version.ref = "androidx-leanback" }
 androidx-leanback-preference = { module = "androidx.leanback:leanback-preference", version.ref = "androidx-leanback" }
-androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidx-lifecycle" }
@@ -127,7 +126,6 @@ acra = [
     "acra-limiter",
 ]
 androidx-lifecycle = [
-    "androidx-lifecycle-livedata",
     "androidx-lifecycle-process",
     "androidx-lifecycle-runtime",
     "androidx-lifecycle-service",


### PR DESCRIPTION
Also migrates all usages of getCurrentUser to the UserDto from the SDK

**Changes**
- Add UserRepository
  - Keeps track of the current UserDto (from SDK)
- Simplify ApiBinder
- Remove current user stuff from TvApp
  - Keeping `getCurrentUser()` for now, although you should not use it.
- Remove livedata library - no longer in use
- Update currentUser usages, sorry we need to call .toString() for ApiClient stuff so the diff is kinda big....

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
