### PR TITLE
Fix ItemRowAdapter.retrieveNext() Query StartIndex

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -509,6 +509,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
             return;
         }
 
+        Integer savedIdx = null;
         switch (queryType) {
             case Persons:
                 if (mPersonsQuery == null) {
@@ -516,9 +517,11 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                 }
                 notifyRetrieveStarted();
 
+                savedIdx = mPersonsQuery.getStartIndex();
                 //set the query to go get the next chunk
                 mPersonsQuery.setStartIndex(itemsLoaded);
                 retrieve(mPersonsQuery);
+                mPersonsQuery.setStartIndex(savedIdx); // is reused so reset
                 break;
 
             case LiveTvChannel:
@@ -527,9 +530,11 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                 }
                 notifyRetrieveStarted();
 
+                savedIdx = mTvChannelQuery.getStartIndex();
                 //set the query to go get the next chunk
                 mTvChannelQuery.setStartIndex(itemsLoaded);
                 retrieve(mTvChannelQuery);
+                mTvChannelQuery.setStartIndex(savedIdx); // is reused so reset
                 break;
 
             case AlbumArtists:
@@ -538,9 +543,11 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                 }
                 notifyRetrieveStarted();
 
+                savedIdx = mArtistsQuery.getStartIndex();
                 //set the query to go get the next chunk
                 mArtistsQuery.setStartIndex(itemsLoaded);
                 retrieve(mArtistsQuery);
+                mArtistsQuery.setStartIndex(savedIdx); // is reused so reset
                 break;
 
             default:
@@ -549,9 +556,11 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                 }
                 notifyRetrieveStarted();
 
+                savedIdx = mQuery.getStartIndex();
                 //set the query to go get the next chunk
                 mQuery.setStartIndex(itemsLoaded);
                 retrieve(mQuery);
+                mQuery.setStartIndex(savedIdx); // is reused so reset
                 break;
         }
     }


### PR DESCRIPTION
**Changes**
Make sure we reset the StartIndex, since the Query object is reused, otherwise all following queries will break.

**Issues**
Issue steps:
* start a library/grid view with a lib > 50 entries
* change focus until retrieveNext() is triggered via loadMoreItemsIfNeeded()
* now enable any filter like "watched" or "favorites"
* the "new" query will have the StartIndex, from the last retrieveNext() call and either display nothing or some single items or a mix of other stuff depending on the set "sortby" filter


PS: @nielsvanvelzen just a quick fix that drove me crazy, since i though my refactor stuff was the cause, yet turned out its a master branch bug.