### PR TITLE
Remove item delete functionality

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -872,29 +872,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
         mActivity.startActivity(intent);
     }
 
-    private void deleteItem() {
-        new AlertDialog.Builder(mActivity)
-                .setTitle(R.string.lbl_delete)
-                .setMessage("This will PERMANENTLY DELETE " + mBaseItem.getName() + " from your library.  Are you VERY sure?")
-                .setPositiveButton("Delete",
-                        (dialog, whichButton) -> apiClient.getValue().DeleteItem(mBaseItem.getId(), new EmptyResponse() {
-                            @Override
-                            public void onResponse() {
-                                Utils.showToast(mActivity, mBaseItem.getName() + " Deleted");
-                                dataRefreshService.getValue().setLastDeletedItemId(mBaseItem.getId());
-                                finish();
-                            }
-
-                            @Override
-                            public void onError(Exception ex) {
-                                Utils.showToast(mActivity, ex.getLocalizedMessage());
-                            }
-                        }))
-                .setNegativeButton("Cancel", (dialog, which) -> Utils.showToast(mActivity, "Item NOT Deleted"))
-                .show()
-                .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
-    }
-
     private TextUnderButton favButton = null;
     private TextUnderButton shuffleButton = null;
     private TextUnderButton goToSeriesButton = null;
@@ -1257,17 +1234,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
             mDetailsOverviewRow.addAction(goToSeriesButton);
         }
 
-        if ((mBaseItem.getBaseItemType() == BaseItemType.Recording && KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getPolicy().getEnableLiveTvManagement() && mBaseItem.getCanDelete()) ||
-                ((mBaseItem.getBaseItemType() == BaseItemType.Movie || mBaseItem.getBaseItemType() == BaseItemType.Episode || mBaseItem.getBaseItemType() == BaseItemType.Video) && KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getPolicy().getEnableContentDeletion())) {
-            deleteButton = TextUnderButton.create(this, R.drawable.ic_trash, buttonSize, 0, getString(R.string.lbl_delete), new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    deleteItem();
-                }
-            });
-            mDetailsOverviewRow.addAction(deleteButton);
-        }
-
         if (mSeriesTimerInfo != null && mBaseItem.getBaseItemType() == BaseItemType.SeriesTimer) {
             //Settings
             mDetailsOverviewRow.addAction(TextUnderButton.create(this, R.drawable.ic_settings, buttonSize, 0, getString(R.string.lbl_series_settings), new View.OnClickListener() {
@@ -1453,9 +1419,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                     return true;
                 case R.id.addQueue:
                     addItemToQueue();
-                    return true;
-                case R.id.delete:
-                    deleteItem();
                     return true;
             }
             return false;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -46,7 +46,6 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -637,10 +636,10 @@ public class ItemListActivity extends FragmentActivity {
                     }));
                 }
 
-                TextUnderButton delete = TextUnderButton.create(this, R.drawable.ic_trash, buttonSize, 0, getString(R.string.lbl_delete), new View.OnClickListener() {
-                    @Override
-                    public void onClick(final View v) {
-                        if (mBaseItem.getId().equals(VIDEO_QUEUE)) {
+                if (mBaseItem.getId().equals(VIDEO_QUEUE)) {
+                    TextUnderButton delete = TextUnderButton.create(this, R.drawable.ic_trash, buttonSize, 0, getString(R.string.lbl_delete), new View.OnClickListener() {
+                        @Override
+                        public void onClick(final View v) {
                             new AlertDialog.Builder(mActivity)
                                     .setTitle(R.string.lbl_clear_queue)
                                     .setMessage(R.string.clear_expanded)
@@ -649,41 +648,18 @@ public class ItemListActivity extends FragmentActivity {
                                         dataRefreshService.getValue().setLastVideoQueueChange(System.currentTimeMillis());
                                         finish();
                                     })
-                                    .setNegativeButton(R.string.btn_cancel, (dialog, which) -> {})
+                                    .setNegativeButton(R.string.btn_cancel, (dialog, which) -> {
+                                    })
                                     .show()
                                     .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
-                        } else {
-                            new AlertDialog.Builder(mActivity)
-                                    .setTitle(R.string.lbl_delete)
-                                    .setMessage(getString(R.string.delete_warning, mBaseItem.getName()))
-                                    .setPositiveButton(R.string.lbl_delete,
-                                            (dialog, whichButton) -> apiClient.getValue().DeleteItem(mBaseItem.getId(), new EmptyResponse() {
-                                                @Override
-                                                public void onResponse() {
-                                                    Utils.showToast(mActivity, getString(R.string.lbl_deleted, mBaseItem.getName()));
-                                                    dataRefreshService.getValue().setLastDeletedItemId(mBaseItem.getId());
-                                                    finish();
-                                                }
-
-                                                @Override
-                                                public void onError(Exception ex) {
-                                                    Utils.showToast(mActivity, ex.getLocalizedMessage());
-                                                }
-                                            }))
-                                    .setNegativeButton(R.string.btn_cancel,
-                                            (dialog, which) -> Utils.showToast(mActivity, R.string.not_deleted))
-                                    .show()
-                                    .getButton(AlertDialog.BUTTON_NEGATIVE).requestFocus();
-
-
                         }
-                    }
-                });
+                    });
 
-                mButtonRow.addView(delete);
-                delete.setOnFocusChangeListener((v, hasFocus) -> {
-                    if (hasFocus) mScrollView.smoothScrollTo(0, 0);
-                });
+                    mButtonRow.addView(delete);
+                    delete.setOnFocusChangeListener((v, hasFocus) -> {
+                        if (hasFocus) mScrollView.smoothScrollTo(0, 0);
+                    });
+                }
             }
         }
 

--- a/app/src/main/res/menu/menu_details_more.xml
+++ b/app/src/main/res/menu/menu_details_more.xml
@@ -18,7 +18,4 @@
     <item
         android:id="@+id/gotoSeries"
         android:title="@string/lbl_goto_series" />
-    <item
-        android:id="@+id/delete"
-        android:title="@string/lbl_delete" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,7 +294,6 @@
     <string name="no_player_message">It doesn\'t appear you have a video capable app installed.  This option requires you install a 3rd party application for playing video content.</string>
     <string name="lbl_clear">Clear</string>
     <string name="clear_expanded">Clear current video queue?</string>
-    <string name="delete_warning">This will PERMANENTLY DELETE %1$s from your library. Are you VERY sure?</string>
     <string name="episode_missing">Episode Missing</string>
     <string name="episode_missing_message">This episode is missing from your library.  Would you like to skip it and continue to the next one?</string>
     <string name="episode_missing_message_2">This episode is missing from your library.  Playback will stop.</string>


### PR DESCRIPTION
The scope Android TV client is to USE the Jellyfin server, not to MANAGE it. While it makes sense for some stuff to have a delete function (like Live TV recordings) it doesn't for actual media. This PR removes all item deletion except for Live TV stuff.

**Changes**
- Remove item delete functionality

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
