### PR TITLE
Ignore server discovery in ServerFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupViewModel.kt
@@ -66,9 +66,12 @@ class StartupViewModel(
 	fun getUserImage(server: Server, user: User): String? =
 		authenticationRepository.getUserImageUrl(server, user)
 
-	fun reloadServers() {
+	fun reloadServers(ignoreDiscovery: Boolean = false) {
 		viewModelScope.launch { serverRepository.loadStoredServers() }
-		viewModelScope.launch(Dispatchers.IO) { serverRepository.loadDiscoveryServers() }
+
+		if (!ignoreDiscovery) {
+			viewModelScope.launch(Dispatchers.IO) { serverRepository.loadDiscoveryServers() }
+		}
 	}
 
 	suspend fun getLastServer(): Server? {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -171,7 +171,7 @@ class ServerFragment : Fragment() {
 	override fun onResume() {
 		super.onResume()
 
-		startupViewModel.reloadServers()
+		startupViewModel.reloadServers(ignoreDiscovery = true)
 		backgroundService.clearBackgrounds()
 
 		val server = serverIdArgument?.let(startupViewModel::getServer)


### PR DESCRIPTION
We don't show them in that screen, so no need to flood the network

**Changes**
- Ignore server discovery in ServerFragment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
