### PR TITLE
Fix live tv guide load more button height

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -15,6 +15,7 @@ import com.bumptech.glide.Glide;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -40,7 +41,10 @@ public class GuideChannelHeader extends RelativeLayout {
         LayoutInflater inflater = LayoutInflater.from(context);
         View v = inflater.inflate(R.layout.channel_header, this, false);
         int headerWidth = Utils.convertDpToPixel(context, 160);
-        v.setLayoutParams(new AbsListView.LayoutParams(headerWidth, Utils.convertDpToPixel(context, 55)));
+        v.setLayoutParams(new AbsListView.LayoutParams(
+            headerWidth,
+            Utils.convertDpToPixel(context, LiveTvGuideActivity.GUIDE_ROW_HEIGHT_DP)
+        ));
         this.addView(v);
         this.setFocusable(true);
         ((TextView) findViewById(R.id.channelName)).setText(channel.getName());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
@@ -35,7 +35,10 @@ public class GuidePagingButton extends RelativeLayout {
 
         setBackgroundResource(R.drawable.gray_gradient);
         TextView txtLabel = new TextView(activity);
-        txtLabel.setHeight(Utils.convertDpToPixel(getContext(), 55));
+        txtLabel.setHeight(Utils.convertDpToPixel(
+            getContext(),
+            LiveTvGuideActivity.GUIDE_ROW_HEIGHT_DP
+        ));
         txtLabel.setTextColor(Color.BLACK);
         setPadding(100,0,0,0);
         txtLabel.setFocusable(true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -59,9 +59,8 @@ import kotlin.Lazy;
 import timber.log.Timber;
 
 public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
-    public int ROW_HEIGHT;
-    public int PIXELS_PER_MINUTE;
-    public int PAGEBUTTON_HEIGHT;
+    public static final int GUIDE_ROW_HEIGHT_DP = 55;
+    public static final int GUIDE_ROW_WIDTH_PER_MIN_DP = 7;
     public static final int PAGE_SIZE = 75;
     public static final int NORMAL_HOURS = 9;
     public static final int FILTERED_HOURS = 4;
@@ -98,6 +97,9 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
     private int mCurrentDisplayChannelStartNdx = 0;
     private int mCurrentDisplayChannelEndNdx = 0;
 
+    private int guideRowHeightPx;
+    private int guideRowWidthPerMinPx;
+
     private Handler mHandler = new Handler();
 
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);
@@ -108,9 +110,8 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
 
         mActivity = this;
 
-        ROW_HEIGHT = Utils.convertDpToPixel(this, 55);
-        PIXELS_PER_MINUTE = Utils.convertDpToPixel(this,7);
-        PAGEBUTTON_HEIGHT = Utils.convertDpToPixel(this, 20);
+        guideRowHeightPx = Utils.convertDpToPixel(this, GUIDE_ROW_HEIGHT_DP);
+        guideRowWidthPerMinPx = Utils.convertDpToPixel(this, GUIDE_ROW_WIDTH_PER_MIN_DP);
 
         setContentView(R.layout.live_tv_guide);
 
@@ -534,7 +535,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
                 }
 
                 TextView placeHolder = new TextView(mActivity);
-                placeHolder.setHeight(PAGEBUTTON_HEIGHT);
+                placeHolder.setHeight(guideRowHeightPx);
                 mChannels.addView(placeHolder);
                 displayedChannels = 0;
 
@@ -601,7 +602,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
                 if (pageDnEnd >= mAllChannels.size()) pageDnEnd = mAllChannels.size()-1;
 
                 TextView placeHolder = new TextView(mActivity);
-                placeHolder.setHeight(PAGEBUTTON_HEIGHT);
+                placeHolder.setHeight(guideRowHeightPx);
                 mChannels.addView(placeHolder);
 
                 mProgramRows.addView(new GuidePagingButton(mActivity, mActivity, mCurrentDisplayChannelEndNdx + 1, getString(R.string.lbl_load_channels)+mAllChannels.get(mCurrentDisplayChannelEndNdx+1).getNumber() + " - "+mAllChannels.get(pageDnEnd).getNumber()));
@@ -643,7 +644,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
                 ProgramGridCell cell = new ProgramGridCell(this, this, empty, false);
                 cell.setId(currentCellId++);
-                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * PIXELS_PER_MINUTE, ROW_HEIGHT));
+                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * guideRowWidthPerMinPx, guideRowHeightPx));
                 cell.setFocusable(true);
                 programRow.addView(cell);
                 if (slot == 0)
@@ -675,7 +676,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(prevEnd+duration)));
                 ProgramGridCell cell = new ProgramGridCell(this, this, empty, false);
                 cell.setId(currentCellId++);
-                cell.setLayoutParams(new ViewGroup.LayoutParams(((Long)(duration / 60000)).intValue() * PIXELS_PER_MINUTE, ROW_HEIGHT));
+                cell.setLayoutParams(new ViewGroup.LayoutParams(((Long)(duration / 60000)).intValue() * guideRowWidthPerMinPx, guideRowHeightPx));
                 cell.setFocusable(true);
                 if (prevEnd == mCurrentLocalGuideStart) {
                     cell.setFirst();
@@ -690,7 +691,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
             if (duration > 0) {
                 ProgramGridCell program = new ProgramGridCell(this, this, item, false);
                 program.setId(currentCellId++);
-                program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * PIXELS_PER_MINUTE, ROW_HEIGHT));
+                program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * guideRowWidthPerMinPx, guideRowHeightPx));
                 program.setFocusable(true);
                 if (start == mCurrentLocalGuideStart) {
                     program.setFirst();
@@ -714,7 +715,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
             empty.setEndDate(TimeUtils.convertToUtcDate(new Date(prevEnd+duration)));
             ProgramGridCell cell = new ProgramGridCell(this, this, empty, false);
             cell.setId(currentCellId++);
-            cell.setLayoutParams(new ViewGroup.LayoutParams(((Long)(duration / 60000)).intValue() * PIXELS_PER_MINUTE, ROW_HEIGHT));
+            cell.setLayoutParams(new ViewGroup.LayoutParams(((Long)(duration / 60000)).intValue() * guideRowWidthPerMinPx, guideRowHeightPx));
             cell.setFocusable(true);
             programRow.addView(cell);
         }
@@ -733,8 +734,8 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
         mDisplayDate.setText(TimeUtils.getFriendlyDate(this, mCurrentGuideStart.getTime()));
         Calendar current = (Calendar) mCurrentGuideStart.clone();
         mCurrentGuideEnd = (Calendar) mCurrentGuideStart.clone();
-        int oneHour = 60 * PIXELS_PER_MINUTE;
-        int halfHour = 30 * PIXELS_PER_MINUTE;
+        int oneHour = 60 * guideRowWidthPerMinPx;
+        int halfHour = 30 * guideRowWidthPerMinPx;
         int interval = current.get(Calendar.MINUTE) >= 30 ? 30 : 60;
         mCurrentGuideEnd.add(Calendar.HOUR, hours);
         mCurrentLocalGuideEnd = mCurrentGuideEnd.getTimeInMillis();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -55,6 +55,7 @@ import org.jellyfin.androidtv.ui.ScrollViewListener;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
+import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpActivity;
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
@@ -891,6 +892,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     private LinearLayout getProgramRow(List<BaseItemDto> programs, String channelId) {
+        int guideRowHeightPx = Utils.convertDpToPixel(getContext(), LiveTvGuideActivity.GUIDE_ROW_HEIGHT_DP);
+        int guideRowWidthPerMinPx = Utils.convertDpToPixel(getContext(), LiveTvGuideActivity.GUIDE_ROW_WIDTH_PER_MIN_DP);
+
         LinearLayout programRow = new LinearLayout(requireContext());
         if (programs.size() == 0) {
 
@@ -905,7 +909,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
                 ProgramGridCell cell = new ProgramGridCell(requireContext(), this, empty, false);
                 cell.setId(currentCellId++);
-                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * Utils.convertDpToPixel(getContext(), 7), Utils.convertDpToPixel(getContext(), 55)));
+                cell.setLayoutParams(new ViewGroup.LayoutParams(30 * guideRowWidthPerMinPx, guideRowHeightPx));
                 cell.setFocusable(true);
                 programRow.addView(cell);
                 if (slot == 0)
@@ -935,7 +939,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(prevEnd + duration)));
                 ProgramGridCell cell = new ProgramGridCell(requireContext(), this, empty, false);
                 cell.setId(currentCellId++);
-                cell.setLayoutParams(new ViewGroup.LayoutParams(((Long) (duration / 60000)).intValue() * Utils.convertDpToPixel(getContext(), 7), Utils.convertDpToPixel(getContext(), 55)));
+                cell.setLayoutParams(new ViewGroup.LayoutParams(((Long) (duration / 60000)).intValue() * guideRowWidthPerMinPx, guideRowHeightPx));
                 cell.setFocusable(true);
                 programRow.addView(cell);
             }
@@ -946,7 +950,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             if (duration > 0) {
                 ProgramGridCell program = new ProgramGridCell(requireContext(), this, item, false);
                 program.setId(currentCellId++);
-                program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * Utils.convertDpToPixel(getContext(), 7), Utils.convertDpToPixel(getContext(), 55)));
+                program.setLayoutParams(new ViewGroup.LayoutParams(duration.intValue() * guideRowWidthPerMinPx, guideRowHeightPx));
                 program.setFocusable(true);
 
                 if (start == getCurrentLocalStartDate())


### PR DESCRIPTION
**Changes**

* Fixes the height of the load more/previous channels buttons in the live tv guide.
* Adds constant values for the guide row height and pixel per minute values, so they aren't defined 20 different times.

(I'll open a separate PR to address the terrible styling of the buttons)

**Issues**
Fixes #1543 
