### PR TITLE
fix grid sort options

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,10 +131,12 @@
     <string name="lbl_from">from</string>
     <string name="lbl_name">Name</string>
     <string name="lbl_date_added">Date Added</string>
+    <string name="lbl_date_played">Date Played</string>
+    <string name="lbl_date_latest">New Content</string>
     <string name="lbl_premier_date">Premier Date</string>
     <string name="lbl_critic_rating">Critic Rating</string>
     <string name="lbl_community_rating">Community Rating</string>
-    <string name="lbl_rating">Rating</string>
+    <string name="lbl_rating">Parental Rating</string>
     <string name="lbl_starting_with">beginning with those whose name starts with</string>
     <string name="btn_done">Done</string>
     <string name="lbl_display_preferences">Display Preferences</string>


### PR DESCRIPTION
**Changes**
Some of the grid sort options made no sense, since they all use descending name fall-backs, which just results in confusing ordering. I also added some more common options and special handling for shows.

- fix grid sort options
- add DateLastContentAdded option
- fix out of focus key handling
- rename "Rating" -> "Parental Rating"