### PR TITLE
Don't try to load splashscreen when disabled in branding options

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreServer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreServer.kt
@@ -18,6 +18,7 @@ data class AuthenticationStoreServer(
 	val address: String,
 	val version: String? = null,
 	@SerialName("login_disclaimer")  val loginDisclaimer: String? = null,
+	@SerialName("splashscreen_enabled")  val splashscreenEnabled: Boolean = false,
 	@SerialName("last_used") val lastUsed: Long = Date().time,
 	@SerialName("last_refreshed") val lastRefreshed: Long = Date().time,
 	val users: Map<UUID, AuthenticationStoreUser> = emptyMap(),

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
@@ -14,6 +14,7 @@ data class Server(
 	var address: String,
 	val version: String? = null,
 	val loginDisclaimer: String? = null,
+	val splashscreenEnabled: Boolean = false,
 	var dateLastAccessed: Date = Date(0),
 ) {
 	private val serverVersion = version?.let(ServerVersion::fromString)

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -133,12 +133,14 @@ class ServerRepositoryImpl(
 				address = chosenRecommendation.address,
 				version = systemInfo.version,
 				loginDisclaimer = branding.loginDisclaimer,
+				splashscreenEnabled = branding.splashscreenEnabled,
 				lastUsed = Date().time
 			) ?: AuthenticationStoreServer(
 				name = systemInfo.serverName ?: "Jellyfin Server",
 				address = chosenRecommendation.address,
 				version = systemInfo.version,
-				loginDisclaimer = branding.loginDisclaimer
+				loginDisclaimer = branding.loginDisclaimer,
+				splashscreenEnabled = branding.splashscreenEnabled,
 			)
 
 			authenticationStore.putServer(id, server)
@@ -195,6 +197,7 @@ class ServerRepositoryImpl(
 			name = systemInfo.serverName ?: server.name,
 			version = systemInfo.version ?: server.version,
 			loginDisclaimer = branding.loginDisclaimer ?: server.loginDisclaimer,
+			splashscreenEnabled = branding.splashscreenEnabled,
 			lastRefreshed = now
 		)
 		authenticationStore.putServer(id, newServer)
@@ -215,6 +218,7 @@ class ServerRepositoryImpl(
 		address = address,
 		version = version,
 		loginDisclaimer = loginDisclaimer,
+		splashscreenEnabled = splashscreenEnabled,
 		dateLastAccessed = Date(lastUsed),
 	)
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -198,6 +198,10 @@ class BackgroundService(
 		if (!userPreferences[UserPreferences.backdropEnabled])
 			return clearBackgrounds()
 
+		// Check if splashscreen is enabled in (cached) branding options
+		if (!server.splashscreenEnabled)
+			return clearBackgrounds()
+
 		// Manually grab the backdrop URL
 		val api = jellyfin.createApi(baseUrl = server.address)
 		val splashscreenUrl = api.imageApi.getSplashscreenUrl()


### PR DESCRIPTION
10.8.1 change

**Changes**
- Save splashscreenEnabled property to server in authentication store
- Don't try to load splashscreen when disabled in branding options

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
