### PR TITLE
Restyle TextSearchFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchActivity.kt
@@ -1,12 +1,16 @@
 package org.jellyfin.androidtv.ui.search
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.speech.SpeechRecognizer
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 
 class SearchActivity : FragmentActivity() {
 	private val isSpeechEnabled by lazy {
 		SpeechRecognizer.isRecognitionAvailable(this)
+			&& ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_DENIED
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/fragment_search_text.xml
+++ b/app/src/main/res/layout/fragment_search_text.xml
@@ -1,34 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/relativeLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- Search bar + icon -->
-    <EditText
-        android:id="@+id/search_bar"
-        android:layout_width="600dp"
-        android:layout_height="56dp"
-        android:layout_marginTop="16dp"
-        android:hint="@string/lbl_search_hint"
-        android:imeOptions="normal|flagNoExtractUi|actionSearch"
-        android:inputType="text"
-        android:singleLine="true"
-        android:textSize="18sp"
-        app:layout_constraintEnd_toEndOf="parent"
+    <ImageView
+        android:id="@+id/logo"
+        android:layout_width="wrap_content"
+        android:layout_height="41dp"
+        android:layout_marginStart="48dp"
+        android:layout_marginTop="27dp"
+        android:layout_marginBottom="27dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/app_name"
+        android:scaleType="centerCrop"
+        android:src="@drawable/app_logo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+
     <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginEnd="8dp"
-        android:src="@drawable/lb_ic_in_app_search"
-        app:layout_constraintBottom_toBottomOf="@+id/search_bar"
-        app:layout_constraintEnd_toStartOf="@+id/search_bar"
-        app:layout_constraintTop_toTopOf="@+id/search_bar" />
+        android:id="@+id/search_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_marginStart="48dp"
+        android:contentDescription="@string/lbl_search"
+        android:src="@drawable/ic_search"
+        app:layout_constraintBottom_toBottomOf="@id/logo"
+        app:layout_constraintStart_toEndOf="@id/logo"
+        app:layout_constraintTop_toTopOf="@id/logo" />
+
+    <EditText
+        android:id="@+id/search_bar"
+        style="@style/Input.Default"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="48dp"
+        android:hint="@string/lbl_search_hint"
+        android:imeOptions="actionSearch"
+        android:importantForAutofill="no"
+        android:inputType="text"
+        app:layout_constraintBottom_toBottomOf="@id/logo"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/search_icon"
+        app:layout_constraintTop_toTopOf="@id/logo" />
 
     <!-- Fragment showing search results -->
     <androidx.fragment.app.FragmentContainerView
@@ -36,9 +52,9 @@
         android:name="androidx.leanback.app.RowsSupportFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="27dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/search_bar" />
+        app:layout_constraintTop_toBottomOf="@id/logo" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -66,6 +66,7 @@
         <item name="android:background">@drawable/input_default_back</item>
         <item name="android:foreground">@drawable/input_default_ripple</item>
         <item name="android:textColor">@drawable/input_default_text</item>
+        <item name="android:textColorHint">@drawable/input_default_text</item>
         <item name="android:paddingTop">8dp</item>
         <item name="android:paddingBottom">8dp</item>
         <item name="android:paddingStart">8dp</item>


### PR DESCRIPTION
Depends on #1744 because I forgot to switch to master

**Changes**
- Check for RECORD_AUDIO permission in SearchActivity
- Add textColorHint to Input.Default
- Restyle TextSearchFragment
  - Now uses new input style
  - Shows the logo in the same position as home screen

**Screenshots**

![image](https://user-images.githubusercontent.com/2305178/170889540-317ef8a5-93aa-4c01-b5c3-57bb4461e289.png)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
