### PR TITLE
Remove whitespace prepended to the no gude data titles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -623,7 +623,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
             int slot = 0;
             do {
                 BaseItemDto empty = new BaseItemDto();
-                empty.setName("  " + getString(R.string.no_program_data));
+                empty.setName(getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*slot) * 60000))));
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
@@ -653,7 +653,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
             if (start > prevEnd) {
                 // fill empty time slot
                 BaseItemDto empty = new BaseItemDto();
-                empty.setName("  " + getString(R.string.no_program_data));
+                empty.setName(getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
                 Long duration = (start - prevEnd);
@@ -690,7 +690,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
         if (prevEnd < mCurrentLocalGuideEnd) {
             // fill empty time slot
             BaseItemDto empty = new BaseItemDto();
-            empty.setName("  " + getString(R.string.no_program_data));
+            empty.setName(getString(R.string.no_program_data));
             empty.setChannelId(channelId);
             empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
             Long duration = (mCurrentLocalGuideEnd - prevEnd);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -903,7 +903,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
             do {
                 BaseItemDto empty = new BaseItemDto();
-                empty.setName("  " + getString(R.string.no_program_data));
+                empty.setName(getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*slot) * 60000))));
                 empty.setEndDate(TimeUtils.convertToUtcDate(new Date(mCurrentLocalGuideStart + ((30*(slot+1)) * 60000))));
@@ -931,7 +931,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             if (start > prevEnd) {
                 // fill empty time slot
                 BaseItemDto empty = new BaseItemDto();
-                empty.setName("  " + getString(R.string.no_program_data));
+                empty.setName(getString(R.string.no_program_data));
                 empty.setChannelId(channelId);
                 empty.setStartDate(TimeUtils.convertToUtcDate(new Date(prevEnd)));
                 Long duration = (start - prevEnd);


### PR DESCRIPTION
**Changes**
Removes whitespace being prepended to the "No Program Data Available" message for reasons unknown

**Issues**
N/A
