### PR TITLE
Always use Quick Connect

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -78,8 +78,6 @@ class ServerFragment : Fragment() {
 						RequireSignInState -> navigateFragment<UserLoginFragment>(bundleOf(
 							UserLoginFragment.ARG_SERVER_ID to server.id.toString(),
 							UserLoginFragment.ARG_USERNAME to user.name,
-							// FIXME: Server does not allow Quick Connect for a specific username
-							UserLoginFragment.ARG_SKIP_QUICKCONNECT to true,
 						))
 						// Errors
 						ServerUnavailableState -> Toast.makeText(context, R.string.server_connection_failed, Toast.LENGTH_LONG).show()


### PR DESCRIPTION
Issue found during final testing phase for 0.14. When installing the client with no previous data you will likely use the following flow:

1. Add server via discovery
2. Press public user to sign in

This opened the password input instead of the quick connect screen because we can't limit a QC login to just a specific user. This is annoying though because you'd need to input a password.

I changed it to always show the quick connect screen. If you enter the code as a different user everything still works fine, just a bit confusing because you don't end up signed in as the user initially used.

**Changes**

- Always show quick connect screen

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
