### PR TITLE
Add season id when querying video queue based on episode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -51,6 +51,7 @@ public class PlaybackHelper {
                     //add subsequent episodes
                     if (mainItem.getSeriesId() != null && mainItem.getId() != null) {
                         EpisodeQuery episodeQuery = new EpisodeQuery();
+                        if (mainItem.getSeasonId() != null) episodeQuery.setSeasonId(mainItem.getSeasonId());
                         episodeQuery.setSeriesId(mainItem.getSeriesId());
                         episodeQuery.setUserId(userId.toString());
                         episodeQuery.setIsVirtualUnaired(false);


### PR DESCRIPTION
I've recently added a bunch of extras to various series I'm watching and for some reason when playing items it would automatically add the previews/trailers/etc to the video queue even though it's in  the extra folders. Fixed by specifying the season id when building the queue.

**Changes**

- Add season id when querying video queue based on episode

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
