### PR TITLE
Fix crash when not restoring a session

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
@@ -129,13 +129,13 @@ class SessionRepositoryImpl(
 		if (success) {
 			userApiClient.applySession(session, deviceInfo)
 
-			// Update crash reporting URL
-			// TODO: Use userApiClient.clientLogApi.logFileUrl(includeCredentials = false) in next SDK release
-			val crashReportUrl = userApiClient.createUrl("/ClientLog/Document")
-			telemetryPreferences[TelemetryPreferences.crashReportUrl] = crashReportUrl
-			telemetryPreferences[TelemetryPreferences.crashReportToken] = session?.accessToken.orEmpty()
-
 			if (session != null) {
+				// Update crash reporting URL
+				// TODO: Use userApiClient.clientLogApi.logFileUrl(includeCredentials = false) in next SDK release
+				val crashReportUrl = userApiClient.createUrl("/ClientLog/Document")
+				telemetryPreferences[TelemetryPreferences.crashReportUrl] = crashReportUrl
+				telemetryPreferences[TelemetryPreferences.crashReportToken] = session.accessToken
+
 				try {
 					val user by userApiClient.userApi.getCurrentUser()
 					userRepository.updateCurrentUser(user)


### PR DESCRIPTION
We don't want to update the crash url/token when there is no session. That causes a crash.

**Changes**

- Don't update crash reporting url/token when session is null

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
