### PR TITLE
Add new experimental picture viewer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -179,6 +179,8 @@
             android:name=".ui.itemdetail.PhotoPlayerActivity"
             android:screenOrientation="landscape" />
 
+        <activity android:name=".ui.picture.PictureViewerActivity" />
+
         <activity
             android:name=".ui.itemdetail.ItemListActivity"
             android:screenOrientation="landscape" />

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -10,6 +10,7 @@ import org.jellyfin.androidtv.data.repository.NotificationsRepositoryImpl
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.data.repository.UserViewsRepositoryImpl
 import org.jellyfin.androidtv.data.service.BackgroundService
+import org.jellyfin.androidtv.ui.picture.PictureViewerViewModel
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
@@ -89,6 +90,7 @@ val appModule = module {
 	viewModel { UserLoginViewModel(get(), get(), get()) }
 	viewModel { ServerAddViewModel(get()) }
 	viewModel { NextUpViewModel(get(), get(), get(), get()) }
+	viewModel { PictureViewerViewModel(get()) }
 
 	single { BackgroundService(get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -164,6 +164,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var playbackRewriteEnabled = booleanPreference("playback_new", false)
 
 		/**
+		 * Use PictureViewer rewrite
+		 */
+		var pictureViewerRewriteEnabled = booleanPreference("picture_viewer_new", false)
+
+		/**
 		 * When to show the clock.
 		 */
 		var clockBehavior = enumPreference("pref_clock_behavior", ClockBehavior.ALWAYS)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.itemdetail;
 import static org.koin.java.KoinJavaComponent.inject;
 
 import android.animation.Animator;
+import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
@@ -34,7 +35,9 @@ import com.flaviofaria.kenburnsview.KenBurnsView;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.databinding.ActivityPhotoPlayerBinding;
+import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
+import org.jellyfin.androidtv.ui.picture.PictureViewerActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.util.ImageHelper;
@@ -71,10 +74,19 @@ public class PhotoPlayerActivity extends FragmentActivity {
     Handler handler;
     private Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        boolean pictureViewerRewriteEnabled = userPreferences.getValue().get(UserPreferences.Companion.getPictureViewerRewriteEnabled());
+        if (pictureViewerRewriteEnabled) {
+            Intent intent = PictureViewerActivity.Companion.createIntent(this, ModelCompat.asSdk(mediaManager.getValue().getCurrentMediaItem().getBaseItem()), getIntent().getBooleanExtra("Play", false));
+            startActivity(intent);
+            finishAfterTransition();
+            return;
+        }
 
         ActivityPhotoPlayerBinding binding = ActivityPhotoPlayerBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerActivity.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.ui.picture
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.View
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.R
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class PictureViewerActivity : FragmentActivity(R.layout.fragment_content_view) {
+	companion object {
+		const val EXTRA_ITEM_ID = "item_id"
+		const val EXTRA_AUTO_PLAY = "auto_play"
+
+		fun createIntent(context: Context, item: BaseItemDto, autoPlay: Boolean): Intent {
+			require(item.type == BaseItemKind.PHOTO) { "Expected item of type PHOTO but got ${item.type}" }
+
+			return Intent(context, PictureViewerActivity::class.java).apply {
+				putExtra(EXTRA_ITEM_ID, item.id.toString())
+				putExtra(EXTRA_AUTO_PLAY, autoPlay)
+			}
+		}
+	}
+
+	private val pictureViewerViewModel by viewModel<PictureViewerViewModel>()
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+
+		// Load requested item in viewmodel
+		lifecycleScope.launch {
+			val itemId = requireNotNull(intent.extras?.getString(EXTRA_ITEM_ID)?.toUUIDOrNull())
+			pictureViewerViewModel.loadItem(itemId)
+
+			val autoPlay = intent.extras?.getBoolean(EXTRA_AUTO_PLAY) == true
+			if (autoPlay) pictureViewerViewModel.startPresentation()
+		}
+
+		// Show fragment
+		supportFragmentManager.commit {
+			add<PictureViewerFragment>(R.id.content_view)
+		}
+	}
+
+	// Forward key events to fragments
+	private fun onKeyEvent(keyCode: Int, event: KeyEvent?): Boolean = supportFragmentManager.fragments
+		.filter { it.isVisible }
+		.filterIsInstance<View.OnKeyListener>()
+		.any { it.onKey(currentFocus, keyCode, event) }
+
+	override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean =
+		onKeyEvent(keyCode, event) || super.onKeyDown(keyCode, event)
+
+	override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean =
+		onKeyEvent(keyCode, event) || super.onKeyUp(keyCode, event)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
@@ -1,0 +1,156 @@
+package org.jellyfin.androidtv.ui.picture
+
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.databinding.FragmentPictureViewerBinding
+import org.jellyfin.androidtv.ui.AsyncImageView
+import org.jellyfin.androidtv.util.createKeyHandler
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
+import org.jellyfin.sdk.api.client.extensions.libraryApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.ImageType
+import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+
+class PictureViewerFragment : Fragment(), View.OnKeyListener {
+	companion object {
+		/**
+		 * The download API is used by jellyfin-web when loading images. Unfortunately with our
+		 * current code it doesn't work for the app. Larger files (gifs, large photos etc.) can
+		 * cause the app to go out of memory. This is mostly catched by Glide but it ends up
+		 * never displaying the picture in those cases.
+		 *
+		 * This toggle is left in the code in case we migrate to a different image processor that
+		 * potentially fixes the issue.
+		 */
+		const val USE_DOWNLOAD_API = false
+	}
+
+	private val pictureViewerViewModel by sharedViewModel<PictureViewerViewModel>()
+	private val api by inject<ApiClient>()
+	private lateinit var binding: FragmentPictureViewerBinding
+
+	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+		binding = FragmentPictureViewerBinding.inflate(inflater, container, false)
+		binding.actionPrevious.setOnClickListener { pictureViewerViewModel.showPrevious() }
+		binding.actionNext.setOnClickListener { pictureViewerViewModel.showNext() }
+		binding.actionPlayPause.setOnClickListener { pictureViewerViewModel.togglePresentation() }
+		binding.root.setOnClickListener { toggleActions() }
+		return binding.root
+	}
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+		super.onViewCreated(view, savedInstanceState)
+
+		lifecycleScope.launch {
+			pictureViewerViewModel.currentItem.filterNotNull().collect { item ->
+				binding.itemSwitcher.getNextView<AsyncImageView>().load(item)
+				binding.itemSwitcher.showNextView()
+			}
+		}
+
+		lifecycleScope.launch {
+			pictureViewerViewModel.presentationActive.collect { active ->
+				binding.actionPlayPause.isActivated = active
+			}
+		}
+	}
+
+	private val keyHandler = createKeyHandler {
+		keyDown(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.KEYCODE_MEDIA_PAUSE)
+			.body { pictureViewerViewModel.togglePresentation() }
+
+		keyDown(KeyEvent.KEYCODE_DPAD_LEFT)
+			.condition { !binding.actions.isVisible }
+			.body { pictureViewerViewModel.showPrevious() }
+
+		keyDown(KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD, KeyEvent.KEYCODE_MEDIA_PREVIOUS)
+			.body { pictureViewerViewModel.showPrevious() }
+
+		keyDown(KeyEvent.KEYCODE_DPAD_RIGHT)
+			.condition { !binding.actions.isVisible }
+			.body { pictureViewerViewModel.showNext() }
+
+		keyDown(KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD, KeyEvent.KEYCODE_MEDIA_NEXT)
+			.body { pictureViewerViewModel.showNext() }
+
+		keyDown(KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER)
+			.condition { !binding.actions.isVisible }
+			.body { showActions() }
+
+		keyDown(KeyEvent.KEYCODE_DPAD_DOWN, KeyEvent.KEYCODE_BACK)
+			.condition { binding.actions.isVisible }
+			.body { hideActions() }
+	}
+
+	override fun onKey(v: View?, keyCode: Int, event: KeyEvent?): Boolean = keyHandler.onKey(event)
+
+	private var focusedActionView: View? = null
+	fun showActions(): Boolean {
+		if (binding.actions.isVisible) return false
+
+		binding.actions.isVisible = true
+		if (focusedActionView?.requestFocus() != true) binding.actionPlayPause.requestFocus()
+		binding.actions.startAnimation(AnimationUtils.loadAnimation(context, R.anim.fade_in))
+		return true
+	}
+
+	fun hideActions(): Boolean {
+		if (!binding.actions.isVisible) return false
+		binding.actions.startAnimation(AnimationUtils.loadAnimation(context, R.anim.fade_out).apply {
+			setAnimationListener(object : Animation.AnimationListener {
+				override fun onAnimationStart(animation: Animation?) = Unit
+
+				override fun onAnimationEnd(animation: Animation?) {
+					focusedActionView = binding.actions.findFocus()
+					binding.actions.isGone = true
+				}
+
+				override fun onAnimationRepeat(animation: Animation?) = Unit
+			})
+		})
+		return true
+	}
+
+	fun toggleActions(): Boolean {
+		return if (binding.actions.isVisible) hideActions()
+		else showActions()
+	}
+
+	private fun AsyncImageView.load(item: BaseItemDto) {
+		val url = when (USE_DOWNLOAD_API) {
+			true -> api.libraryApi.getDownloadUrl(
+				itemId = item.id,
+				includeCredentials = true, // TODO send authentication via header
+			)
+			false -> api.imageApi.getItemImageUrl(
+				itemId = item.id,
+				imageType = ImageType.PRIMARY,
+				tag = item.imageTags?.get(ImageType.PRIMARY),
+				// Ask the server to downscale the image to avoid the app going out of memory
+				// unfortunately this can be a bit slow for larger files
+				maxWidth = context.resources.displayMetrics.widthPixels,
+				maxHeight = context.resources.displayMetrics.heightPixels,
+			)
+		}
+
+		load(
+			url = url,
+			blurHash = item.imageBlurHashes?.get(ImageType.PRIMARY)?.get(item.imageTags?.get(ImageType.PRIMARY)),
+			aspectRatio = item.primaryImageAspectRatio ?: 1.0,
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
@@ -30,7 +30,7 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 		/**
 		 * The download API is used by jellyfin-web when loading images. Unfortunately with our
 		 * current code it doesn't work for the app. Larger files (gifs, large photos etc.) can
-		 * cause the app to go out of memory. This is mostly catched by Glide but it ends up
+		 * cause the app to go out of memory. This is mostly caught by Glide but it ends up
 		 * never displaying the picture in those cases.
 		 *
 		 * This toggle is left in the code in case we migrate to a different image processor that
@@ -87,7 +87,10 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 		keyDown(KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD, KeyEvent.KEYCODE_MEDIA_NEXT)
 			.body { pictureViewerViewModel.showNext() }
 
-		keyDown(KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER)
+		keyDown(
+			KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN,
+			KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER,
+		)
 			.condition { !binding.actions.isVisible }
 			.body { showActions() }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
@@ -32,7 +32,7 @@ class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
 		_currentItem.value = itemResponse
 
 		val albumResponse by api.itemsApi.getItemsByUserId(
-			parentId = itemResponse.albumId,
+			parentId = itemResponse.parentId,
 			includeItemTypes = setOf(BaseItemKind.PHOTO),
 			fields = setOf(ItemFields.PRIMARY_IMAGE_ASPECT_RATIO),
 			sortBy = listOf(ItemFields.SORT_NAME.name), // TODO: Order should be consistent with the stdgridview the user comes from, which allows to change the order

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
@@ -1,0 +1,103 @@
+package org.jellyfin.androidtv.ui.picture
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemFields
+import org.jellyfin.sdk.model.api.SortOrder
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
+	private var album: List<BaseItemDto> = emptyList()
+	private var albumIndex = -1
+
+	private val _currentItem = MutableStateFlow<BaseItemDto?>(null)
+	val currentItem = _currentItem.asStateFlow()
+
+	suspend fun loadItem(id: UUID) {
+		// Load requested item
+		val itemResponse by api.userLibraryApi.getItem(itemId = id)
+		_currentItem.value = itemResponse
+
+		val albumResponse by api.itemsApi.getItemsByUserId(
+			parentId = itemResponse.albumId,
+			includeItemTypes = setOf(BaseItemKind.PHOTO),
+			fields = setOf(ItemFields.PRIMARY_IMAGE_ASPECT_RATIO),
+			sortBy = listOf(ItemFields.SORT_NAME.name), // TODO: Order should be consistent with the stdgridview the user comes from, which allows to change the order
+			sortOrder = listOf(SortOrder.ASCENDING),
+		)
+		album = albumResponse.items.orEmpty()
+		albumIndex = album.indexOfFirst { it.id == id }
+	}
+
+	// Album actions
+
+	fun showNext() {
+		albumIndex++
+		if (albumIndex == album.size) albumIndex = 0
+
+		_currentItem.value = album[albumIndex]
+		restartPresentation()
+	}
+
+	fun showPrevious() {
+		albumIndex--
+		if (albumIndex == -1) albumIndex = album.size - 1
+
+		_currentItem.value = album[albumIndex]
+		restartPresentation()
+	}
+
+	// Presentation
+
+	private var presentationJob: Job? = null
+	private val _presentationActive = MutableStateFlow(false)
+	val presentationActive = _presentationActive.asStateFlow()
+	var presentationDelay = 8.seconds
+
+	fun createPresentationJob() = viewModelScope.launch(Dispatchers.IO) {
+		while (isActive) {
+			delay(presentationDelay)
+			showNext()
+		}
+	}
+
+	fun startPresentation() {
+		if (presentationActive.value) return
+		_presentationActive.value = true
+
+		presentationJob = createPresentationJob()
+	}
+
+	fun restartPresentation() {
+		if (!presentationActive.value) return
+
+		presentationJob?.cancel()
+		presentationJob = createPresentationJob()
+	}
+
+	fun stopPresentation() {
+		if (!presentationActive.value) return
+
+		presentationJob?.cancel()
+		presentationJob = null
+		_presentationActive.value = false
+	}
+
+	fun togglePresentation() {
+		if (presentationActive.value) stopPresentation()
+		else startPresentation()
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -31,6 +31,13 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 
 					bind(userPreferences, UserPreferences.playbackRewriteEnabled)
 				}
+
+				checkbox {
+					title = "Enable new picture viewer"
+					setContent(R.string.enable_playback_module_description)
+
+					bind(userPreferences, UserPreferences.pictureViewerRewriteEnabled)
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -33,7 +33,7 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 				}
 
 				checkbox {
-					title = "Enable new picture viewer"
+					title = getString(R.string.enable_picture_viewer_title)
 					setContent(R.string.enable_playback_module_description)
 
 					bind(userPreferences, UserPreferences.pictureViewerRewriteEnabled)

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyHandler.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyHandler.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.util
 
 import android.view.KeyEvent
+import timber.log.Timber
 
 @DslMarker
 annotation class KeyHandlerDsl
@@ -16,6 +17,8 @@ class KeyHandler(
 			.filter { it.type == event.action }
 			.filter { it.conditions.isEmpty() || it.conditions.all { predicate -> predicate.invoke() } }
 			.firstOrNull() ?: return false
+
+		Timber.d("Key press detected: code=${event.keyCode} type=${event.action} action=$action")
 
 		action.body()
 		return true

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyHandler.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyHandler.kt
@@ -1,0 +1,124 @@
+package org.jellyfin.androidtv.util
+
+import android.view.KeyEvent
+
+@DslMarker
+annotation class KeyHandlerDsl
+
+class KeyHandler(
+	private val actions: Collection<KeyHandlerAction>
+) {
+	fun onKey(event: KeyEvent?): Boolean {
+		if (event == null) return false
+
+		val action = actions
+			.filter { it.keys.contains(event.keyCode) }
+			.filter { it.type == event.action }
+			.filter { it.conditions.isEmpty() || it.conditions.all { predicate -> predicate.invoke() } }
+			.firstOrNull() ?: return false
+
+		action.body()
+		return true
+	}
+}
+
+data class KeyHandlerAction(
+	val type: Int,
+	val keys: Collection<Int>,
+	val conditions: Collection<() -> Boolean>,
+	val body: () -> Unit
+)
+
+class KeyHandlerBuilder {
+	private val actions = mutableListOf<KeyHandlerAction>()
+
+	fun addAction(action: KeyHandlerAction) {
+		actions.add(action)
+	}
+
+	fun build(): KeyHandler = KeyHandler(actions)
+
+	@KeyHandlerDsl
+	fun keyDown(vararg keys: Int) = KeyHandlerActionBuilder(this).apply {
+		setType(KeyEvent.ACTION_DOWN)
+		for (key in keys) addKey(key)
+	}
+
+	@KeyHandlerDsl
+	fun keyDown(vararg keys: Int, action: () -> Unit) = KeyHandlerActionBuilder(this).apply {
+		setType(KeyEvent.ACTION_DOWN)
+		for (key in keys) addKey(key)
+		setBody(action)
+	}.build()
+
+	@KeyHandlerDsl
+	fun keyUp(vararg keys: Int) = KeyHandlerActionBuilder(this).apply {
+		setType(KeyEvent.ACTION_UP)
+		for (key in keys) addKey(key)
+	}
+
+	@KeyHandlerDsl
+	fun keyUp(vararg keys: Int, action: () -> Unit) = KeyHandlerActionBuilder(this).apply {
+		setType(KeyEvent.ACTION_UP)
+		for (key in keys) addKey(key)
+		setBody(action)
+	}.build()
+}
+
+class KeyHandlerActionBuilder(
+	private val context: KeyHandlerBuilder
+) {
+	private var type = KeyEvent.ACTION_DOWN
+	private val keys = mutableListOf<Int>()
+	private val conditions = mutableListOf<() -> Boolean>()
+	private var body: (() -> Unit)? = null
+
+	fun setType(type: Int) {
+		require(type == KeyEvent.ACTION_DOWN || type == KeyEvent.ACTION_UP) {
+			"Type must be KeyEvent.ACTION_DOWN or KeyEvent.ACTION_UP"
+		}
+
+		this.type = type
+	}
+
+	fun addKey(key: Int) {
+		keys.add(key)
+	}
+
+	fun addCondition(condition: () -> Boolean) {
+		conditions.add(condition)
+	}
+
+	fun setBody(body: () -> Unit) {
+		this.body = body
+	}
+
+	fun build() {
+		require(keys.isNotEmpty()) { "Keys should contain at least 1 key" }
+		requireNotNull(body) { "Body must be set" }
+
+		val action = KeyHandlerAction(type, keys, conditions, body!!)
+		context.addAction(action)
+	}
+
+	@KeyHandlerDsl
+	fun condition(condition: () -> Boolean) = apply {
+		addCondition(condition)
+	}
+
+	@KeyHandlerDsl
+	fun condition(condition: () -> Boolean, action: () -> Unit) = apply {
+		addCondition(condition)
+		setBody(action)
+	}.build()
+
+	@KeyHandlerDsl
+	fun body(action: () -> Unit) = apply {
+		setBody(action)
+	}.build()
+}
+
+@KeyHandlerDsl
+inline fun createKeyHandler(body: KeyHandlerBuilder.() -> Unit) = KeyHandlerBuilder().apply {
+	body()
+}.build()

--- a/app/src/main/res/drawable/button_bar_back.xml
+++ b/app/src/main/res/drawable/button_bar_back.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="?attr/buttonRounding" />
+    <solid android:color="@color/black_transparent_light" />
+</shape>

--- a/app/src/main/res/drawable/button_icon_tint_animated.xml
+++ b/app/src/main/res/drawable/button_icon_tint_animated.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" android:enterFadeDuration="@integer/button_fade_duration" android:exitFadeDuration="@integer/button_fade_duration">
+    <item android:color="@color/button_default_normal_text" android:state_enabled="true" android:state_focused="false" />
+    <item android:color="@color/button_default_disabled_text" android:state_enabled="false" />
+    <item android:color="@color/button_default_highlight_text" android:state_enabled="true" android:state_focused="true" />
+</selector>

--- a/app/src/main/res/drawable/ica_play_pause.xml
+++ b/app/src/main/res/drawable/ica_play_pause.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <item
+        android:id="@+id/normal"
+        android:drawable="@drawable/ic_play"
+        android:state_activated="false" />
+    <item
+        android:id="@+id/activated"
+        android:drawable="@drawable/ic_pause"
+        android:state_activated="true" />
+
+    <transition
+        android:fromId="@id/normal"
+        android:toId="@id/activated">
+        <aapt:attr name="android:drawable">
+            <animated-vector>
+                <aapt:attr name="android:drawable">
+                    <vector
+                        android:width="24dp"
+                        android:height="24dp"
+                        android:viewportWidth="24"
+                        android:viewportHeight="24">
+                        <group
+                            android:name="group"
+                            android:pivotX="12"
+                            android:pivotY="12">
+                            <path
+                                android:name="path"
+                                android:fillColor="#fff"
+                                android:pathData="M 8 5 L 8 19 L 19 12 Z"
+                                android:strokeWidth="1" />
+                        </group>
+                    </vector>
+                </aapt:attr>
+                <target android:name="path">
+                    <aapt:attr name="android:animation">
+                        <objectAnimator
+                            android:duration="300"
+                            android:interpolator="@android:interpolator/fast_out_slow_in"
+                            android:propertyName="pathData"
+                            android:valueFrom="M 8 5 L 8 12 L 19 12 L 19 12 L 8 5 M 8 12 L 8 19 L 19 12 L 19 12 L 8 12"
+                            android:valueTo="M 5 6 L 5 10 L 19 10 L 19 6 L 5 6 M 5 14 L 5 18 L 19 18 L 19 14 L 5 14"
+                            android:valueType="pathType" />
+                    </aapt:attr>
+                </target>
+                <target android:name="group">
+                    <aapt:attr name="android:animation">
+                        <objectAnimator
+                            android:duration="300"
+                            android:interpolator="@android:interpolator/fast_out_slow_in"
+                            android:propertyName="rotation"
+                            android:valueFrom="0"
+                            android:valueTo="90"
+                            android:valueType="floatType" />
+                    </aapt:attr>
+                </target>
+            </animated-vector>
+        </aapt:attr>
+    </transition>
+    <transition
+        android:fromId="@id/activated"
+        android:toId="@id/normal">
+        <aapt:attr name="android:drawable">
+            <animated-vector>
+                <aapt:attr name="android:drawable">
+                    <vector
+                        android:width="24dp"
+                        android:height="24dp"
+                        android:viewportWidth="24"
+                        android:viewportHeight="24">
+                        <group
+                            android:name="group"
+                            android:pivotX="12"
+                            android:pivotY="12">
+                            <path
+                                android:name="path"
+                                android:fillColor="#fff"
+                                android:pathData="M 8 5 L 8 19 L 19 12 Z"
+                                android:strokeWidth="1" />
+                        </group>
+                    </vector>
+                </aapt:attr>
+                <target android:name="path">
+                    <aapt:attr name="android:animation">
+                        <objectAnimator
+                            android:duration="300"
+                            android:interpolator="@android:interpolator/fast_out_slow_in"
+                            android:propertyName="pathData"
+                            android:valueFrom="M 5 6 L 5 10 L 19 10 L 19 6 L 5 6 M 5 14 L 5 18 L 19 18 L 19 14 L 5 14"
+                            android:valueTo="M 8 5 L 8 12 L 19 12 L 19 12 L 8 5 M 8 12 L 8 19 L 19 12 L 19 12 L 8 12"
+                            android:valueType="pathType" />
+                    </aapt:attr>
+                </target>
+                <target android:name="group">
+                    <aapt:attr name="android:animation">
+                        <objectAnimator
+                            android:duration="300"
+                            android:interpolator="@android:interpolator/fast_out_slow_in"
+                            android:propertyName="rotation"
+                            android:valueFrom="90"
+                            android:valueTo="0"
+                            android:valueType="floatType" />
+                    </aapt:attr>
+                </target>
+            </animated-vector>
+
+        </aapt:attr>
+    </transition>
+</animated-selector>

--- a/app/src/main/res/layout/fragment_picture_viewer.xml
+++ b/app/src/main/res/layout/fragment_picture_viewer.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:keepScreenOn="true">
+
+    <org.jellyfin.androidtv.ui.FadeViewSwitcherLayout
+        android:id="@+id/item_switcher"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <org.jellyfin.androidtv.ui.AsyncImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/black" />
+
+        <org.jellyfin.androidtv.ui.AsyncImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/black" />
+    </org.jellyfin.androidtv.ui.FadeViewSwitcherLayout>
+
+    <LinearLayout
+        android:id="@+id/actions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="27dp"
+        android:background="@drawable/button_bar_back"
+        android:padding="12dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible">
+
+        <ImageButton
+            android:id="@+id/action_previous"
+            style="@style/Button.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_previous" />
+
+        <androidx.legacy.widget.Space
+            android:layout_width="12dp"
+            android:layout_height="wrap_content" />
+
+        <ImageButton
+            android:id="@+id/action_play_pause"
+            style="@style/Button.Icon.Animated"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ica_play_pause" />
+
+        <androidx.legacy.widget.Space
+            android:layout_width="12dp"
+            android:layout_height="wrap_content" />
+
+        <ImageButton
+            android:id="@+id/action_next"
+            style="@style/Button.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_next" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,4 +498,5 @@
     <string name="pref_crash_report_logs_disabled">Logs will not be included in crash reports</string>
     <string name="crash_report_toast">Oops! Something went wrong, a crash report was send to your Jellyfin server.</string>
     <string name="server_setup_incomplete">The setup of this server has not been completed. Open Jellyfin in a web browser to finish setup before signing in.</string>
+    <string name="enable_picture_viewer_title">Enable new picture viewer</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -64,6 +64,10 @@
         <item name="android:stateListAnimator">@null</item>
     </style>
 
+    <style name="Button.Icon.Animated" parent="Button.Icon">
+        <item name="android:tint">@drawable/button_icon_tint_animated</item>
+    </style>
+
     <style name="Input.Default" parent="android:Widget.EditText">
         <item name="android:background">@drawable/input_default_back</item>
         <item name="android:foreground">@drawable/input_default_ripple</item>


### PR DESCRIPTION
I started work on this around 2 months ago but didn't completely finish it yet. It already uses a feature flag which is disabled in releases so it won't hurt to merge it. I've made a new column in my board (https://github.com/jellyfin/jellyfin-androidtv/projects/15#column-19021853) that shows the remaining tasks.

The biggest feature is that it doesn't depend on the media manager anymore so it's sort of a part of the playback rewrite (#1057).

**Changes**
- Add preference to enable new picture viewer
  - Like the playback rewrite; only shows in development builds
- Add KeyHandler DSL to write readable key press handlers
- Add new picture viewer
  - Supports portrait mode
  - Sort of supports touch
  - Supports slideshows
  - Shows controls to make it easy to start slideshows and navigate forward/backward

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
