### PR TITLE
Fix sign-in screen claiming invalid credentials when server is unavailable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -16,6 +16,7 @@ import org.jellyfin.androidtv.auth.model.PrivateUser
 import org.jellyfin.androidtv.auth.model.QuickConnectAuthenticateMethod
 import org.jellyfin.androidtv.auth.model.RequireSignInState
 import org.jellyfin.androidtv.auth.model.Server
+import org.jellyfin.androidtv.auth.model.ServerUnavailableState
 import org.jellyfin.androidtv.auth.model.ServerVersionNotSupported
 import org.jellyfin.androidtv.auth.model.User
 import org.jellyfin.androidtv.auth.store.AccountManagerStore
@@ -26,6 +27,7 @@ import org.jellyfin.androidtv.util.sdk.forUser
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
+import org.jellyfin.sdk.api.client.exception.TimeoutException
 import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
 import org.jellyfin.sdk.api.client.extensions.authenticateWithQuickConnect
 import org.jellyfin.sdk.api.client.extensions.imageApi
@@ -86,6 +88,10 @@ class AuthenticationRepositoryImpl(
 		val result = try {
 			val response = api.userApi.authenticateUserByName(username, password)
 			response.content
+		} catch (err: TimeoutException) {
+			Timber.e(err, "Failed to connect to server trying to sign in $username")
+			emit(ServerUnavailableState)
+			return@flow
 		} catch (err: ApiClientException) {
 			Timber.e(err, "Unable to sign in as $username")
 			emit(RequireSignInState)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
This makes the "Unable to connect" message appear when trying to sign into an unavailable server instead of the one claiming invalid credentials by having `AuthenticationRepository` emit the `ServerUnavailableState` when authentication with credentials fails due to a network error.

Possibly this `catch` Block should also be added to the other authentication methods.

Depends on https://github.com/jellyfin/jellyfin-sdk-kotlin/pull/442 for the appropriate exception to be raised.

**Issues**
None
