### PR TITLE
Fix serverRepository.getServer not working when server info is not refreshing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -164,7 +164,7 @@ class ServerRepositoryImpl(
 			null
 		}
 
-		return updatedServer?.asServer(id)
+		return (updatedServer ?: server).asServer(id)
 	}
 
 	override suspend fun updateServer(server: Server): Boolean {


### PR DESCRIPTION
This issue only happens when using the function within a 10 minute window and causes login to fail (without any hints as to why)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Properly return the original server info when there is no updated server info in ServerRepository.getServer
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
