### PR TITLE
Fix not opening last active server on authentication clearance

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/LoginViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/LoginViewModel.kt
@@ -73,7 +73,10 @@ class LoginViewModel(
 		viewModelScope.launch { serverRepository.loadStoredServers() }
 	}
 
-	fun getLastServer(): Server? = serverRepository.storedServers.value.maxByOrNull { it.dateLastAccessed }
+	suspend fun getLastServer(): Server? {
+		serverRepository.loadStoredServers()
+		return serverRepository.storedServers.value.maxByOrNull { it.dateLastAccessed }
+	}
 
 	suspend fun updateServer(server: Server): Boolean = serverRepository.updateServer(server)
 }


### PR DESCRIPTION
The storedServers was empty when the StartupActivity called getLastServer(). Fixed by loading the servers first.

**Changes**

- Load servers before searching the last active server

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
