### PR TITLE
Always use SDK SearchHint

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -31,12 +31,12 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.model.Server
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.util.sdk.compat.asSdk
-import org.jellyfin.apiclient.model.search.SearchHint
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.SearchHint
 import org.jellyfin.sdk.model.serializer.toUUID
 import timber.log.Timber
 import java.util.UUID

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.java
@@ -18,14 +18,13 @@ import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
-import org.jellyfin.apiclient.model.apiclient.ServerInfo;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.ImageType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto;
-import org.jellyfin.apiclient.model.search.SearchHint;
 import org.jellyfin.sdk.model.api.BaseItemPerson;
+import org.jellyfin.sdk.model.api.SearchHint;
 import org.jellyfin.sdk.model.api.UserDto;
 import org.koin.java.KoinJavaComponent;
 
@@ -40,8 +39,6 @@ public class BaseRowItem {
     private BaseItemDto baseItem;
     private BaseItemPerson person;
     private ChapterItemInfo chapterInfo;
-    private ServerInfo serverInfo;
-    private UserDto user;
     private SearchHint searchHint;
     private ChannelInfoDto channelInfo;
     private SeriesTimerInfoDto seriesTimerInfo;
@@ -131,14 +128,6 @@ public class BaseRowItem {
 
     public ChapterItemInfo getChapterInfo() {
         return chapterInfo;
-    }
-
-    public ServerInfo getServerInfo() {
-        return serverInfo;
-    }
-
-    public UserDto getUser() {
-        return user;
     }
 
     public SearchHint getSearchHint() {
@@ -249,7 +238,7 @@ public class BaseRowItem {
                 return ImageUtils.getResourceUrl(context, R.drawable.tile_land_series_timer);
             case SearchHint:
                 if (Utils.isNonEmpty(searchHint.getPrimaryImageTag())) {
-                    return ImageUtils.getImageUrl(searchHint.getItemId(), ImageType.Primary, searchHint.getPrimaryImageTag());
+                    return ImageUtils.getImageUrl(searchHint.getItemId().toString(), ImageType.Primary, searchHint.getPrimaryImageTag());
                 } else if (Utils.isNonEmpty(searchHint.getThumbImageItemId())) {
                     return ImageUtils.getImageUrl(searchHint.getThumbImageItemId(), ImageType.Thumb, searchHint.getThumbImageTag());
                 }
@@ -363,7 +352,7 @@ public class BaseRowItem {
             case GridButton:
                 return null;
             case SearchHint:
-                return searchHint.getItemId();
+                return searchHint.getItemId().toString();
             case SeriesTimer:
                 return seriesTimerInfo.getId();
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -35,7 +35,7 @@ import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
-import org.jellyfin.apiclient.model.search.SearchHint;
+import org.jellyfin.sdk.model.api.SearchHint;
 import org.jellyfin.sdk.model.constant.CollectionType;
 import org.koin.java.KoinJavaComponent;
 
@@ -283,7 +283,7 @@ public class ItemLauncher {
             case SearchHint:
                 final SearchHint hint = rowItem.getSearchHint();
                 //Retrieve full item for display and playback
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(hint.getItemId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(hint.getItemId().toString(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         if (response.getIsFolderItem() && response.getBaseItemType() != BaseItemType.Series) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -33,6 +33,7 @@ import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.TextItemPresenter;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
@@ -808,7 +809,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     for (SearchHint item : response.getSearchHints()) {
                         if (userViewsRepository.getValue().isSupported(item.getType())) {
                             i++;
-                            adapter.add(new BaseRowItem(item));
+                            adapter.add(new BaseRowItem(ModelCompat.asSdk(item)));
                         }
                     }
                     totalItems = response.getTotalRecordCount();

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
@@ -10,6 +10,7 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
+import java.util.UUID
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod as LegacySubtitleDeliveryMethod
 import org.jellyfin.apiclient.model.drawing.ImageOrientation as LegacyImageOrientation
 import org.jellyfin.apiclient.model.dto.BaseItemDto as LegacyBaseItemDto
@@ -40,6 +41,7 @@ import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto as LegacySeriesTim
 import org.jellyfin.apiclient.model.mediainfo.MediaProtocol as LegacyMediaProtocol
 import org.jellyfin.apiclient.model.mediainfo.TransportStreamTimestamp as LegacyTransportStreamTimestamp
 import org.jellyfin.apiclient.model.providers.ExternalUrl as LegacyExternalUrl
+import org.jellyfin.apiclient.model.search.SearchHint as LegacySearchHint
 import org.jellyfin.sdk.model.api.BaseItemDto as ModernBaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemPerson as ModernBaseItemPerson
 import org.jellyfin.sdk.model.api.ChannelType as ModernChannelType
@@ -63,6 +65,7 @@ import org.jellyfin.sdk.model.api.NameGuidPair as ModernNameGuidPair
 import org.jellyfin.sdk.model.api.NameIdPair as ModernNameIdPair
 import org.jellyfin.sdk.model.api.PlayAccess as ModernPlayAccess
 import org.jellyfin.sdk.model.api.ProgramAudio as ModernProgramAudio
+import org.jellyfin.sdk.model.api.SearchHint as ModernSearchHint
 import org.jellyfin.sdk.model.api.SeriesTimerInfoDto as ModernSeriesTimerInfoDto
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod as ModernSubtitleDeliveryMethod
 import org.jellyfin.sdk.model.api.TransportStreamTimestamp as ModernTransportStreamTimestamp
@@ -604,3 +607,35 @@ fun LegacyDayPattern.asSdk(): ModernDayPattern = when (this) {
 }
 
 fun Array<LegacyBaseItemPerson>.asSdk() = map(LegacyBaseItemPerson::asSdk).toTypedArray()
+
+fun LegacySearchHint.asSdk(): ModernSearchHint = ModernSearchHint(
+	itemId = this.itemId.toUUID(),
+	id = this.itemId.toUUID(),
+	name = this.name,
+	matchedTerm = this.matchedTerm,
+	indexNumber = this.indexNumber,
+	productionYear = this.productionYear,
+	parentIndexNumber = this.parentIndexNumber,
+	primaryImageTag = this.primaryImageTag,
+	thumbImageTag = this.thumbImageTag,
+	thumbImageItemId = this.thumbImageItemId,
+	backdropImageTag = this.backdropImageTag,
+	backdropImageItemId = this.backdropImageItemId,
+	type = this.type,
+	isFolder = null, // this.isFolder
+	runTimeTicks = this.runTimeTicks,
+	mediaType = this.mediaType,
+	startDate = null, // this.startDate
+	endDate = null, // this.endDate
+	series = this.series,
+	status = null, // this.status
+	album = this.album,
+	albumId = UUID.randomUUID(), // this.albumId
+	albumArtist = this.albumArtist,
+	artists = this.artists?.toList(),
+	songCount = this.songCount,
+	episodeCount = this.episodeCount,
+	channelId = this.channelId.toUUID(),
+	channelName = this.channelName,
+	primaryImageAspectRatio = this.primaryImageAspectRatio,
+)


### PR DESCRIPTION
The SearchHint model is quite garbage, a bunch of it's values should be nullable but the server sends `00000000-0000-0000-0000-000000000000` as UUID instead lol. It also contains duplicate fields (id and itemId) and the "album" property is the name of an album instead of the id! That one is in the albumId field which the legacy apiclient didn't have.

**Changes**

- Always use SDK SearchHint
  - There is actually only one single place it's retrieved from the API so it should be fairly easy to convert that call in a future PR


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
