### PR TITLE
fix subtitle background alignment, center subtitle text

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -1461,7 +1462,12 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             if (subtitlesBackgroundEnabled) {
                 // Disable the text outlining when the background is enabled
                 binding.subtitlesText.setStrokeWidth(0.0f);
-                span.setSpan(new PaddedLineBackgroundSpan(ContextCompat.getColor(requireContext(), R.color.black_opaque), SUBTITLE_PADDING), 0, span.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+                // get the alignment gravity of the TextView
+                // extract the absolute horizontal gravity so the span can draw its background aligned
+                int gravity = binding.subtitlesText.getGravity();
+                int horizontalGravity = Gravity.getAbsoluteGravity(gravity, binding.subtitlesText.getLayoutDirection()) & Gravity.HORIZONTAL_GRAVITY_MASK;
+                span.setSpan(new PaddedLineBackgroundSpan(ContextCompat.getColor(requireContext(), R.color.black_opaque), SUBTITLE_PADDING, horizontalGravity), 0, span.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
             }
 
             binding.subtitlesText.setText(span);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/PaddedLineBackgroundSpan.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/PaddedLineBackgroundSpan.kt
@@ -37,12 +37,14 @@ class PaddedLineBackgroundSpan(
 		// Measure the current line of text
 		val textWidth = paint.measureText(text, start, end).roundToInt()
 
+		@Suppress("RtlHardcoded")
 		val rectLeft = when(horizontalGravity) {
 			Gravity.CENTER_HORIZONTAL -> ((right - textWidth) / 2) - horizontalPadding
 			Gravity.RIGHT -> right - textWidth - horizontalPadding
 			else -> left - horizontalPadding
 		}
 
+		@Suppress("RtlHardcoded")
 		val rectRight = when(horizontalGravity) {
 			Gravity.CENTER_HORIZONTAL -> right - rectLeft
 			Gravity.RIGHT -> right + horizontalPadding

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/PaddedLineBackgroundSpan.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/PaddedLineBackgroundSpan.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.shared
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
+import android.view.Gravity
 import android.text.style.LineBackgroundSpan
 import androidx.annotation.ColorInt
 import androidx.annotation.Dimension
@@ -14,7 +15,8 @@ import kotlin.math.roundToInt
  */
 class PaddedLineBackgroundSpan(
 	@ColorInt private val backgroundColor: Int,
-	@Dimension private val horizontalPadding: Int
+	@Dimension private val horizontalPadding: Int,
+	private val horizontalGravity: Int,
 ) : LineBackgroundSpan {
 	private val backgroundRect = Rect()
 
@@ -35,11 +37,23 @@ class PaddedLineBackgroundSpan(
 		// Measure the current line of text
 		val textWidth = paint.measureText(text, start, end).roundToInt()
 
+		val rectLeft = when(horizontalGravity) {
+			Gravity.CENTER_HORIZONTAL -> ((right - textWidth) / 2) - horizontalPadding
+			Gravity.RIGHT -> right - textWidth - horizontalPadding
+			else -> left - horizontalPadding
+		}
+
+		val rectRight = when(horizontalGravity) {
+			Gravity.CENTER_HORIZONTAL -> right - rectLeft
+			Gravity.RIGHT -> right + horizontalPadding
+			else -> left + textWidth + horizontalPadding
+		}
+
 		// Set the dimensions of the background rectangle
 		backgroundRect.set(
-			left - horizontalPadding,
+			rectLeft,
 			top,
-			left + textWidth + horizontalPadding,
+			rectRight,
 			bottom
 		)
 

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -52,6 +52,7 @@
             android:layout_gravity="bottom|center_horizontal"
             android:layout_marginHorizontal="120dp"
             android:layout_marginBottom="48dp"
+            android:gravity="center"
             android:textColor="@color/white"
             android:textSize="28sp"
             app:strokeWidth="5.0"


### PR DESCRIPTION
**Changes**
* Set the subtitle text alignment (gravity) to 'center'
* Get the alignment value from the TextView and pass that to the PaddedLineBackgroundSpan so it can set its rect size accordingly.
* Use the horizontal absolute gravity to create the size of the span background

**Issues**
* Fixes #1565
* PaddedLineBackgroundSpan only worked for left/start alignment
