### PR TITLE
Fix button remapping not saving the new button

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapPreference.kt
@@ -15,13 +15,10 @@ class ButtonRemapPreference @JvmOverloads constructor(
 ) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
 	override fun getDialogLayoutResource() = R.layout.preference_button_remap
 
-	private var innerKeyCode: Int = -1
-	var keyCode: Int
-		get() = innerKeyCode
+	var keyCode: Int = -1
 		set(value) {
-			innerKeyCode = value
-			notifyDependencyChange(false)
-			notifyChanged()
+			field = value
+			callChangeListener(value)
 		}
 	var defaultKeyCode: Int = -1
 


### PR DESCRIPTION
The change listener was never called so the value was never saved. I guess this feature never worked since it was added lol.

**Changes**
- Fix button remapping not saving the new button

**Issues**

Fixes #1677