### PR TITLE
Use AsyncImageView in ClockUserView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.RelativeLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import com.bumptech.glide.Glide
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.databinding.ClockUserBugBinding
@@ -39,20 +39,11 @@ class ClockUserView @JvmOverloads constructor(
 
 		val currentUser = userRepository.currentUser.value
 
-		if (currentUser != null) {
-			if (currentUser.primaryImageTag != null) {
-				Glide.with(context)
-					.load(ImageUtils.getPrimaryImageUrl(currentUser))
-					.placeholder(R.drawable.ic_user)
-					.centerInside()
-					.circleCrop()
-					.into(binding.clockUserImage)
-			} else {
-				binding.clockUserImage.setImageResource(R.drawable.ic_user)
-			}
-			binding.clockUserImage.isVisible = true
-		} else {
-			binding.clockUserImage.isVisible = false
-		}
+		binding.clockUserImage.load(
+			url = currentUser?.let(ImageUtils::getPrimaryImageUrl),
+			placeholder = ContextCompat.getDrawable(context, R.drawable.ic_user)
+		)
+
+		binding.clockUserImage.isVisible = currentUser != null
 	}
 }

--- a/app/src/main/res/layout/clock_user_bug.xml
+++ b/app/src/main/res/layout/clock_user_bug.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="7dp"
     android:layout_marginEnd="8dp"
-    android:orientation="horizontal"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
 
-        <ImageView
-            android:id="@+id/clock_user_image"
-            android:layout_width="41dp"
-            android:layout_height="41dp"
-            android:padding="4dp"
-            android:src="@drawable/ic_user" />
+    <org.jellyfin.androidtv.ui.AsyncImageView
+        android:id="@+id/clock_user_image"
+        android:layout_width="41dp"
+        android:layout_height="41dp"
+        android:padding="4dp"
+        app:circleCrop="true"
+        tools:src="@drawable/ic_user" />
 
-        <TextClock
-            android:id="@+id/clock"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:fontFamily="sans-serif-light"
-            android:format12Hour="h:mm"
-            android:format24Hour="k:mm"
-            android:paddingStart="24dp"
-            android:shadowColor="@color/black"
-            android:shadowRadius="4"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            tools:text="13:37"
-            tools:ignore="RtlSymmetry" />
+    <TextClock
+        android:id="@+id/clock"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-light"
+        android:format12Hour="h:mm"
+        android:format24Hour="k:mm"
+        android:paddingStart="24dp"
+        android:shadowColor="@color/black"
+        android:shadowRadius="4"
+        android:textColor="@color/white"
+        android:textSize="20sp"
+        tools:ignore="RtlSymmetry"
+        tools:text="13:37" />
 </LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -34,4 +34,8 @@
     <declare-styleable name="StrokeTextView">
         <attr name="strokeWidth" format="float" />
     </declare-styleable>
+    <declare-styleable name="AsyncImageView">
+        <attr name="crossfadeDuration" format="integer" />
+        <attr name="circleCrop" format="boolean" />
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
We prefer AsyncImageView for displaying (networked) images since it allows us to easily set the fallback/blurhash and moves all Glide code to a single place. This PR migrates the ClockUserView.

**Changes**
- Support circle crop in AsyncImageView
- Use AsyncImageView in ClockUserView

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
