### PR TITLE
adjust TV detection logic

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
@@ -39,6 +39,8 @@ class NotificationsRepositoryImpl(
 		val isTouch = context.packageManager.hasSystemFeature("android.hardware.touchscreen")
 		val hasHdmiCec = context.packageManager.hasSystemFeature("android.hardware.hdmi.cec")
 
-		if (invalidUiMode && isTouch && !hasHdmiCec) addNotification(context.getString(R.string.app_notification_uimode_invalid))
+		if (invalidUiMode && isTouch && !hasHdmiCec) {
+			addNotification(context.getString(R.string.app_notification_uimode_invalid))
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
@@ -36,7 +36,9 @@ class NotificationsRepositoryImpl(
 	private fun addUiModeNotification() {
 		val supportedUiModes = setOf(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_TYPE_UNDEFINED)
 		val invalidUiMode = !supportedUiModes.contains(uiModeManager.currentModeType)
+		val isTouch = context.packageManager.hasSystemFeature("android.hardware.touchscreen")
+		val hasHdmiCec = context.packageManager.hasSystemFeature("android.hardware.hdmi.cec")
 
-		if (invalidUiMode) addNotification(context.getString(R.string.app_notification_uimode_invalid))
+		if (invalidUiMode && isTouch && !hasHdmiCec) addNotification(context.getString(R.string.app_notification_uimode_invalid))
 	}
 }


### PR DESCRIPTION
**Changes**
- adjust TV detection logic

**Issues**
All TV media boxes running normal Android, instead of AndroidTV will fail this check. 
All none AndroidTV certified devices run Android, which is the largest segment for TV media devices. 
The main reason is the harder AndroidTV certification process and licensing cost, so this will not change in the future.

So we should never rely on anything specific AndroidTv related.

