### PR TITLE
Set defaultFocusHighlightEnabled to false in TextUnderButton

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/TextUnderButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/TextUnderButton.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.ui
 
 import android.content.Context
+import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -22,6 +23,7 @@ class TextUnderButton @JvmOverloads constructor(
 		isFocusable = true
 		isFocusableInTouchMode = true
 		descendantFocusability = FOCUS_BLOCK_DESCENDANTS
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) defaultFocusHighlightEnabled = false
 	}
 
 	fun setLabel(text: String?) {


### PR DESCRIPTION
Same as #2027 but for TextUnderButton

**Changes**
- Set defaultFocusHighlightEnabled to false in TextUnderButton

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
