### PR TITLE
Throw error when EditServerScreen and EditUserScreen open with invalid arguments

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditServerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditServerScreen.kt
@@ -21,10 +21,11 @@ class EditServerScreen : OptionsFragment() {
 	override val rebuildOnResume = true
 
 	override val screen by optionsScreen {
-		val serverUUID = requireArguments().get(ARG_SERVER_UUID) as? UUID
-			?: return@optionsScreen
+		val serverUUID = requireNotNull(
+			requireArguments().get(ARG_SERVER_UUID) as? UUID
+		) { "Server null or malformed uuid" }
 
-		val server = startupViewModel.getServer(serverUUID) ?: return@optionsScreen
+		val server = requireNotNull(startupViewModel.getServer(serverUUID)) { "Server not found" }
 		val users = serverUserRepository.getStoredServerUsers(server)
 
 		title = server.name
@@ -46,8 +47,8 @@ class EditServerScreen : OptionsFragment() {
 						)
 
 						withFragment<EditUserScreen>(bundleOf(
-							EditUserScreen.ARG_SERVER_UUID to user.serverId,
-							EditUserScreen.ARG_USER_UUID to user.id
+							EditUserScreen.ARG_SERVER_UUID to server.id,
+							EditUserScreen.ARG_USER_UUID to user.id,
 						))
 					}
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditUserScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditUserScreen.kt
@@ -17,13 +17,16 @@ class EditUserScreen : OptionsFragment() {
 	private val serverUserRepository: ServerUserRepository by inject()
 
 	override val screen by optionsScreen {
-		val serverUUID = requireArguments().get(ARG_SERVER_UUID)
-		val userUUID = requireArguments().get(ARG_USER_UUID)
+		val serverUUID = requireNotNull(requireArguments().get(ARG_SERVER_UUID)) { "Missing server id" }
+		val userUUID = requireNotNull(requireArguments().get(ARG_USER_UUID)) { "Missing user id" }
 
-		if (serverUUID !is UUID || userUUID !is UUID) return@optionsScreen
+		require(serverUUID is UUID) { "Server id is malformed" }
+		require(userUUID is UUID) { "Server id is malformed" }
 
-		val server = startupViewModel.getServer(serverUUID) ?: return@optionsScreen
-		val user = serverUserRepository.getStoredServerUsers(server).find { it.id == userUUID } ?: return@optionsScreen
+		val server = requireNotNull(startupViewModel.getServer(serverUUID)) { "Server not found" }
+		val user = requireNotNull(
+			serverUserRepository.getStoredServerUsers(server).find { it.id == userUUID }
+		) { "User not found" }
 
 		title = context?.getString(R.string.lbl_user_server, user.name, server.name)
 


### PR DESCRIPTION
Update authentication preferences to throw errors instead of silently returning for invalid state. This should help us with debugging auth issues.

**Changes**
- Throw error when EditServerScreen and EditUserScreen open with invalid arguments

**Issues**

Should help with #1790