### PR TITLE
 Fix srt newline parsing, revert subtitle alignment back to left align

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1477,6 +1477,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             // Encode whitespace as html entities
             final String htmlText = text
                     .replaceAll("\\r\\n", "<br>")
+                    .replaceAll("\\n", "<br>")
                     .replaceAll("\\\\h", "&ensp;");
 
             final SpannableString span = new SpannableString(TextUtilsKt.toHtmlSpanned(htmlText));

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -54,7 +54,6 @@
             android:layout_marginBottom="48dp"
             android:textColor="@color/white"
             android:textSize="28sp"
-            android:gravity="center"
             app:strokeWidth="5.0"
             tools:text="Subtitles" />
 


### PR DESCRIPTION
**Changes**
* add an additional search and replace to convert newlines into `<br>`. Subtitles that use line-feed only (`\n`) can now be parsed in addition to CRLF (`\r` + `\n`), which was previously the only format parsed.
* removed `gravity="center"` for the subtitle TextView

**Issues**
* Fixes #1633 caused by #1572
* With `.srt` subtitles as an example, some use the "line-feed only" format, which wasn't handled. Because of this, subtitles which should be displayed as multiple lines could display as only one.

**Notes**
* I have tried a few things including adding an `AlignmentSpan` to get the `PaddedBackgroundSpan` to draw its background around the centered text. Unfortunately, this didn't work. Working with spans is a pain, and it seems like a solution that allows for centered text and functional backgrounds might require a custom span.