### PR TITLE
Fix crash when reporting a crash

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
@@ -51,12 +51,14 @@ object TelemetryService {
 	}
 
 	class AcraReportSender(
-		private val config: CoreConfiguration,
-		private val url: String,
-		private val token: String,
+		private val url: String?,
+		private val token: String?,
 		private val includeLogs: Boolean,
 	) : ReportSender {
 		override fun send(context: Context, errorContent: CrashReportData) = try {
+			if (url.isNullOrBlank()) throw ReportSenderException("No telemetry crash report URL available.")
+			if (token.isNullOrBlank()) throw ReportSenderException("No telemetry crash report token available.")
+
 			// Create connection
 			val connection = URL(url).openConnection() as HttpURLConnection
 			// Add authorization
@@ -165,10 +167,7 @@ object TelemetryService {
 			val token = preferences?.getString(TelemetryPreferences.crashReportToken.key, null)
 			val includeLogs = preferences?.getBoolean(TelemetryPreferences.crashReportIncludeLogs.key, true) ?: true
 
-			if (url.isNullOrBlank()) throw ReportSenderException("No telemetry crash report URL available.")
-			if (token.isNullOrBlank()) throw ReportSenderException("No telemetry crash report token available.")
-
-			return AcraReportSender(config, url, token, includeLogs)
+			return AcraReportSender(url, token, includeLogs)
 		}
 	}
 }


### PR DESCRIPTION
Until the user signs in to a server the report url and token are not set. We throw an exception in this case so ACRA automatically retries sending the report later.. One issue though: the exception was thrown from the wrong place.

**Changes**
- Move throwing of ReportSenderException to the sender, this causes ACRA to retry the report later

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
