### PR TITLE
Use MutableObjectAdapter<Object> as base for ItemRowAdapter

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -956,7 +956,7 @@ public class BrowseGridFragment extends Fragment {
                 @Override
                 public void onResponse() {
 
-                    mAdapter.notifyArrayItemRangeChanged(mAdapter.indexOf(mCurrentItem), 1);
+                    mAdapter.notifyItemRangeChanged(mAdapter.indexOf(mCurrentItem), 1);
                     //Now - if filtered make sure we still pass
                     if (mAdapter.getFilters() != null) {
                         if ((mAdapter.getFilters().isFavoriteOnly() && !mCurrentItem.isFavorite()) || (mAdapter.getFilters().isUnwatchedOnly() && mCurrentItem.isPlayed())) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -362,7 +362,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader {
                 @Override
                 public void onResponse() {
                     ItemRowAdapter adapter = (ItemRowAdapter) mCurrentRow.getAdapter();
-                    adapter.notifyArrayItemRangeChanged(adapter.indexOf(mCurrentItem), 1);
+                    adapter.notifyItemRangeChanged(adapter.indexOf(mCurrentItem), 1);
                 }
             });
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/StdBrowseFragment.java
@@ -225,7 +225,7 @@ public class StdBrowseFragment extends BrowseSupportFragment implements RowLoade
                 @Override
                 public void onResponse() {
                     ItemRowAdapter adapter = (ItemRowAdapter) ((ListRow)mCurrentRow).getAdapter();
-                    adapter.notifyArrayItemRangeChanged(adapter.indexOf(mCurrentItem), 1);
+                    adapter.notifyItemRangeChanged(adapter.indexOf(mCurrentItem), 1);
                 }
             });
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -210,7 +210,7 @@ class HomeFragment : RowsSupportFragment(), AudioEventListener {
 			item.refresh(object : EmptyResponse() {
 				override fun onResponse() {
 					val adapter = currentRow?.adapter as? ItemRowAdapter
-					adapter?.notifyArrayItemRangeChanged(adapter.indexOf(item), 1)
+					adapter?.notifyItemRangeChanged(adapter.indexOf(item), 1)
 				}
 			})
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -159,7 +159,7 @@ public class ItemLauncher {
                             Timber.d("playing audio item");
                             List<BaseItemDto> audioItemsAsList = new ArrayList<>();
 
-                            for (Object item : adapter.unmodifiableList()) {
+                            for (Object item : adapter) {
                                 if (item instanceof BaseRowItem && ((BaseRowItem) item).getBaseItem() != null)
                                     audioItemsAsList.add(((BaseRowItem) item).getBaseItem());
                             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -74,7 +74,7 @@ import java.util.TimeZone;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class ItemRowAdapter extends ArrayObjectAdapter {
+public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     private ItemQuery mQuery;
     private NextUpQuery mNextUpQuery;
     private SeasonQuery mSeasonQuery;
@@ -785,7 +785,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -861,7 +861,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     } else if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -907,7 +907,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     } else if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -937,7 +937,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     } else if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -1002,7 +1002,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                                         } else if (existing.getBaseItem().getParentIndexNumber() > item.getParentIndexNumber()) {
                                             //Replace the newer item with the earlier season
                                             Timber.d("Replacing newer episode 1 with an older season for %s", item.getSeriesName());
-                                            adapter.replace(existingPos, new BaseRowItem(i++, item, preferParentThumb, false));
+                                            adapter.set(existingPos, new BaseRowItem(i++, item, preferParentThumb, false));
                                         } // otherwise, just ignore this newer season premiere since we have the older one already
 
                                     } else {
@@ -1154,7 +1154,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     } else if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -1193,7 +1193,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     } else if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -1245,7 +1245,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     } else if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us
@@ -1535,7 +1535,7 @@ public class ItemRowAdapter extends ArrayObjectAdapter {
                     if (prevItems > 0) {
                         // remove previous items as we re-retrieved
                         // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeItems(0, prevItems);
+                        removeAt(0, prevItems);
                     }
                 } else {
                     // no results - don't show us

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -573,7 +573,7 @@ public class MediaManager {
             if (mManagedAudioQueue != null) {
                 mManagedAudioQueue.remove(mCurrentAudioQueue.get(ndx));
             }
-            mCurrentAudioQueue.removeItems(ndx, 1);
+            mCurrentAudioQueue.removeAt(ndx, 1);
             mCurrentAudioQueuePosition--;
             mCurrentAudioPosition = 0;
             if (ndx >= 0 && ndx < mCurrentAudioQueue.size()) {
@@ -584,7 +584,7 @@ public class MediaManager {
             }
         } else {
             //just remove it
-            mCurrentAudioQueue.removeItems(ndx, 1);
+            mCurrentAudioQueue.removeAt(ndx, 1);
             if (mCurrentAudioQueuePosition > ndx) mCurrentAudioQueuePosition--;
         }
 
@@ -869,11 +869,11 @@ public class MediaManager {
         BaseRowItem rowItem = (BaseRowItem) mCurrentAudioQueue.get(mCurrentAudioQueuePosition);
         if (rowItem != null) {
             rowItem.setIsPlaying(playing);
-            mCurrentAudioQueue.notifyArrayItemRangeChanged(mCurrentAudioQueuePosition, 1);
+            mCurrentAudioQueue.notifyItemRangeChanged(mCurrentAudioQueuePosition, 1);
             if (mManagedAudioQueue != null && mManagedAudioQueue.size() > 0) {
                 BaseRowItem managedItem = (BaseRowItem) mManagedAudioQueue.get(0);
                 managedItem.setIsPlaying(playing);
-                mManagedAudioQueue.notifyArrayItemRangeChanged(0, 1);
+                mManagedAudioQueue.notifyItemRangeChanged(0, 1);
             }
         }
     }
@@ -888,7 +888,7 @@ public class MediaManager {
         stopAudio(false);
         if (mManagedAudioQueue != null && mManagedAudioQueue.size() > 1) {
             //don't remove last item as it causes framework crashes
-            mManagedAudioQueue.removeItems(0, 1);
+            mManagedAudioQueue.removeAt(0, 1);
         }
         int ndx = mCurrentAudioQueuePosition +1;
         if (ndx >= mCurrentAudioQueue.size()) ndx = 0;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.ListUpdateCallback
  * A leanback ObjectAdapter using a Kotlin list as backend. Implements Iterable to allow collection
  * operations. And uses generics for strong typing. Uses a MutableList as internal stucture.
  */
-class MutableObjectAdapter<T : Any> : ObjectAdapter, Iterable<T> {
+open class MutableObjectAdapter<T : Any> : ObjectAdapter, Iterable<T> {
 	private val data = mutableListOf<T>()
 
 	// Constructors
@@ -75,12 +75,14 @@ class MutableObjectAdapter<T : Any> : ObjectAdapter, Iterable<T> {
 		return removed
 	}
 
-	fun removeAt(index: Int): Boolean {
+	fun removeAt(index: Int, length: Int = 1): Boolean {
 		if (index < 0 || index >= data.size) return false
 
-		data.removeAt(index)
-		notifyItemRangeRemoved(index, 1)
+		data.subList(index, index + length).clear()
+		notifyItemRangeRemoved(index, length)
 
 		return true
 	}
+
+	fun indexOf(item: T) = data.indexOf(item)
 }


### PR DESCRIPTION
Depends on #2075

**Changes**
Use MutableObjectAdapter<Object> as base for ItemRowAdapter. In a future PR we can leverage the replaceAll function to properly handle item mutations in rows. Right now most code does a clear() and then add all items again, this is inefficient and screws with the focused item.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
