### PR TITLE
Add monochrome layer to adaptive icon

### DIFF
--- a/app/src/main/res/drawable-v26/app_icon.xml
+++ b/app/src/main/res/drawable-v26/app_icon.xml
@@ -1,4 +1,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/app_icon_background" />
     <foreground android:drawable="@drawable/app_icon_foreground_padded" />
+    <monochrome android:drawable="@drawable/app_icon_foreground_padded" />
 </adaptive-icon>


### PR DESCRIPTION
Android 13 feature, doesn't make that much sense on a TV but it's an easy change so yeah

**Changes**
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2305178/188321690-637dff83-fcea-4b4f-a6ac-da74f043802e.png) | ![image](https://user-images.githubusercontent.com/2305178/188321719-33819b78-447c-47bc-9e93-3c4287995f1c.png) |

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
