### PR TITLE
Use popup menu styling for popup windows

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -3,13 +3,10 @@ package org.jellyfin.androidtv.ui.browsing;
 import static org.koin.java.KoinJavaComponent.inject;
 
 import android.content.Intent;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Gravity;
 import android.view.KeyEvent;
-import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageButton;
@@ -487,11 +484,9 @@ public class StdGridFragment extends GridFragment {
         private final AlphaPickerView alphaPicker;
 
         JumplistPopup() {
-            LayoutInflater inflater = LayoutInflater.from(requireContext());
-            PopupEmptyBinding layout = PopupEmptyBinding.inflate(inflater, mGridDock, false);
+            PopupEmptyBinding layout = PopupEmptyBinding.inflate(getLayoutInflater(), mGridDock, false);
             popupWindow = new PopupWindow(layout.emptyPopup, WIDTH, HEIGHT, true);
             popupWindow.setOutsideTouchable(true);
-            popupWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT)); // necessary for popup to dismiss
             popupWindow.setAnimationStyle(R.style.WindowAnimation_SlideTop);
 
             alphaPicker = new AlphaPickerView(requireContext(), null);

--- a/app/src/main/res/layout/guide_filter_popup.xml
+++ b/app/src/main/res/layout/guide_filter_popup.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/popupWindowBackground">
+    android:background="@drawable/popup_menu_back">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/guide_options_popup.xml
+++ b/app/src/main/res/layout/guide_options_popup.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/popupWindowBackground">
+    android:background="@drawable/popup_menu_back">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/new_program_record_popup.xml
+++ b/app/src/main/res/layout/new_program_record_popup.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/popupWindowBackground">
+    android:background="@drawable/popup_menu_back">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/popup_empty.xml
+++ b/app/src/main/res/layout/popup_empty.xml
@@ -4,6 +4,6 @@
     android:id="@+id/empty_popup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/popupWindowBackground"
+    android:background="@drawable/popup_menu_back"
     android:padding="10dp"
     tools:ignore="Overdraw" />

--- a/app/src/main/res/layout/program_detail_popup.xml
+++ b/app/src/main/res/layout/program_detail_popup.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/popupWindowBackground">
+    android:background="@drawable/popup_menu_back">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/settings_popup.xml
+++ b/app/src/main/res/layout/settings_popup.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/popupWindowBackground"
+    android:background="@drawable/popup_menu_back"
     android:padding="20dp">
 
     <TextView

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -9,8 +9,6 @@
         <attr name="progressBackground" format="reference|color" />
         <attr name="progressPrimary" format="reference|color" />
         <attr name="progressSecondary" format="reference|color" />
-        <!-- Popup Window Attributes -->
-        <attr name="popupWindowBackground" format="reference|color" />
         <!-- CardView Attributes -->
         <attr name="cardImageBackground" format="reference|color" />
         <attr name="cardViewBackground" format="reference|color" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -76,4 +76,9 @@
         <item name="android:popupBackground">@drawable/popup_menu_back</item>
         <item name="android:textColor">@color/indigo_dye</item>
     </style>
+
+    <style name="PopupWindow" parent="android:Widget.Material.PopupWindow">
+        <item name="android:popupBackground">@drawable/popup_menu_back</item>
+        <item name="android:textColor">@color/indigo_dye</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -8,8 +8,6 @@
         <item name="android:colorAccent">@color/jellyfin_blue</item>
         <!-- Background resource or color -->
         <item name="android:windowBackground">@color/not_quite_black</item>
-        <!-- Background color for popup windows -->
-        <item name="popupWindowBackground">@color/not_quite_black</item>
         <!-- Background color for CardViews -->
         <item name="cardImageBackground">@color/grey</item>
         <item name="cardViewBackground">@android:color/transparent</item>
@@ -41,6 +39,7 @@
 
         <item name="preferenceTheme">@style/PreferenceThemeOverlayLeanback</item>
         <item name="android:popupMenuStyle">@style/PopupMenu</item>
+        <item name="android:popupWindowStyle">@style/PopupWindow</item>
 
         <!-- Rounding Values -->
         <item name="cardRounding">4dp</item>


### PR DESCRIPTION
**Changes**
- Use popup menu styling for popup windows

**Screenshots**
![image](https://user-images.githubusercontent.com/2305178/170862907-f451758b-19f6-4e39-979c-80a1383a2ad0.png)

The AlphaPicker popup when using the purple theme.

![image](https://user-images.githubusercontent.com/2305178/170862967-e5786177-1433-42c8-ad94-97aab81c44bd.png)

The audio/sub delay thingy when using purple theme.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
