### PR TITLE
Remove stateListAnimator from button styles

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -49,6 +49,7 @@
         <item name="android:drawablePadding">8dp</item>
         <item name="android:paddingEnd">16dp</item>
         <item name="android:minHeight">0dp</item>
+        <item name="android:stateListAnimator">@null</item>
     </style>
 
     <style name="Button.Icon" parent="android:Widget.Button">
@@ -60,6 +61,7 @@
         <item name="android:paddingStart">4dp</item>
         <item name="android:paddingEnd">4dp</item>
         <item name="android:minHeight">4dp</item>
+        <item name="android:stateListAnimator">@null</item>
     </style>
 
     <style name="Input.Default" parent="android:Widget.EditText">


### PR DESCRIPTION
Amazon changes the platform Button widget to scale when pressed, this doesn't work nice with some of our custom button styles and is not consistent with other platforms. This change removes the animation.

**Changes**

- Remove stateListAnimator from button styles

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
