### PR TITLE
Use random device id when initializing QuickConnect

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -92,7 +92,7 @@ val appModule = module {
 	single<ItemMutationRepository> { ItemMutationRepositoryImpl(get(), get()) }
 
 	viewModel { StartupViewModel(get(), get(), get(), get()) }
-	viewModel { UserLoginViewModel(get(), get(), get()) }
+	viewModel { UserLoginViewModel(get(), get(), get(), get(defaultDeviceInfo)) }
 	viewModel { ServerAddViewModel(get()) }
 	viewModel { NextUpViewModel(get(), get(), get(), get()) }
 	viewModel { PictureViewerViewModel(get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginViewModel.kt
@@ -22,9 +22,11 @@ import org.jellyfin.androidtv.auth.model.UnknownQuickConnectState
 import org.jellyfin.androidtv.auth.model.User
 import org.jellyfin.androidtv.auth.repository.AuthenticationRepository
 import org.jellyfin.androidtv.auth.repository.ServerRepository
+import org.jellyfin.androidtv.util.sdk.forUser
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.quickConnectApi
+import org.jellyfin.sdk.model.DeviceInfo
 import timber.log.Timber
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
@@ -33,6 +35,7 @@ class UserLoginViewModel(
 	jellyfin: Jellyfin,
 	private val serverRepository: ServerRepository,
 	private val authenticationRepository: AuthenticationRepository,
+	private val defaultDeviceInfo: DeviceInfo,
 ) : ViewModel() {
 	private val _loginState = MutableStateFlow<LoginState?>(null)
 	val loginState = _loginState.asStateFlow()
@@ -74,6 +77,7 @@ class UserLoginViewModel(
 		_quickConnectState.emit(UnknownQuickConnectState)
 		quickConnectSecret = null
 		quickConnectApi.baseUrl = server.address
+		quickConnectApi.deviceInfo = defaultDeviceInfo.forUser(UUID.randomUUID())
 
 		try {
 			val response by quickConnectApi.quickConnectApi.initiate()


### PR DESCRIPTION
Temporary fix until @crobibero creates a new authentication controller (let's call it v2) from scratch, with proper JWT access tokens, refresh tokens and device info included in that access token instead of the stupid header stuff.

**Changes**

- Use random device id when initializing QuickConnect
 - This fixes the issue where existing sessions get destroyed by the server

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
