### PR TITLE
Use AsyncImageView in GuideChannelHeader

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuideChannelHeader.java
@@ -11,8 +11,6 @@ import android.widget.TextView;
 
 import androidx.core.content.ContextCompat;
 
-import com.bumptech.glide.Glide;
-
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideActivity;
@@ -23,7 +21,7 @@ import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.koin.java.KoinJavaComponent;
 
 public class GuideChannelHeader extends RelativeLayout {
-    private ImageView mChannelImage;
+    private AsyncImageView mChannelImage;
     private ImageView mFavImage;
     private ChannelInfoDto mChannel;
     private Context mContext;
@@ -57,14 +55,13 @@ public class GuideChannelHeader extends RelativeLayout {
     }
 
     public void loadImage() {
-        int imageWidth = Utils.convertDpToPixel(mContext, 50);
-        int imageHeight = Utils.convertDpToPixel(mContext, 30);
-
-        Glide.with(mContext)
-                .load(ImageUtils.getPrimaryImageUrl(mChannel, KoinJavaComponent.<ApiClient>get(ApiClient.class)))
-                .override(imageWidth, imageHeight)
-                .centerInside()
-                .into(mChannelImage);
+        mChannelImage.load(
+                ImageUtils.getPrimaryImageUrl(mChannel, KoinJavaComponent.<ApiClient>get(ApiClient.class)),
+                null,
+                null,
+                0.0,
+                0
+        );
     }
 
     public ChannelInfoDto getChannel() { return mChannel; }

--- a/app/src/main/res/layout/channel_header.xml
+++ b/app/src/main/res/layout/channel_header.xml
@@ -28,13 +28,13 @@
         android:layout_below="@+id/channelName"
         android:layout_alignParentStart="true" />
 
-    <ImageView
+    <org.jellyfin.androidtv.ui.AsyncImageView
         android:layout_width="100sp"
         android:layout_height="50sp"
         android:id="@+id/channelImage"
         android:layout_alignParentTop="true"
         android:layout_toEndOf="@+id/channelName"
-        android:scaleType="center" />
+        android:scaleType="centerInside" />
 
     <ImageView
         android:layout_width="wrap_content"


### PR DESCRIPTION
We prefer AsyncImageView for displaying (networked) images since it allows us to easily set the fallback/blurhash and moves all Glide code to a single place. This PR migrates the GuideChannelHeader.

**Changes**
- Use AsyncImageView in GuideChannelHeader
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
