### PR TITLE
Fix EAC3 transcoding in libvlc on 10.8.0-beta3

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -59,6 +59,7 @@ class LibVlcProfile(
 					Codec.Audio.MP3,
 					Codec.Audio.MP2,
 					Codec.Audio.AC3,
+					Codec.Audio.EAC3,
 					Codec.Audio.WMA,
 					Codec.Audio.WMAV2,
 					Codec.Audio.DCA,


### PR DESCRIPTION
Fixes EAC3 transcoding in libvlc of 10.8.0-beta3

**Changes**
Previously, it would transcode when EAC3 files are played (especially audio channels ≥ 6), and if direct play is forced, they do not play at all with the error `Cannot play this video format`. Therefore, I added the codec EAC3 as an audio profile to the libVLC profile. This has fixed the issue where when EAC3 files are played using libvlc on Jellyfin, it resorts to transcoding on Jellyfin Server v10.8.0-beta3.

**Issues**
Fixes #1723 
