### PR TITLE
Don't open library settings for unsupported types

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/UserViewsRepository.kt
@@ -12,6 +12,7 @@ interface UserViewsRepository {
 
 	fun isSupported(collectionType: String?): Boolean
 	fun allowViewSelection(collectionType: String?): Boolean
+	fun allowGridView(collectionType: String?): Boolean
 }
 
 class UserViewsRepositoryImpl(
@@ -26,13 +27,25 @@ class UserViewsRepositoryImpl(
 	}
 
 	override fun isSupported(collectionType: String?) = collectionType !in unsupportedCollectionTypes
-	override fun allowViewSelection(collectionType: String?) = collectionType != CollectionType.Music
+	override fun allowViewSelection(collectionType: String?) = collectionType !in disallowViewSelectionCollectionTypes
+	override fun allowGridView(collectionType: String?) = collectionType !in disallowGridViewCollectionTypes
 
 	private companion object {
 		private val unsupportedCollectionTypes = arrayOf(
 			CollectionType.Books,
 			CollectionType.Games,
 			CollectionType.Folders
+		)
+
+		private val disallowViewSelectionCollectionTypes = arrayOf(
+			CollectionType.livetv,
+			CollectionType.Music,
+			CollectionType.Photos,
+		)
+
+		private val disallowGridViewCollectionTypes = arrayOf(
+			CollectionType.livetv,
+			CollectionType.Music
 		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/LibrariesPreferencesScreen.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.ui.browsing.DisplayPreferencesScreen
+import org.jellyfin.androidtv.ui.livetv.GuideOptionsScreen
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.apiclient.model.entities.CollectionType
 import org.koin.android.ext.android.inject
 
 class LibrariesPreferencesScreen : OptionsFragment() {
@@ -37,11 +39,20 @@ class LibrariesPreferencesScreen : OptionsFragment() {
 
 				link {
 					title = it.name
-					icon = R.drawable.ic_folder
-					withFragment<DisplayPreferencesScreen>(bundleOf(
-						DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to allowViewSelection,
-						DisplayPreferencesScreen.ARG_PREFERENCES_ID to it.displayPreferencesId,
-					))
+
+					if (userViewsRepository.allowGridView(it.collectionType)) {
+						icon = R.drawable.ic_folder
+						withFragment<DisplayPreferencesScreen>(bundleOf(
+							DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to allowViewSelection,
+							DisplayPreferencesScreen.ARG_PREFERENCES_ID to it.displayPreferencesId,
+						))
+					} else if (it.collectionType == CollectionType.livetv) {
+						icon = R.drawable.ic_guide
+						withFragment<GuideOptionsScreen>()
+					} else {
+						icon = R.drawable.ic_folder
+						enabled = false
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Only collection types that use the grid should open the DisplayPreferencesScreen in the settings (Customization->Libraries). Added a special case to open the Live TV (guide) settings as a bonus.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Don't open library settings for unsupported types

**Screenshots**
![image](https://user-images.githubusercontent.com/2305178/184508181-143d92cc-eb41-4de4-a773-83de656380a8.png)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
