### PR TITLE
Fix SessionRepository trying to fetch user data when session is null

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/SessionRepository.kt
@@ -126,8 +126,12 @@ class SessionRepositoryImpl(
 
 		if (success) runBlocking {
 			userApiClient.applySession(session, deviceInfo)
-			val user by userApiClient.userApi.getCurrentUser()
-			userRepository.updateCurrentUser(user)
+			if (session != null) {
+				val user by userApiClient.userApi.getCurrentUser()
+				userRepository.updateCurrentUser(user)
+			} else {
+				userRepository.updateCurrentUser(null)
+			}
 			preferencesRepository.onSessionChanged()
 			_currentSession.value = session
 		} else {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix SessionRepository trying to fetch user data when session is null

**Issues**

Fix #1598 