### PR TITLE
Fix alignment of ClockUserView in live TV guide

### DIFF
--- a/app/src/main/res/layout/live_tv_guide.xml
+++ b/app/src/main/res/layout/live_tv_guide.xml
@@ -92,7 +92,7 @@
         android:layout_height="150sp"
         android:id="@+id/programImage"
         android:layout_gravity="left|top"
-        android:layout_margin="15sp" />
+        android:layout_margin="20sp" />
 
     <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
Other screens use 20sp but live tv used 15sp offset 🤷‍♂️ 

**Changes**
- Fix alignment of ClockUserView in live TV guide

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
