### PR TITLE
Disable Detekt InvalidPackageDeclaration rule

### DIFF
--- a/detekt.yaml
+++ b/detekt.yaml
@@ -14,6 +14,10 @@ complexity:
     thresholdInInterfaces: 15
     thresholdInClasses: 15
 
+naming:
+  InvalidPackageDeclaration:
+    active: false
+
 style:
   # Allow TODO and FIXME comments
   ForbiddenComment:


### PR DESCRIPTION
It doesn't work properly because we don't have an org/jellyfin/androidtv package in the playback and preference modules

**Changes**
- Disable Detekt InvalidPackageDeclaration rule

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
