### PR TITLE
Fix favorite button in 0.13.z

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -15,6 +15,7 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
@@ -622,7 +623,7 @@ public class ItemListActivity extends FragmentActivity {
                             @Override
                             public void onResponse(UserItemDataDto response) {
                                 mBaseItem.setUserData(response);
-                                ((TextUnderButton)v).setImageResource(response.getIsFavorite() ? R.drawable.ic_heart_red : R.drawable.ic_heart);
+                                ((ImageButton)v).setImageResource(response.getIsFavorite() ? R.drawable.ic_heart_red : R.drawable.ic_heart);
                                 dataRefreshService.getValue().setLastFavoriteUpdate(System.currentTimeMillis());
                             }
                         });


### PR DESCRIPTION
So the "v" variable was not an instance of TextUnderButton but an ImageButton (the inner view of the TextUnderButton). This bug is already fixed in 0.14 because I remade the TextUnderButton.

The casting failed and threw an exception, but the apiclient onResponse handler catches all exceptions and ignores them lol.

**Changes**

- Fix favorite button in item list view in 0,13

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
