### PR TITLE
Fix live tv guide sorting

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -245,11 +245,6 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
         }
     }
 
-    private void reload() {
-        fillTimeLine(System.currentTimeMillis(), getGuideHours());
-        displayChannels(mCurrentDisplayChannelStartNdx, PAGE_SIZE);
-    }
-
     @Override
     protected void onResume() {
         super.onResume();
@@ -259,18 +254,8 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
     }
 
     protected void doLoad() {
-
         if (TvManager.shouldForceReload() || System.currentTimeMillis() >= mCurrentLocalGuideStart + 1800000  || mChannels.getChildCount() == 0) {
-            if (mAllChannels == null) {
-                mAllChannels = TvManager.getAllChannels();
-                if (mAllChannels == null) {
-                    load();
-                } else {
-                    reload();
-                }
-            } else {
-                reload();
-            }
+            load();
 
             mFirstFocusChannelId = TvManager.getLastLiveTvChannel();
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -145,7 +145,6 @@ public class TvManager {
             for (ChannelInfoDto channel : allChannels) {
                 channelIds[i++] = channel.getId();
                 if (channel.getId().equals(last)) ndx = i;
-                //TvApp.getApplication().getLogger().Debug("Last played for "+channel.getName()+ " is "+channel.getUserData().getLastPlayedDate());
             }
         }
 
@@ -262,10 +261,8 @@ public class TvManager {
             if (otherCell != null) {
                 if (up) {
                     cell.setNextFocusUpId(otherCell.getId());
-                    //TvApp.getApplication().getLogger().Debug("Setting up focus for " + cell.getProgram().getName() + " to " + otherCell.getProgram().getName()+"("+otherCell.getId()+")");
                 } else {
                     cell.setNextFocusDownId(otherCell.getId());
-                    //TvApp.getApplication().getLogger().Debug("Setting down focus for " + cell.getProgram().getName() + " to " + otherCell.getProgram().getName());
                 }
             }
         }


### PR DESCRIPTION
**Changes**
Fixes the sorting options not working in the live tv guide by removing the client side sorting and caching of channel orders... this matches the web implementation that just queries the channels endpoint when the order is changed

**Issues**
I couldn't find one, but it has annoyed me forever...
