### PR TITLE
Require context in Utils.downMixAudio()

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -198,7 +198,7 @@ public class MediaManager {
             return false;
         }
 
-        return createPlayer(600);
+        return createPlayer(TvApp.getApplication(), 600);
     }
 
     private boolean isPaused() {
@@ -268,14 +268,14 @@ public class MediaManager {
         }
     }
 
-    private boolean createPlayer(int buffer) {
+    private boolean createPlayer(Context context, int buffer) {
         try {
 
             // Create a new media player based on platform
             if (DeviceUtils.is60()) {
                 Timber.i("creating audio player using: exoplayer");
                 nativeMode = true;
-                mExoPlayer = new ExoPlayer.Builder(TvApp.getApplication()).build();
+                mExoPlayer = new ExoPlayer.Builder(context).build();
                 mExoPlayer.addListener(new Player.EventListener() {
                     @Override
                     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
@@ -301,10 +301,10 @@ public class MediaManager {
                 options.add("--no-audio-time-stretch");
                 options.add("-v");
 
-                mLibVLC = new LibVLC(TvApp.getApplication(), options);
+                mLibVLC = new LibVLC(context, options);
 
                 mVlcPlayer = new org.videolan.libvlc.MediaPlayer(mLibVLC);
-                if(!Utils.downMixAudio()) {
+                if(!Utils.downMixAudio(context)) {
                     mVlcPlayer.setAudioDigitalOutputEnabled(true);
                 } else {
                     mVlcPlayer.setAudioOutput("opensles_android");
@@ -340,7 +340,7 @@ public class MediaManager {
             }
         } catch (Exception e) {
             Timber.e(e, "Error creating VLC player");
-            Utils.showToast(TvApp.getApplication(), TvApp.getApplication().getString(R.string.msg_video_playback_error));
+            Utils.showToast(context, context.getString(R.string.msg_video_playback_error));
             return false;
         }
 
@@ -700,9 +700,9 @@ public class MediaManager {
         options.setMediaSources(item.getMediaSources());
         DeviceProfile profile;
         if (DeviceUtils.is60()) {
-            profile = new ExoPlayerProfile();
+            profile = new ExoPlayerProfile(TvApp.getApplication(), false, false, false);
         } else {
-            profile = new LibVlcProfile();
+            profile = new LibVlcProfile(TvApp.getApplication(), false);
         }
         options.setProfile(profile);
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -515,7 +515,7 @@ public class PlaybackController {
                 }
                 vlcOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
                 vlcOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
-                DeviceProfile vlcProfile = new LibVlcProfile(isLiveTv);
+                DeviceProfile vlcProfile = new LibVlcProfile(mFragment.getContext(), isLiveTv);
                 vlcOptions.setProfile(vlcProfile);
 
                 VideoOptions internalOptions = new VideoOptions();
@@ -524,12 +524,13 @@ public class PlaybackController {
                 internalOptions.setMaxBitrate(Utils.getMaxBitrate());
                 if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
                     internalOptions.setEnableDirectStream(false);
-                internalOptions.setMaxAudioChannels(Utils.downMixAudio() ? 2 : null); //have to downmix at server
+                internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
                 internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
                 internalOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
                 DeviceProfile internalProfile = new BaseProfile();
                 if (DeviceUtils.is60() || userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())) {
                     internalProfile = new ExoPlayerProfile(
+                            mFragment.getContext(),
                             isLiveTv,
                             userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
                             userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
@@ -646,7 +647,7 @@ public class PlaybackController {
                                                 vlcResponse.getMediaSource().getDefaultAudioStream() == null ||
                                                 (!"ac3".equals(vlcResponse.getMediaSource().getDefaultAudioStream().getCodec()) &&
                                                         !"truehd".equals(vlcResponse.getMediaSource().getDefaultAudioStream().getCodec()))) &&
-                                        (Utils.downMixAudio() ||
+                                        (Utils.downMixAudio(mFragment.getContext()) ||
                                                 !DeviceUtils.is60() ||
                                                 internalResponse.getPlayMethod().equals(PlayMethod.Transcode) ||
                                                 !userPreferences.getValue().get(UserPreferences.Companion.getDtsEnabled()) ||

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -717,7 +717,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     private void setVlcAudioOptions() {
-        if (!Utils.downMixAudio()) {
+        if (!Utils.downMixAudio(mActivity)) {
             mVlcPlayer.setAudioDigitalOutputEnabled(true);
         } else {
             setCompatibleAudio();

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -7,7 +7,6 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
-import org.jellyfin.androidtv.TvApp;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.AudioBehavior;
 import org.jellyfin.sdk.model.api.UserDto;
@@ -124,9 +123,8 @@ public class Utils {
         return themeColor;
     }
 
-    public static boolean downMixAudio() {
-        // FIXME: Require context
-        AudioManager am = (AudioManager) TvApp.getApplication().getSystemService(Context.AUDIO_SERVICE);
+    public static boolean downMixAudio(@NonNull Context context) {
+        AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         if (am.isBluetoothA2dpOn()) {
             Timber.i("Downmixing audio due to wired headset");
             return true;

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.util.profile
 
+import android.content.Context
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
@@ -23,6 +24,7 @@ import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod
 import org.jellyfin.apiclient.model.dlna.TranscodingProfile
 
 class ExoPlayerProfile(
+	context: Context,
 	isLiveTV: Boolean = false,
 	isLiveTVDirectPlayEnabled: Boolean = false,
 	isAC3Enabled: Boolean = false,
@@ -57,7 +59,7 @@ class ExoPlayerProfile(
 			// TS video profile
 			TranscodingProfile().apply {
 				type = DlnaProfileType.Video
-				context = EncodingContext.Streaming
+				this.context = EncodingContext.Streaming
 				container = Codec.Container.TS
 				videoCodec = buildList {
 					if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
@@ -74,7 +76,7 @@ class ExoPlayerProfile(
 			// MP3 audio profile
 			TranscodingProfile().apply {
 				type = DlnaProfileType.Audio
-				context = EncodingContext.Streaming
+				this.context = EncodingContext.Streaming
 				container = Codec.Container.MP3
 				audioCodec = Codec.Audio.MP3
 			}
@@ -112,7 +114,7 @@ class ExoPlayerProfile(
 					).joinToString(",")
 
 					audioCodec = when {
-						Utils.downMixAudio() -> downmixSupportedAudioCodecs
+						Utils.downMixAudio(context) -> downmixSupportedAudioCodecs
 						else -> allSupportedAudioCodecs
 					}.joinToString(",")
 				})

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.util.profile
 
+import android.content.Context
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
@@ -20,7 +21,8 @@ import org.jellyfin.apiclient.model.dlna.ProfileConditionValue
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod
 
 class LibVlcProfile(
-	isLiveTV: Boolean = false
+	context: Context,
+	isLiveTV: Boolean = false,
 ) : BaseProfile() {
 	init {
 		name = "AndroidTV-libVLC"
@@ -67,7 +69,7 @@ class LibVlcProfile(
 					Codec.Audio.OPUS,
 					Codec.Audio.FLAC,
 					Codec.Audio.TRUEHD,
-					if (!Utils.downMixAudio() && isLiveTV) Codec.Audio.AAC_LATM else null
+					if (!Utils.downMixAudio(context) && isLiveTV) Codec.Audio.AAC_LATM else null
 				).joinToString(",")
 			},
 			// Audio direct play


### PR DESCRIPTION
**Changes**
- Require context in Utils.downMixAudio()
  - I tried to use a proper context where possible but some places use TvApp.getApplication right now because ItemLauncher/MediaManager have no context.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
