### PR TITLE
Use context in MediaManager

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -82,7 +82,7 @@ val appModule = module {
 	}
 
 	// Non API related
-	single { MediaManager() }
+	single { MediaManager(get()) }
 
 	single { DataRefreshService() }
 	single { PlaybackControllerContainer() }


### PR DESCRIPTION
**Changes**
- Send context to MediaManager constructor
- Always use context in MediaManager (replaced TvApp.getApplication)
- Change some function signatures to use Context instead of Activity

This is basically the same behavior as before, as the context injected now is the application context.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
