### PR TITLE
add default menu, play actions to grid

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericGridActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericGridActivity.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import android.os.Bundle
-import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.ui.shared.BaseActivity
 
-class GenericGridActivity : FragmentActivity() {
+class GenericGridActivity : BaseActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -526,6 +526,9 @@ public class StdGridFragment extends GridFragment {
             mActivity.registerKeyListener(new KeyListener() {
                 @Override
                 public boolean onKeyUp(int key, KeyEvent event) {
+                    if (mGridDock == null || !mGridDock.hasFocus()) {
+                        return false;
+                    }
                     if (key == KeyEvent.KEYCODE_MEDIA_PLAY || key == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE) {
                         mediaManager.getValue().setCurrentMediaAdapter(mGridAdapter);
                         mediaManager.getValue().setCurrentMediaPosition(mCurrentItem.getIndex());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -1608,7 +1608,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     }
 
     protected void play(final BaseItemDto item, final int pos, final boolean shuffle) {
-        PlaybackHelper.getItemsToPlay(item, pos == 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
+        PlaybackHelper.getItemsToPlay(item, pos <= 0 && item.getBaseItemType() == BaseItemType.Movie, shuffle, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
                 PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -95,15 +95,14 @@ public class KeyProcessor {
                                 return true;
                             case Series:
                             case Season:
-                            case BoxSet:
-                                createPlayMenu(rowItem.getBaseItem(), true, false, activity);
+                                // play next, resume or play
+                                PlaybackHelper.playOrPlayNextUp(item, activity);
                                 return true;
+                            case BoxSet:
                             case MusicAlbum:
                             case MusicArtist:
-                                createPlayMenu(rowItem.getBaseItem(), true, true, activity);
-                                return true;
                             case Playlist:
-                                createPlayMenu(rowItem.getBaseItem(), true, "Audio".equals(rowItem.getBaseItem().getMediaType()), activity);
+                                PlaybackHelper.retrieveAndPlay(item.getId(), false, activity);
                                 return true;
                             case Photo:
                                 // open photo player
@@ -380,15 +379,17 @@ public class KeyProcessor {
                     query.setSortBy(new String[]{ItemSortBy.SortName});
                     query.setSortOrder(SortOrder.Ascending);
                     query.setLimit(1);
-                    query.setExcludeItemTypes(new String[] {"Series","Season","Folder","MusicAlbum","Playlist","BoxSet"});
+                    // NOTE: exclude filters seem broken?
+//                    query.setExcludeItemTypes(new String[]{"Series", "Season", "Folder", "MusicAlbum", "Playlist", "BoxSet"});
+                    query.setIncludeItemTypes(new String[]{"Episode", "Movie", "Video"});
                     query.setFilters(new ItemFilter[] {ItemFilter.IsUnplayed});
                     KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemsAsync(query, new Response<ItemsResult>() {
                         @Override
                         public void onResponse(ItemsResult response) {
-                            if (response.getTotalRecordCount() == 0) {
-                                Utils.showToast(mCurrentActivity, R.string.msg_no_items);
-                            } else {
+                            if (response.getItems() != null && response.getItems().length > 0) {
                                 PlaybackHelper.retrieveAndPlay(response.getItems()[0].getId(), false, mCurrentActivity);
+                            } else {
+                                Utils.showToast(mCurrentActivity, R.string.msg_no_items);
                             }
                         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.java
@@ -21,6 +21,8 @@ import timber.log.Timber;
  * A collection of utility methods, all static.
  */
 public class Utils {
+    static public final long RUNTIME_TICKS_TO_MS = 10000;
+
     /**
      * Shows a (long) toast
      *


### PR DESCRIPTION
Update on #1818 

**Changes**
add default menu, play actions to grid
fix default play actions for collections
fix album play action

**Issues**
Add default key handling/menu's to the grid views.
Now a play hotkey action does trigger a actual "play" in all cases, where this is possible.
Exception is "Audio" via AudioQueueItem, which needs additional fixes, as it does not support the menu key as example.