### PR TITLE
Fix wrong counter/pos onResponse via loadMoreItemsIfNeeded

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -554,9 +554,11 @@ public class StdGridFragment extends GridFragment {
             @Override
             public void onResponse() {
                 setStatusText(mFolder.getName());
-                updateCounter(mGridAdapter.getTotalItems() > 0 ? 1 : 0);
+                if (mCurrentItem == null) { // don't mess-up pos via loadMoreItemsIfNeeded
+                    setItem(null);
+                    updateCounter(mGridAdapter.getTotalItems() > 0 ? 1 : 0);
+                }
                 mLetterButton.setVisibility(ItemSortBy.SortName.equals(mGridAdapter.getSortBy()) ? View.VISIBLE : View.GONE);
-                setItem(null);
                 if (mGridAdapter.getTotalItems() == 0) {
                     mToolBar.requestFocus();
                     mHandler.postDelayed(new Runnable() {


### PR DESCRIPTION
**Changes**
onResponse will set the wrong Countertext/pos if it was triggered by loadMoreItemsIfNeeded, resulting in a "1" position, instead of the current selected one.

