### PR TITLE
Use enum for refresh rate switching setting - allow choosing between scaling on device or on tv

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -11,6 +11,7 @@ import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
+import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
 import org.jellyfin.androidtv.preference.constant.defaultAudioBehavior
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.preference.booleanPreference
@@ -96,9 +97,9 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var videoPlayer = enumPreference("video_player", PreferredVideoPlayer.EXOPLAYER)
 
 		/**
-		 * Enable refresh rate switching when device supports it
+		 * Change refresh rate to match media when device supports it
 		 */
-		var refreshRateSwitchingEnabled = booleanPreference("pref_refresh_switching", false)
+		var refreshRateSwitchingBehavior = enumPreference("pref_refresh_switching", RefreshRateSwitchingBehavior.DISABLED)
 
 		/**
 		 * Send a path instead to the external player
@@ -235,6 +236,15 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 
 				// Disable AC3 (Dolby Digital) on Fire Stick Gen 1 devices
 				if (DeviceUtils.isFireTvStickGen1()) putBoolean("pref_bitstream_ac3", false)
+			}
+
+			// v0.12.x to v0.13.x
+			migration(toVersion = 6) {
+				putEnum("pref_refresh_switching",
+					when {
+						it.getBoolean("pref_refresh_switching", false) -> RefreshRateSwitchingBehavior.SCALE_ON_TV
+						else -> RefreshRateSwitchingBehavior.DISABLED
+					})
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -99,7 +99,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Change refresh rate to match media when device supports it
 		 */
-		var refreshRateSwitchingBehavior = enumPreference("pref_refresh_switching", RefreshRateSwitchingBehavior.DISABLED)
+		var refreshRateSwitchingBehavior = enumPreference("refresh_rate_switching_behavior", RefreshRateSwitchingBehavior.DISABLED)
 
 		/**
 		 * Send a path instead to the external player
@@ -240,7 +240,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 
 			// v0.12.x to v0.13.x
 			migration(toVersion = 6) {
-				putEnum("pref_refresh_switching",
+				putEnum("refresh_rate_switching_behavior",
 					when {
 						it.getBoolean("pref_refresh_switching", false) -> RefreshRateSwitchingBehavior.SCALE_ON_TV
 						else -> RefreshRateSwitchingBehavior.DISABLED

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -238,7 +238,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 				if (DeviceUtils.isFireTvStickGen1()) putBoolean("pref_bitstream_ac3", false)
 			}
 
-			// v0.12.x to v0.13.x
+			// v0.13.3 to v0.13.4
 			migration(toVersion = 6) {
 				putEnum("refresh_rate_switching_behavior",
 					when {

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
@@ -4,20 +4,18 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.preference.dsl.EnumDisplayOptions
 
 enum class RefreshRateSwitchingBehavior {
-	/**
-	 *  Don't change
-	 */
 	@EnumDisplayOptions(R.string.lbl_disabled)
 	DISABLED,
 
 	/**
-	 *  Don't change
+	 * When comparing modes, use difference in resolution to rank modes.
 	 */
 	@EnumDisplayOptions(R.string.pref_refresh_rate_scale_tv)
 	SCALE_ON_TV,
 
 	/**
-	 *  Force ExoPlayer
+	 *  When comparing modes, rank native resolution modes highest.
+	 *  Otherwise use difference in resolution to rank modes.
 	 */
 	@EnumDisplayOptions(R.string.pref_refresh_rate_scale_on_device)
 	SCALE_ON_DEVICE,

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
@@ -10,7 +10,7 @@ enum class RefreshRateSwitchingBehavior {
 	/**
 	 * When comparing modes, use difference in resolution to rank modes.
 	 */
-	@EnumDisplayOptions(R.string.pref_refresh_rate_scale_tv)
+	@EnumDisplayOptions(R.string.pref_refresh_rate_scale_on_tv)
 	SCALE_ON_TV,
 
 	/**

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.androidtv.preference.constant
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.preference.dsl.EnumDisplayOptions
+
+enum class RefreshRateSwitchingBehavior {
+	/**
+	 *  Don't change
+	 */
+	@EnumDisplayOptions(R.string.lbl_disabled)
+	DISABLED,
+
+	/**
+	 *  Don't change
+	 */
+	@EnumDisplayOptions(R.string.pref_refresh_rate_scale_tv)
+	SCALE_ON_TV,
+
+	/**
+	 *  Force ExoPlayer
+	 */
+	@EnumDisplayOptions(R.string.pref_refresh_rate_scale_on_device)
+	SCALE_ON_DEVICE,
+}

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/RefreshRateSwitchingBehavior.kt
@@ -4,7 +4,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.preference.dsl.EnumDisplayOptions
 
 enum class RefreshRateSwitchingBehavior {
-	@EnumDisplayOptions(R.string.lbl_disabled)
+	@EnumDisplayOptions(R.string.state_disabled)
 	DISABLED,
 
 	/**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -316,6 +316,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         Timber.d("trying to find display mode for video: %dx%d@%f", videoStream.getWidth(), videoStream.getHeight(), videoStream.getRealFrameRate());
         for (Display.Mode mode : mDisplayModes) {
+            Timber.d("considering display mode: %s - %dx%d@%f", mode.getModeId(), mode.getPhysicalWidth(), mode.getPhysicalHeight(), mode.getRefreshRate());
+
             // Skip unwanted display modes
             if (mode.getPhysicalWidth() < 1280 || mode.getPhysicalHeight() < 720)  // Skip non-HD
                 continue;
@@ -337,7 +339,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
                     refreshRateSwitchingBehavior == RefreshRateSwitchingBehavior.SCALE_ON_TV) {
 
-                resolutionDifference = mode.getPhysicalWidth() - videoStream.getWidth();
+                resolutionDifference = Math.abs(mode.getPhysicalWidth() - videoStream.getWidth());
             }
             int refreshRateDifference = rate - sourceRate;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -334,7 +334,10 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
             // if scaling on-device, keep native resolution modes at diff 0 (best score)
             // for other resolutions when scaling on device, or if scaling on tv, score based on distance from media resolution
-            int resolutionDifference = 0;
+
+            // use -1 as the default so, with SCALE_ON_DEVICE, a mode at native resolution will rank higher than
+            // a mode with equal refresh rate and the same resolution as the media
+            int resolutionDifference = -1;
             if ((refreshRateSwitchingBehavior == RefreshRateSwitchingBehavior.SCALE_ON_DEVICE &&
                     !(mode.getPhysicalWidth() == defaultMode.getPhysicalWidth() && mode.getPhysicalHeight() == defaultMode.getPhysicalHeight())) ||
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -24,6 +24,7 @@ import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.UserSettingPreferences;
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior;
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer;
+import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
@@ -115,15 +116,17 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private long lastPlaybackError = 0;
 
     private Display.Mode[] mDisplayModes;
-    private boolean refreshRateSwitchingEnabled;
+    private RefreshRateSwitchingBehavior refreshRateSwitchingBehavior = RefreshRateSwitchingBehavior.DISABLED;
 
     public PlaybackController(List<BaseItemDto> items, CustomPlaybackOverlayFragment fragment) {
         mItems = items;
         mFragment = fragment;
         mHandler = new Handler();
 
-        refreshRateSwitchingEnabled = DeviceUtils.is60() && userPreferences.getValue().get(UserPreferences.Companion.getRefreshRateSwitchingEnabled());
-        if (refreshRateSwitchingEnabled) getDisplayModes();
+        if (DeviceUtils.is60())
+            refreshRateSwitchingBehavior = userPreferences.getValue().get(UserPreferences.Companion.getRefreshRateSwitchingBehavior());
+            if (refreshRateSwitchingBehavior != RefreshRateSwitchingBehavior.DISABLED)
+                getDisplayModes();
 
         // Set default value for useVlc field
         // when set to auto the default will be exoplayer
@@ -296,7 +299,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         mDisplayModes = display.getSupportedModes();
         Timber.i("** Available display refresh rates:");
         for (Display.Mode mDisplayMode : mDisplayModes) {
-            Timber.i("%f", mDisplayMode.getRefreshRate());
+            Timber.d("display mode %s - %dx%d@%f", mDisplayMode.getModeId(), mDisplayMode.getPhysicalWidth(), mDisplayMode.getPhysicalHeight(), mDisplayMode.getRefreshRate());
         }
     }
 
@@ -311,7 +314,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         Display.Mode defaultMode = mFragment.requireActivity().getWindowManager().getDefaultDisplay().getMode();
 
-        Timber.d("trying to find display mode for video: %sx%s @%sfps", videoStream.getWidth(), videoStream.getHeight(), videoStream.getRealFrameRate());
+        Timber.d("trying to find display mode for video: %dx%d@%f", videoStream.getWidth(), videoStream.getHeight(), videoStream.getRealFrameRate());
         for (Display.Mode mode : mDisplayModes) {
             // Skip unwanted display modes
             if (mode.getPhysicalWidth() < 1280 || mode.getPhysicalHeight() < 720)  // Skip non-HD
@@ -324,18 +327,25 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             if (rate != sourceRate && rate != sourceRate * 2 && rate != Math.round(sourceRate * 2.5)) // Skip inappropriate rates
                 continue;
 
-            Timber.d("qualifying display mode: %sx%s @%sfps", mode.getPhysicalWidth(), mode.getPhysicalHeight(), mode.getRefreshRate());
+            Timber.d("qualifying display mode: %s - %dx%d@%f", mode.getModeId(), mode.getPhysicalWidth(), mode.getPhysicalHeight(), mode.getRefreshRate());
 
+            // if scaling on-device, keep native resolution modes at diff 0 (best score)
+            // for other resolutions when scaling on device, or if scaling on tv, score based on distance from media resolution
             int resolutionDifference = 0;
-            if (!(mode.getPhysicalWidth() == defaultMode.getPhysicalWidth() && mode.getPhysicalHeight() == defaultMode.getPhysicalHeight()))
+            if ((refreshRateSwitchingBehavior == RefreshRateSwitchingBehavior.SCALE_ON_DEVICE &&
+                    !(mode.getPhysicalWidth() == defaultMode.getPhysicalWidth() && mode.getPhysicalHeight() == defaultMode.getPhysicalHeight())) ||
+
+                    refreshRateSwitchingBehavior == RefreshRateSwitchingBehavior.SCALE_ON_TV) {
+
                 resolutionDifference = mode.getPhysicalWidth() - videoStream.getWidth();
+            }
             int refreshRateDifference = rate - sourceRate;
 
             // use 100,000 to account for refresh rates 120Hz+ (at 120Hz rate == 12,000)
             int weight = 100000 - refreshRateDifference + 100000 - resolutionDifference;
 
             if (weight > curWeight) {
-                Timber.d("preferring mode: %sx%s @%sfps", mode.getPhysicalWidth(), mode.getPhysicalHeight(), mode.getRefreshRate());
+                Timber.d("preferring mode: %s - %dx%d@%f", mode.getModeId(), mode.getPhysicalWidth(), mode.getPhysicalHeight(), mode.getRefreshRate());
                 curWeight = weight;
                 bestMode = mode;
             }
@@ -357,7 +367,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             Timber.i("*** Best refresh mode is: %s - %dx%d/%f",
                     best.getModeId(), best.getPhysicalWidth(), best.getPhysicalHeight(), best.getRefreshRate());
             if (current.getModeId() != best.getModeId()) {
-                Timber.i("*** Attempting to change refresh rate from %s/%s", current.getModeId(), current.getRefreshRate());
+                Timber.i("*** Attempting to change refresh rate from: %s - %dx%d@%f", current.getModeId(), current.getPhysicalWidth(),
+                                                                                                current.getPhysicalHeight(),current.getRefreshRate());
                 WindowManager.LayoutParams params = mFragment.requireActivity().getWindow().getAttributes();
                 params.preferredDisplayModeId = best.getModeId();
                 mFragment.requireActivity().getWindow().setAttributes(params);
@@ -365,7 +376,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 Timber.i("Display is already in best mode");
             }
         } else {
-            Timber.i("*** Unable to find display mode for refresh rate: %s", videoStream.getRealFrameRate());
+            Timber.i("*** Unable to find display mode for refresh rate: %f", videoStream.getRealFrameRate());
         }
     }
 
@@ -777,7 +788,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         }
 
         // set refresh rate
-        if (refreshRateSwitchingEnabled) {
+        if (refreshRateSwitchingBehavior != RefreshRateSwitchingBehavior.DISABLED) {
             setRefreshRate(response.getMediaSource().getVideoStream());
         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -123,10 +123,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         mFragment = fragment;
         mHandler = new Handler();
 
-        if (DeviceUtils.is60())
+        if (DeviceUtils.is60()) {
             refreshRateSwitchingBehavior = userPreferences.getValue().get(UserPreferences.Companion.getRefreshRateSwitchingBehavior());
             if (refreshRateSwitchingBehavior != RefreshRateSwitchingBehavior.DISABLED)
                 getDisplayModes();
+        }
 
         // Set default value for useVlc field
         // when set to auto the default will be exoplayer

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -7,6 +7,7 @@ import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
+import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
@@ -134,11 +135,10 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				depends { userPreferences[UserPreferences.videoPlayer] == PreferredVideoPlayer.EXTERNAL }
 			}
 
-			checkbox {
+			enum<RefreshRateSwitchingBehavior> {
 				setTitle(R.string.lbl_refresh_switching)
-				setContent(R.string.pref_refresh_switching_description)
-				bind(userPreferences, UserPreferences.refreshRateSwitchingEnabled)
-				depends { DeviceUtils.is60() && userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL }
+				bind(userPreferences, UserPreferences.refreshRateSwitchingBehavior)
+				depends { DeviceUtils.is60() }
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -138,7 +138,7 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 			enum<RefreshRateSwitchingBehavior> {
 				setTitle(R.string.lbl_refresh_switching)
 				bind(userPreferences, UserPreferences.refreshRateSwitchingBehavior)
-				depends { DeviceUtils.is60() }
+				depends { DeviceUtils.is60() && userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL }
 			}
 		}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,6 @@
     <string name="login_quickconnect_step_2">2. Open the user menu and go to the Quick Connect page</string>
     <string name="login_quickconnect_step_3">3. Enter the following code:</string>
     <string name="lbl_refresh_switching">Refresh rate switching</string>
-    <string name="pref_refresh_rate_scale_tv">Scale on TV</string>
+    <string name="pref_refresh_rate_scale_on_tv">Scale on TV</string>
     <string name="pref_refresh_rate_scale_on_device">Scale on device</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="settings_title">Preferences</string>
     <string name="pref_authentication_cat">Authentication</string>
     <string name="chapters">Chapters</string>
+    <string name="lbl_disabled">Disabled</string>
     <string name="lbl_settings">Preferences</string>
     <string name="lbl_continue_watching">Continue Watching</string>
     <string name="lbl_next_up">Next Up</string>
@@ -201,8 +202,6 @@
     <string name="lbl_open">Open</string>
     <string name="lbl_show_backdrop">Show backdrops</string>
     <string name="pref_show_backdrop_description">Change background image to selected items</string>
-    <string name="lbl_refresh_switching">Refresh rate switching</string>
-    <string name="pref_refresh_switching_description">Monitor refresh rate is changed to match video</string>
     <string name="lbl_show_premieres">Show season premieres</string>
     <string name="desc_premieres">Show a row of new episode pilots for any series you watch</string>
     <string name="lbl_bitstream_dts">Bitstream DTS audio</string>
@@ -491,4 +490,7 @@
     <string name="login_quickconnect_step_1">1. Open the Jellyfin app on your phone or webbrowser, and sign in with your account</string>
     <string name="login_quickconnect_step_2">2. Open the user menu and go to the Quick Connect page</string>
     <string name="login_quickconnect_step_3">3. Enter the following code:</string>
+    <string name="lbl_refresh_switching">Refresh rate switching</string>
+    <string name="pref_refresh_rate_scale_tv">Scale on TV</string>
+    <string name="pref_refresh_rate_scale_on_device">Scale on device</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="settings_title">Preferences</string>
     <string name="pref_authentication_cat">Authentication</string>
     <string name="chapters">Chapters</string>
-    <string name="lbl_disabled">Disabled</string>
+    <string name="state_disabled">Disabled</string>
     <string name="lbl_settings">Preferences</string>
     <string name="lbl_continue_watching">Continue Watching</string>
     <string name="lbl_next_up">Next Up</string>


### PR DESCRIPTION
**Changes**
* Changed refresh rate switching setting (boolean) to enum (`disabled`, `scale on tv`, `scale on device`) and added a migration that migrates an old value of `true` -> `scale on tv`. `scale on tv` is chosen because scaling on the device seems to only be useful for devices like Nvidia Shield, which has "AI upscaling".

* added some extra logging to `findBestDisplayMode()` so that every mode will be logged
* standardized the logging format for printing "resolution@refresh rate" in `findBestDisplayMode()`: `%dx%d@%f`

**Issues**
fixes #1646

**Notes**
My display config doesn't support refresh rate or resolution switching so someone else will need to test this.
