### PR TITLE
Fix app crashing when opening "other options" menu in FullDetailsActivity

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -875,7 +875,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
     private TextUnderButton shuffleButton = null;
     private TextUnderButton goToSeriesButton = null;
     private TextUnderButton queueButton = null;
-    private TextUnderButton deleteButton = null;
     private TextUnderButton moreButton;
     private TextUnderButton playButton = null;
     private TextUnderButton trailerButton = null;
@@ -1323,12 +1322,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
                     more.getMenu().getItem(5).setVisible(true);
                 }
 
-                if (deleteButton == null || ViewKt.isVisible(deleteButton)) {
-                    more.getMenu().getItem(6).setVisible(false);
-                } else if (deleteButton != null) {
-                    more.getMenu().getItem(6).setVisible(true);
-                }
-
                 more.show();
             }
         });
@@ -1377,7 +1370,6 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
         if (trailerButton != null) actionsList.add(trailerButton);
         if (favButton != null) actionsList.add(favButton);
         if (goToSeriesButton != null) actionsList.add(goToSeriesButton);
-        if (deleteButton != null) actionsList.add(deleteButton);
 
         // reverse the list so the less important actions are hidden first
         Collections.reverse(actionsList);


### PR DESCRIPTION
Some left over code from the earlier removal of the delete option caused the crash because item 6 didn't exist.

**Changes**
- Fix app crashing when opening "other options" menu in FullDetailsActivity

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
