### PR TITLE
Fix crash when trying to start a picture slideshow

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -987,8 +987,11 @@ public class MediaManager {
     }
 
     public void setCurrentMediaPosition(int currentMediaPosition) {
-        if (!hasVideoQueueItems() || currentMediaPosition < 0 || currentMediaPosition > getCurrentVideoQueue().size())
-            return;
+        if (currentMediaPosition < 0) return;
+        if (mCurrentMediaAdapter == null && mCurrentVideoQueue == null) return;
+        if (mCurrentMediaAdapter != null && currentMediaPosition > mCurrentMediaAdapter.size()) return;
+        if (mCurrentVideoQueue != null && currentMediaPosition > mCurrentVideoQueue.size()) return;
+
         mCurrentMediaPosition = currentMediaPosition;
     }
 


### PR DESCRIPTION


**Changes**
- Check for both the media adapter items and the video queue instead of video queue only in MediaManager

**Issues**

Regression from #1951