### PR TITLE
Fix AuthPreferencesScreen sometimes not showing any servers/users

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -44,6 +44,7 @@ class AuthPreferencesScreen : OptionsFragment() {
 
 		viewLifecycleOwner.lifecycleScope.launch {
 			viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+				serverRepository.loadStoredServers()
 				serverRepository.storedServers.collect { rebuild() }
 			}
 		}


### PR DESCRIPTION
When opening the AuthPreferencesScreen without another part of the app (pre-)loading the stored servers the list would be empty. This issue never really showed until #1756 which skips the server selection screen.

**Changes**
- Fix AuthPreferencesScreen sometimes not showing any servers/users

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
