### PR TITLE
Fix inconsistent red color for recordings

### DIFF
--- a/app/src/main/res/drawable/ic_record_series_red.xml
+++ b/app/src/main/res/drawable/ic_record_series_red.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#c33"
+    android:tint="@color/red"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,7 +9,7 @@
     <color name="not_quite_black">#101010</color>
     <color name="black">#000000</color>
     <color name="white">#FFFFFF</color>
-    <color name="red">#FF0000</color>
+    <color name="red">#CC3333</color>
     <color name="transparent">#00000000</color>
 
     <!-- Semi-Transparent Blacks -->


### PR DESCRIPTION
**Changes**
The recording icons were using two different shades of red. This updates the icons to both use the same (less harsh) red color.

**Issues**
N/A
