### PR TITLE
Use JF_BOT_TOKEN in app-publish workflow

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload release archive to GitHub release
         uses: alexellis/upload-assets@0.3.0
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
         with:
           asset_paths: '["build/jellyfin-publish/*"]'
       - name: Upload release archive to repo.jellyfin.org


### PR DESCRIPTION
This should fix the publish CI while keeping the default token read-only. Remind me to cherrypick it to the 0.13 branch if we do a 0.13.5 👀.

**Changes**
- Use JF_BOT_TOKEN in app-publish workflow

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
