### PR TITLE
fix, don't send invalid sub/audio index

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
@@ -90,8 +90,11 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
 
         streamInfo = new StreamInfo();
         streamInfo.setItemId(options.getItemId());
-        streamInfo.setMediaType(DlnaProfileType.Audio);
-
+        if (isVideo) {
+            streamInfo.setMediaType(DlnaProfileType.Video);
+        } else {
+            streamInfo.setMediaType(DlnaProfileType.Audio);
+        }
         streamInfo.setMediaSource(mediaSourceInfo);
         streamInfo.setRunTimeTicks(mediaSourceInfo.getRunTimeTicks());
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -69,13 +69,20 @@ public class PlaybackManager {
         request.setUserId(apiClient.getCurrentUserId());
         request.setMaxStreamingBitrate(Long.valueOf(options.getMaxBitrate()));
         request.setMediaSourceId(options.getMediaSourceId());
-        request.setAudioStreamIndex(options.getAudioStreamIndex());
-        request.setSubtitleStreamIndex(options.getSubtitleStreamIndex());
         request.setStartTimeTicks(startPositionTicks);
         request.setDeviceProfile(options.getProfile());
         request.setEnableDirectStream(options.getEnableDirectStream());
         request.setEnableDirectPlay(options.getEnableDirectPlay());
         request.setMaxAudioChannels(options.getMaxAudioChannels());
+
+        Integer audioIdx = options.getAudioStreamIndex();
+        if (audioIdx != null && audioIdx >= 0) {
+            request.setAudioStreamIndex(audioIdx);
+        }
+        Integer subIdx = options.getSubtitleStreamIndex();
+        if (subIdx != null && subIdx >= 0) {
+            request.setSubtitleStreamIndex(subIdx);
+        }
 
         request.setAllowVideoStreamCopy(true);
         request.setAllowAudioStreamCopy(true);


### PR DESCRIPTION
**Changes**
- fix server broken "-rangetype" behavior
- fix don't send -1 subIndex
- fix DlnaProfileType

**Issues**
In transcode cases the client will always trigger a video-stream transcode, since the rangetype is always missing.
Hotfix until jellyfin/jellyfin#8078 is merged and we get a new server release.