### PR TITLE
Remove generation timestamp from AboutLibraries data file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,11 @@ android {
 	}
 }
 
+aboutLibraries {
+	// Remove the "generated" timestamp to allow for reproducible builds
+	excludeFields = arrayOf("generated")
+}
+
 val versionTxt by tasks.registering {
 	val path = buildDir.resolve("version.txt")
 


### PR DESCRIPTION
This should fix our reproducible builds for F-Droid.

**Changes**

- Remove generation timestamp from AboutLibraries data file

**Issues**

Fix #1639
Ref https://github.com/mikepenz/AboutLibraries/issues/784