### PR TITLE
Set defaultFocusHighlightEnabled to false in DefaultCardView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/DefaultCardView.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.card
 import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -25,6 +26,7 @@ class DefaultCardView @JvmOverloads constructor(
 	init {
 		isFocusable = true
 		descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) defaultFocusHighlightEnabled = false
 	}
 
 	val binding = ViewCardDefaultBinding.inflate(LayoutInflater.from(context), this, true)


### PR DESCRIPTION
Fixes an incompatibility with Android 13

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Set defaultFocusHighlightEnabled to false in DefaultCardView
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
