### PR TITLE
Add AsyncImageView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -1,0 +1,73 @@
+package org.jellyfin.androidtv.ui
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.widget.ImageView
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.doOnAttach
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.util.BlurHashDecoder
+import kotlin.math.round
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * An extension to the [ImageView] that makes it easy to load images from the network.
+ * The [load] function takes a url, blurhash and placeholder to asynchronously load the image
+ * using the lifecycle of the current fragment or activity.
+ */
+class AsyncImageView @JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+	defStyleAttr: Int = 0,
+) : AppCompatImageView(context, attrs, defStyleAttr) {
+	private val lifeCycleOwner get() = findViewTreeLifecycleOwner()
+
+	/**
+	 * The duration of the crossfade when changing switching the images of the url, blurhash and
+	 * placeholder.
+	 */
+	var crossFadeDuration = 100.milliseconds
+
+	/**
+	 * Load an image from the network using [url]. When the [url] is null or returns a bad response
+	 * the [placeholder] is shown. A [blurHash] is shown while loading the image. An aspect ratio is
+	 * required when using a BlurHash or the sizing will be incorrect.
+	 */
+	fun load(
+		url: String? = null,
+		blurHash: String? = null,
+		placeholder: Drawable? = null,
+		aspectRatio: Double = 1.0,
+		blurHashResolution: Int = 32,
+	) = doOnAttach {
+		lifeCycleOwner?.lifecycleScope?.launch {
+			var placeholderOrBlurHash = placeholder
+
+			// Only show blurhash if an image is going to be loaded from the network
+			if (url != null && blurHash != null) withContext(Dispatchers.IO) {
+				val blurHashBitmap = BlurHashDecoder.decode(
+					blurHash,
+					if (aspectRatio > 1) round(blurHashResolution * aspectRatio).toInt() else blurHashResolution,
+					if (aspectRatio >= 1) blurHashResolution else round(blurHashResolution / aspectRatio).toInt(),
+				)
+				if (blurHashBitmap != null) placeholderOrBlurHash = blurHashBitmap.toDrawable(resources)
+			}
+
+			// Start loading image or placeholder
+			Glide.with(this@AsyncImageView)
+				.load(url ?: placeholder)
+				.placeholder(placeholderOrBlurHash)
+				.error(placeholder)
+				.transition(DrawableTransitionOptions.withCrossFade(crossFadeDuration.inWholeMilliseconds.toInt()))
+				.into(this@AsyncImageView)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -10,7 +10,6 @@ import androidx.core.view.doOnAttach
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -66,7 +65,8 @@ class AsyncImageView @JvmOverloads constructor(
 				.load(url ?: placeholder)
 				.placeholder(placeholderOrBlurHash)
 				.error(placeholder)
-				.transition(DrawableTransitionOptions.withCrossFade(crossFadeDuration.inWholeMilliseconds.toInt()))
+				// FIXME: Glide is unable to scale the image when transitions are enabled
+				//.transition(DrawableTransitionOptions.withCrossFade(crossFadeDuration.inWholeMilliseconds.toInt()))
 				.into(this@AsyncImageView)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridButton.kt
@@ -6,7 +6,6 @@ open class GridButton(
 	val id: Int,
 	val text: String,
 	@DrawableRes val imageRes: Int,
-	val imageUrl: String? = null
 ) {
 	override fun toString() = text
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -5,9 +5,9 @@ import android.content.Intent
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
-import com.bumptech.glide.Glide
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.ViewNowPlayingBinding
 import org.jellyfin.androidtv.ui.playback.AudioEventListener
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.apiclient.model.entities.ImageType
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -62,11 +63,9 @@ class NowPlayingView @JvmOverloads constructor(
 	}
 
 	private fun setInfo(item: BaseItemDto) {
-		Glide.with(context)
-			.load(ImageUtils.getPrimaryImageUrl(item))
-			.error(R.drawable.ic_album)
-			.centerInside()
-			.into(binding.npIcon)
+		val placeholder = ContextCompat.getDrawable(context, R.drawable.ic_album)
+		val blurHash = item.imageBlurHashes?.get(ImageType.Primary)?.get(item.imageTags?.get(ImageType.Primary))
+		binding.npIcon.load(ImageUtils.getPrimaryImageUrl(item), blurHash, placeholder, item.primaryImageAspectRatio ?: 1.0)
 
 		currentDuration = TimeUtils.formatMillis(if (item.runTimeTicks != null) item.runTimeTicks / 10_000 else 0)
 		binding.npDesc.text = if (item.albumArtist != null) item.albumArtist else item.name

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -169,8 +169,8 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
         ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
-        gridRowAdapter.add(new GridButton(SCHEDULE, getString(R.string.lbl_schedule), R.drawable.tile_port_time, null));
-        gridRowAdapter.add(new GridButton(SERIES, mActivity.getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer, null));
+        gridRowAdapter.add(new GridButton(SCHEDULE, getString(R.string.lbl_schedule), R.drawable.tile_port_time));
+        gridRowAdapter.add(new GridButton(SERIES, mActivity.getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer));
         rowAdapter.add(new ListRow(gridHeader, gridRowAdapter));
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -473,27 +473,23 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
             gridRowAdapter.add(new GridButton(
                 LiveTvOption.LIVE_TV_GUIDE_OPTION_ID,
                 getString(R.string.lbl_live_tv_guide),
-                R.drawable.tile_port_guide,
-                null
+                R.drawable.tile_port_guide
             ));
             gridRowAdapter.add(new GridButton(
                 LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID,
                 getString(R.string.lbl_recorded_tv),
-                R.drawable.tile_port_record,
-                null
+                R.drawable.tile_port_record
             ));
             if (Utils.canManageRecordings(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue())) {
                 gridRowAdapter.add(new GridButton(
                     LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID,
                     getString(R.string.lbl_schedule),
-                    R.drawable.tile_port_time,
-                    null
+                    R.drawable.tile_port_time
                 ));
                 gridRowAdapter.add(new GridButton(
                     LiveTvOption.LIVE_TV_SERIES_OPTION_ID,
                     getString(R.string.lbl_series),
-                    R.drawable.tile_port_series_timer,
-                    null
+                    R.drawable.tile_port_series_timer
                 ));
             }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -294,14 +294,14 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
 
         switch (itemTypeString) {
             case "Movie":
-                gridRowAdapter.add(new GridButton(SUGGESTED, getString(R.string.lbl_suggested), R.drawable.tile_suggestions, null));
+                gridRowAdapter.add(new GridButton(SUGGESTED, getString(R.string.lbl_suggested), R.drawable.tile_suggestions));
                 addStandardViewButtons(gridRowAdapter);
                 break;
 
             case "MusicAlbum":
-                gridRowAdapter.add(new GridButton(ALBUMS, getString(R.string.lbl_albums), R.drawable.tile_audio, null));
-                gridRowAdapter.add(new GridButton(ARTISTS, getString(R.string.lbl_artists), R.drawable.tile_artists, null));
-                gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres, null));
+                gridRowAdapter.add(new GridButton(ALBUMS, getString(R.string.lbl_albums), R.drawable.tile_audio));
+                gridRowAdapter.add(new GridButton(ARTISTS, getString(R.string.lbl_artists), R.drawable.tile_artists));
+                gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres));
                 break;
 
             default:
@@ -313,9 +313,9 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
     }
 
     protected void addStandardViewButtons(ArrayObjectAdapter gridRowAdapter) {
-        gridRowAdapter.add(new GridButton(GRID, getString(R.string.lbl_all_items), R.drawable.tile_port_grid, null));
-        gridRowAdapter.add(new GridButton(BY_LETTER, getString(R.string.lbl_by_letter), R.drawable.tile_letters, null));
-        gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres, null));
+        gridRowAdapter.add(new GridButton(GRID, getString(R.string.lbl_all_items), R.drawable.tile_port_grid));
+        gridRowAdapter.add(new GridButton(BY_LETTER, getString(R.string.lbl_by_letter), R.drawable.tile_letters));
+        gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres));
         // Disabled because the screen doesn't behave properly
         // gridRowAdapter.add(new GridButton(PERSONS, getString(R.string.lbl_performers), R.drawable.tile_actors));
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
@@ -2,14 +2,13 @@ package org.jellyfin.androidtv.ui.card
 
 import android.content.Context
 import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.annotation.DrawableRes
 import androidx.core.view.updateLayoutParams
-import com.bumptech.glide.Glide
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.ViewCardDefaultBinding
 import org.jellyfin.androidtv.util.MenuBuilder
@@ -56,16 +55,10 @@ class DefaultCardView @JvmOverloads constructor(
 	}
 
 	fun setImage(
-		image: String?,
-		@DrawableRes placeholder: Int? = null,
-	) {
-		Glide.with(context)
-			.load(image).apply {
-				if (placeholder != null)
-					placeholder(placeholder)
-			}
-			.into(binding.banner)
-	}
+		url: String? = null,
+		blurHash: String? = null,
+		placeholder: Drawable? = null,
+	) = binding.banner.load(url, blurHash, placeholder)
 
 	fun setPopupMenu(init: MenuBuilder.() -> Unit) {
 		setOnLongClickListener {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -15,6 +15,7 @@ import androidx.leanback.widget.BaseCardView;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.databinding.ViewCardLegacyImageBinding;
+import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.ContextExtensionsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
@@ -63,7 +64,7 @@ public class LegacyImageCardView extends BaseCardView {
         mBanner.setVisibility(VISIBLE);
     }
 
-    public final ImageView getMainImageView() {
+    public final AsyncImageView getMainImageView() {
         return binding.mainImage;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -30,8 +29,6 @@ import androidx.leanback.widget.OnItemViewSelectedListener;
 import androidx.leanback.widget.Presenter;
 import androidx.leanback.widget.Row;
 import androidx.leanback.widget.RowPresenter;
-
-import com.bumptech.glide.Glide;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.UserRepository;
@@ -104,7 +101,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import kotlin.Lazy;
 import timber.log.Timber;
@@ -477,17 +473,8 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                     }
 
             }
-            try {
-                //Main image
-                Bitmap poster = Glide.with(mActivity)
-                        .asBitmap()
-                        .load(primaryImageUrl)
-                        .submit()
-                        .get();
-                mDetailsOverviewRow.setImageBitmap(mActivity, poster);
-            } catch (ExecutionException | InterruptedException e) {
-                Timber.e(e, "Error loading image");
-            }
+
+            mDetailsOverviewRow.setImageBitmap(primaryImageUrl);
 
             return mDetailsOverviewRow;
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -14,16 +14,14 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
 import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
-
-import com.bumptech.glide.Glide;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.UserRepository;
@@ -32,6 +30,7 @@ import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.databinding.ActivityItemListBinding;
 import org.jellyfin.androidtv.databinding.ViewRowDetailsBinding;
+import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.ItemListView;
 import org.jellyfin.androidtv.ui.ItemRowView;
 import org.jellyfin.androidtv.ui.TextUnderButton;
@@ -75,7 +74,7 @@ public class ItemListActivity extends FragmentActivity {
 
     private TextView mTitle;
     private TextView mGenreRow;
-    private ImageView mPoster;
+    private AsyncImageView mPoster;
     private TextView mSummary;
     private LinearLayout mButtonRow;
     private ItemListView mItemList;
@@ -478,21 +477,10 @@ public class ItemListActivity extends FragmentActivity {
                 mPoster.setImageResource(R.drawable.ic_video_queue);
                 break;
             default:
-                // Figure image size
                 Double aspect = ImageUtils.getImageAspectRatio(item, false);
-                int posterHeight = aspect > 1 ? Utils.convertDpToPixel(this, 160) : Utils.convertDpToPixel(this, 250);
-                int posterWidth = (int)((aspect) * posterHeight);
-                if (posterHeight < 10) posterWidth = Utils.convertDpToPixel(this, 150);  //Guard against zero size images causing picasso to barf
-
-                String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, false, posterHeight);
-
-
-                Glide.with(this)
-                        .load(primaryImageUrl)
-                        .override(posterWidth,posterHeight)
-                        .fitCenter()
-                        .into(mPoster);
-
+                String primaryImageUrl = ImageUtils.getPrimaryImageUrl(item);
+                mPoster.setPadding(0, 0, 0, 0);
+                mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(this, R.drawable.ic_album), aspect, 0);
                 break;
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.java
@@ -1,11 +1,7 @@
 package org.jellyfin.androidtv.ui.itemdetail;
 
-import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Drawable;
-
 import androidx.annotation.IntRange;
+import androidx.annotation.Nullable;
 import androidx.core.view.ViewKt;
 import androidx.leanback.widget.Row;
 
@@ -18,7 +14,7 @@ import java.util.List;
 
 public class MyDetailsOverviewRow extends Row {
     private BaseItemDto mItem;
-    private Drawable mImageDrawable;
+    private String mImageDrawable;
     private String mSummary;
     private int mProgress;
     private InfoItem mInfoItem1;
@@ -59,9 +55,9 @@ public class MyDetailsOverviewRow extends Row {
     }
 
     public BaseItemDto getItem() { return mItem; }
-    public Drawable getImageDrawable() { return mImageDrawable; }
+    public String getImageDrawable() { return mImageDrawable; }
 
-    public void setImageBitmap(Context context, Bitmap bm) { mImageDrawable = new BitmapDrawable(context.getResources(), bm); }
+    public void setImageBitmap(@Nullable String url) { mImageDrawable = url; }
 
     public void addAction(TextUnderButton button) {
         mActions.add(button);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -859,7 +859,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
     private void retrieveAudioPlaylists(final ItemQuery query) {
         //Add specialized playlists first
         clear();
-        add(new GridButton(EnhancedBrowseFragment.FAVSONGS, context.getString(R.string.lbl_favorites), R.drawable.favorites, null));
+        add(new GridButton(EnhancedBrowseFragment.FAVSONGS, context.getString(R.string.lbl_favorites), R.drawable.favorites));
         itemsLoaded = 1;
         retrieve(query);
     }
@@ -1237,14 +1237,14 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     int prevItems = adapter.size() > 0 ? adapter.size() : 0;
                     if (adapter.chunkSize == 0) {
                         // and recordings as first item if showing all
-                        adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, context.getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record, null)));
+                        adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, context.getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record)));
                         i++;
                         if (Utils.canManageRecordings(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue())) {
                             // and schedule
-                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, context.getString(R.string.lbl_schedule), R.drawable.tile_port_time, null)));
+                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, context.getString(R.string.lbl_schedule), R.drawable.tile_port_time)));
                             i++;
                             // and series
-                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, context.getString(R.string.lbl_series), R.drawable.tile_port_series_timer, null)));
+                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, context.getString(R.string.lbl_series), R.drawable.tile_port_series_timer)));
                             i++;
                         }
                     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -18,6 +18,7 @@ import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
 import androidx.leanback.widget.HeaderItem;
@@ -28,11 +29,10 @@ import androidx.leanback.widget.Presenter;
 import androidx.leanback.widget.Row;
 import androidx.leanback.widget.RowPresenter;
 
-import com.bumptech.glide.Glide;
-
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.databinding.ActivityAudioNowPlayingBinding;
+import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.ClockUserView;
 import org.jellyfin.androidtv.ui.itemdetail.FullDetailsActivity;
 import org.jellyfin.androidtv.ui.itemdetail.ItemListActivity;
@@ -78,7 +78,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
     private TextView mSongTitle;
     private TextView mAlbumTitle;
     private TextView mCurrentNdx;
-    private ImageView mPoster;
+    private AsyncImageView mPoster;
     private ProgressBar mCurrentProgress;
     private TextView mCurrentPos;
     private TextView mRemainingTime;
@@ -418,18 +418,10 @@ public class AudioNowPlayingActivity extends BaseActivity {
         // Figure image size
         Double aspect = ImageUtils.getImageAspectRatio(mBaseItem, false);
         int posterHeight = aspect > 1 ? Utils.convertDpToPixel(mActivity, 150) : Utils.convertDpToPixel(mActivity, 250);
-        int posterWidth = (int) ((aspect) * posterHeight);
-        if (posterHeight < 10)
-            posterWidth = Utils.convertDpToPixel(mActivity, 150);  //Guard against zero size images causing picasso to barf
 
         String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, false, posterHeight);
         Timber.d("Audio Poster url: %s", primaryImageUrl);
-        Glide.with(mActivity)
-                .load(primaryImageUrl)
-                .error(R.drawable.ic_album)
-                .override(posterWidth, posterHeight)
-                .centerInside()
-                .into(mPoster);
+        mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(this, R.drawable.ic_album), aspect, 0);
     }
 
     private void loadItem() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -6,7 +6,6 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
-import android.graphics.drawable.Drawable;
 import android.media.AudioManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -36,12 +35,6 @@ import androidx.leanback.widget.OnItemViewClickedListener;
 import androidx.leanback.widget.Presenter;
 import androidx.leanback.widget.Row;
 import androidx.leanback.widget.RowPresenter;
-
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.DataSource;
-import com.bumptech.glide.load.engine.GlideException;
-import com.bumptech.glide.request.RequestListener;
-import com.bumptech.glide.request.target.Target;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.UserRepository;
@@ -1295,24 +1288,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             if (imageUrl != null) {
                 binding.itemLogo.setVisibility(View.VISIBLE);
                 binding.itemTitle.setVisibility(View.GONE);
-                Glide.with(requireContext())
-                    .load(imageUrl)
-                    .centerInside()
-                    .listener(new RequestListener<Drawable>() {
-                        @Override
-                        public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
-                            binding.itemLogo.setContentDescription(current.getName());
-                            return false;
-                        }
-
-                        @Override
-                        public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
-                            binding.itemLogo.setVisibility(View.GONE);
-                            binding.itemTitle.setVisibility(View.VISIBLE);
-                            return false;
-                        }
-                    })
-                    .into(binding.itemLogo);
+                binding.itemLogo.setContentDescription(current.getName());
+                binding.itemLogo.load(imageUrl, null, null, 1.0, 0);
             } else {
                 binding.itemLogo.setVisibility(View.GONE);
                 binding.itemTitle.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -34,8 +34,16 @@ class NextUpFragment : Fragment() {
 
 					backgroundService.setBackground(data.baseItem)
 
-					binding.logo.setImageBitmap(data.logo)
-					binding.image.setImageBitmap(data.thumbnail)
+					binding.logo.load(
+						url = data.logo.url,
+						blurHash = data.logo.blurHash,
+						aspectRatio = data.logo.aspectRatio
+					)
+					binding.image.load(
+						url = data.thumbnail.url,
+						blurHash = data.thumbnail.blurHash,
+						aspectRatio = data.thumbnail.aspectRatio
+					)
 					binding.title.text = data.title
 				}
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpItemData.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpItemData.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.playback.nextup
 
-import android.graphics.Bitmap
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 
@@ -8,6 +7,8 @@ data class NextUpItemData(
 	val baseItem: BaseItemDto,
 	val id: UUID,
 	val title: String,
-	val thumbnail: Bitmap?,
-	val logo: Bitmap?
-)
+	val thumbnail: Image,
+	val logo: Image,
+) {
+	data class Image(val url: String?, val blurHash: String?, val aspectRatio: Double)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -14,9 +14,6 @@ import androidx.leanback.widget.Presenter;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ViewTreeLifecycleOwner;
 
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
-
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.constant.ImageType;
 import org.jellyfin.androidtv.preference.UserPreferences;
@@ -24,7 +21,6 @@ import org.jellyfin.androidtv.preference.constant.RatingType;
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior;
 import org.jellyfin.androidtv.ui.card.LegacyImageCardView;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
-import org.jellyfin.androidtv.util.BlurHashUtils;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
@@ -37,8 +33,6 @@ import org.koin.java.KoinJavaComponent;
 
 import java.util.Date;
 import java.util.HashMap;
-
-import timber.log.Timber;
 
 public class CardPresenter extends Presenter {
     private static final double ASPECT_RATIO_BANNER = 1000.0 / 185.0;
@@ -336,32 +330,7 @@ public class CardPresenter extends Presenter {
         }
 
         protected void updateCardViewImage(@Nullable String url, @Nullable String blurHash) {
-            try {
-                if (url == null) {
-                    Glide.with(mCardView.getContext())
-                            .load(mDefaultCardImage)
-                            .into(mCardView.getMainImageView());
-                } else {
-                    BlurHashUtils.createBlurHashDrawable(
-                            lifecycleOwner,
-                            blurHash,
-                            (aspect > 1) ? (int) Math.round(32 * aspect) : 32,
-                            (aspect >= 1) ? 32 : (int) Math.round(32 / aspect),
-                            bitmap -> {
-                                Glide.with(mCardView.getContext())
-                                        .load(url)
-                                        .error(mDefaultCardImage)
-                                        .thumbnail(Glide.with(mCardView.getContext()).load(bitmap != null ? bitmap : mDefaultCardImage).centerCrop())
-                                        .transition(DrawableTransitionOptions.withCrossFade(200))
-                                        .into(mCardView.getMainImageView());
-
-                                return null;
-                            }
-                    );
-                }
-            } catch (IllegalArgumentException e) {
-                Timber.i("Image load aborted due to activity closing");
-            }
+            mCardView.getMainImageView().load(url, blurHash, mDefaultCardImage, aspect, 32);
         }
 
         protected void resetCardView() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.java
@@ -6,10 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.ColorInt;
-import androidx.annotation.DrawableRes;
 import androidx.leanback.widget.Presenter;
-
-import com.bumptech.glide.Glide;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.ui.GridButton;
@@ -44,22 +41,11 @@ public class GridButtonPresenter extends Presenter {
         public void setItem(GridButton m, int width, int height) {
             gridButton = m;
             cardView.setMainImageDimensions(width, height);
-            if (gridButton.getImageUrl() == null) {
-                cardView.getMainImageView().setImageResource(gridButton.getImageRes());
-            } else {
-                Glide.with(cardView.getContext())
-                        .load(gridButton.getImageUrl())
-                        .error(gridButton.getImageRes())
-                        .into(cardView.getMainImageView());
-            }
+            cardView.getMainImageView().setImageResource(gridButton.getImageRes());
         }
 
         public GridButton getItem() {
             return gridButton;
-        }
-
-        protected void updateCardViewImage(@DrawableRes int image) {
-            cardView.getMainImageView().setImageResource(image);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.ui.presentation;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
@@ -13,6 +12,7 @@ import androidx.leanback.widget.RowPresenter;
 
 import org.jellyfin.androidtv.data.model.InfoItem;
 import org.jellyfin.androidtv.databinding.ViewRowDetailsBinding;
+import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.DetailRowView;
 import org.jellyfin.androidtv.ui.TextUnderButton;
 import org.jellyfin.androidtv.ui.itemdetail.MyDetailsOverviewRow;
@@ -38,7 +38,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
         private TextView mGenreRow;
         private LinearLayout mInfoRow;
         private TextView mTitle;
-        private ImageView mPoster;
+        private AsyncImageView mPoster;
         private TextView mSummary;
         private LinearLayout mButtonRow;
         private ProgressBar mProgress;
@@ -109,9 +109,10 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
         setInfo2(row.getInfoItem2());
         setInfo3(row.getInfoItem3());
 
-        vh.mPoster.setImageDrawable(row.getImageDrawable());
+        String posterUrl = row.getImageDrawable();
+        vh.mPoster.load(posterUrl, null, null, 1.0, 0);
         int progress = row.getProgress();
-        if (progress > 0 && vh.mPoster.getDrawable() != null) {
+        if (progress > 0 && posterUrl != null) {
             vh.mProgress.setProgress(progress);
             vh.mProgress.setVisibility(View.VISIBLE);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -191,7 +192,10 @@ class ServerFragment : Fragment() {
 
 		override fun onBindViewHolder(holder: ViewHolder, user: User) {
 			holder.cardView.title = user.name
-			holder.cardView.setImage(startupViewModel.getUserImage(server, user), R.drawable.tile_port_user)
+			holder.cardView.setImage(
+				url = startupViewModel.getUserImage(server, user),
+				placeholder = ContextCompat.getDrawable(context, R.drawable.tile_port_user)
+			)
 			holder.cardView.setPopupMenu {
 				// Logout button
 				if (user is PrivateUser && user.accessToken != null) {

--- a/app/src/main/res/layout/activity_audio_now_playing.xml
+++ b/app/src/main/res/layout/activity_audio_now_playing.xml
@@ -205,7 +205,7 @@
                 </LinearLayout>
             </RelativeLayout>
 
-            <ImageView
+            <org.jellyfin.androidtv.ui.AsyncImageView
                 android:id="@+id/poster"
                 android:layout_width="250dp"
                 android:layout_height="250dp"

--- a/app/src/main/res/layout/fragment_next_up.xml
+++ b/app/src/main/res/layout/fragment_next_up.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:background="@drawable/moviebg">
 
-    <ImageView
+    <org.jellyfin.androidtv.ui.AsyncImageView
         android:id="@+id/logo"
         android:layout_width="190dp"
         android:layout_height="wrap_content"
@@ -41,7 +41,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_goneMarginEnd="0dp">
 
-            <ImageView
+            <org.jellyfin.androidtv.ui.AsyncImageView
                 android:id="@+id/image"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/view_card_default.xml
+++ b/app/src/main/res/layout/view_card_default.xml
@@ -18,7 +18,7 @@
         android:foreground="@drawable/ripple"
         app:cardCornerRadius="?attr/cardRounding">
 
-        <ImageView
+        <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/banner"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/view_card_legacy_image.xml
+++ b/app/src/main/res/layout/view_card_legacy_image.xml
@@ -26,7 +26,7 @@
         tools:ignore="UnusedAttribute"
         tools:visibility="visible">
 
-        <ImageView
+        <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/main_image"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/view_now_playing.xml
+++ b/app/src/main/res/layout/view_now_playing.xml
@@ -8,7 +8,7 @@
     android:maxWidth="250dp"
     android:padding="5dp">
 
-    <ImageView
+    <org.jellyfin.androidtv.ui.AsyncImageView
         android:id="@+id/npIcon"
         android:layout_width="35dp"
         android:layout_height="35dp"

--- a/app/src/main/res/layout/view_row_details.xml
+++ b/app/src/main/res/layout/view_row_details.xml
@@ -148,7 +148,7 @@
         android:layout_alignParentTop="true"
         android:layout_toEndOf="@+id/middleFrame">
 
-        <ImageView
+        <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/mainImage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -86,7 +86,7 @@
         android:clickable="false"
         android:visibility="invisible">
 
-        <ImageView
+        <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/item_logo"
             android:layout_width="wrap_content"
             android:layout_height="60dp"


### PR DESCRIPTION
The AsyncImageView makes it easier to load images with an optional placeholder and blurhash. This change is a part of something bigger I'm working on, extracting it to make that PR smaller.

**Changes**
- Add AsyncImageView
  - Use AsyncImageView in DefaultCardView
  - Use AsyncImageView in NextUpFragment
  - Use AsyncImageView in FullDetailsActivity poster
  - Use AsyncImageView in AudioNowPlayingActivity poster
  - Use AsyncImageView in LegacyImageCardView
  - Use AsyncImageView in CustomPlaybackOverlayFragment logo
  - Use AsyncImageView in NowPlayingView
  - Use AsyncImageView in ItemListActivity
- Remove unused imageUrl from GridButton


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
