### PR TITLE
use an error fallback if glide fails to load image - for series logo in player create fallback bitmap from textview

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -44,6 +44,7 @@ class AsyncImageView @JvmOverloads constructor(
 		url: String? = null,
 		blurHash: String? = null,
 		placeholder: Drawable? = null,
+		error: Drawable? = null,
 		aspectRatio: Double = 1.0,
 		blurHashResolution: Int = 32,
 	) = doOnAttach {
@@ -64,7 +65,7 @@ class AsyncImageView @JvmOverloads constructor(
 			Glide.with(this@AsyncImageView)
 				.load(url ?: placeholder)
 				.placeholder(placeholderOrBlurHash)
-				.error(placeholder)
+				.error(error ?: placeholder)
 				// FIXME: Glide is unable to scale the image when transitions are enabled
 				//.transition(DrawableTransitionOptions.withCrossFade(crossFadeDuration.inWholeMilliseconds.toInt()))
 				.into(this@AsyncImageView)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -65,7 +65,7 @@ class NowPlayingView @JvmOverloads constructor(
 	private fun setInfo(item: BaseItemDto) {
 		val placeholder = ContextCompat.getDrawable(context, R.drawable.ic_album)
 		val blurHash = item.imageBlurHashes?.get(ImageType.Primary)?.get(item.imageTags?.get(ImageType.Primary))
-		binding.npIcon.load(ImageUtils.getPrimaryImageUrl(item), blurHash, placeholder, item.primaryImageAspectRatio ?: 1.0)
+		binding.npIcon.load(ImageUtils.getPrimaryImageUrl(item), blurHash, placeholder, null, item.primaryImageAspectRatio ?: 1.0)
 
 		currentDuration = TimeUtils.formatMillis(if (item.runTimeTicks != null) item.runTimeTicks / 10_000 else 0)
 		binding.npDesc.text = if (item.albumArtist != null) item.albumArtist else item.name

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -480,7 +480,7 @@ public class ItemListActivity extends FragmentActivity {
                 Double aspect = ImageUtils.getImageAspectRatio(item, false);
                 String primaryImageUrl = ImageUtils.getPrimaryImageUrl(item);
                 mPoster.setPadding(0, 0, 0, 0);
-                mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(this, R.drawable.ic_album), aspect, 0);
+                mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(this, R.drawable.ic_album), null, aspect, 0);
                 break;
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -421,7 +421,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
 
         String primaryImageUrl = ImageUtils.getPrimaryImageUrl(this, mBaseItem, false, posterHeight);
         Timber.d("Audio Poster url: %s", primaryImageUrl);
-        mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(this, R.drawable.ic_album), aspect, 0);
+        mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(this, R.drawable.ic_album), null, aspect, 0);
     }
 
     private void loadItem() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -5,7 +5,10 @@ import static org.koin.java.KoinJavaComponent.inject;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.drawable.BitmapDrawable;
 import android.media.AudioManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -1287,10 +1290,18 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             // Update the logo
             String imageUrl = ImageUtils.getLogoImageUrl(current, 440, false);
             if (imageUrl != null) {
+                // FIXME: add support for loading SVG with glide or support server-side for converting to SVG
+                // create a bitmap from the itemTitle TextView to use as a placeholder in case the image fails to load
+                // or in case the image as a unsupported format such as SVG
+                binding.itemTitle.measure(0, 0);
+                Bitmap bitmap = Bitmap.createBitmap(binding.itemTitle.getMeasuredWidth(), binding.itemTitle.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+                Canvas canvas = new Canvas(bitmap);
+                binding.itemTitle.draw(canvas);
+
                 binding.itemLogo.setVisibility(View.VISIBLE);
                 binding.itemTitle.setVisibility(View.GONE);
                 binding.itemLogo.setContentDescription(current.getName());
-                binding.itemLogo.load(imageUrl, null, null, 1.0, 0);
+                binding.itemLogo.load(imageUrl, null, new BitmapDrawable(getResources(), bitmap), 1.0, 0);
             } else {
                 binding.itemLogo.setVisibility(View.GONE);
                 binding.itemTitle.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1301,7 +1301,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 binding.itemLogo.setVisibility(View.VISIBLE);
                 binding.itemTitle.setVisibility(View.GONE);
                 binding.itemLogo.setContentDescription(current.getName());
-                binding.itemLogo.load(imageUrl, null, new BitmapDrawable(getResources(), bitmap), 1.0, 0);
+                binding.itemLogo.load(imageUrl, null, null, new BitmapDrawable(getResources(), bitmap), 1.0, 0);
             } else {
                 binding.itemLogo.setVisibility(View.GONE);
                 binding.itemTitle.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -336,7 +336,7 @@ public class CardPresenter extends Presenter {
         }
 
         protected void updateCardViewImage(@Nullable String url, @Nullable String blurHash) {
-            mCardView.getMainImageView().load(url, blurHash, mDefaultCardImage, aspect, 32);
+            mCardView.getMainImageView().load(url, blurHash, mDefaultCardImage, null, aspect, 32);
         }
 
         protected void resetCardView() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.java
@@ -110,7 +110,7 @@ public class MyDetailsOverviewRowPresenter extends RowPresenter {
         setInfo3(row.getInfoItem3());
 
         String posterUrl = row.getImageDrawable();
-        vh.mPoster.load(posterUrl, null, null, 1.0, 0);
+        vh.mPoster.load(posterUrl, null, null, null, 1.0, 0);
         int progress = row.getProgress();
         if (progress > 0 && posterUrl != null) {
             vh.mProgress.setProgress(progress);


### PR DESCRIPTION
**Changes**
* add an `error` parameter to `AsyncImageView` and use it if it's not null, and otherwise use `placeholder`.
* refactor uses of `AsyncImageView.load()` to use the new `error` parameter.
* create a bitmap from the series title TextView in `CustomPlaybackOverlayFragment` and pass that as the `error` placeholder to `AsyncImageView`.
 In situations where the logo image isn't a supported format (such as SVG), this results in the title still displaying normally.

**Issues**
* In the player, if the item logo has a url but the logo is an unsupported image format, no title will be shown at all since the TextView item title is hidden if a url exists for the logo.
