### PR TITLE
Remove usages of BaseItemType's that don't exist in the server anymore

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.kt
@@ -17,7 +17,6 @@ enum class QueryType {
 	LiveTvChannel,
 	LiveTvProgram,
 	LiveTvRecording,
-	LiveTvRecordingGroup,
 	StaticItems,
 	Persons,
 	StaticAudioQueueItems,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -18,7 +18,6 @@ import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
-import org.jellyfin.apiclient.model.livetv.RecordingGroupQuery;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
 import org.jellyfin.apiclient.model.livetv.TimerInfoDto;
 import org.jellyfin.apiclient.model.livetv.TimerQuery;
@@ -103,11 +102,6 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         kids.setEnableImages(true);
         kids.setIsKids(true);
         mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_kids), kids, 60));
-
-        //All Recordings by group - will only be there for non-internal TV
-        RecordingGroupQuery recordingGroups = new RecordingGroupQuery();
-        recordingGroups.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
-        mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_all_recordings), recordingGroups));
 
         rowLoader.loadRows(mRows);
         addNext24Timers();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
@@ -5,7 +5,6 @@ import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.querying.ViewQuery;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery;
-import org.jellyfin.apiclient.model.livetv.RecordingGroupQuery;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerQuery;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
@@ -30,7 +29,6 @@ public class BrowseRowDef {
     private LiveTvChannelQuery tvChannelQuery;
     private RecommendedProgramQuery programQuery;
     private RecordingQuery recordingQuery;
-    private RecordingGroupQuery recordingGroupQuery;
     private SeriesTimerQuery seriesTimerQuery;
 
     private ArtistsQuery artistsQuery;
@@ -145,12 +143,6 @@ public class BrowseRowDef {
         this.queryType = QueryType.LiveTvRecording;
     }
 
-    public BrowseRowDef(String header, RecordingGroupQuery query) {
-        headerText = header;
-        this.recordingGroupQuery = query;
-        this.queryType = QueryType.LiveTvRecordingGroup;
-    }
-
     public BrowseRowDef(String header, PersonsQuery query, int chunkSize) {
         headerText = header;
         this.personsQuery = query;
@@ -240,9 +232,5 @@ public class BrowseRowDef {
 
     public ChangeTriggerType[] getChangeTriggers() {
         return changeTriggers;
-    }
-
-    public RecordingGroupQuery getRecordingGroupQuery() {
-        return recordingGroupQuery;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -26,7 +26,6 @@ import org.jellyfin.apiclient.model.entities.LocationType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery;
-import org.jellyfin.apiclient.model.livetv.RecordingGroupQuery;
 import org.jellyfin.apiclient.model.livetv.RecordingQuery;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerQuery;
 import org.jellyfin.apiclient.model.livetv.TimerInfoDto;
@@ -372,10 +371,6 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                                     recordings.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
                                     recordings.setEnableImages(true);
                                     mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_recent_recordings), recordings, 50));
-                                    //All Recordings by group - will only be there for non-internal TV
-                                    RecordingGroupQuery recordingGroups = new RecordingGroupQuery();
-                                    recordingGroups.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
-                                    mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_all_recordings), recordingGroups));
                                     rowLoader.loadRows(mRows);
 
                                     //Now insert our smart rows

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -258,9 +258,6 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
                 case LiveTvRecording:
                     rowAdapter = new ItemRowAdapter(requireContext(), def.getRecordingQuery(), def.getChunkSize(), mCardPresenter, mRowsAdapter);
                     break;
-                case LiveTvRecordingGroup:
-                    rowAdapter = new ItemRowAdapter(requireContext(), def.getRecordingGroupQuery(), mCardPresenter, mRowsAdapter);
-                    break;
                 case Premieres:
                     rowAdapter = new ItemRowAdapter(requireContext(), def.getQuery(), def.getChunkSize(), def.getPreferParentThumb(), def.isStaticHeight(), mCardPresenter, mRowsAdapter, def.getQueryType());
                     break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.java
@@ -3,85 +3,59 @@ package org.jellyfin.androidtv.ui.browsing;
 import android.os.Bundle;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.SortOrder;
-import org.jellyfin.apiclient.model.livetv.RecordingQuery;
-import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
 import org.jellyfin.apiclient.model.querying.ItemSortBy;
-import org.koin.java.KoinJavaComponent;
 
 import java.util.Arrays;
 
 public class GenericFolderFragment extends EnhancedBrowseFragment {
-
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
     }
 
-    private static BaseItemType[] showSpecialViewTypes = new BaseItemType[] {BaseItemType.CollectionFolder, BaseItemType.Folder, BaseItemType.UserView, BaseItemType.ChannelFolderItem };
+    private static BaseItemType[] showSpecialViewTypes = new BaseItemType[]{BaseItemType.CollectionFolder, BaseItemType.Folder, BaseItemType.UserView, BaseItemType.ChannelFolderItem};
 
     @Override
     protected void setupQueries(RowLoader rowLoader) {
+        if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0 ||
+                mFolder.getBaseItemType() == BaseItemType.Channel ||
+                mFolder.getBaseItemType() == BaseItemType.ChannelFolderItem ||
+                mFolder.getBaseItemType() == BaseItemType.UserView ||
+                mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {
+            boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getBaseItemType()) && !"channels".equals(mFolder.getCollectionType());
 
-        if (mFolder.getBaseItemType() == BaseItemType.RecordingGroup){
-            RecordingQuery query = new RecordingQuery();
-            query.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
-            query.setGroupId(mFolder.getId());
-            query.setFields(new ItemFields[] {
-                    ItemFields.PrimaryImageAspectRatio,
-                    ItemFields.ChildCount
-            });
-            mRows.add(new BrowseRowDef(getString(R.string.lbl_all_items), query));
-            rowLoader.loadRows(mRows);
-        } else {
-
-            if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0 ||
-                    mFolder.getBaseItemType() == BaseItemType.Channel ||
-                    mFolder.getBaseItemType() == BaseItemType.ChannelFolderItem ||
-                    mFolder.getBaseItemType() == BaseItemType.UserView ||
-                    mFolder.getBaseItemType() == BaseItemType.CollectionFolder) {
-                boolean showSpecialViews = Arrays.asList(showSpecialViewTypes).contains(mFolder.getBaseItemType()) && !"channels".equals(mFolder.getCollectionType());
-
-                if (showSpecialViews) {
-                    if (mFolder.getBaseItemType() != BaseItemType.ChannelFolderItem) {
-                        StdItemQuery resume = new StdItemQuery();
-                        resume.setParentId(mFolder.getId());
-                        resume.setLimit(50);
-                        resume.setFilters(new ItemFilter[]{ItemFilter.IsResumable});
-                        resume.setSortBy(new String[]{ItemSortBy.DatePlayed});
-                        resume.setSortOrder(SortOrder.Descending);
-                        mRows.add(new BrowseRowDef(getString(R.string.lbl_continue_watching), resume, 0));
-                    }
-
-                    StdItemQuery latest = new StdItemQuery();
-                    latest.setParentId(mFolder.getId());
-                    latest.setLimit(50);
-                    latest.setFilters(new ItemFilter[]{ItemFilter.IsUnplayed});
-                    latest.setSortBy(new String[]{ItemSortBy.DateCreated});
-                    latest.setSortOrder(SortOrder.Descending);
-                    mRows.add(new BrowseRowDef(getString(R.string.lbl_latest_additions), latest, 0));
-
+            if (showSpecialViews) {
+                if (mFolder.getBaseItemType() != BaseItemType.ChannelFolderItem) {
+                    StdItemQuery resume = new StdItemQuery();
+                    resume.setParentId(mFolder.getId());
+                    resume.setLimit(50);
+                    resume.setFilters(new ItemFilter[]{ItemFilter.IsResumable});
+                    resume.setSortBy(new String[]{ItemSortBy.DatePlayed});
+                    resume.setSortOrder(SortOrder.Descending);
+                    mRows.add(new BrowseRowDef(getString(R.string.lbl_continue_watching), resume, 0));
                 }
 
-
-                StdItemQuery byName = new StdItemQuery();
-                byName.setParentId(mFolder.getId());
-                String header = (mFolder.getBaseItemType() == BaseItemType.Season) ? mFolder.getName() : getString(R.string.lbl_by_name);
-                mRows.add(new BrowseRowDef(header, byName, 100));
-
-                rowLoader.loadRows(mRows);
+                StdItemQuery latest = new StdItemQuery();
+                latest.setParentId(mFolder.getId());
+                latest.setLimit(50);
+                latest.setFilters(new ItemFilter[]{ItemFilter.IsUnplayed});
+                latest.setSortBy(new String[]{ItemSortBy.DateCreated});
+                latest.setSortOrder(SortOrder.Descending);
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_latest_additions), latest, 0));
 
             }
 
+            StdItemQuery byName = new StdItemQuery();
+            byName.setParentId(mFolder.getId());
+            String header = (mFolder.getBaseItemType() == BaseItemType.Season) ? mFolder.getName() : getString(R.string.lbl_by_name);
+            mRows.add(new BrowseRowDef(header, byName, 100));
+
+            rowLoader.loadRows(mRows);
         }
-
     }
-
-
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
@@ -149,9 +149,6 @@ public class StdBrowseFragment extends BrowseSupportFragment implements RowLoade
                 case LiveTvRecording:
                     rowAdapter = new ItemRowAdapter(requireContext(), def.getRecordingQuery(), def.getChunkSize(), mCardPresenter, mRowsAdapter);
                     break;
-                case LiveTvRecordingGroup:
-                    rowAdapter = new ItemRowAdapter(requireContext(), def.getRecordingGroupQuery(), mCardPresenter, mRowsAdapter);
-                    break;
                 default:
                     rowAdapter = new ItemRowAdapter(requireContext(), def.getQuery(), def.getChunkSize(), def.getPreferParentThumb(), def.isStaticHeight(), mCardPresenter, mRowsAdapter, def.getQueryType());
                     break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdGridFragment.java
@@ -480,9 +480,6 @@ public class StdGridFragment extends GridFragment {
             case LiveTvRecording:
                 mGridAdapter = new ItemRowAdapter(requireContext(), mRowDef.getRecordingQuery(), chunkSize, mCardPresenter, null);
                 break;
-            case LiveTvRecordingGroup:
-                mGridAdapter = new ItemRowAdapter(requireContext(), mRowDef.getRecordingGroupQuery(), mCardPresenter, null);
-                break;
             case AlbumArtists:
                 mGridAdapter = new ItemRowAdapter(requireContext(), mRowDef.getArtistsQuery(), chunkSize, mCardPresenter, null);
                 break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdRowsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdRowsFragment.java
@@ -152,9 +152,6 @@ public class StdRowsFragment extends RowsSupportFragment implements RowLoader {
                 case LiveTvRecording:
                     rowAdapter = new ItemRowAdapter(requireContext(), def.getRecordingQuery(), def.getChunkSize(), mCardPresenter, mRowsAdapter);
                     break;
-                case LiveTvRecordingGroup:
-                    rowAdapter = new ItemRowAdapter(requireContext(), def.getRecordingGroupQuery(), mCardPresenter, mRowsAdapter);
-                    break;
                 default:
                     rowAdapter = new ItemRowAdapter(requireContext(), def.getQuery(), def.getChunkSize(), def.getPreferParentThumb(), def.isStaticHeight(), mCardPresenter, mRowsAdapter, def.getQueryType());
                     break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentBrowseRowDefRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentBrowseRowDefRow.kt
@@ -33,7 +33,6 @@ class HomeFragmentBrowseRowDefRow(
 			QueryType.LiveTvChannel -> ItemRowAdapter(context, browseRowDef.tvChannelQuery, 40, cardPresenter, rowsAdapter)
 			QueryType.LiveTvProgram -> ItemRowAdapter(context, browseRowDef.programQuery, cardPresenter, rowsAdapter)
 			QueryType.LiveTvRecording -> ItemRowAdapter(context, browseRowDef.recordingQuery, browseRowDef.chunkSize, cardPresenter, rowsAdapter)
-			QueryType.LiveTvRecordingGroup -> ItemRowAdapter(context, browseRowDef.recordingGroupQuery, cardPresenter, rowsAdapter)
 			else -> ItemRowAdapter(context, browseRowDef.query, browseRowDef.chunkSize, browseRowDef.preferParentThumb, browseRowDef.isStaticHeight, cardPresenter, rowsAdapter, browseRowDef.queryType)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -347,7 +347,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
         BaseItemType.Video,
         BaseItemType.Recording,
         BaseItemType.Program,
-        BaseItemType.ChannelVideoItem,
         BaseItemType.Trailer,
         BaseItemType.MusicArtist,
         BaseItemType.Person,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -191,7 +191,7 @@ public class BaseRowItem {
 
     public boolean showCardInfoOverlay() {
         return type == ItemType.BaseItem && baseItem != null
-                && Arrays.asList(BaseItemType.Folder, BaseItemType.PhotoAlbum, BaseItemType.RecordingGroup,
+                && Arrays.asList(BaseItemType.Folder, BaseItemType.PhotoAlbum,
                 BaseItemType.UserView, BaseItemType.CollectionFolder, BaseItemType.Photo,
                 BaseItemType.Video, BaseItemType.Person, BaseItemType.Playlist,
                 BaseItemType.MusicArtist).contains(baseItem.getBaseItemType());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -167,7 +167,6 @@ public class ItemLauncher {
 
                         return;
                     case Season:
-                    case RecordingGroup:
                         //Start activity for enhanced browse
                         Intent seasonIntent = new Intent(activity, GenericFolderActivity.class);
                         seasonIntent.putExtra(Extras.Folder, KoinJavaComponent.<GsonJsonSerializer>get(GsonJsonSerializer.class).SerializeToString(baseItem));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -131,9 +131,6 @@ public class CardPresenter extends Presenter {
                             }
                             showWatched = false;
                             break;
-                        case RecordingGroup:
-                            mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_record);
-                            break;
                         case Season:
                         case Series:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_tv);
@@ -169,9 +166,6 @@ public class CardPresenter extends Presenter {
                             isUserView = true;
                             break;
                         case Folder:
-                        case MovieGenreFolder:
-                        case MusicGenreFolder:
-                        case MovieGenre:
                         case Genre:
                         case MusicGenre:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_folder);

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -73,9 +73,6 @@ public class InfoLayoutHelper {
             case Program:
                 addProgramInfo(context, item, layout);
                 break;
-            case RecordingGroup:
-                addRecordingCount(context, item, layout);
-                break;
             case MusicArtist:
                 Integer artistAlbums = item.getAlbumCount() != null ? item.getAlbumCount() : item.getChildCount();
                 addCount(context, artistAlbums, layout, artistAlbums != null && artistAlbums == 1 ? context.getResources().getString(R.string.lbl_album) : context.getResources().getString(R.string.lbl_albums));
@@ -144,15 +141,6 @@ public class InfoLayoutHelper {
             TextView amt = new TextView(context);
             amt.setTextSize(textSize);
             amt.setText(count.toString()+" "+ label +"  ");
-            layout.addView(amt);
-        }
-    }
-
-    private static void addRecordingCount(Context context, BaseItemDto item, LinearLayout layout) {
-        if (item.getRecordingCount() != null && item.getRecordingCount() > 0) {
-            TextView amt = new TextView(context);
-            amt.setTextSize(textSize);
-            amt.setText(item.getRecordingCount().toString() + " " + context.getResources().getString(item.getRecordingCount() > 1 ? R.string.lbl_recordings : R.string.lbl_recording) + "  ");
             layout.addView(amt);
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -88,7 +88,6 @@ public class KeyProcessor {
                             case TvChannel:
                             case Video:
                             case Program:
-                            case ChannelVideoItem:
                             case Trailer:
                                 // retrieve full item and play
                                 PlaybackHelper.retrieveAndPlay(item.getId(), false, activity);
@@ -175,7 +174,6 @@ public class KeyProcessor {
                             case TvChannel:
                             case Video:
                             case Program:
-                            case ChannelVideoItem:
                             case Series:
                             case Season:
                             case BoxSet:


### PR DESCRIPTION
Removed some old code that shouldn't be used anymore. See the attachment below for the diff I made for the item types between apiclient<>SDK. There is one special type "SeriesTimer" which I believe never existed in the server but was a lazy hack in FullDetailsActivity: https://github.com/jellyfin/jellyfin-androidtv/blob/fea1236559e5d9752f5105fed7821ead556a1619/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java#L385-L393
So I kept that one for now.

**Changes**
- Remove usages of BaseItemType's that don't exist in the server/SDK

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

## Attachment 1

```
# Removed (exist in apiclient, not in SDK)

ChannelVideoItem
MovieGenre
MovieGenreFolder
MusicGenreFolder
RecordingGroup
SeriesTimer

# Added (exist in SDK, not in apiclient)

AudioBook
BasePluginFolder
Book
LiveTvProgram
ManualPlaylistsFolder
PlaylistsFolder
TvProgram
UserRootFolder
Year
```
