### PR TITLE
Validate server version on session restore and show outdated server notification

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -25,7 +25,7 @@ val authModule = module {
 	single<ServerRepository> { ServerRepositoryImpl(get(), get()) }
 	single<ServerUserRepository> { ServerUserRepositoryImpl(get(), get(), get()) }
 	single<SessionRepository> {
-		SessionRepositoryImpl(get(), get(), get(), get(), get(), get(), get(defaultDeviceInfo), get())
+		SessionRepositoryImpl(get(), get(), get(), get(), get(), get(), get(defaultDeviceInfo), get(), get())
 	}
 
 	single { ApiBinder(get(), get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.add
@@ -139,6 +140,13 @@ class ServerFragment : Fragment() {
 		binding.serverButton.setOnClickListener {
 			navigateFragment<SelectServerFragment>(keepToolbar = true)
 		}
+
+		binding.notification.isGone = server.versionSupported
+		binding.notification.text = getString(
+			R.string.server_unsupported_notification,
+			server.version,
+			ServerRepository.minimumServerVersion.toString(),
+		)
 	}
 
 	private inline fun <reified F : Fragment> navigateFragment(

--- a/app/src/main/res/layout/fragment_server.xml
+++ b/app/src/main/res/layout/fragment_server.xml
@@ -10,15 +10,32 @@
     android:paddingBottom="@dimen/overscan_vertical">
 
     <TextView
+        android:id="@+id/notification"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/red_gradient_end"
+        android:gravity="center"
+        android:padding="16dp"
+        android:text="@string/server_unsupported_notification"
+        android:textColor="@color/white"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <TextView
         android:id="@+id/title"
         style="@style/Widget.Jellyfin.Row.Header"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
         android:gravity="center"
         android:text="@string/who_is_watching"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/notification"
+        app:layout_goneMarginTop="0dp" />
 
     <androidx.leanback.widget.HorizontalGridView
         android:id="@+id/users"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,4 +499,5 @@
     <string name="action_connect">Connect</string>
     <string name="live_tv_preferences">Live TV options</string>
     <string name="app_notification_uimode_invalid">This app is optimized for televisions. We recommend using our mobile app on other devices.</string>
+    <string name="server_unsupported_notification">This server uses Jellyfin version %1$s which is unsupported. Please update to Jellyfin %2$s to continue using the app.</string>
 </resources>


### PR DESCRIPTION
**Changes**
- Validate server version on session restore
  - This prevents autologin from opening a 10.7 server (which is incompatible)
- Show notification when server version is not supported
  - Shows on the user selection screen, it's kinda big:

![image](https://user-images.githubusercontent.com/2305178/177964155-d7c77230-4116-4309-824e-c7b1d5d76f6c.png)

Note that trying to add a user or selecting one also shows an error that the server is outdated. The server information update when opening this screen and when restoring a session (with a ratelimit of once every 10 minutes). So if the user updates their server and reopenens the app the info should update and go back to autologin.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
