### PR TITLE
Update activity lifecycle callbacks to act before activity lifecycle events trigger

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AppThemeCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AppThemeCallbacks.kt
@@ -13,7 +13,7 @@ class AppThemeCallbacks(
 	private var lastTheme: AppTheme? = null
 	private var lastPreferencesTheme: AppTheme? = null
 
-	override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+	override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
 		userPreferences[UserPreferences.appTheme].let {
 			Timber.i("Applying theme: %s", it)
 			activity.setTheme(ThemeManager.getTheme(activity, it))
@@ -24,7 +24,7 @@ class AppThemeCallbacks(
 		}
 	}
 
-	override fun onActivityResumed(activity: Activity) {
+	override fun onActivityPreResumed(activity: Activity) {
 		val lastThemeForActivity = if (activity is PreferencesActivity) lastPreferencesTheme else lastTheme
 		userPreferences[UserPreferences.appTheme].let {
 			if (lastThemeForActivity != null && lastThemeForActivity != it) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
@@ -9,7 +9,7 @@ import org.jellyfin.androidtv.ui.startup.StartupActivity
 import timber.log.Timber
 
 /**
- * ActivityLifecycleCallback that bounces to the StartupActivity if an Activity is created and
+ * ActivityLifecycleCallback that bounces to the StartupActivity when an activity is created and
  * the currentUser is null.
  */
 class AuthenticatedUserCallbacks(
@@ -27,7 +27,7 @@ class AuthenticatedUserCallbacks(
 		)
 	}
 
-	override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+	override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
 		val name = activity::class.qualifiedName
 
 		if (name in ignoredClassNames) {


### PR DESCRIPTION
It's a bit difficult to test the AuthenticatedUserCallbacks one because it only triggers on crashes and we fixed most of those..

**Changes**

- Update activity lifecycle callbacks to act before activity lifecycle events trigger
- Update AuthenticatedUserCallbacks comment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
