### PR TITLE
Rewrite crash reporting

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -25,7 +25,7 @@ val authModule = module {
 	single<ServerRepository> { ServerRepositoryImpl(get(), get()) }
 	single<ServerUserRepository> { ServerUserRepositoryImpl(get(), get(), get()) }
 	single<SessionRepository> {
-		SessionRepositoryImpl(get(), get(), get(), get(), get(), get(), get(defaultDeviceInfo), get(), get())
+		SessionRepositoryImpl(get(), get(), get(), get(), get(), get(), get(defaultDeviceInfo), get(), get(), get())
 	}
 
 	single { ApiBinder(get(), get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.di
 import org.jellyfin.androidtv.preference.LiveTvPreferences
 import org.jellyfin.androidtv.preference.PreferencesRepository
 import org.jellyfin.androidtv.preference.SystemPreferences
+import org.jellyfin.androidtv.preference.TelemetryPreferences
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.koin.dsl.module
@@ -14,4 +15,5 @@ val preferenceModule = module {
 	single { UserSettingPreferences(get()) }
 	single { UserPreferences(get()) }
 	single { SystemPreferences(get()) }
+	single { TelemetryPreferences(get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/TelemetryPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/TelemetryPreferences.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.androidtv.preference
+
+import android.content.Context
+import org.acra.ACRA
+import org.jellyfin.preference.booleanPreference
+import org.jellyfin.preference.store.SharedPreferenceStore
+import org.jellyfin.preference.stringPreference
+
+class TelemetryPreferences(context: Context) : SharedPreferenceStore(
+	sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+) {
+	companion object {
+		const val SHARED_PREFERENCES_NAME = "telemetry"
+
+		var crashReportEnabled = booleanPreference(ACRA.PREF_ENABLE_ACRA, true)
+		var crashReportIncludeLogs = booleanPreference(ACRA.PREF_ENABLE_SYSTEM_LOGS, true)
+
+		var crashReportToken = stringPreference("server_token", "")
+		var crashReportUrl = stringPreference("server_url", "")
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -3,15 +3,14 @@ package org.jellyfin.androidtv.preference
 import android.content.Context
 import android.view.KeyEvent
 import androidx.preference.PreferenceManager
-import org.acra.ACRA
 import org.jellyfin.androidtv.preference.constant.AppTheme
 import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.preference.constant.RatingType
-import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
+import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.preference.constant.defaultAudioBehavior
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.preference.booleanPreference
@@ -163,22 +162,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Use playback rewrite module
 		 */
 		var playbackRewriteEnabled = booleanPreference("playback_new", false)
-
-		/* ACRA */
-		/**
-		 * Enable ACRA crash reporting
-		 */
-		var acraEnabled = booleanPreference(ACRA.PREF_ENABLE_ACRA, true)
-
-		/**
-		 * Never prompt to report crash logs
-		 */
-		var acraNoPrompt = booleanPreference(ACRA.PREF_ALWAYS_ACCEPT, false)
-
-		/**
-		 * Include system logs in crash reports
-		 */
-		var acraIncludeSystemLogs = booleanPreference(ACRA.PREF_ENABLE_SYSTEM_LOGS, true)
 
 		/**
 		 * When to show the clock.

--- a/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
@@ -1,0 +1,174 @@
+package org.jellyfin.androidtv.telemetry
+
+import android.app.Application
+import android.content.Context
+import org.acra.ACRA
+import org.acra.ReportField
+import org.acra.config.CoreConfiguration
+import org.acra.config.toast
+import org.acra.data.CrashReportData
+import org.acra.ktx.initAcra
+import org.acra.plugins.Plugin
+import org.acra.plugins.PluginLoader
+import org.acra.plugins.ServicePluginLoader
+import org.acra.plugins.SimplePluginLoader
+import org.acra.sender.ReportSender
+import org.acra.sender.ReportSenderException
+import org.acra.sender.ReportSenderFactory
+import org.jellyfin.androidtv.BuildConfig
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.TelemetryPreferences
+import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
+import java.net.HttpURLConnection
+import java.net.URL
+
+object TelemetryService {
+	/**
+	 * Call in the attachBaseContext function of the application.
+	 */
+	fun init(context: Application) {
+		ACRA.DEV_LOGGING = true
+		context.initAcra {
+			buildConfigClass = BuildConfig::class.java
+			sharedPreferencesName = TelemetryPreferences.SHARED_PREFERENCES_NAME
+			pluginLoader = AcraPluginLoader(AcraReportSenderFactory::class.java)
+
+			toast {
+				text = context.getString(R.string.crash_report_toast)
+			}
+		}
+	}
+
+	class AcraPluginLoader(vararg plugins: Class<out Plugin>) : PluginLoader {
+		private val simplePluginLoader = SimplePluginLoader(*plugins)
+		private val servicePluginLoader = ServicePluginLoader()
+
+		override fun <T : Plugin> load(clazz: Class<T>): List<T> =
+			simplePluginLoader.load(clazz) + servicePluginLoader.load(clazz)
+
+		override fun <T : Plugin> loadEnabled(config: CoreConfiguration, clazz: Class<T>): List<T> =
+			simplePluginLoader.loadEnabled(config, clazz) + servicePluginLoader.loadEnabled(config, clazz)
+	}
+
+	class AcraReportSender(
+		private val config: CoreConfiguration,
+		private val url: String,
+		private val token: String,
+		private val includeLogs: Boolean,
+	) : ReportSender {
+		override fun send(context: Context, errorContent: CrashReportData) = try {
+			// Create connection
+			val connection = URL(url).openConnection() as HttpURLConnection
+			// Add authorization
+			val authorization = AuthorizationHeaderBuilder.buildHeader(
+				clientName = BuildConfig.APPLICATION_ID,
+				clientVersion = BuildConfig.VERSION_NAME,
+				deviceId = "",
+				deviceName = "",
+				accessToken = token,
+			)
+			connection.setRequestProperty("Authorization", authorization)
+			// Write POST body
+			connection.requestMethod = "POST"
+			connection.doOutput = true
+			connection.outputStream.apply {
+				write(errorContent.toReport().toByteArray())
+				flush()
+				close()
+			}
+			// Close
+			connection.inputStream.close()
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			throw ReportSenderException("Unable to send crash report to server", e)
+		}
+
+		private fun StringBuilder.appendSection(name: String, content: StringBuilder.() -> Unit) {
+			appendLine("### $name")
+			appendLine()
+			content()
+			appendLine()
+		}
+
+		private fun StringBuilder.appendItem(name: String, value: StringBuilder.() -> Unit) {
+			append("***$name***: ")
+			value()
+			appendLine("  ")
+		}
+
+		private fun StringBuilder.appendCodeBlock(language: String, code: String?) {
+			appendLine()
+			appendLine("```$language")
+			appendLine(code ?: "<null>")
+			append("```")
+		}
+
+		private fun StringBuilder.appendValue(value: String?) {
+			append("`", value ?: "<null>", "`")
+		}
+
+		private fun CrashReportData.toReport(): String = buildString {
+			// Header
+			appendLine("---")
+			appendLine("client: Jellyfin for Android TV")
+			appendLine("client_version: ${BuildConfig.VERSION_NAME}")
+			appendLine("client_repository: https://github.com/jellyfin/jellyfin-androidtv")
+			appendLine("type: crash_report")
+			appendLine("format: markdown")
+			appendLine("---")
+
+			// Content
+			appendSection("Logs") {
+				appendItem("Stack Trace") { appendCodeBlock("log", getString(ReportField.STACK_TRACE)) }
+				appendItem("Logcat") {
+					if (includeLogs) appendCodeBlock("log", getString(ReportField.LOGCAT))
+					else append("Logs are disabled")
+				}
+			}
+
+			appendSection("App information") {
+				appendItem("App version") {
+					appendValue(getString(ReportField.APP_VERSION_NAME))
+					append(" (")
+					appendValue(getString(ReportField.APP_VERSION_CODE))
+					append(")")
+				}
+				appendItem("Package name") { appendValue(getString(ReportField.PACKAGE_NAME)) }
+				appendItem("Build") { appendCodeBlock("json", getString(ReportField.BUILD)) }
+				appendItem("Build config") { appendCodeBlock("json", getString(ReportField.BUILD_CONFIG)) }
+			}
+
+			appendSection("Device information") {
+				appendItem("Android version") { appendValue(getString(ReportField.ANDROID_VERSION)) }
+				appendItem("Device brand") { appendValue(getString(ReportField.BRAND)) }
+				appendItem("Device product") { appendValue(getString(ReportField.PRODUCT)) }
+				appendItem("Device model") { appendValue(getString(ReportField.PHONE_MODEL)) }
+			}
+
+			appendSection("Crash information") {
+				appendItem("Start time") { appendValue(getString(ReportField.USER_APP_START_DATE)) }
+				appendItem("Crash time") { appendValue(getString(ReportField.USER_CRASH_DATE)) }
+			}
+
+			// Dump
+			if (BuildConfig.DEVELOPMENT) {
+				appendSection("Dump") {
+					appendCodeBlock("json", toJSON())
+				}
+			}
+		}
+	}
+
+	class AcraReportSenderFactory : ReportSenderFactory {
+		override fun create(context: Context, config: CoreConfiguration): ReportSender {
+			val preferences = context.getSharedPreferences(TelemetryPreferences.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+			val url = preferences?.getString(TelemetryPreferences.crashReportUrl.key, null)
+			val token = preferences?.getString(TelemetryPreferences.crashReportToken.key, null)
+			val includeLogs = preferences?.getBoolean(TelemetryPreferences.crashReportIncludeLogs.key, true) ?: true
+
+			if (url.isNullOrBlank()) throw ReportSenderException("No telemetry crash report URL available.")
+			if (token.isNullOrBlank()) throw ReportSenderException("No telemetry crash report token available.")
+
+			return AcraReportSender(config, url, token, includeLogs)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CrashReportingPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CrashReportingPreferencesScreen.kt
@@ -1,37 +1,30 @@
 package org.jellyfin.androidtv.ui.preference.screen
 
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.TelemetryPreferences
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.koin.android.ext.android.inject
 
 class CrashReportingPreferencesScreen : OptionsFragment() {
-	private val userPreferences: UserPreferences by inject()
+	private val telemetryPreferences: TelemetryPreferences by inject()
 
 	override val screen by optionsScreen {
-		setTitle(R.string.pref_acra_category)
+		setTitle(R.string.pref_telemetry_category)
 
 		category {
 			checkbox {
-				setTitle(R.string.pref_enable_acra)
-				setContent(R.string.pref_acra_enabled, R.string.pref_acra_disabled)
-				bind(userPreferences, UserPreferences.acraEnabled)
+				setTitle(R.string.pref_crash_reports)
+				setContent(R.string.pref_crash_reports_enabled, R.string.pref_crash_reports_disabled)
+				bind(telemetryPreferences, TelemetryPreferences.crashReportEnabled)
 			}
 
 			checkbox {
-				setTitle(R.string.pref_acra_alwaysaccept)
-				setContent(R.string.pref_acra_alwaysaccept_enabled, R.string.pref_acra_alwaysaccept_disabled)
-				bind(userPreferences, UserPreferences.acraNoPrompt)
-				depends { userPreferences[UserPreferences.acraEnabled] }
-			}
-
-			checkbox {
-				setTitle(R.string.pref_acra_syslog)
-				setContent(R.string.pref_acra_syslog_enabled, R.string.pref_acra_syslog_disabled)
-				bind(userPreferences, UserPreferences.acraIncludeSystemLogs)
-				depends { userPreferences[UserPreferences.acraEnabled] }
+				setTitle(R.string.pref_crash_report_logs)
+				setContent(R.string.pref_crash_report_logs_enabled, R.string.pref_crash_report_logs_disabled)
+				bind(telemetryPreferences, TelemetryPreferences.crashReportIncludeLogs)
+				depends { telemetryPreferences[TelemetryPreferences.crashReportEnabled] }
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/UserPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/UserPreferencesScreen.kt
@@ -33,8 +33,8 @@ class UserPreferencesScreen : OptionsFragment() {
 			}
 
 			link {
-				setTitle(R.string.pref_acra_category)
-				setContent(R.string.pref_acra_description)
+				setTitle(R.string.pref_telemetry_category)
+				setContent(R.string.pref_telemetry_description)
 				icon = R.drawable.ic_error
 				withFragment<CrashReportingPreferencesScreen>()
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
@@ -20,8 +20,6 @@ class AuthenticatedUserCallbacks(
 			// Startup activities
 			StartupActivity::class.qualifiedName,
 			PreferencesActivity::class.qualifiedName,
-			// Third party
-			org.acra.dialog.CrashReportDialog::class.qualifiedName,
 			// Screensaver activity is not exposed in Android SDK
 			"android.service.dreams.DreamActivity"
 		)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,18 +245,6 @@
     <string name="lbl_song_title">Song Title</string>
     <string name="pref_use_direct_path_title">Pass Direct Path for external player</string>
     <string name="pref_use_direct_path_summary">Pass the file system path instead of streaming URL</string>
-    <string name="pref_acra_category">Crash reporting</string>
-    <string name="pref_enable_acra">Send crash reports to developers</string>
-    <string name="pref_acra_enabled">You will be prompted to submit crash reports</string>
-    <string name="pref_acra_disabled">Crash reports will not be submitted</string>
-    <string name="pref_acra_alwaysaccept">Submit without prompting</string>
-    <string name="pref_acra_alwaysaccept_enabled">Crash reports will be submitted without prompting</string>
-    <string name="pref_acra_alwaysaccept_disabled">A dialog will be displayed before submitting any crash report</string>
-    <string name="pref_acra_syslog">Include system logs.\nThis may include private data from other applications if it was logged at the time of the crash.</string>
-    <string name="pref_acra_syslog_enabled">System logs will be included in crash reports</string>
-    <string name="pref_acra_syslog_disabled">System logs will not be included in crash reports</string>
-    <string name="acra_dialog_title">Oh no! Something went wrong.</string>
-    <string name="acra_dialog_text">Would you like to send a crash report to the developers?\n\nThis information will be submitted to a third party (tracepot.com).\n\nThis prompt can be disabled in the Crash Reporting section in the Jellyfin app\'s preferences.</string>
     <string name="lbl_tv_channel_status">%1$d of %2$d channels</string>
     <string name="lbl_tv_filter_status"> for next %1$d hours</string>
     <string name="lbl_news">News</string>
@@ -477,7 +465,6 @@
     <string name="pref_login_description">Servers, accounts, automatic sign in</string>
     <string name="pref_customization_description">Theme, home, remapping</string>
     <string name="pref_playback_description">Video, subtitles, live tv, next up</string>
-    <string name="pref_acra_description">Crash dialog, auto-upload, system logs</string>
     <string name="pref_video">Video</string>
     <string name="pref_subtitles">Subtitles</string>
     <string name="pref_audio">Audio</string>
@@ -501,4 +488,13 @@
     <string name="live_tv_preferences">Live TV options</string>
     <string name="app_notification_uimode_invalid">This app is optimized for televisions. We recommend using our mobile app on other devices.</string>
     <string name="server_unsupported_notification">This server uses Jellyfin version %1$s which is unsupported. Please update to Jellyfin %2$s to continue using the app.</string>
+    <string name="pref_telemetry_category">Crash reporting</string>
+    <string name="pref_telemetry_description">Send crash reports, include logs</string>
+    <string name="pref_crash_reports">Send crash reports to server</string>
+    <string name="pref_crash_reports_enabled">Crash reports will be sent to your last used server</string>
+    <string name="pref_crash_reports_disabled">Crash reports will not be submitted</string>
+    <string name="pref_crash_report_logs">Include logs</string>
+    <string name="pref_crash_report_logs_enabled">Logs will be included in crash reports</string>
+    <string name="pref_crash_report_logs_disabled">Logs will not be included in crash reports</string>
+    <string name="crash_report_toast">Oops! Something went wrong, a crash report was send to your Jellyfin server.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,9 +100,8 @@ glide-core = { module = "com.github.bumptech.glide:glide", version.ref = "glide"
 kenburnsview = { module = "com.flaviofaria:kenburnsview", version.ref = "kenburnsview" }
 
 # Crash Reporting
-acra-dialog = { module = "ch.acra:acra-dialog", version.ref = "acra" }
-acra-http = { module = "ch.acra:acra-http", version.ref = "acra" }
-acra-limiter = { module = "ch.acra:acra-limiter", version.ref = "acra" }
+acra-core = { module = "ch.acra:acra-toast", version.ref = "acra" }
+acra-toast = { module = "ch.acra:acra-toast", version.ref = "acra" }
 
 # Libraries
 aboutlibraries = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
@@ -124,9 +123,8 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [bundles]
 acra = [
-    "acra-dialog",
-    "acra-http",
-    "acra-limiter",
+    "acra-core",
+    "acra-toast",
 ]
 androidx-lifecycle = [
     "androidx-lifecycle-process",


### PR DESCRIPTION
This PR replaces our current crash reporting with a new implementation that sends the logs to the last used Jellyfin server. The reports use markdown with a YAML header indicating the format. This can be used in the future if we create a log viewer in jellyfin-web.

The crash reporting functionality caches the Jellyfin server url and access token when restoring a session (login/app open). When the app crashes these values are used to manually connect to the Jellyfin server instead of using the SDK. This is so we can catch SDK issues too.

**Changes**

- Fix ACRA process running Application.onCreate
- Move crash reporting to new TelemetryService
- Use ACRA Toast instead of dialog (always auto-submits now)
  - This is to avoid an issue where the dialog is inresponsive
- Upload crash report to Jellyfin server instead of Tracepot
- Remove ACRA limitter

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
