### PR TITLE
Move preference code to new preference module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ val versionTxt by tasks.registering {
 dependencies {
 	// Jellyfin
 	implementation(projects.playback)
+	implementation(projects.preference)
 	implementation(libs.jellyfin.apiclient)
 	implementation(libs.jellyfin.sdk) {
 		// Change version if desired

--- a/app/src/main/java/org/jellyfin/androidtv/constant/HomeSectionType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/HomeSectionType.kt
@@ -1,8 +1,8 @@
 package org.jellyfin.androidtv.constant
 
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.preference.PreferenceEnum
 import org.jellyfin.androidtv.ui.preference.dsl.EnumDisplayOptions
+import org.jellyfin.preference.PreferenceEnum
 
 /**
  * All possible homesections, "synced" with jellyfin-web.

--- a/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/AuthenticationPreferences.kt
@@ -3,6 +3,8 @@ package org.jellyfin.androidtv.preference
 import android.content.Context
 import org.jellyfin.androidtv.auth.model.AuthenticationSortBy
 import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.store.SharedPreferenceStore
 
 class AuthenticationPreferences(context: Context) : SharedPreferenceStore(
 	sharedPreferences = context.getSharedPreferences("authentication", Context.MODE_PRIVATE)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LibraryPreferences.kt
@@ -3,8 +3,10 @@ package org.jellyfin.androidtv.preference
 import org.jellyfin.androidtv.constant.GridDirection
 import org.jellyfin.androidtv.constant.ImageType
 import org.jellyfin.androidtv.constant.PosterSize
+import org.jellyfin.androidtv.preference.store.DisplayPreferencesStore
 import org.jellyfin.apiclient.model.entities.SortOrder
 import org.jellyfin.apiclient.model.querying.ItemSortBy
+import org.jellyfin.preference.Preference
 import org.jellyfin.sdk.api.client.ApiClient
 
 class LibraryPreferences(

--- a/app/src/main/java/org/jellyfin/androidtv/preference/LiveTvPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/LiveTvPreferences.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.androidtv.preference
 
+import org.jellyfin.androidtv.preference.store.DisplayPreferencesStore
 import org.jellyfin.apiclient.model.querying.ItemSortBy
+import org.jellyfin.preference.Preference
 import org.jellyfin.sdk.api.client.ApiClient
 
 class LiveTvPreferences(

--- a/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
@@ -2,6 +2,8 @@ package org.jellyfin.androidtv.preference
 
 import android.content.Context
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.store.SharedPreferenceStore
 
 /**
  * System preferences are not possible to modify by the user.

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -13,6 +13,9 @@ import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.preference.constant.defaultAudioBehavior
 import org.jellyfin.androidtv.util.DeviceUtils
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.migration.putEnum
+import org.jellyfin.preference.store.SharedPreferenceStore
 
 /**
  * User preferences are configurable by the user and change behavior of the application.

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserSettingPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserSettingPreferences.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.androidtv.preference
 
 import org.jellyfin.androidtv.constant.HomeSectionType
+import org.jellyfin.androidtv.preference.store.DisplayPreferencesStore
+import org.jellyfin.preference.Preference
 import org.jellyfin.sdk.api.client.ApiClient
 
 class UserSettingPreferences(

--- a/app/src/main/java/org/jellyfin/androidtv/preference/store/DisplayPreferencesStore.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/store/DisplayPreferencesStore.kt
@@ -1,5 +1,8 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.androidtv.preference.store
 
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.PreferenceEnum
+import org.jellyfin.preference.store.AsyncPreferenceStore
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.displayPreferencesApi

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DisplayPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DisplayPreferencesScreen.kt
@@ -5,12 +5,12 @@ import org.jellyfin.androidtv.constant.GridDirection
 import org.jellyfin.androidtv.constant.ImageType
 import org.jellyfin.androidtv.constant.PosterSize
 import org.jellyfin.androidtv.preference.LibraryPreferences
-import org.jellyfin.androidtv.preference.PreferenceStore
 import org.jellyfin.androidtv.preference.PreferencesRepository
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.enum
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.preference.store.PreferenceStore
 import org.koin.android.ext.android.inject
 
 class DisplayPreferencesScreen : OptionsFragment() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsFragment.kt
@@ -5,8 +5,8 @@ import androidx.leanback.preference.LeanbackPreferenceFragmentCompat
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
-import org.jellyfin.androidtv.preference.AsyncPreferenceStore
-import org.jellyfin.androidtv.preference.PreferenceStore
+import org.jellyfin.preference.store.AsyncPreferenceStore
+import org.jellyfin.preference.store.PreferenceStore
 
 abstract class OptionsFragment : LeanbackPreferenceFragmentCompat() {
 	abstract val screen: OptionsScreen

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemEnum.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemEnum.kt
@@ -3,9 +3,9 @@ package org.jellyfin.androidtv.ui.preference.dsl
 import android.content.Context
 import androidx.annotation.StringRes
 import androidx.preference.PreferenceCategory
-import org.jellyfin.androidtv.preference.Preference
-import org.jellyfin.androidtv.preference.PreferenceStore
 import org.jellyfin.androidtv.ui.preference.custom.RichListPreference
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.store.PreferenceStore
 import java.util.UUID
 
 class OptionsItemEnum<T : Enum<T>>(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemMutable.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemMutable.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.androidtv.ui.preference.dsl
 
-import org.jellyfin.androidtv.preference.Preference
-import org.jellyfin.androidtv.preference.PreferenceStore
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.store.PreferenceStore
 
 abstract class OptionsItemMutable<T : Any> : OptionsItem {
 	var title: String? = null

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -3,10 +3,9 @@ package org.jellyfin.androidtv.ui.preference.screen
 import androidx.core.os.bundleOf
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.AuthenticationRepository
-import org.jellyfin.androidtv.auth.model.AuthenticationSortBy
 import org.jellyfin.androidtv.auth.SessionRepository
+import org.jellyfin.androidtv.auth.model.AuthenticationSortBy
 import org.jellyfin.androidtv.preference.AuthenticationPreferences
-import org.jellyfin.androidtv.preference.Preference
 import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
 import org.jellyfin.androidtv.ui.preference.category.aboutCategory
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsBinder
@@ -18,6 +17,7 @@ import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.preference.dsl.userPicker
 import org.jellyfin.androidtv.ui.startup.preference.EditServerScreen
+import org.jellyfin.preference.Preference
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/HomePreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/HomePreferencesScreen.kt
@@ -2,11 +2,11 @@ package org.jellyfin.androidtv.ui.preference.screen
 
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.HomeSectionType
-import org.jellyfin.androidtv.preference.PreferenceStore
 import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.enum
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.preference.store.PreferenceStore
 import org.koin.android.ext.android.inject
 
 class HomePreferencesScreen : OptionsFragment() {

--- a/preference/build.gradle.kts
+++ b/preference/build.gradle.kts
@@ -22,8 +22,21 @@ android {
 		lintConfig = file("$rootDir/android-lint.xml")
 		abortOnError = false
 	}
+
+	testOptions.unitTests.all {
+		it.useJUnitPlatform()
+	}
 }
 
 dependencies {
+	// Kotlin
+	implementation(libs.kotlinx.coroutines)
 
+	// Logging
+	implementation(libs.timber)
+
+	// Testing
+	testImplementation(libs.kotest.runner.junit5)
+	testImplementation(libs.kotest.assertions)
+	testImplementation(libs.mockk)
 }

--- a/preference/src/main/AndroidManifest.xml
+++ b/preference/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.jellyfin.preference">
+
+    <application>
+
+    </application>
+</manifest>

--- a/preference/src/main/kotlin/Preference.kt
+++ b/preference/src/main/kotlin/Preference.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.preference
 
 import kotlin.reflect.KClass
 

--- a/preference/src/main/kotlin/PreferenceEnum.kt
+++ b/preference/src/main/kotlin/PreferenceEnum.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.preference
 
 interface PreferenceEnum {
 	val serializedName: String

--- a/preference/src/main/kotlin/migration/MigrationContext.kt
+++ b/preference/src/main/kotlin/migration/MigrationContext.kt
@@ -1,7 +1,7 @@
-package org.jellyfin.androidtv.preference.migrations
+package org.jellyfin.preference.migration
 
 import timber.log.Timber
-import java.lang.Integer.max
+import kotlin.math.max
 
 class MigrationContext<E, V> {
 	private val migrations = mutableListOf<Migration<E, V>>()

--- a/preference/src/main/kotlin/migration/MigrationEditor.kt
+++ b/preference/src/main/kotlin/migration/MigrationEditor.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.preference.migration
 
 import android.content.SharedPreferences
 

--- a/preference/src/main/kotlin/store/AsyncPreferenceStore.kt
+++ b/preference/src/main/kotlin/store/AsyncPreferenceStore.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.preference.store
 
 import kotlinx.coroutines.runBlocking
 

--- a/preference/src/main/kotlin/store/PreferenceStore.kt
+++ b/preference/src/main/kotlin/store/PreferenceStore.kt
@@ -1,4 +1,6 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.preference.store
+
+import org.jellyfin.preference.Preference
 
 /**
  * Abstract class defining the required functions for a preference store.

--- a/preference/src/main/kotlin/store/SharedPreferenceStore.kt
+++ b/preference/src/main/kotlin/store/SharedPreferenceStore.kt
@@ -1,7 +1,10 @@
-package org.jellyfin.androidtv.preference
+package org.jellyfin.preference.store
 
 import android.content.SharedPreferences
-import org.jellyfin.androidtv.preference.migrations.MigrationContext
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.PreferenceEnum
+import org.jellyfin.preference.migration.MigrationContext
+import org.jellyfin.preference.migration.MigrationEditor
 import timber.log.Timber
 
 /**

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ include(":app")
 
 // Modules
 include(":playback")
+include(":preference")
 
 pluginManagement {
 	repositories {


### PR DESCRIPTION
Another one from my "short term" list (was only added like 6 months ago!). This PR moves the core logic for preferences to a separate module. This is part of an effort for modularization of the app, just like how the new playback code is in it's own module.

**Changes**
- Move preference library code to it's own module
  - this does not include the user interface code (yet)
- Update package from "org.jellyfin.androidtv.preference" to "org.jellyfin.preference"
- Move some stuff around in the PreferenceStoreTests

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
