### PR TITLE
Hide currently watching video from next up integration

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -227,6 +227,7 @@ class LeanbackChannelWorker(
 				limit = 10,
 				mediaTypes = listOf(MediaType.Video),
 				includeItemTypes = listOf(BaseItemKind.EPISODE, BaseItemKind.MOVIE),
+				excludeActiveSessions = true,
 			).content.items.orEmpty()
 		}
 


### PR DESCRIPTION
The getResumeItems operation includes the video you're watching when the cal is made, 10.8 added a new option to exclude those items and only show the resumable video that is not being watched at the time of calling the API.

**Changes**
- Add excludeActiveSessions optino to getResumeItems (introduced in 10.8)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
