### PR TITLE
Add empty playback modules for rewrite

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,7 +92,10 @@ val versionTxt by tasks.registering {
 
 dependencies {
 	// Jellyfin
-	implementation(projects.playback)
+	implementation(projects.playback.core)
+	implementation(projects.playback.exoplayer)
+	implementation(projects.playback.jellyfin)
+	implementation(projects.playback.ui)
 	implementation(projects.preference)
 	implementation(libs.jellyfin.apiclient)
 	implementation(libs.jellyfin.sdk) {

--- a/playback/core/build.gradle.kts
+++ b/playback/core/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("com.android.library")
 	kotlin("android")
+	alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -9,10 +10,6 @@ android {
 	defaultConfig {
 		minSdk = 21
 		targetSdk = 32
-	}
-
-	buildFeatures {
-		viewBinding = true
 	}
 
 	sourceSets["main"].java.srcDirs("src/main/kotlin")
@@ -29,9 +26,6 @@ android {
 }
 
 dependencies {
-	// Jellyfin
-	compileOnly(libs.jellyfin.sdk)
-
 	// Kotlin
 	implementation(libs.kotlinx.coroutines)
 	implementation(libs.kotlinx.coroutines.guava)
@@ -42,13 +36,10 @@ dependencies {
 	implementation(libs.androidx.appcompat)
 	implementation(libs.androidx.constraintlayout)
 	implementation(libs.bundles.androidx.lifecycle)
+	implementation(libs.androidx.media2.session)
 
 	// Dependency Injection
 	implementation(libs.bundles.koin)
-
-	// Media
-	implementation(libs.exoplayer)
-	implementation(libs.androidx.media2.session)
 
 	// Logging
 	implementation(libs.timber)

--- a/playback/core/src/main/AndroidManifest.xml
+++ b/playback/core/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jellyfin.playback">
+    package="org.jellyfin.playback.core">
 
     <application>
 

--- a/playback/exoplayer/build.gradle.kts
+++ b/playback/exoplayer/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+	id("com.android.library")
+	kotlin("android")
+}
+
+android {
+	compileSdk = 32
+
+	defaultConfig {
+		minSdk = 21
+		targetSdk = 32
+	}
+
+	sourceSets["main"].java.srcDirs("src/main/kotlin")
+	sourceSets["test"].java.srcDirs("src/test/kotlin")
+
+	lint {
+		lintConfig = file("$rootDir/android-lint.xml")
+		abortOnError = false
+	}
+
+	testOptions.unitTests.all {
+		it.useJUnitPlatform()
+	}
+}
+
+dependencies {
+	// Jellyfin
+	implementation(projects.playback.core)
+
+	// ExoPlayer
+	implementation(libs.exoplayer)
+
+	// Logging
+	implementation(libs.timber)
+
+	// Testing
+	testImplementation(libs.kotest.runner.junit5)
+	testImplementation(libs.kotest.assertions)
+	testImplementation(libs.mockk)
+}

--- a/playback/exoplayer/src/main/AndroidManifest.xml
+++ b/playback/exoplayer/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.jellyfin.playback.exoplayer" />

--- a/playback/jellyfin/build.gradle.kts
+++ b/playback/jellyfin/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+	id("com.android.library")
+	kotlin("android")
+}
+
+android {
+	compileSdk = 32
+
+	defaultConfig {
+		minSdk = 21
+		targetSdk = 32
+	}
+
+	sourceSets["main"].java.srcDirs("src/main/kotlin")
+	sourceSets["test"].java.srcDirs("src/test/kotlin")
+
+	lint {
+		lintConfig = file("$rootDir/android-lint.xml")
+		abortOnError = false
+	}
+
+	testOptions.unitTests.all {
+		it.useJUnitPlatform()
+	}
+}
+
+dependencies {
+	// Jellyfin
+	implementation(projects.playback.core)
+	implementation(libs.jellyfin.sdk)
+
+	// Logging
+	implementation(libs.timber)
+
+	// Testing
+	testImplementation(libs.kotest.runner.junit5)
+	testImplementation(libs.kotest.assertions)
+	testImplementation(libs.mockk)
+}

--- a/playback/jellyfin/src/main/AndroidManifest.xml
+++ b/playback/jellyfin/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.jellyfin.playback.jellyfin" />

--- a/playback/ui/build.gradle.kts
+++ b/playback/ui/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+	id("com.android.library")
+	kotlin("android")
+}
+
+android {
+	compileSdk = 32
+
+	defaultConfig {
+		minSdk = 21
+		targetSdk = 32
+	}
+
+	buildFeatures {
+		viewBinding = true
+	}
+
+	sourceSets["main"].java.srcDirs("src/main/kotlin")
+	sourceSets["test"].java.srcDirs("src/test/kotlin")
+
+	lint {
+		lintConfig = file("$rootDir/android-lint.xml")
+		abortOnError = false
+	}
+
+	testOptions.unitTests.all {
+		it.useJUnitPlatform()
+	}
+}
+
+dependencies {
+	// Jellyfin
+	implementation(projects.playback.core)
+	implementation(projects.playback.jellyfin)
+	implementation(libs.jellyfin.sdk)
+
+	// Android(x)
+	implementation(libs.androidx.core)
+	implementation(libs.androidx.appcompat)
+	implementation(libs.androidx.constraintlayout)
+	implementation(libs.bundles.androidx.lifecycle)
+	implementation(libs.androidx.media2.session)
+
+	// Dependency Injection
+	implementation(libs.bundles.koin)
+
+	// Logging
+	implementation(libs.timber)
+
+	// Testing
+	testImplementation(libs.kotest.runner.junit5)
+	testImplementation(libs.kotest.assertions)
+	testImplementation(libs.mockk)
+}

--- a/playback/ui/src/main/AndroidManifest.xml
+++ b/playback/ui/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.jellyfin.playback.ui">
+
+    <application>
+
+    </application>
+</manifest>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,10 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")
 
 // Modules
-include(":playback")
+include(":playback:core")
+include(":playback:exoplayer")
+include(":playback:jellyfin")
+include(":playback:ui")
 include(":preference")
 
 pluginManagement {


### PR DESCRIPTION
_Yeah I'm still working on it and yes it takes a lot of time._

**Changes**

Update the Gradle modules to the current wip playback rewrite code. Instead of a single module it uses 4 now; core (logic), ui (player activity/fragment), exoplayer (player implementation) and jellyfin (SDK implementation for item retrieval etc).
The Gradle build files are copied, the manifests are emptied because no actual code is included in this PR.

**Issues**

Part of #1057 
