### PR TITLE
Fix channel logo display

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
@@ -233,14 +234,19 @@ public class CardPresenter extends Presenter {
                     break;
                 case LiveTvChannel:
                     ChannelInfoDto channel = mItem.getChannelInfo();
-                    double tvAspect = imageType.equals(ImageType.BANNER) ? ASPECT_RATIO_BANNER : imageType.equals(ImageType.THUMB) ? ImageUtils.ASPECT_RATIO_16_9 : Utils.getSafeValue(channel.getPrimaryImageAspectRatio(), ImageUtils.ASPECT_RATIO_7_9);
+                    // TODO: Is it even possible to have channels with banners or thumbs?
+                    double tvAspect = imageType.equals(ImageType.BANNER) ? ASPECT_RATIO_BANNER :
+                        imageType.equals(ImageType.THUMB) ? ImageUtils.ASPECT_RATIO_16_9 :
+                        Utils.getSafeValue(channel.getPrimaryImageAspectRatio(), 1.0);
                     cardHeight = !m.isStaticHeight() ? tvAspect > 1 ? lHeight : pHeight : sHeight;
                     cardWidth = (int) ((tvAspect) * cardHeight);
                     if (cardWidth < 10) {
                         cardWidth = 230;  //Guard against zero size images causing picasso to barf
                     }
                     mCardView.setMainImageDimensions(cardWidth, cardHeight);
-                    mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_tv);
+                    // Channel logos should fit within the view
+                    mCardView.getMainImageView().setScaleType(ImageView.ScaleType.FIT_CENTER);
+                    mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_square_tv);
                     break;
                 case LiveTvProgram:
                     BaseItemDto program = mItem.getProgramInfo();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -246,7 +246,7 @@ public class CardPresenter extends Presenter {
                     mCardView.setMainImageDimensions(cardWidth, cardHeight);
                     // Channel logos should fit within the view
                     mCardView.getMainImageView().setScaleType(ImageView.ScaleType.FIT_CENTER);
-                    mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_square_tv);
+                    mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_tv);
                     break;
                 case LiveTvProgram:
                     BaseItemDto program = mItem.getProgramInfo();

--- a/app/src/main/res/drawable/tile_square_tv.xml
+++ b/app/src/main/res/drawable/tile_square_tv.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size
+                android:width="384dp"
+                android:height="384dp" />
+            <solid android:color="?attr/tile_port_tv_bg" />
+        </shape>
+    </item>
+
+    <item
+        android:bottom="124dp"
+        android:drawable="@drawable/ic_tv"
+        android:left="124dp"
+        android:right="124dp"
+        android:top="124dp" />
+</layer-list>

--- a/app/src/main/res/drawable/tile_tv.xml
+++ b/app/src/main/res/drawable/tile_tv.xml
@@ -3,16 +3,16 @@
     <item>
         <shape android:shape="rectangle">
             <size
-                android:width="384dp"
-                android:height="384dp" />
+                android:width="256dp"
+                android:height="256dp" />
             <solid android:color="?attr/tile_port_tv_bg" />
         </shape>
     </item>
 
     <item
-        android:bottom="124dp"
+        android:bottom="60dp"
         android:drawable="@drawable/ic_tv"
-        android:left="124dp"
-        android:right="124dp"
-        android:top="124dp" />
+        android:left="60dp"
+        android:right="60dp"
+        android:top="60dp" />
 </layer-list>


### PR DESCRIPTION
**Changes**

* Makes the default aspect ratio for channels square (1.0)
* Changes the scale type to fit center so logos do not overflow the view
* Adds a square tv icon resource to use as a default

**Issues**
Fixes #1773 
