### PR TITLE
Bump Android compile and target SDK to 32 (Android 12L)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.androidtv"
-	compileSdk = 31
+	compileSdk = 32
 
 	defaultConfig {
 		minSdk = 21
-		targetSdk = 31
+		targetSdk = 32
 
 		// Release version
 		applicationId = namespace

--- a/playback/build.gradle.kts
+++ b/playback/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-	compileSdk = 31
+	compileSdk = 32
 
 	defaultConfig {
 		minSdk = 21
-		targetSdk = 31
+		targetSdk = 32
 	}
 
 	buildFeatures {

--- a/preference/build.gradle.kts
+++ b/preference/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-	compileSdk = 31
+	compileSdk = 32
 
 	defaultConfig {
 		minSdk = 21
-		targetSdk = 31
+		targetSdk = 32
 	}
 
 	buildFeatures {


### PR DESCRIPTION
Required for the new appcompat version (#1954)

**Changes**
- Bump Android compile and target SDK to 32 (Android 12L)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
