### PR TITLE
set max audio channels to 8 for exoplayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -194,7 +194,7 @@ class ExoPlayerProfile(
 				})
 			}
 			// Audio channel profile
-			add(maxAudioChannelsCodecProfile(channels = 6))
+			add(maxAudioChannelsCodecProfile(channels = 8))
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(


### PR DESCRIPTION
**Changes**
* set max audio channels for the exoplayer profile to 8, which is what the libVLC profile uses.

**Issues**
* current max channels is arbitrarily 6

**Notes**
* In the future perhaps the available # of channels could be queried from exoplayer or the system
  
  https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/audio/AudioCapabilities.html#getMaxChannelCount()
  
  https://developer.android.com/reference/android/media/AudioManager#getDevices(int)

