### PR TITLE
Avoid multiple discovery processes running at the same time

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -167,7 +167,8 @@ class SelectServerFragment : Fragment() {
 	override fun onResume() {
 		super.onResume()
 
-		startupViewModel.reloadServers()
+		startupViewModel.reloadStoredServers()
+		startupViewModel.loadDiscoveryservers()
 	}
 
 	class ServerAdapter(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -171,7 +171,7 @@ class ServerFragment : Fragment() {
 	override fun onResume() {
 		super.onResume()
 
-		startupViewModel.reloadServers(ignoreDiscovery = true)
+		startupViewModel.reloadStoredServers()
 		backgroundService.clearBackgrounds()
 
 		val server = serverIdArgument?.let(startupViewModel::getServer)


### PR DESCRIPTION
When switching between the user and server selection screens the process continuously restarted. This causes a lot of logs and network activity. Prevent this by running only one process at a time.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Add mutex to only run one discovery process at a time
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
