### PR TITLE
fix NextUp not working without clearing old video queue items

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -113,7 +113,7 @@ public class MediaManager {
     }
 
     public void setCurrentVideoQueue(List<BaseItemDto> items) {
-        if (items == null) {
+        if (items == null || items.size() < 1) {
             clearVideoQueue();
             return;
         }
@@ -986,7 +986,9 @@ public class MediaManager {
     }
 
     public void setCurrentMediaPosition(int currentMediaPosition) {
-        this.mCurrentMediaPosition = currentMediaPosition;
+        if (!hasVideoQueueItems() || currentMediaPosition < 0 || currentMediaPosition > getCurrentVideoQueue().size())
+            return;
+        mCurrentMediaPosition = currentMediaPosition;
     }
 
     public BaseRowItem getMediaItem(int pos) {


### PR DESCRIPTION
**Changes**
* sync video queue pos between `playbackController` and `mediaManager`
 set the video queue index in `mediaManager` via `playbackController` in `next()`, `prev()`, and `itemCompleted()`
* delete `removePreviousQueueItems()`
 it was used to clear already-played items from `playbackController` before opening NextUp because there previously wasn't support for starting playback from a specific video queue index (added in #1939)
* simplified `itemComplete()`

**Issues**
* Needed for #1941 to be fully functional. As discussed there, the `previous` button will break if the previous video queue items have been removed by `removePreviousQueueItems()` 😂

**Notes**
* Managing the video queue and its position in both `playbackController` and `videoManager` and then syncing them is kinda lame. 😔