### PR TITLE
Let ExoPlayer and VLC handle external subtitles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
@@ -76,5 +76,6 @@ object Codec {
 		const val SUB = "sub"
 		const val SUBRIP = "subrip"
 		const val VTT = "vtt"
+		const val WEBVTT = "webvtt"
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -10,9 +10,6 @@ import android.media.AudioManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.Spannable;
-import android.text.SpannableString;
-import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -26,7 +23,6 @@ import android.widget.TextView;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -43,7 +39,6 @@ import org.jellyfin.androidtv.constant.CustomMessage;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
 import org.jellyfin.androidtv.databinding.OverlayTvGuideBinding;
 import org.jellyfin.androidtv.databinding.VlcPlayerInterfaceBinding;
-import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.ui.GuideChannelHeader;
 import org.jellyfin.androidtv.ui.GuidePagingButton;
 import org.jellyfin.androidtv.ui.HorizontalScrollViewListener;
@@ -62,10 +57,8 @@ import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.ChannelCardPresenter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
-import org.jellyfin.androidtv.ui.shared.PaddedLineBackgroundSpan;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
-import org.jellyfin.androidtv.util.TextUtilsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
@@ -78,8 +71,6 @@ import org.jellyfin.apiclient.model.dto.ChapterInfoDto;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
-import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackEvent;
-import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackInfo;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
@@ -135,14 +126,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private LeanbackOverlayFragment leanbackOverlayFragment;
 
     // Subtitle fields
-    private static final int SUBTITLE_PADDING = 8;
-    private static final long SUBTITLE_RENDER_INTERVAL_MS = 50;
-    private SubtitleTrackInfo subtitleTrackInfo;
-    private int currentSubtitleIndex = 0;
-    private int subtitlesSize = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getDefaultSubtitlesSize());
-    private long lastSubtitlePositionMs = 0;
-    private boolean subtitlesBackgroundEnabled = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getSubtitlesBackgroundEnabled());
-
     private final Lazy<ApiClient> apiClient = inject(ApiClient.class);
     private final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
     private final Lazy<PlaybackControllerContainer> playbackControllerContainer = inject(PlaybackControllerContainer.class);
@@ -239,14 +222,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) return;
 
         prepareOverlayFragment();
-
-        //manual subtitles
-        // This configuration is required for the PaddedLineBackgroundSpan to work
-        binding.subtitlesText.setShadowLayer(SUBTITLE_PADDING, 0, 0, Color.TRANSPARENT);
-        binding.subtitlesText.setPadding(SUBTITLE_PADDING, 0, SUBTITLE_PADDING, 0);
-
-        // Subtitles font size configuration
-        binding.subtitlesText.setTextSize(subtitlesSize);
 
         //pre-load animations
         fadeOut = AnimationUtils.loadAnimation(requireContext(), R.anim.abc_fade_out);
@@ -1347,134 +1322,5 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         intent.putExtra(NextUpActivity.EXTRA_ID, id);
         startActivity(intent);
         finish();
-    }
-
-    public void addManualSubtitles(@Nullable SubtitleTrackInfo info) {
-        subtitleTrackInfo = info;
-        currentSubtitleIndex = -1;
-        lastSubtitlePositionMs = 0;
-        clearSubtitles();
-    }
-
-    public void showSubLoadingMsg(final boolean show) {
-        if (show) {
-            renderSubtitles(requireContext().getString(R.string.msg_subtitles_loading));
-        } else {
-            clearSubtitles();
-        }
-    }
-
-    public void updateSubtitles(long positionMs) {
-        int iterCount = 1;
-        final long positionTicks = positionMs * 10000;
-        final long lastPositionTicks = lastSubtitlePositionMs * 10000;
-
-        if (subtitleTrackInfo == null
-                || subtitleTrackInfo.getTrackEvents() == null
-                || subtitleTrackInfo.getTrackEvents().size() < 1
-                || currentSubtitleIndex >= subtitleTrackInfo.getTrackEvents().size()) {
-            return;
-        }
-
-        if (positionTicks < subtitleTrackInfo.getTrackEvents().get(0).getStartPositionTicks())
-            return;
-
-        // Skip rendering if the interval ms have not passed since last render
-        if (lastSubtitlePositionMs > 0
-                && Math.abs(lastSubtitlePositionMs - positionMs) < SUBTITLE_RENDER_INTERVAL_MS) {
-            return;
-        }
-
-        // If the user has skipped back, reset the subtitle index
-        if (lastSubtitlePositionMs > positionMs) {
-            currentSubtitleIndex = -1;
-            clearSubtitles();
-        }
-
-        if (currentSubtitleIndex == -1)
-            Timber.d("subtitle track events size %s", subtitleTrackInfo.getTrackEvents().size());
-
-        // Find the next subtitle event that should be rendered
-        for (int tmpSubtitleIndex = currentSubtitleIndex == -1 ? 0 : currentSubtitleIndex; tmpSubtitleIndex < subtitleTrackInfo.getTrackEvents().size(); tmpSubtitleIndex++) {
-            SubtitleTrackEvent trackEvent = subtitleTrackInfo.getTrackEvents().get(tmpSubtitleIndex);
-
-            if (positionTicks >= trackEvent.getStartPositionTicks()
-                    && positionTicks < trackEvent.getEndPositionTicks()) {
-                // This subtitle event should be displayed now
-                // use lastPositionTicks to ensure it is only rendered once
-
-                if (lastPositionTicks < trackEvent.getStartPositionTicks() || lastPositionTicks >= trackEvent.getEndPositionTicks()) {
-                    Timber.d("rendering subtitle event: %s (pos %s start %s end %s)", tmpSubtitleIndex, positionMs, trackEvent.getStartPositionTicks() / 10000, trackEvent.getEndPositionTicks() / 10000);
-                    renderSubtitles(trackEvent.getText());
-                }
-
-                currentSubtitleIndex = tmpSubtitleIndex;
-                lastSubtitlePositionMs = positionMs;
-                // rendering should happen on the 2nd iteration
-                if (iterCount > 2)
-                    Timber.d("subtitles handled in %s iterations", iterCount);
-                return;
-            } else if (tmpSubtitleIndex < subtitleTrackInfo.getTrackEvents().size() - 1) {
-                SubtitleTrackEvent nextTrackEvent = subtitleTrackInfo.getTrackEvents().get(tmpSubtitleIndex + 1);
-
-                if (positionTicks >= trackEvent.getEndPositionTicks() && positionTicks < nextTrackEvent.getStartPositionTicks()) {
-                    // clear the subtitles if between events
-                    // use lastPositionTicks to ensure it is only cleared once
-
-                    if (currentSubtitleIndex > -1 && !(lastPositionTicks >= trackEvent.getEndPositionTicks() && lastPositionTicks < nextTrackEvent.getStartPositionTicks())) {
-                        Timber.d("clearing subtitle event: %s (pos %s - event end %s)", tmpSubtitleIndex, positionMs, trackEvent.getEndPositionTicks() / 10000);
-                        clearSubtitles();
-                    }
-
-                    // set currentSubtitleIndex in case it was -1
-                    currentSubtitleIndex = tmpSubtitleIndex;
-                    lastSubtitlePositionMs = positionMs;
-                    if (iterCount > 1)
-                        Timber.d("subtitles handled in %s iterations", iterCount);
-                    return;
-                }
-            }
-            iterCount++;
-        }
-        // handles clearing the last event
-        if (iterCount > 1)
-            Timber.d("subtitles handled in %s iterations", iterCount);
-        clearSubtitles();
-    }
-
-    private void clearSubtitles() {
-        requireActivity().runOnUiThread(() -> {
-            binding.subtitlesText.setVisibility(View.INVISIBLE);
-            binding.subtitlesText.setText(null);
-        });
-    }
-
-    private void renderSubtitles(@Nullable final String text) {
-        if (text == null || text.length() == 0) {
-            clearSubtitles();
-            return;
-        }
-        requireActivity().runOnUiThread(() -> {
-            // Encode whitespace as html entities
-            final String htmlText = text
-                    .replaceAll("\\r\\n", "<br>")
-                    .replaceAll("\\n", "<br>")
-                    .replaceAll("\\\\h", "&ensp;");
-
-            final SpannableString span = new SpannableString(TextUtilsKt.toHtmlSpanned(htmlText));
-            if (subtitlesBackgroundEnabled) {
-                // Disable the text outlining when the background is enabled
-                binding.subtitlesText.setStrokeWidth(0.0f);
-
-                // get the alignment gravity of the TextView
-                // extract the absolute horizontal gravity so the span can draw its background aligned
-                int gravity = binding.subtitlesText.getGravity();
-                int horizontalGravity = Gravity.getAbsoluteGravity(gravity, binding.subtitlesText.getLayoutDirection()) & Gravity.HORIZONTAL_GRAVITY_MASK;
-                span.setSpan(new PaddedLineBackgroundSpan(ContextCompat.getColor(requireContext(), R.color.black_opaque), SUBTITLE_PADDING, horizontalGravity), 0, span.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-            }
-
-            binding.subtitlesText.setText(span);
-            binding.subtitlesText.setVisibility(View.VISIBLE);
-        });
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -30,7 +30,6 @@ import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
-import org.jellyfin.androidtv.util.apiclient.StreamHelper;
 import org.jellyfin.androidtv.util.profile.BaseProfile;
 import org.jellyfin.androidtv.util.profile.ExoPlayerProfile;
 import org.jellyfin.androidtv.util.profile.LibVlcProfile;
@@ -47,7 +46,6 @@ import org.jellyfin.apiclient.model.entities.MediaStream;
 import org.jellyfin.apiclient.model.entities.MediaStreamType;
 import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
-import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackInfo;
 import org.jellyfin.apiclient.model.session.PlayMethod;
 import org.koin.java.KoinJavaComponent;
 
@@ -842,8 +840,14 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             mVideoManager.setAudioMode();
         }
 
-        if (mVideoManager != null) {
-            mVideoManager.setVideoPath(response.getMediaUrl());
+        if (mVideoManager != null && !isTranscoding()) {
+            List<MediaStream> allStreams = getCurrentlyPlayingItem().getMediaStreams();
+            String baseUrl = String.format("%1$s/Videos/%2$s/%3$s/Subtitles/",
+                    apiClient.getValue().getApiUrl(),
+                    mCurrentStreamInfo.getItemId(),
+                    mCurrentStreamInfo.getMediaSourceId());
+
+            mVideoManager.setMedia(response.getMediaUrl(), baseUrl, allStreams);
             mVideoManager.setVideoTrack(response.getMediaSource());
         }
 
@@ -962,105 +966,37 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
 
     public void switchSubtitleStream(int index) {
-        if (!hasInitializedVideoManager())
-            return;
-        // get current timestamp first
-        refreshCurrentPosition();
-        Timber.d("Setting subtitle index to: %d", index);
+        int currSubtitleIndex = getSubtitleStreamIndex();
+        Timber.d("trying to switch subtitle stream from %s to %s", currSubtitleIndex, index);
 
-        // clear subtitles first
-        if (mFragment != null) mFragment.addManualSubtitles(null);
-        mVideoManager.disableSubs();
-        // clear the default in case there's an error loading the subtitles
-        mDefaultSubIndex = -1;
+        if (currSubtitleIndex == index) {
+            Timber.d("skipping setting subtitle stream, already set to request index %s", index);
 
-        // handle setting subtitles as disabled
-        // restart playback if turning off burnt-in subtitles
-        if (index < 0) {
-            mCurrentOptions.setSubtitleStreamIndex(-1);
-            if (burningSubs) {
-                stop();
-                play(mCurrentPosition, -1);
+            if (mCurrentOptions.getSubtitleStreamIndex() == null || mCurrentOptions.getSubtitleStreamIndex() != index) {
+                Timber.d("setting mCurrentOptions subtitle stream index from %s to %s", mCurrentOptions.getSubtitleStreamIndex(), index);
+                mCurrentOptions.setSubtitleStreamIndex(index);
             }
+
             return;
         }
 
-        MediaStream stream = StreamHelper.getMediaStream(getCurrentMediaSource(), index);
-        if (stream == null) {
-            if (mFragment != null)
-                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.subtitle_error));
-            return;
-        }
-        SubtitleStreamInfo streamInfo = getSubtitleStreamInfo(index);
-        if (streamInfo == null) {
-            if (mFragment != null)
-                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
-            return;
-        }
+        refreshCurrentPosition();
 
-        // handle switching on or between burnt-in subtitles, or switching to non-burnt subtitles
-        // if switching from burnt-in subtitles to another type, playback still needs to be restarted
-        if (burningSubs || streamInfo.getDeliveryMethod() == SubtitleDeliveryMethod.Encode) {
+        if (isNativeMode() && !isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.Subtitle, getCurrentlyPlayingItem().getMediaStreams())) {
+            mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
+            mCurrentOptions.setSubtitleStreamIndex(index);
+        }
+        else if (!isNativeMode() && !isTranscoding() && mVideoManager.setVLCSubtitleTrack(index, getCurrentlyPlayingItem().getMediaStreams())) {
+            mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
+            mCurrentOptions.setSubtitleStreamIndex(index);
+        }
+        else {
+            startSpinner();
+            mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
+            mCurrentOptions.setSubtitleStreamIndex(index);
             stop();
-            if (mFragment != null && streamInfo.getDeliveryMethod() == SubtitleDeliveryMethod.Encode)
-                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_burn_sub_warning));
-            play(mCurrentPosition, index);
-            return;
-        }
-
-        // when burnt-in subtitles are selected, mCurrentOptions SubtitleStreamIndex is set in startItem() as soon as playback starts
-        // otherwise mCurrentOptions SubtitleStreamIndex is kept null until now so we knew subtitles needed to be enabled but weren't already
-
-        switch (streamInfo.getDeliveryMethod()) {
-            case Embed:
-                if (!mVideoManager.isNativeMode()) {
-                    if (!mVideoManager.setSubtitleTrack(index, getCurrentlyPlayingItem().getMediaStreams())) {
-                        // error selecting internal subs
-                        if (mFragment != null)
-                            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
-                    } else {
-                        mCurrentOptions.setSubtitleStreamIndex(index);
-                        mDefaultSubIndex = index;
-                    }
-                    break;
-                }
-                // not using vlc - fall through to external handling
-            case External:
-                if (mFragment != null) mFragment.showSubLoadingMsg(true);
-                stream.setDeliveryMethod(SubtitleDeliveryMethod.External);
-                stream.setDeliveryUrl(String.format("%1$s/Videos/%2$s/%3$s/Subtitles/%4$s/0/Stream.JSON", apiClient.getValue().getApiUrl(), mCurrentStreamInfo.getItemId(), mCurrentStreamInfo.getMediaSourceId(), String.valueOf(stream.getIndex())));
-                apiClient.getValue().getSubtitles(stream.getDeliveryUrl(), new Response<SubtitleTrackInfo>() {
-
-                    @Override
-                    public void onResponse(final SubtitleTrackInfo info) {
-
-                        if (info != null) {
-                            Timber.d("Adding json subtitle track to player");
-                            if (mFragment != null) mFragment.addManualSubtitles(info);
-                            mCurrentOptions.setSubtitleStreamIndex(index);
-                            mDefaultSubIndex = index;
-                        } else {
-                            Timber.e("Empty subtitle result");
-                            if (mFragment != null) {
-                                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
-                                mFragment.showSubLoadingMsg(false);
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void onError(Exception ex) {
-                        Timber.e(ex, "Error downloading subtitles");
-                        if (mFragment != null) {
-                            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
-                            mFragment.showSubLoadingMsg(false);
-                        }
-                    }
-
-                });
-                break;
-            case Hls:
-                break;
+            playInternal(getCurrentlyPlayingItem(), mCurrentPosition, mCurrentOptions, mCurrentOptions);
+            mPlaybackState = PlaybackState.BUFFERING;
         }
     }
 
@@ -1534,8 +1470,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 // crossed fire off an async routine to update the program info
                 updateTvProgramInfo();
             }
-            if (mFragment != null && finishedInitialSeek)
-                mFragment.updateSubtitles(mCurrentPosition);
         }
         if (mFragment != null)
             mFragment.setCurrentTime(mCurrentPosition);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -430,10 +430,14 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                     case Codec.Subtitle.ASS:
                     case Codec.Subtitle.SSA:
                         mimetype = MimeTypes.TEXT_SSA;
+                        // Jellyfin reports codec as ass but requires passing .SSA (and not .ASS) in the url to retrieve the subtitles
+                        codec = Codec.Subtitle.SSA;
                         break;
                     case Codec.Subtitle.VTT:
                     case Codec.Subtitle.WEBVTT:
                         mimetype = MimeTypes.TEXT_VTT;
+                        // Jellyfin reports codec as webvtt but requires passing .VTT (and not .WEBVTT) in the url to retrieve the subtitles
+                        codec = Codec.Subtitle.VTT;
                         break;
                     case Codec.Subtitle.PGS:
                     case Codec.Subtitle.PGSSUB:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -400,7 +400,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
     }
 
-    // Add external subtitles (as SRT) streams to ExoPlayer and VLC as media sources
+    // Add external subtitles streams to ExoPlayer and VLC as media sources
     // TODO: Also handle external audio streams
     public void setMedia(@NonNull String mediaPath, @NonNull String baseUrl, @NonNull List<MediaStream> allStreams) {
         Timber.i("Video path set to: %s", mediaPath);

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/BaseProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/BaseProfile.kt
@@ -43,6 +43,7 @@ open class BaseProfile : DeviceProfile() {
 			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.External),
+			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.External)
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -199,14 +199,22 @@ class ExoPlayerProfile(
 
 		subtitleProfiles = arrayOf(
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Encode),
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -198,17 +198,17 @@ class ExoPlayerProfile(
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(
-			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
-			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Encode),
-			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Encode),
-			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Encode),
-			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Encode),
+			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.Embed),
-			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Embed),
-			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Embed)
+			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Encode),
+			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Encode),
 		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExternalPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExternalPlayerProfile.kt
@@ -75,6 +75,7 @@ class ExternalPlayerProfile : DeviceProfile() {
 			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SMI, SubtitleDeliveryMethod.Embed)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -123,17 +123,29 @@ class LibVlcProfile(
 
 		subtitleProfiles = arrayOf(
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SMI, SubtitleDeliveryMethod.Embed),
-			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Embed)
+			subtitleProfile(Codec.Subtitle.SMI, SubtitleDeliveryMethod.External),
+			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.External),
 		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -122,7 +122,6 @@ class LibVlcProfile(
 		)
 
 		subtitleProfiles = arrayOf(
-			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Embed),
@@ -131,6 +130,7 @@ class LibVlcProfile(
 			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.WEBVTT, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SMI, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.IDX, SubtitleDeliveryMethod.Embed)

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -45,19 +45,6 @@
             android:layout_height="match_parent"
             android:layout_gravity="center" />
 
-        <org.jellyfin.androidtv.ui.shared.StrokeTextView
-            android:id="@+id/subtitles_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|center_horizontal"
-            android:layout_marginHorizontal="120dp"
-            android:layout_marginBottom="48dp"
-            android:gravity="center"
-            android:textColor="@color/white"
-            android:textSize="28sp"
-            app:strokeWidth="5.0"
-            tools:text="Subtitles" />
-
     </FrameLayout>
 
     <FrameLayout


### PR DESCRIPTION
Right now, external subtitles are downloaded and displayed by code in `CustomPlaybackOverlayFragment`. This delegates this task to the players to improve subtitle support.

**Changes**
- Let ExoPlayer and VLC handle external subtitle tracks, adding them as `MediaItem`s when creating the players.
- Updated codecs to allow external subtitles of any format. Also, updated ExoPlayer codecs as it natively displays various formats that were marked for transcoding (e.g.: PGS, VTT).

**Issues**
Fixes: #145

