### PR TITLE
Add context menus to startup fragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -10,6 +11,9 @@ import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.ViewButtonServerBinding
+import org.jellyfin.androidtv.util.MenuBuilder
+import org.jellyfin.androidtv.util.popupMenu
+import org.jellyfin.androidtv.util.showIfNotEmpty
 
 class ServerButtonView @JvmOverloads constructor(
 	context: Context,
@@ -73,6 +77,21 @@ class ServerButtonView @JvmOverloads constructor(
 				}
 			}
 		}
+
+	fun setPopupMenu(init: MenuBuilder.() -> Unit) {
+		setOnLongClickListener {
+			popupMenu(context, binding.root, init = init).showIfNotEmpty()
+		}
+	}
+
+	override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+		if (super.onKeyUp(keyCode, event)) return true
+
+		// Menu key should show the popup menu
+		if (event.keyCode == KeyEvent.KEYCODE_MENU) return performLongClick()
+
+		return false
+	}
 
 	enum class State {
 		DEFAULT,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
@@ -19,10 +19,6 @@ class DefaultCardView @JvmOverloads constructor(
 	defStyleAttr: Int = 0,
 	defStyleRes: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
-	companion object {
-		const val ANIMATION_DURATION = 150L // 150ms
-	}
-
 	init {
 		isFocusable = true
 		descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
@@ -77,7 +73,7 @@ class DefaultCardView @JvmOverloads constructor(
 			animate().apply {
 				scaleX(scale)
 				scaleY(scale)
-				duration = ANIMATION_DURATION
+				duration = resources.getInteger(R.integer.card_scale_duration).toLong()
 				withLayer()
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.card
 import android.content.Context
 import android.graphics.Rect
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -11,6 +12,9 @@ import androidx.core.view.updateLayoutParams
 import com.bumptech.glide.Glide
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.ViewCardDefaultBinding
+import org.jellyfin.androidtv.util.MenuBuilder
+import org.jellyfin.androidtv.util.popupMenu
+import org.jellyfin.androidtv.util.showIfNotEmpty
 import kotlin.math.roundToInt
 
 class DefaultCardView @JvmOverloads constructor(
@@ -61,6 +65,21 @@ class DefaultCardView @JvmOverloads constructor(
 					placeholder(placeholder)
 			}
 			.into(binding.banner)
+	}
+
+	fun setPopupMenu(init: MenuBuilder.() -> Unit) {
+		setOnLongClickListener {
+			popupMenu(context, binding.root, init = init).showIfNotEmpty()
+		}
+	}
+
+	override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+		if (super.onKeyUp(keyCode, event)) return true
+
+		// Menu key should show the popup menu
+		if (event.keyCode == KeyEvent.KEYCODE_MENU) return performLongClick()
+
+		return false
 	}
 
 	override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/MenuBuilder.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/MenuBuilder.kt
@@ -1,0 +1,42 @@
+package org.jellyfin.androidtv.util
+
+import android.content.Context
+import android.view.Gravity
+import android.view.Menu
+import android.view.MenuItem
+import android.view.SubMenu
+import android.view.View
+import android.widget.PopupMenu
+import androidx.annotation.GravityInt
+
+class MenuBuilder(
+	private val menu: Menu
+) {
+	fun item(
+		title: String,
+		onClick: () -> Unit
+	): MenuItem = menu.add(title).apply {
+		setOnMenuItemClickListener {
+			onClick()
+			true
+		}
+	}
+
+	fun subMenu(title: String, init: MenuBuilder.() -> Unit): SubMenu = menu.addSubMenu(title).apply {
+		MenuBuilder(this).init()
+	}
+}
+
+fun popupMenu(
+	context: Context,
+	anchor: View,
+	@GravityInt gravity: Int = Gravity.NO_GRAVITY,
+	init: MenuBuilder.() -> Unit
+): PopupMenu = PopupMenu(context, anchor, gravity).apply {
+	MenuBuilder(menu).init()
+}
+
+fun PopupMenu.showIfNotEmpty() = if (menu.hasVisibleItems()) {
+	show()
+	true
+} else false

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Animation durations are always defined in milliseconds -->
     <integer name="button_fade_duration">200</integer>
     <integer name="input_fade_duration">200</integer>
+    <integer name="card_scale_duration">150</integer>
 </resources>


### PR DESCRIPTION
**Changes**
- Move DefaultCardView animation duration to integers.xml
- Add MenuBuilder and DefaultCardView.setPopupMenu to easily create context menus for cards
- Add context menu to the users in the server screen:
  - Logout
  - Remove
- Add context menu to stored servers in the server select screen:
  - Remove

**Screenshots**

![image](https://user-images.githubusercontent.com/2305178/167209759-8b2f8fd6-d235-4939-9c61-5cc48c6cc18d.png)

Just a popup menu

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
