### PR TITLE
Fix null text in info row

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -198,7 +198,7 @@ public class InfoLayoutHelper {
         layout.removeAllViews();
         TextView text = new TextView(context);
         text.setTextSize(textSize);
-        text.setText(item.getSubText(context) + " ");
+        text.setText(Utils.getSafeValue(item.getSubText(context), "") + " ");
         layout.addView(text);
 
     }


### PR DESCRIPTION
**Changes**
Prevents "null" from showing up in the info row / subheading while browsing. I noticed this in the live tv view when a (iptv) channel had no number.

**Issues**
N/A
