### PR TITLE
Remove seasonal greetings & libvlc subtitle delay preferences

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -51,11 +51,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var premieresEnabled = booleanPreference("pref_enable_premieres", false)
 
-		/**
-		 * Show a little notification to celebrate a set of holidays
-		 */
-		var seasonalGreetingsEnabled = booleanPreference("pref_enable_themes", true)
-
 		/* Playback - General*/
 		/**
 		 * Maximum bitrate in megabit for playback. A value of [MAX_BITRATE_AUTO] is used when
@@ -125,11 +120,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Default audio delay in milliseconds for libVLC
 		 */
 		var libVLCAudioDelay = intPreference("libvlc_audio_delay", 0)
-
-		/**
-		 * Default audio subtitle in milliseconds for libVLC
-		 */
-		var libVLCSubtitleDelay = intPreference("libvlc_subtitle_delay", 0)
 
 		/* Live TV */
 		/**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -28,12 +28,6 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.appTheme)
 			}
 
-			checkbox {
-				setTitle(R.string.lbl_enable_seasonal_themes)
-				setContent(R.string.desc_seasonal_themes)
-				bind(userPreferences, UserPreferences.seasonalGreetingsEnabled)
-			}
-
 			enum<ClockBehavior> {
 				setTitle(R.string.pref_clock_display)
 				bind(userPreferences, UserPreferences.clockBehavior)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -153,17 +153,6 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 
 			@Suppress("MagicNumber")
 			seekbar {
-				setTitle(R.string.pref_libvlc_subtitle_delay_title)
-				min = -50_000
-				max = 50_000
-				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-					override fun display(value: Int) = "${value}ms"
-				}
-				bind(userPreferences, UserPreferences.libVLCSubtitleDelay)
-			}
-
-			@Suppress("MagicNumber")
-			seekbar {
 				setTitle(R.string.pref_subtitles_size)
 				min = 10
 				max = 38

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,8 +180,6 @@
     <string name="lbl_save_as_playlist">Save as Playlist</string>
     <string name="lbl_delete">Delete</string>
     <string name="msg_item_added">" item added"</string>
-    <string name="lbl_enable_seasonal_themes">Seasonal themes</string>
-    <string name="desc_seasonal_themes">Display special colors and suggestions at certain times of the year</string>
     <string name="desc_automatic_fav_songs">Automatic playlist of favorite songs</string>
     <string name="lbl_new_premieres">New Premieres</string>
     <string name="lbl_bitstream_ac3">Bitstream Dolby Digital audio</string>
@@ -277,7 +275,6 @@
     <string name="watch_now">Watch now</string>
     <string name="pref_next_up_behavior_title">Show next video info</string>
     <string name="pref_libvlc_audio_delay_title">Default audio delay for LibVLC</string>
-    <string name="pref_libvlc_subtitle_delay_title">Default subtitle delay for LibVLC</string>
     <string name="pref_app_theme">App theme</string>
     <string name="pref_device_model">Device model</string>
     <string name="grid_direction">Grid Direction</string>


### PR DESCRIPTION
Both were unused

**Changes**

- Remove seasonal greetings preference
- Remove libvlc subtitle delay preference
- Remove related strings

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
