### PR TITLE
initialize video manager when falling back to vlc after getting stream info for exoplayer fails

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -677,15 +677,22 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                             if (mVideoManager == null)
                                 return;
                             mVideoManager.init(getBufferAmount(), useDeinterlacing);
-
-                            Timber.d("server default: %s inferred first track: %s", internalResponse.getMediaSource().getDefaultAudioStreamIndex(), bestGuessAudioTrack(internalResponse.getMediaSource()));
                             mCurrentOptions = useVlc ? vlcOptions : internalOptions;
                             startItem(item, position, useVlc ? vlcResponse : internalResponse);
                         }
 
                         @Override
                         public void onError(Exception exception) {
-                            Timber.e(exception, "Unable to get internal stream info");
+                            Timber.e(exception, "Unable to get stream info for internal player - falling back to libVLC");
+                            if (mVideoManager == null)
+                                return;
+
+                            boolean useDeinterlacing = vlcResponse.getMediaSource().getVideoStream() != null &&
+                                    vlcResponse.getMediaSource().getVideoStream().getIsInterlaced() &&
+                                    (vlcResponse.getMediaSource().getVideoStream().getWidth() == null ||
+                                            vlcResponse.getMediaSource().getVideoStream().getWidth() > 1200);
+
+                            mVideoManager.init(getBufferAmount(), useDeinterlacing);
                             mCurrentOptions = vlcOptions;
                             startItem(item, position, vlcResponse);
                         }


### PR DESCRIPTION
**Changes**
* removed a debug log line that isn't useful anymore
* copied the video manager init logic and definition of `useDeinterlacing` into `onError()` from:
https://github.com/jellyfin/jellyfin-androidtv/blob/9feaf107b24b289718ab69b21953f6271674916d/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java#L677-L679
and
https://github.com/jellyfin/jellyfin-androidtv/blob/9feaf107b24b289718ab69b21953f6271674916d/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java#L634-L637

**Issues**
* With transcoding disabled for a user, playback of files with ASS subtitles in libVLC would fail to start. This is due to `getVideoStreamInfo()` failing to produce a valid stream URL for exoplayer because it isn't allowed to transcode. Where playback actually fails to start is when `startItem()` was called without first calling `mVideoManager.init()`
* likely fixes issue mentioned in this comment: https://github.com/jellyfin/jellyfin-androidtv/issues/1625#issuecomment-1114207216
