### PR TITLE
Migrate DefaultLifecycleObserver setup to androidx.startup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,9 @@
             <meta-data
                 android:name="org.jellyfin.androidtv.SessionInitializer"
                 android:value="androidx.startup" />
+            <meta-data
+                android:name="org.jellyfin.androidtv.ProcessLifecycleInitializer"
+                android:value="androidx.startup" />
         </provider>
 
         <provider

--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -2,8 +2,6 @@ package org.jellyfin.androidtv
 
 import android.app.Application
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.work.BackoffPolicy
@@ -15,16 +13,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.acra.ACRA
-import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.data.eventhandling.SocketHandler
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.jellyfin.androidtv.telemetry.TelemetryService
 import org.jellyfin.androidtv.util.AutoBitrate
-import org.koin.android.ext.android.get
-import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.android.inject
-import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
 @Suppress("unused")
@@ -37,28 +31,6 @@ class JellyfinApplication : Application() {
 
 		val notificationsRepository by inject<NotificationsRepository>()
 		notificationsRepository.addDefaultNotifications()
-
-		// Register application lifecycle events
-		ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
-			/**
-			 * Called by the Process Lifecycle when the app is created. It is called after [onCreate].
-			 */
-			override fun onCreate(owner: LifecycleOwner) {
-				// Register activity lifecycle callbacks
-				getKoin().getAll<ActivityLifecycleCallbacks>().forEach(::registerActivityLifecycleCallbacks)
-			}
-
-			/**
-			 * Called by the Process Lifecycle when the app is activated in the foreground (activity opened).
-			 */
-			override fun onStart(owner: LifecycleOwner) {
-				Timber.i("Process lifecycle started")
-
-				owner.lifecycleScope.launch {
-					get<SessionRepository>().restoreSession()
-				}
-			}
-		})
 	}
 
 	/**

--- a/app/src/main/java/org/jellyfin/androidtv/ProcessLifecycleInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ProcessLifecycleInitializer.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.androidtv
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.startup.AppInitializer
+import androidx.startup.Initializer
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.auth.repository.SessionRepository
+import org.jellyfin.androidtv.di.KoinInitializer
+import timber.log.Timber
+
+@Suppress("unused")
+class ProcessLifecycleInitializer : Initializer<Unit> {
+	override fun create(context: Context) {
+		val koin = AppInitializer.getInstance(context)
+			.initializeComponent(KoinInitializer::class.java)
+			.koin
+
+		// Register application lifecycle events
+		ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+			/**
+			 * Called by the Process Lifecycle when the app is created. It is called after [onCreate].
+			 */
+			override fun onCreate(owner: LifecycleOwner) {
+				// Register activity lifecycle callbacks
+				val callbacks = koin.getAll<Application.ActivityLifecycleCallbacks>()
+				Timber.i("Registering ${callbacks.size} ActivityLifecycleCallbacks")
+				val app = context.applicationContext as Application
+				callbacks.forEach { callback -> app.registerActivityLifecycleCallbacks(callback) }
+			}
+
+			/**
+			 * Called by the Process Lifecycle when the app is activated in the foreground (activity opened).
+			 */
+			override fun onStart(owner: LifecycleOwner) {
+				Timber.i("Process lifecycle started")
+
+				owner.lifecycleScope.launch {
+					koin.get<SessionRepository>().restoreSession()
+				}
+			}
+		})
+	}
+
+	override fun dependencies() = listOf(KoinInitializer::class.java)
+}


### PR DESCRIPTION
This PR changes the way we create the DefaultLifecycleObserver that ends up injecting the activity callbacks (including the one that manages the theme). It now uses it's own initializer. This doesn't change any behavior, just moves the code to make it more managable.

**Changes**
- Migrate DefaultLifecycleObserver setup to androidx.startup

**Issues**
