### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/app-build.yaml
+++ b/.github/workflows/app-build.yaml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/app-lint.yaml
+++ b/.github/workflows/app-lint.yaml
@@ -7,8 +7,14 @@ on:
       - release-*
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -7,6 +7,9 @@ on:
       - release-*
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**/gradlе-wrapper.jar'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
