### PR TITLE
Migrate a lot of code to use BaseItemDto from SDK

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/AudioOptions.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/AudioOptions.java
@@ -2,9 +2,9 @@ package org.jellyfin.androidtv.data.compat;
 
 import org.jellyfin.apiclient.model.dlna.DeviceProfile;
 import org.jellyfin.apiclient.model.dlna.EncodingContext;
-import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
+import org.jellyfin.sdk.model.api.MediaSourceInfo;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class AudioOptions.
@@ -50,13 +50,13 @@ public class AudioOptions {
         ItemId = value;
     }
 
-    private ArrayList<MediaSourceInfo> MediaSources;
+    private List<MediaSourceInfo> MediaSources;
 
-    public final ArrayList<MediaSourceInfo> getMediaSources() {
+    public final List<MediaSourceInfo> getMediaSources() {
         return MediaSources;
     }
 
-    public final void setMediaSources(ArrayList<MediaSourceInfo> value) {
+    public final void setMediaSources(List<MediaSourceInfo> value) {
         MediaSources = value;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamBuilder.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamBuilder.java
@@ -9,9 +9,9 @@ import org.jellyfin.apiclient.model.session.PlayMethod;
 @Deprecated
 public class StreamBuilder
 {
-    public static SubtitleProfile GetSubtitleProfile(MediaStream subtitleStream, SubtitleProfile[] subtitleProfiles, PlayMethod playMethod)
+    public static SubtitleProfile GetSubtitleProfile(org.jellyfin.sdk.model.api.MediaStream subtitleStream, SubtitleProfile[] subtitleProfiles, PlayMethod playMethod)
     {
-        if (playMethod != PlayMethod.Transcode && !subtitleStream.getIsExternal())
+        if (playMethod != PlayMethod.Transcode && !subtitleStream.isExternal())
         {
             // Look for supported embedded subs
             for (SubtitleProfile profile : subtitleProfiles)
@@ -26,7 +26,7 @@ public class StreamBuilder
                     continue;
                 }
 
-                if (subtitleStream.getIsTextSubtitleStream() == MediaStream.IsTextFormat(profile.getFormat()) && Utils.equalsIgnoreCase(profile.getFormat(), subtitleStream.getCodec()))
+                if (subtitleStream.isTextSubtitleStream() == MediaStream.IsTextFormat(profile.getFormat()) && Utils.equalsIgnoreCase(profile.getFormat(), subtitleStream.getCodec()))
                 {
                     return profile;
                 }
@@ -42,7 +42,7 @@ public class StreamBuilder
         return (tempVar2 != null) ? tempVar2 : (tempVar3 != null) ? tempVar3 : tempVar;
     }
 
-    private static SubtitleProfile GetExternalSubtitleProfile(MediaStream subtitleStream, SubtitleProfile[] subtitleProfiles, PlayMethod playMethod, boolean allowConversion)
+    private static SubtitleProfile GetExternalSubtitleProfile(org.jellyfin.sdk.model.api.MediaStream subtitleStream, SubtitleProfile[] subtitleProfiles, PlayMethod playMethod, boolean allowConversion)
     {
         for (SubtitleProfile profile : subtitleProfiles)
         {
@@ -61,7 +61,7 @@ public class StreamBuilder
                 continue;
             }
 
-            if ((profile.getMethod() == SubtitleDeliveryMethod.External && subtitleStream.getIsTextSubtitleStream() == MediaStream.IsTextFormat(profile.getFormat())) || (profile.getMethod() == SubtitleDeliveryMethod.Hls && subtitleStream.getIsTextSubtitleStream()))
+            if ((profile.getMethod() == SubtitleDeliveryMethod.External && subtitleStream.isTextSubtitleStream() == MediaStream.IsTextFormat(profile.getFormat())) || (profile.getMethod() == SubtitleDeliveryMethod.Hls && subtitleStream.isTextSubtitleStream()))
             {
                 boolean requiresConversion = !Utils.equalsIgnoreCase(subtitleStream.getCodec(), profile.getFormat());
 
@@ -75,7 +75,7 @@ public class StreamBuilder
                     continue;
                 }
 
-                if (subtitleStream.getIsTextSubtitleStream() && subtitleStream.getSupportsExternalStream() && subtitleStream.SupportsSubtitleConversionTo(profile.getFormat()))
+                if (subtitleStream.isTextSubtitleStream() && subtitleStream.getSupportsExternalStream() && supportsSubtitleConversionTo(subtitleStream, profile.getFormat()))
                 {
                     return profile;
                 }
@@ -83,5 +83,16 @@ public class StreamBuilder
         }
 
         return null;
+    }
+
+    public static boolean supportsSubtitleConversionTo(org.jellyfin.sdk.model.api.MediaStream mediaStream, String codec)
+    {
+        if (!mediaStream.isTextSubtitleStream())
+        {
+            return false;
+        }
+
+        // Can't convert from this
+        return !("ass".equalsIgnoreCase(mediaStream.getCodec()) || "ssa".equalsIgnoreCase(mediaStream.getCodec()) || "ass".equalsIgnoreCase(codec) || "ssa".equalsIgnoreCase(codec));
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -7,12 +7,12 @@ import org.jellyfin.apiclient.model.dlna.EncodingContext;
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 import org.jellyfin.apiclient.model.dlna.SubtitleProfile;
 import org.jellyfin.apiclient.model.dlna.TranscodeSeekInfo;
-import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.dto.NameValuePair;
-import org.jellyfin.apiclient.model.entities.MediaStream;
-import org.jellyfin.apiclient.model.entities.MediaStreamType;
-import org.jellyfin.apiclient.model.mediainfo.MediaProtocol;
 import org.jellyfin.apiclient.model.session.PlayMethod;
+import org.jellyfin.sdk.model.api.MediaProtocol;
+import org.jellyfin.sdk.model.api.MediaSourceInfo;
+import org.jellyfin.sdk.model.api.MediaStream;
+import org.jellyfin.sdk.model.api.MediaStreamType;
 
 import java.util.ArrayList;
 
@@ -304,8 +304,8 @@ public class StreamInfo {
         long startPositionTicks = getPlayMethod() == PlayMethod.Transcode ? getStartPositionTicks() : 0;
 
         if (!includeSelectedTrackOnly) {
-            for (MediaStream stream : getMediaSource().getMediaStreams()) {
-                if (stream.getType() == MediaStreamType.Subtitle) {
+            for (org.jellyfin.sdk.model.api.MediaStream stream : getMediaSource().getMediaStreams()) {
+                if (stream.getType() == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE) {
                     AddSubtitleProfiles(list, stream, enableAllProfiles, baseUrl, accessToken, startPositionTicks);
                 }
             }
@@ -314,7 +314,7 @@ public class StreamInfo {
         return list;
     }
 
-    private void AddSubtitleProfiles(ArrayList<SubtitleStreamInfo> list, MediaStream stream, boolean enableAllProfiles, String baseUrl, String accessToken, long startPositionTicks) {
+    private void AddSubtitleProfiles(ArrayList<SubtitleStreamInfo> list, org.jellyfin.sdk.model.api.MediaStream stream, boolean enableAllProfiles, String baseUrl, String accessToken, long startPositionTicks) {
         if (enableAllProfiles) {
             for (SubtitleProfile profile : getDeviceProfile().getSubtitleProfiles()) {
                 SubtitleStreamInfo info = GetSubtitleStreamInfo(stream, baseUrl, accessToken, startPositionTicks, new SubtitleProfile[]{profile});
@@ -328,7 +328,7 @@ public class StreamInfo {
         }
     }
 
-    private SubtitleStreamInfo GetSubtitleStreamInfo(MediaStream stream, String baseUrl, String accessToken, long startPositionTicks, SubtitleProfile[] subtitleProfiles) {
+    private SubtitleStreamInfo GetSubtitleStreamInfo(org.jellyfin.sdk.model.api.MediaStream stream, String baseUrl, String accessToken, long startPositionTicks, SubtitleProfile[] subtitleProfiles) {
         SubtitleProfile subtitleProfile = StreamBuilder.GetSubtitleProfile(stream, subtitleProfiles, getPlayMethod());
         SubtitleStreamInfo tempVar = new SubtitleStreamInfo();
         String tempVar2 = stream.getLanguage();
@@ -340,7 +340,7 @@ public class StreamInfo {
         SubtitleStreamInfo info = tempVar;
 
         if (info.getDeliveryMethod() == SubtitleDeliveryMethod.External) {
-            if (getMediaSource().getProtocol() == MediaProtocol.File || !stream.getCodec().equalsIgnoreCase(subtitleProfile.getFormat())) {
+            if (getMediaSource().getProtocol() == MediaProtocol.FILE || !stream.getCodec().equalsIgnoreCase(subtitleProfile.getFormat())) {
                 info.setUrl(String.format("%1$s/Videos/%2$s/%3$s/Subtitles/%4$s/%5$s/Stream.%6$s", baseUrl, getItemId(), getMediaSourceId(), String.valueOf(stream.getIndex()), String.valueOf(startPositionTicks), subtitleProfile.getFormat()));
 
                 if (!Utils.isEmpty(accessToken)) {
@@ -355,13 +355,13 @@ public class StreamInfo {
     }
 
     public final ArrayList<MediaStream> GetSelectableAudioStreams() {
-        return GetSelectableStreams(MediaStreamType.Audio);
+        return GetSelectableStreams(MediaStreamType.AUDIO);
     }
 
-    public final ArrayList<MediaStream> GetSelectableStreams(MediaStreamType type) {
-        ArrayList<MediaStream> list = new ArrayList<MediaStream>();
+    public final ArrayList<org.jellyfin.sdk.model.api.MediaStream> GetSelectableStreams(MediaStreamType type) {
+        ArrayList<org.jellyfin.sdk.model.api.MediaStream> list = new ArrayList<org.jellyfin.sdk.model.api.MediaStream>();
 
-        for (MediaStream stream : getMediaSource().getMediaStreams()) {
+        for (org.jellyfin.sdk.model.api.MediaStream stream : getMediaSource().getMediaStreams()) {
             if (type == stream.getType()) {
                 list.add(stream);
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
@@ -2,8 +2,8 @@ package org.jellyfin.androidtv.ui
 
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.FrameLayout
 import android.view.LayoutInflater
+import android.widget.FrameLayout
 import org.jellyfin.androidtv.databinding.ViewRowDetailsBinding
 
 class DetailRowView @JvmOverloads constructor(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -16,8 +16,6 @@ import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.TimeUtils
-import org.jellyfin.apiclient.model.dto.BaseItemDto
-import org.jellyfin.apiclient.model.entities.ImageType
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -62,12 +60,12 @@ class NowPlayingView @JvmOverloads constructor(
 		if (!isInEditMode) mediaManager.removeAudioEventListener(audioEventListener)
 	}
 
-	private fun setInfo(item: BaseItemDto) {
+	private fun setInfo(item: org.jellyfin.sdk.model.api.BaseItemDto) {
 		val placeholder = ContextCompat.getDrawable(context, R.drawable.ic_album)
-		val blurHash = item.imageBlurHashes?.get(ImageType.Primary)?.get(item.imageTags?.get(ImageType.Primary))
+		val blurHash = item.imageBlurHashes?.get(org.jellyfin.sdk.model.api.ImageType.PRIMARY)?.get(item.imageTags?.get(org.jellyfin.sdk.model.api.ImageType.PRIMARY))
 		binding.npIcon.load(ImageUtils.getPrimaryImageUrl(item), blurHash, placeholder, item.primaryImageAspectRatio ?: 1.0)
 
-		currentDuration = TimeUtils.formatMillis(if (item.runTimeTicks != null) item.runTimeTicks / 10_000 else 0)
+		currentDuration = TimeUtils.formatMillis(if (item.runTimeTicks != null) item.runTimeTicks!! / 10_000 else 0)
 		binding.npDesc.text = if (item.albumArtist != null) item.albumArtist else item.name
 	}
 
@@ -80,7 +78,7 @@ class NowPlayingView @JvmOverloads constructor(
 	}
 
 	private var audioEventListener: AudioEventListener = object : AudioEventListener {
-		override fun onPlaybackStateChange(newState: PlaybackController.PlaybackState, currentItem: BaseItemDto?) {
+		override fun onPlaybackStateChange(newState: PlaybackController.PlaybackState, currentItem: org.jellyfin.sdk.model.api.BaseItemDto?) {
 			when {
 				currentItem == null -> Unit
 				newState == PlaybackController.PlaybackState.PLAYING -> setInfo(currentItem)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -18,6 +18,7 @@ import org.jellyfin.androidtv.databinding.ViewCardLegacyImageBinding;
 import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.ContextExtensionsKt;
+import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 
 import java.text.NumberFormat;
@@ -116,7 +117,7 @@ public class LegacyImageCardView extends BaseCardView {
         if (getCardType() == BaseCardView.CARD_TYPE_MAIN_ONLY && item.showCardInfoOverlay()) {
             switch (item.getBaseItemType()) {
                 case PHOTO:
-                    binding.overlayText.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(getContext()).format(item.getBaseItem().getPremiereDate()) : item.getFullName(getContext()));
+                    binding.overlayText.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(getContext()).format(TimeUtils.getDate(item.getBaseItem().getPremiereDate())) : item.getFullName(getContext()));
                     binding.icon.setImageResource(R.drawable.ic_camera);
                     break;
                 case PHOTO_ALBUM:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -18,7 +18,6 @@ import org.jellyfin.androidtv.databinding.ViewCardLegacyImageBinding;
 import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.ContextExtensionsKt;
-import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 
 import java.text.NumberFormat;
@@ -117,7 +116,7 @@ public class LegacyImageCardView extends BaseCardView {
         if (getCardType() == BaseCardView.CARD_TYPE_MAIN_ONLY && item.showCardInfoOverlay()) {
             switch (item.getBaseItemType()) {
                 case PHOTO:
-                    binding.overlayText.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(getContext()).format(TimeUtils.convertToLocalDate(item.getBaseItem().getPremiereDate())) : item.getFullName(getContext()));
+                    binding.overlayText.setText(item.getBaseItem().getPremiereDate() != null ? android.text.format.DateFormat.getDateFormat(getContext()).format(item.getBaseItem().getPremiereDate()) : item.getFullName(getContext()));
                     binding.icon.setImageResource(R.drawable.ic_camera);
                     break;
                 case PHOTO_ALBUM:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -36,7 +36,6 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter
 import org.jellyfin.androidtv.ui.shared.BaseActivity
 import org.jellyfin.androidtv.util.KeyProcessor
-import org.jellyfin.androidtv.util.sdk.compat.asSdk
 import org.jellyfin.apiclient.interaction.EmptyResponse
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
@@ -251,7 +250,7 @@ class HomeFragment : RowsSupportFragment(), AudioEventListener {
 
 				(row.adapter as? ItemRowAdapter)?.loadMoreItemsIfNeeded(item.index.toLong())
 
-				backgroundService.setBackground(item.baseItem?.asSdk())
+				backgroundService.setBackground(item.baseItem)
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/PhotoPlayerActivity.java
@@ -41,7 +41,6 @@ import org.jellyfin.androidtv.ui.picture.PictureViewerActivity;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.util.ImageHelper;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 
 import kotlin.Lazy;
@@ -84,7 +83,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
         if (pictureViewerRewriteEnabled) {
             Intent intent = PictureViewerActivity.Companion.createIntent(
                     this,
-                    ModelCompat.asSdk(mediaManager.getValue().getCurrentMediaItem().getBaseItem()),
+                    mediaManager.getValue().getCurrentMediaItem().getBaseItem(),
                     getIntent().getBooleanExtra("Play", false),
                     mediaManager.getValue().getCurrentMediaAdapter().getSortBy(),
                     mediaManager.getValue().getCurrentMediaAdapter().getSortOrder()
@@ -113,7 +112,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
         currentImageView().pause();
         nextImageView().pause();
 
-        currentPhoto = ModelCompat.asSdk(mediaManager.getValue().getCurrentMediaItem().getBaseItem());
+        currentPhoto = mediaManager.getValue().getCurrentMediaItem().getBaseItem();
         loadImage(currentPhoto, currentImageView(), getIntent().getBooleanExtra("Play", false));
         loadImage(currentPhoto, nextImageView());
         loadNext();
@@ -169,7 +168,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
                     if (isLoadingPrev || isTransitioning)
                         return true; //swallow too fast requests
                     if (isPlaying) stop();
-                    currentPhoto = ModelCompat.asSdk(mediaManager.getValue().prevMedia().getBaseItem());
+                    currentPhoto = mediaManager.getValue().prevMedia().getBaseItem();
                     nextImage.setImageDrawable(currentImageView().getDrawable());
                     nextImageView().setImageDrawable(prevImage.getDrawable());
                     transition(750);
@@ -204,7 +203,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
             if (isPlaying) stop();
             hideThumbPanel();
             mediaManager.getValue().setCurrentMediaPosition(mPopupRowPresenter.getPosition());
-            loadImage(ModelCompat.asSdk(mediaManager.getValue().getCurrentMediaItem().getBaseItem()), currentImageView());
+            loadImage(mediaManager.getValue().getCurrentMediaItem().getBaseItem(), currentImageView());
             nextImageView().setAlpha(0f);
             currentImageView().resume();
             loadNext();
@@ -228,7 +227,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
             if (isPlaying) stop();
             hideThumbPanel();
             mediaManager.getValue().setCurrentMediaPosition(mPopupRowPresenter.getPosition());
-            loadImage(ModelCompat.asSdk(mediaManager.getValue().getCurrentMediaItem().getBaseItem()), currentImageView());
+            loadImage(mediaManager.getValue().getCurrentMediaItem().getBaseItem(), currentImageView());
             nextImageView().setAlpha(0f);
             loadNext();
 
@@ -245,7 +244,7 @@ public class PhotoPlayerActivity extends FragmentActivity {
     }
 
     private void next(int transDuration) {
-        currentPhoto = ModelCompat.asSdk(mediaManager.getValue().nextMedia().getBaseItem());
+        currentPhoto = mediaManager.getValue().nextMedia().getBaseItem();
         prevImage.setImageDrawable(currentImageView().getDrawable());
         nextImageView().setImageDrawable(nextImage.getDrawable());
         transition(transDuration);
@@ -292,12 +291,12 @@ public class PhotoPlayerActivity extends FragmentActivity {
 
     private void loadNext() {
         if (mediaManager.getValue().hasNextMediaItem())
-            loadImage(ModelCompat.asSdk(mediaManager.getValue().peekNextMediaItem().getBaseItem()), nextImage);
+            loadImage(mediaManager.getValue().peekNextMediaItem().getBaseItem(), nextImage);
     }
 
     private void loadPrev() {
         if (mediaManager.getValue().hasPrevMediaItem())
-            loadImage(ModelCompat.asSdk(mediaManager.getValue().peekPrevMediaItem().getBaseItem()), prevImage);
+            loadImage(mediaManager.getValue().peekPrevMediaItem().getBaseItem(), prevImage);
     }
 
     private void transition(int duration) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/AudioQueueItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/AudioQueueItem.kt
@@ -1,12 +1,18 @@
 package org.jellyfin.androidtv.ui.itemhandling
 
-import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
 
 class AudioQueueItem(
 	index: Int,
 	item: BaseItemDto,
 ) : BaseRowItem(
+	baseRowType = when (item.type) {
+		BaseItemKind.PROGRAM -> BaseRowType.LiveTvProgram
+		BaseItemKind.RECORDING -> BaseRowType.LiveTvRecording
+		else -> BaseRowType.BaseItem
+	},
 	index = index,
-	item = item,
-	staticHeight = true
+	staticHeight = true,
+	baseItem = item,
 )

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -244,11 +244,11 @@ open class BaseRowItem protected constructor(
 			).joinToString(" - ")
 
 			val timestamp = buildString {
-				append(SimpleDateFormat("d MMM").format(baseItem!!.startDate))
+				append(SimpleDateFormat("d MMM").format(TimeUtils.getDate(baseItem!!.startDate)))
 				append(" ")
-				append((DateFormat.getTimeFormat(context).format(baseItem!!.startDate)))
+				append((DateFormat.getTimeFormat(context).format(TimeUtils.getDate(baseItem!!.startDate))))
 				append(" - ")
-				append(DateFormat.getTimeFormat(context).format(baseItem!!.endDate))
+				append(DateFormat.getTimeFormat(context).format(TimeUtils.getDate(baseItem!!.endDate)))
 			}
 
 			"$title $timestamp"

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -28,14 +28,14 @@ import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
+import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
-import org.jellyfin.apiclient.model.library.PlayAccess;
-import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
+import org.jellyfin.sdk.model.api.PlayAccess;
 import org.jellyfin.sdk.model.api.SearchHint;
 import org.jellyfin.sdk.model.constant.CollectionType;
 import org.koin.java.KoinJavaComponent;
@@ -98,24 +98,24 @@ public class ItemLauncher {
         switch (rowItem.getBaseRowType()) {
 
             case BaseItem:
-                final BaseItemDto baseItem = rowItem.getBaseItem();
+                org.jellyfin.sdk.model.api.BaseItemDto baseItem = rowItem.getBaseItem();
                 try {
-                    Timber.d("Item selected: %d - %s (%s)", rowItem.getIndex(), baseItem.getName(), baseItem.getBaseItemType().toString());
+                    Timber.d("Item selected: %d - %s (%s)", rowItem.getIndex(), baseItem.getName(), baseItem.getType().toString());
                 } catch (Exception e) {
                     //swallow it
                 }
 
                 //specialized type handling
-                switch (baseItem.getBaseItemType()) {
-                    case UserView:
-                    case CollectionFolder:
-                        launchUserView(ModelCompat.asSdk(baseItem), activity, false);
+                switch (baseItem.getType()) {
+                    case USER_VIEW:
+                    case COLLECTION_FOLDER:
+                        launchUserView(baseItem, activity, false);
                         return;
-                    case Series:
-                    case MusicArtist:
+                    case SERIES:
+                    case MUSIC_ARTIST:
                         //Start activity for details display
                         Intent intent = new Intent(activity, FullDetailsActivity.class);
-                        intent.putExtra("ItemId", baseItem.getId());
+                        intent.putExtra("ItemId", baseItem.getId().toString());
                         if (noHistory) {
                             intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                         }
@@ -124,11 +124,11 @@ public class ItemLauncher {
 
                         return;
 
-                    case MusicAlbum:
-                    case Playlist:
+                    case MUSIC_ALBUM:
+                    case PLAYLIST:
                         //Start activity for song list display
                         Intent songListIntent = new Intent(activity, ItemListActivity.class);
-                        songListIntent.putExtra("ItemId", baseItem.getId());
+                        songListIntent.putExtra("ItemId", baseItem.getId().toString());
                         if (noHistory) {
                             songListIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                         }
@@ -137,7 +137,7 @@ public class ItemLauncher {
 
                         return;
 
-                    case Audio:
+                    case AUDIO:
                         Timber.d("got pos %s", pos);
                         if (rowItem.getBaseItem() == null)
                             return;
@@ -157,7 +157,7 @@ public class ItemLauncher {
                             mediaManager.playFrom(pos);
                         } else {
                             Timber.d("playing audio item");
-                            List<BaseItemDto> audioItemsAsList = new ArrayList<>();
+                            List<org.jellyfin.sdk.model.api.BaseItemDto> audioItemsAsList = new ArrayList<>();
 
                             for (Object item : adapter) {
                                 if (item instanceof BaseRowItem && ((BaseRowItem) item).getBaseItem() != null)
@@ -167,10 +167,10 @@ public class ItemLauncher {
                         }
 
                         return;
-                    case Season:
+                    case SEASON:
                         //Start activity for enhanced browse
                         Intent seasonIntent = new Intent(activity, GenericFolderActivity.class);
-                        seasonIntent.putExtra(Extras.Folder, Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), ModelCompat.asSdk(baseItem)));
+                        seasonIntent.putExtra(Extras.Folder, Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), baseItem));
                         if (noHistory) {
                             seasonIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                         }
@@ -179,10 +179,10 @@ public class ItemLauncher {
 
                         return;
 
-                    case BoxSet:
+                    case BOX_SET:
                         // open collection browsing
                         Intent collectionIntent = new Intent(activity, CollectionActivity.class);
-                        collectionIntent.putExtra(Extras.Folder, Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), ModelCompat.asSdk(baseItem)));
+                        collectionIntent.putExtra(Extras.Folder, Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), baseItem));
                         if (noHistory) {
                             collectionIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                         }
@@ -190,7 +190,7 @@ public class ItemLauncher {
                         activity.startActivity(collectionIntent);
                         return;
 
-                    case Photo:
+                    case PHOTO:
                         // open photo player
                         KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentMediaPosition(pos);
                         Intent photoIntent = new Intent(activity, PhotoPlayerActivity.class);
@@ -201,16 +201,16 @@ public class ItemLauncher {
                 }
 
                 // or generic handling
-                if (baseItem.getIsFolderItem()) {
+                if (baseItem.isFolder()) {
                     // Some items don't have a display preferences id, but it's required for StdGridFragment
                     // Use the id of the item as a workaround, it's a unique key for the specific item
                     // Which is exactly what we want
                     if (baseItem.getDisplayPreferencesId() == null) {
-                        baseItem.setDisplayPreferencesId(baseItem.getId());
+                        baseItem = JavaCompat.copyWithDisplayPreferencesId(baseItem, baseItem.getId().toString());
                     }
 
                     Intent intent = new Intent(activity, GenericGridActivity.class);
-                    intent.putExtra(Extras.Folder, Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), ModelCompat.asSdk(baseItem)));
+                    intent.putExtra(Extras.Folder, Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), baseItem));
                     if (noHistory) {
                         intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                     }
@@ -222,19 +222,20 @@ public class ItemLauncher {
                         case ShowDetails:
                             //Start details fragment for display and playback
                             Intent intent = new Intent(activity, FullDetailsActivity.class);
-                            intent.putExtra("ItemId", baseItem.getId());
+                            intent.putExtra("ItemId", baseItem.getId().toString());
                             if (noHistory) {
                                 intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                             }
                             activity.startActivity(intent);
                             break;
                         case Play:
-                            if (baseItem.getPlayAccess() == PlayAccess.Full) {
+                            if (baseItem.getPlayAccess() == org.jellyfin.sdk.model.api.PlayAccess.FULL) {
                                 //Just play it directly
-                                PlaybackHelper.getItemsToPlay(baseItem, ModelCompat.asSdk(baseItem).getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
+                                final BaseItemKind itemType = baseItem.getType();
+                                PlaybackHelper.getItemsToPlay(baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<org.jellyfin.sdk.model.api.BaseItemDto>>() {
                                     @Override
-                                    public void onResponse(List<BaseItemDto> response) {
-                                        Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(ModelCompat.asSdk(baseItem).getType());
+                                    public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
+                                        Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(itemType);
                                         Intent intent = new Intent(activity, newActivity);
                                         KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(response);
                                         intent.putExtra("Position", 0);
@@ -267,7 +268,7 @@ public class ItemLauncher {
                     public void onResponse(BaseItemDto response) {
                         List<BaseItemDto> items = new ArrayList<>();
                         items.add(response);
-                        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(items);
+                        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
                         Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(ModelCompat.asSdk(response).getType());
                         Intent intent = new Intent(activity, newActivity);
                         Long start = chapter.getStartPositionTicks() / 10000;
@@ -299,7 +300,7 @@ public class ItemLauncher {
 
                         } else {
                             Intent intent = new Intent(activity, FullDetailsActivity.class);
-                            intent.putExtra("ItemId", response.getId());
+                            intent.putExtra("ItemId", response.getId().toString());
                             if (ModelCompat.asSdk(response).getType() == BaseItemKind.PROGRAM) {
                                 // TODO: Seems like this is never used...
                                 intent.putExtra("ItemType", response.getBaseItemType().name());
@@ -319,33 +320,33 @@ public class ItemLauncher {
                 });
                 break;
             case LiveTvProgram:
-                BaseItemDto program = rowItem.getBaseItem();
+                org.jellyfin.sdk.model.api.BaseItemDto program = rowItem.getBaseItem();
                 switch (rowItem.getSelectAction()) {
 
                     case ShowDetails:
                         //Start details fragment for display and playback
                         Intent programIntent = new Intent(activity, FullDetailsActivity.class);
-                        programIntent.putExtra("ItemId", program.getId());
+                        programIntent.putExtra("ItemId", program.getId().toString());
 
                         // TODO Seems unused
-                        programIntent.putExtra("ItemType", program.getBaseItemType().name());
+                        programIntent.putExtra("ItemType", program.getType().name());
 
                         programIntent.putExtra("ChannelId", program.getChannelId());
-                        programIntent.putExtra("ProgramInfo", Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), ModelCompat.asSdk(program)));
+                        programIntent.putExtra("ProgramInfo", Json.Default.encodeToString(org.jellyfin.sdk.model.api.BaseItemDto.Companion.serializer(), program));
 
                         activity.startActivity(programIntent);
                         break;
                     case Play:
-                        if (program.getPlayAccess() == PlayAccess.Full) {
+                        if (program.getPlayAccess() == org.jellyfin.sdk.model.api.PlayAccess.FULL) {
                             //Just play it directly - need to retrieve program channel via items api to convert to BaseItem
-                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(program.getChannelId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
+                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(program.getChannelId().toString(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
                                     Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(ModelCompat.asSdk(response).getType());
                                     Intent intent = new Intent(activity, newActivity);
-                                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(items);
+                                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
                                     intent.putExtra("Position", 0);
                                     activity.startActivity(intent);
 
@@ -359,15 +360,15 @@ public class ItemLauncher {
 
             case LiveTvChannel:
                 //Just tune to it by playing
-                final ChannelInfoDto channel = rowItem.getChannelInfo();
-                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(channel.getId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
+                final org.jellyfin.sdk.model.api.BaseItemDto channel = rowItem.getBaseItem();
+                KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(channel.getId().toString(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
-                        PlaybackHelper.getItemsToPlay(response, false, false, new Response<List<BaseItemDto>>() {
+                        PlaybackHelper.getItemsToPlay(ModelCompat.asSdk(response), false, false, new Response<List<org.jellyfin.sdk.model.api.BaseItemDto>>() {
                             @Override
-                            public void onResponse(List<BaseItemDto> response) {
+                            public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
                                 // TODO Check whether this usage of BaseItemType.valueOf is okay.
-                                Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(BaseItemKind.valueOf(channel.getType()));
+                                Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(channel.getType());
                                 Intent intent = new Intent(activity, newActivity);
                                 KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(response);
                                 intent.putExtra("Position", 0);
@@ -385,21 +386,21 @@ public class ItemLauncher {
                     case ShowDetails:
                         //Start details fragment for display and playback
                         Intent recIntent = new Intent(activity, FullDetailsActivity.class);
-                        recIntent.putExtra("ItemId", rowItem.getBaseItem().getId());
+                        recIntent.putExtra("ItemId", rowItem.getBaseItem().getId().toString());
 
                         activity.startActivity(recIntent);
                         break;
                     case Play:
-                        if (rowItem.getBaseItem().getPlayAccess() == PlayAccess.Full) {
+                        if (rowItem.getBaseItem().getPlayAccess() == PlayAccess.FULL) {
                             //Just play it directly but need to retrieve as base item
-                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(rowItem.getBaseItem().getId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
+                            KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(rowItem.getBaseItem().getId().toString(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<BaseItemDto>() {
                                 @Override
                                 public void onResponse(BaseItemDto response) {
                                     Class newActivity = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackActivityClass(rowItem.getBaseItemType());
                                     Intent intent = new Intent(activity, newActivity);
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
-                                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(items);
+                                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
                                     intent.putExtra("Position", 0);
                                     activity.startActivity(intent);
                                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -35,6 +35,7 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.TextItemPresenter;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
@@ -104,7 +105,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
 
     private BaseItemPerson[] mPersons;
     private List<ChapterItemInfo> mChapters;
-    private List<BaseItemDto> mItems;
+    private List<org.jellyfin.sdk.model.api.BaseItemDto> mItems;
 
     private MutableObjectAdapter<Row> mParent;
     private ListRow mRow;
@@ -260,7 +261,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
         queryType = QueryType.StaticChapters;
     }
 
-    public ItemRowAdapter(Context context, List<BaseItemDto> items, Presenter presenter, MutableObjectAdapter<Row> parent, QueryType queryType) {
+    public ItemRowAdapter(Context context, List<org.jellyfin.sdk.model.api.BaseItemDto> items, Presenter presenter, MutableObjectAdapter<Row> parent, QueryType queryType) {
         super(presenter);
         this.context = context;
         mParent = parent;
@@ -272,7 +273,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
         super(presenter);
         this.context = context;
         mParent = parent;
-        mItems = items;
+        mItems = JavaCompat.mapBaseItemCollection(items);
         queryType = QueryType.StaticItems;
     }
 
@@ -738,7 +739,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
 
     private void loadStaticItems() {
         if (mItems != null) {
-            for (BaseItemDto item : mItems) {
+            for (org.jellyfin.sdk.model.api.BaseItemDto item : mItems) {
                 add(new BaseRowItem(item));
             }
             itemsLoaded = mItems.size();
@@ -752,7 +753,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     private void loadStaticAudioItems() {
         if (mItems != null) {
             int i = 0;
-            for (BaseItemDto item : mItems) {
+            for (org.jellyfin.sdk.model.api.BaseItemDto item : mItems) {
                 add(new AudioQueueItem(i++, item));
             }
             itemsLoaded = i;
@@ -1048,11 +1049,11 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
                     } else {
                         //If this was for a single series, get the rest of the episodes in the season
                         if (query.getSeriesId() != null) {
-                            BaseItemDto first = adapter.size() == 1 ? ((BaseRowItem) adapter.get(0)).getBaseItem() : null;
+                            org.jellyfin.sdk.model.api.BaseItemDto first = adapter.size() == 1 ? ((BaseRowItem) adapter.get(0)).getBaseItem() : null;
                             if (first != null && first.getIndexNumber() != null && first.getSeasonId() != null) {
                                 StdItemQuery rest = new StdItemQuery();
                                 rest.setUserId(query.getUserId());
-                                rest.setParentId(first.getSeasonId());
+                                rest.setParentId(first.getSeasonId().toString());
                                 rest.setStartIndex(first.getIndexNumber());
                                 apiClient.getValue().GetItemsAsync(rest, new Response<ItemsResult>() {
                                     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideActivity.java
@@ -775,7 +775,7 @@ public class LiveTvGuideActivity extends BaseActivity implements LiveTvGuide {
 
         if (mSelectedProgram.getId() != null) {
             mDisplayDate.setText(TimeUtils.getFriendlyDate(this, TimeUtils.convertToLocalDate(mSelectedProgram.getStartDate())));
-            String url = ImageUtils.getPrimaryImageUrl(mSelectedProgram);
+            String url = ImageUtils.getPrimaryImageUrl(ModelCompat.asSdk(mSelectedProgram));
             int imageSize = Utils.convertDpToPixel(this, 150);
             Glide.with(mActivity)
                     .load(url)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioEventListener.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioEventListener.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.androidtv.ui.playback
 
-import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemDto
 
 interface AudioEventListener {
 	fun onPlaybackStateChange(newState: PlaybackController.PlaybackState, currentItem: BaseItemDto?) = Unit

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingActivity.java
@@ -18,6 +18,8 @@ import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -43,10 +45,9 @@ import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
-import org.jellyfin.apiclient.model.dto.BaseItemDto;
+import org.jellyfin.sdk.model.api.BaseItemDto;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import kotlin.Lazy;
 import timber.log.Timber;
@@ -91,7 +92,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
     private AudioNowPlayingActivity mActivity;
     private final Handler mLoopHandler = new Handler();
 
-    private BaseItemDto mBaseItem;
+    private org.jellyfin.sdk.model.api.BaseItemDto mBaseItem;
     private ListRow mQueueRow;
 
     private boolean queueRowHasFocus = false;
@@ -350,7 +351,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
 
     private AudioEventListener audioEventListener = new AudioEventListener() {
         @Override
-        public void onPlaybackStateChange(PlaybackController.PlaybackState newState, BaseItemDto currentItem) {
+        public void onPlaybackStateChange(@NonNull PlaybackController.PlaybackState newState, @Nullable org.jellyfin.sdk.model.api.BaseItemDto currentItem) {
             Timber.d("**** Got playstate change: %s", newState.toString());
             if (newState == PlaybackController.PlaybackState.PLAYING && currentItem != mBaseItem) {
                 // new item started
@@ -469,12 +470,12 @@ public class AudioNowPlayingActivity extends BaseActivity {
         });
     }
 
-    private String getArtistName(BaseItemDto item) {
+    private String getArtistName(org.jellyfin.sdk.model.api.BaseItemDto item) {
         String artistName = item.getArtists() != null && item.getArtists().size() > 0 ? item.getArtists().get(0) : item.getAlbumArtist();
         return artistName != null ? artistName : "";
     }
 
-    private void updateInfo(BaseItemDto item) {
+    private void updateInfo(org.jellyfin.sdk.model.api.BaseItemDto item) {
         if (item != null) {
             mArtistName.setText(getArtistName(item));
             mSongTitle.setText(item.getName());
@@ -499,7 +500,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
     }
 
     private void addGenres(TextView textView) {
-        ArrayList<String> genres = mBaseItem.getGenres();
+        List<String> genres = mBaseItem.getGenres();
         textView.setText(genres == null ? "" : TextUtils.join(" / ", genres));
     }
 
@@ -513,7 +514,7 @@ public class AudioNowPlayingActivity extends BaseActivity {
             if (ssActive) {
                 stopScreenSaver();
             } else {
-                popupMenu = KeyProcessor.createItemMenu((BaseRowItem) item, ModelCompat.asSdk(((BaseRowItem) item).getBaseItem()).getUserData(), mActivity);
+                popupMenu = KeyProcessor.createItemMenu((BaseRowItem) item, ((BaseRowItem) item).getBaseItem().getUserData(), mActivity);
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
@@ -4,6 +4,7 @@ import org.jellyfin.androidtv.data.compat.AudioOptions;
 import org.jellyfin.androidtv.data.compat.PlaybackException;
 import org.jellyfin.androidtv.data.compat.StreamInfo;
 import org.jellyfin.androidtv.data.compat.VideoOptions;
+import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.QueryStringDictionary;
 import org.jellyfin.apiclient.interaction.Response;
@@ -95,7 +96,7 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
         } else {
             streamInfo.setMediaType(DlnaProfileType.Audio);
         }
-        streamInfo.setMediaSource(mediaSourceInfo);
+        streamInfo.setMediaSource(ModelCompat.asSdk(mediaSourceInfo));
         streamInfo.setRunTimeTicks(mediaSourceInfo.getRunTimeTicks());
 
         streamInfo.setContext(options.getContext());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -35,24 +35,23 @@ import org.jellyfin.androidtv.util.profile.BaseProfile;
 import org.jellyfin.androidtv.util.profile.ExoPlayerProfile;
 import org.jellyfin.androidtv.util.profile.LibVlcProfile;
 import org.jellyfin.androidtv.util.sdk.ModelUtils;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
+import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dlna.DeviceProfile;
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
-import org.jellyfin.apiclient.model.entities.LocationType;
-import org.jellyfin.apiclient.model.entities.MediaStream;
-import org.jellyfin.apiclient.model.entities.MediaStreamType;
-import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.mediainfo.SubtitleTrackInfo;
 import org.jellyfin.apiclient.model.session.PlayMethod;
 import org.jellyfin.sdk.model.api.BaseItemKind;
+import org.jellyfin.sdk.model.api.LocationType;
+import org.jellyfin.sdk.model.api.MediaSourceInfo;
+import org.jellyfin.sdk.model.api.MediaStream;
+import org.jellyfin.sdk.model.api.MediaStreamType;
+import org.jellyfin.sdk.model.api.PlayAccess;
 import org.koin.java.KoinJavaComponent;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import kotlin.Lazy;
@@ -72,7 +71,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
 
-    List<BaseItemDto> mItems;
+    List<org.jellyfin.sdk.model.api.BaseItemDto> mItems;
     VideoManager mVideoManager;
     int mCurrentIndex = 0;
     private long mCurrentPosition = 0;
@@ -119,11 +118,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private Display.Mode[] mDisplayModes;
     private RefreshRateSwitchingBehavior refreshRateSwitchingBehavior = RefreshRateSwitchingBehavior.DISABLED;
 
-    public PlaybackController(List<BaseItemDto> items, CustomPlaybackOverlayFragment fragment) {
+    public PlaybackController(List<org.jellyfin.sdk.model.api.BaseItemDto> items, CustomPlaybackOverlayFragment fragment) {
         this(items, fragment, 0);
     }
 
-    public PlaybackController(List<BaseItemDto> items, CustomPlaybackOverlayFragment fragment, int startIndex) {
+    public PlaybackController(List<org.jellyfin.sdk.model.api.BaseItemDto> items, CustomPlaybackOverlayFragment fragment, int startIndex) {
         mItems = items;
         mCurrentIndex = 0;
         if (items != null && startIndex > 0 && startIndex < items.size()) {
@@ -162,7 +161,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         directStreamLiveTv = userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled());
     }
 
-    public void setItems(List<BaseItemDto> items) {
+    public void setItems(List<org.jellyfin.sdk.model.api.BaseItemDto> items) {
         mItems = items;
         mCurrentIndex = 0;
     }
@@ -192,7 +191,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         }
     }
 
-    public BaseItemDto getCurrentlyPlayingItem() {
+    public org.jellyfin.sdk.model.api.BaseItemDto getCurrentlyPlayingItem() {
         return mItems.size() > mCurrentIndex ? mItems.get(mCurrentIndex) : null;
     }
 
@@ -200,11 +199,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         return mVideoManager != null && mVideoManager.isInitialized();
     }
 
-    public MediaSourceInfo getCurrentMediaSource() {
+    public org.jellyfin.sdk.model.api.MediaSourceInfo getCurrentMediaSource() {
         if (mCurrentStreamInfo != null && mCurrentStreamInfo.getMediaSource() != null) {
             return mCurrentStreamInfo.getMediaSource();
         } else {
-            ArrayList<MediaSourceInfo> mediaSources = getCurrentlyPlayingItem().getMediaSources();
+            List<org.jellyfin.sdk.model.api.MediaSourceInfo> mediaSources = getCurrentlyPlayingItem().getMediaSources();
 
             if (mediaSources == null || mediaSources.isEmpty()) {
                 return null;
@@ -256,7 +255,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         return mItems != null && mCurrentIndex < mItems.size() - 1;
     }
 
-    public BaseItemDto getNextItem() {
+    public org.jellyfin.sdk.model.api.BaseItemDto getNextItem() {
         return hasNextItem() ? mItems.get(mCurrentIndex + 1) : null;
     }
 
@@ -264,7 +263,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         return mItems != null && mCurrentIndex - 1 >= 0;
     }
 
-    public BaseItemDto getPreviousItem() {
+    public org.jellyfin.sdk.model.api.BaseItemDto getPreviousItem() {
         return hasPreviousItem() ? mItems.get(mCurrentIndex - 1) : null;
     }
 
@@ -386,7 +385,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     @TargetApi(23)
-    private void setRefreshRate(MediaStream videoStream) {
+    private void setRefreshRate(org.jellyfin.sdk.model.api.MediaStream videoStream) {
         if (videoStream == null || mFragment == null) {
             Timber.e("Null video stream attempting to set refresh rate");
             return;
@@ -484,7 +483,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     mFragment.setFadingEnabled(false);
                 }
 
-                BaseItemDto item = getCurrentlyPlayingItem();
+                org.jellyfin.sdk.model.api.BaseItemDto item = getCurrentlyPlayingItem();
 
                 if (item == null) {
                     Timber.d("item is null - aborting play");
@@ -496,7 +495,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 }
 
                 // make sure item isn't missing
-                if (item.getLocationType() == LocationType.Virtual && mFragment != null) {
+                if (item.getLocationType() == LocationType.VIRTUAL && mFragment != null) {
                     if (hasNextItem()) {
                         new AlertDialog.Builder(mFragment.getContext())
                                 .setTitle(R.string.episode_missing)
@@ -532,15 +531,15 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 }
 
                 // confirm we actually can play
-                if (item.getPlayAccess() != PlayAccess.Full) {
+                if (item.getPlayAccess() != PlayAccess.FULL) {
                     if (mFragment == null) return;
 
-                    String msg = item.getIsPlaceHolder() ? mFragment.getString(R.string.msg_cannot_play) : mFragment.getString(R.string.msg_cannot_play_time);
+                    String msg = item.isPlaceHolder() ? mFragment.getString(R.string.msg_cannot_play) : mFragment.getString(R.string.msg_cannot_play_time);
                     Utils.showToast(mFragment.getContext(), msg);
                     return;
                 }
 
-                isLiveTv = ModelCompat.asSdk(item).getType() == BaseItemKind.TV_CHANNEL;
+                isLiveTv = item.getType() == BaseItemKind.TV_CHANNEL;
                 startSpinner();
 
                 // undo setting mSeekPosition for liveTV
@@ -567,9 +566,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     @NonNull
-    private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item, int maxBitrate) {
+    private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, org.jellyfin.sdk.model.api.BaseItemDto item, int maxBitrate) {
         VideoOptions internalOptions = new VideoOptions();
-        internalOptions.setItemId(item.getId());
+        internalOptions.setItemId(item.getId().toString());
         internalOptions.setMediaSources(item.getMediaSources());
         internalOptions.setMaxBitrate(maxBitrate);
         if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
@@ -594,9 +593,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     @NonNull
-    private VideoOptions buildVLCOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item, int maxBitrate) {
+    private VideoOptions buildVLCOptions(@Nullable Integer forcedSubtitleIndex, org.jellyfin.sdk.model.api.BaseItemDto item, int maxBitrate) {
         VideoOptions vlcOptions = new VideoOptions();
-        vlcOptions.setItemId(item.getId());
+        vlcOptions.setItemId(item.getId().toString());
         vlcOptions.setMediaSources(item.getMediaSources());
         vlcOptions.setMaxBitrate(maxBitrate);
         if (vlcErrorEncountered) {
@@ -615,11 +614,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         return 600;
     }
 
-    private void playInternal(final BaseItemDto item, final Long position, final VideoOptions vlcOptions, final VideoOptions internalOptions) {
+    private void playInternal(final org.jellyfin.sdk.model.api.BaseItemDto item, final Long position, final VideoOptions vlcOptions, final VideoOptions internalOptions) {
         if (isLiveTv) {
             liveTvChannelName = " (" + item.getName() + ")";
             updateTvProgramInfo();
-            TvManager.setLastLiveTvChannel(item.getId());
+            TvManager.setLastLiveTvChannel(item.getId().toString());
             //Choose appropriate player now to avoid opening two streams
             if (!directStreamLiveTv || userPreferences.getValue().get(UserPreferences.Companion.getLiveTvVideoPlayer()) != PreferredVideoPlayer.VLC) {
                 //internal/exo player
@@ -649,7 +648,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     public void onResponse(StreamInfo response) {
                         if (mVideoManager == null)
                             return;
-                        mVideoManager.init(getBufferAmount(), response.getMediaSource().getVideoStream().getIsInterlaced() && (response.getMediaSource().getVideoStream().getWidth() == null || response.getMediaSource().getVideoStream().getWidth() > 1200));
+                        mVideoManager.init(getBufferAmount(), JavaCompat.getVideoStream(response.getMediaSource()).isInterlaced() && (JavaCompat.getVideoStream(response.getMediaSource()).getWidth() == null || JavaCompat.getVideoStream(response.getMediaSource()).getWidth() > 1200));
                         mCurrentOptions = vlcOptions;
                         useVlc = true;
                         startItem(item, position, response);
@@ -673,10 +672,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                         @Override
                         public void onResponse(StreamInfo internalResponse) {
                             Timber.i("Internal player would %s", internalResponse.getPlayMethod().equals(PlayMethod.Transcode) ? "transcode" : "direct stream");
-                            boolean useDeinterlacing = vlcResponse.getMediaSource().getVideoStream() != null &&
-                                    vlcResponse.getMediaSource().getVideoStream().getIsInterlaced() &&
-                                    (vlcResponse.getMediaSource().getVideoStream().getWidth() == null ||
-                                            vlcResponse.getMediaSource().getVideoStream().getWidth() > 1200);
+                            org.jellyfin.sdk.model.api.MediaStream videoStream = JavaCompat.getVideoStream(vlcResponse.getMediaSource());
+                            boolean useDeinterlacing = videoStream != null &&
+                                    videoStream.isInterlaced() &&
+                                    (videoStream.getWidth() == null ||
+                                            videoStream.getWidth() > 1200);
                             Timber.i(useDeinterlacing ? "Explicit deinterlacing will be used" : "Explicit deinterlacing will NOT be used");
 
                             PreferredVideoPlayer preferredVideoPlayer = userPreferences.getValue().get(UserPreferences.Companion.getVideoPlayer());
@@ -697,16 +697,16 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                                         (DeviceUtils.is60() ||
                                                 !userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()) ||
                                                 vlcResponse.getMediaSource() == null ||
-                                                vlcResponse.getMediaSource().getDefaultAudioStream() == null ||
-                                                (!"ac3".equals(vlcResponse.getMediaSource().getDefaultAudioStream().getCodec()) &&
-                                                        !"truehd".equals(vlcResponse.getMediaSource().getDefaultAudioStream().getCodec()))) &&
+                                                JavaCompat.getDefaultAudioStream(vlcResponse.getMediaSource()) == null ||
+                                                (!"ac3".equals(JavaCompat.getDefaultAudioStream(vlcResponse.getMediaSource()).getCodec()) &&
+                                                        !"truehd".equals(JavaCompat.getDefaultAudioStream(vlcResponse.getMediaSource()).getCodec()))) &&
                                         (Utils.downMixAudio(mFragment.getContext()) ||
                                                 !DeviceUtils.is60() ||
                                                 internalResponse.getPlayMethod().equals(PlayMethod.Transcode) ||
                                                 !userPreferences.getValue().get(UserPreferences.Companion.getDtsEnabled()) ||
                                                 internalResponse.getMediaSource() == null ||
-                                                internalResponse.getMediaSource().getDefaultAudioStream() == null ||
-                                                (vlcResponse.getMediaSource().getVideoStream() != null && vlcResponse.getMediaSource().getVideoStream().getWidth() < 1000));
+                                                JavaCompat.getDefaultAudioStream(internalResponse.getMediaSource()) == null ||
+                                                (JavaCompat.getVideoStream(vlcResponse.getMediaSource()) != null && JavaCompat.getVideoStream(vlcResponse.getMediaSource()).getWidth() < 1000));
                             } else if (preferredVideoPlayer == PreferredVideoPlayer.CHOOSE) {
                                 PreferredVideoPlayer preferredVideoPlayerByPlayWith = systemPreferences.getValue().get(SystemPreferences.Companion.getChosenPlayer());
 
@@ -729,10 +729,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                             if (mVideoManager == null)
                                 return;
 
-                            boolean useDeinterlacing = vlcResponse.getMediaSource().getVideoStream() != null &&
-                                    vlcResponse.getMediaSource().getVideoStream().getIsInterlaced() &&
-                                    (vlcResponse.getMediaSource().getVideoStream().getWidth() == null ||
-                                            vlcResponse.getMediaSource().getVideoStream().getWidth() > 1200);
+                            org.jellyfin.sdk.model.api.MediaStream videoStream = JavaCompat.getVideoStream(vlcResponse.getMediaSource());
+                            boolean useDeinterlacing = videoStream != null &&
+                                    videoStream.isInterlaced() &&
+                                    (videoStream.getWidth() == null ||
+                                            videoStream.getWidth() > 1200);
 
                             mVideoManager.init(getBufferAmount(), useDeinterlacing);
                             mCurrentOptions = vlcOptions;
@@ -778,7 +779,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (mFragment != null) mFragment.finish();
     }
 
-    private void startItem(BaseItemDto item, long position, StreamInfo response) {
+    private void startItem(org.jellyfin.sdk.model.api.BaseItemDto item, long position, StreamInfo response) {
         if (!hasInitializedVideoManager() || !hasFragment()) {
             Timber.d("Error - attempting to play without:%s%s", hasInitializedVideoManager() ? "" : " [videoManager]", hasFragment() ? "" : " [overlay fragment]");
             return;
@@ -826,7 +827,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         // set refresh rate
         if (refreshRateSwitchingBehavior != RefreshRateSwitchingBehavior.DISABLED) {
-            setRefreshRate(response.getMediaSource().getVideoStream());
+            setRefreshRate(JavaCompat.getVideoStream(response.getMediaSource()));
         }
 
         // set playback speed to user selection, or 1 if we're watching live-tv
@@ -839,12 +840,12 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (mVideoManager != null && !mVideoManager.isNativeMode() &&
                 ((isLiveTv && DeviceUtils.isFireTv()) ||
                         (response.getMediaSource() != null &&
-                                response.getMediaSource().getDefaultAudioStream() != null &&
-                                response.getMediaSource().getDefaultAudioStream().getChannels() != null &&
-                                (response.getMediaSource().getDefaultAudioStream().getChannels() <= 2 ||
+                                JavaCompat.getDefaultAudioStream(response.getMediaSource()) != null &&
+                                JavaCompat.getDefaultAudioStream(response.getMediaSource()).getChannels() != null &&
+                                (JavaCompat.getDefaultAudioStream(response.getMediaSource()).getChannels() <= 2 ||
                                         (DeviceUtils.isFireTv() &&
-                                                ("ac3".equals(response.getMediaSource().getDefaultAudioStream().getCodec()) ||
-                                                        "truehd".equals(response.getMediaSource().getDefaultAudioStream().getCodec()))))))) {
+                                                ("ac3".equals(JavaCompat.getDefaultAudioStream(response.getMediaSource()).getCodec()) ||
+                                                        "truehd".equals(JavaCompat.getDefaultAudioStream(response.getMediaSource()).getCodec()))))))) {
             mVideoManager.setCompatibleAudio();
             Timber.i("Setting compatible audio mode...");
         } else if (mVideoManager != null) {
@@ -871,7 +872,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             }
         }, 750);
 
-        dataRefreshService.getValue().setLastPlayedItem(ModelCompat.asSdk(item));
+        dataRefreshService.getValue().setLastPlayedItem(item);
         ReportingHelper.reportStart(item, mbPos);
     }
 
@@ -897,7 +898,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         } else if (isTranscoding() && getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
             currIndex = getCurrentMediaSource().getDefaultAudioStreamIndex();
         } else if (hasInitializedVideoManager() && !isTranscoding()) {
-            currIndex = isNativeMode() ? mVideoManager.getExoPlayerTrack(MediaStreamType.Audio, getCurrentlyPlayingItem().getMediaStreams()) :
+            currIndex = isNativeMode() ? mVideoManager.getExoPlayerTrack(org.jellyfin.sdk.model.api.MediaStreamType.AUDIO, getCurrentlyPlayingItem().getMediaStreams()) :
                                             mVideoManager.getVLCAudioTrack(getCurrentlyPlayingItem().getMediaStreams());
         }
         return currIndex;
@@ -908,11 +909,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return null;
 
         boolean videoFound = false;
-        for (MediaStream track : info.getMediaStreams()) {
-            if (track.getType() == MediaStreamType.Video) {
+        for (org.jellyfin.sdk.model.api.MediaStream track : info.getMediaStreams()) {
+            if (track.getType() == org.jellyfin.sdk.model.api.MediaStreamType.VIDEO) {
                 videoFound = true;
             } else {
-                if (videoFound && track.getType() == MediaStreamType.Audio)
+                if (videoFound && track.getType() == org.jellyfin.sdk.model.api.MediaStreamType.AUDIO)
                     return track.getIndex();
             }
         }
@@ -951,7 +952,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         // get current timestamp first
         refreshCurrentPosition();
 
-        if (isNativeMode() && !isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.Audio, getCurrentlyPlayingItem().getMediaStreams())) {
+        if (isNativeMode() && !isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.AUDIO, getCurrentlyPlayingItem().getMediaStreams())) {
             mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
             mCurrentOptions.setAudioStreamIndex(index);
         } else if (!isNativeMode() && !isTranscoding() && mVideoManager.setVLCAudioTrack(index, getCurrentlyPlayingItem().getMediaStreams()) == index) {
@@ -994,7 +995,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        org.jellyfin.sdk.model.api.MediaStream stream = StreamHelper.getMediaStream(ModelCompat.asSdk(getCurrentMediaSource()), index);
+        org.jellyfin.sdk.model.api.MediaStream stream = StreamHelper.getMediaStream(getCurrentMediaSource(), index);
         if (stream == null) {
             if (mFragment != null)
                 Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.subtitle_error));
@@ -1131,10 +1132,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             }
             Long mbPos = mCurrentPosition * 10000;
             ReportingHelper.reportStopped(getCurrentlyPlayingItem(), getCurrentStreamInfo(), mbPos);
-            if (!isLiveTv) {
-                // update the actual items resume point
-                getCurrentlyPlayingItem().getUserData().setPlaybackPositionTicks(mbPos);
-            }
             clearPlaybackSessionOptions();
         }
     }
@@ -1314,22 +1311,23 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     public void updateTvProgramInfo() {
         // Get the current program info when playing a live TV channel
-        final BaseItemDto channel = getCurrentlyPlayingItem();
-        if (ModelCompat.asSdk(channel).getType() == BaseItemKind.TV_CHANNEL) {
-            apiClient.getValue().GetLiveTvChannelAsync(channel.getId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<ChannelInfoDto>() {
+        final org.jellyfin.sdk.model.api.BaseItemDto channel = getCurrentlyPlayingItem();
+        if (channel.getType() == BaseItemKind.TV_CHANNEL) {
+            apiClient.getValue().GetLiveTvChannelAsync(channel.getId().toString(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<ChannelInfoDto>() {
                 @Override
                 public void onResponse(ChannelInfoDto response) {
                     BaseItemDto program = response.getCurrentProgram();
                     if (program != null) {
-                        channel.setName(program.getName() + liveTvChannelName);
-                        channel.setPremiereDate(program.getStartDate());
-                        channel.setEndDate(program.getEndDate());
-                        channel.setOfficialRating(program.getOfficialRating());
-                        channel.setOverview(program.getOverview());
-                        channel.setRunTimeTicks(program.getRunTimeTicks());
-                        channel.setCurrentProgram(program);
-                        mCurrentProgramEndTime = channel.getEndDate() != null ? TimeUtils.convertToLocalDate(channel.getEndDate()).getTime() : 0;
-                        mCurrentProgramStartTime = channel.getPremiereDate() != null ? TimeUtils.convertToLocalDate(channel.getPremiereDate()).getTime() : 0;
+                        // TODO Do we need these setters?
+//                        channel.setName(program.getName() + liveTvChannelName);
+//                        channel.setPremiereDate(program.getStartDate());
+//                        channel.setEndDate(program.getEndDate());
+//                        channel.setOfficialRating(program.getOfficialRating());
+//                        channel.setOverview(program.getOverview());
+//                        channel.setRunTimeTicks(program.getRunTimeTicks());
+//                        channel.setCurrentProgram(program);
+                        mCurrentProgramEndTime = program.getEndDate() != null ? program.getEndDate().getTime() : 0;
+                        mCurrentProgramStartTime = program.getPremiereDate() != null ? program.getPremiereDate().getTime() : 0;
                         if (mFragment != null) mFragment.updateDisplay();
                     }
                 }
@@ -1373,7 +1371,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         mReportLoop = new Runnable() {
             @Override
             public void run() {
-                BaseItemDto currentItem = getCurrentlyPlayingItem();
+                org.jellyfin.sdk.model.api.BaseItemDto currentItem = getCurrentlyPlayingItem();
                 if (currentItem == null) {
                     // Loop was called while nothing was playing!
                     stopReportLoop();
@@ -1426,8 +1424,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         stop();
         resetPlayerErrors();
 
-        BaseItemDto nextItem = getNextItem();
-        BaseItemDto curItem = getCurrentlyPlayingItem();
+        org.jellyfin.sdk.model.api.BaseItemDto nextItem = getNextItem();
+        org.jellyfin.sdk.model.api.BaseItemDto curItem = getCurrentlyPlayingItem();
         if (nextItem == null || curItem == null) {
             endPlayback(true);
             return;
@@ -1435,13 +1433,13 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         Timber.d("Moving to next queue item. Index: %s", (mCurrentIndex + 1));
         if (userPreferences.getValue().get(UserPreferences.Companion.getNextUpBehavior()) != NextUpBehavior.DISABLED
-                && ModelCompat.asSdk(curItem).getType() != BaseItemKind.TRAILER) {
+                && curItem.getType() != BaseItemKind.TRAILER) {
             mCurrentIndex++;
             mediaManager.getValue().setCurrentMediaPosition(mCurrentIndex);
             spinnerOff = false;
 
             // Show "Next Up" fragment
-            if (mFragment != null) mFragment.showNextUp(nextItem.getId());
+            if (mFragment != null) mFragment.showNextUp(nextItem.getId().toString());
             endPlayback();
         } else {
             next();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.ui.playback.rewrite.PlaybackForwardingActivity
-import org.jellyfin.apiclient.model.dto.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 
 interface PlaybackLauncher {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -8,13 +8,13 @@ import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dlna.PlaybackErrorCode;
-import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
-import org.jellyfin.apiclient.model.entities.MediaStream;
 import org.jellyfin.apiclient.model.mediainfo.PlaybackInfoRequest;
 import org.jellyfin.apiclient.model.session.PlaybackProgressInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStartInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStopInfo;
 import org.jellyfin.sdk.model.DeviceInfo;
+import org.jellyfin.sdk.model.api.MediaSourceInfo;
+import org.jellyfin.sdk.model.api.MediaStream;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -9,7 +9,6 @@ import androidx.leanback.app.PlaybackSupportFragment;
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer;
-import org.jellyfin.apiclient.model.dto.BaseItemDto;
 
 import kotlin.Lazy;
 
@@ -70,7 +69,7 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
     }
 
     public void mediaInfoChanged() {
-        BaseItemDto currentlyPlayingItem = playbackController.getCurrentlyPlayingItem();
+        org.jellyfin.sdk.model.api.BaseItemDto currentlyPlayingItem = playbackController.getCurrentlyPlayingItem();
         if (currentlyPlayingItem == null) return;
 
         playerGlue.invalidatePlaybackControls();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -7,9 +7,7 @@ import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.StreamHelper;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
-import org.jellyfin.apiclient.model.dto.BaseItemDto;
-import org.jellyfin.apiclient.model.dto.ChapterInfoDto;
+import org.jellyfin.sdk.model.api.ChapterInfo;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.List;
@@ -101,11 +99,11 @@ public class VideoPlayerAdapter extends PlayerAdapter {
     }
 
     boolean hasSubs() {
-        return StreamHelper.getSubtitleStreams(ModelCompat.asSdk(playbackController.getCurrentMediaSource())).size() > 0;
+        return StreamHelper.getSubtitleStreams(playbackController.getCurrentMediaSource()).size() > 0;
     }
 
     boolean hasMultiAudio() {
-        return StreamHelper.getAudioStreams(ModelCompat.asSdk(playbackController.getCurrentMediaSource())).size() > 1;
+        return StreamHelper.getAudioStreams(playbackController.getCurrentMediaSource()).size() > 1;
     }
 
     boolean hasNextItem() {
@@ -147,18 +145,18 @@ public class VideoPlayerAdapter extends PlayerAdapter {
     }
 
     boolean canRecordLiveTv() {
-        BaseItemDto currentlyPlayingItem = getCurrentlyPlayingItem();
+        org.jellyfin.sdk.model.api.BaseItemDto currentlyPlayingItem = getCurrentlyPlayingItem();
         return currentlyPlayingItem.getCurrentProgram() != null
                 && Utils.canManageRecordings(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue());
     }
 
     void toggleRecording() {
-        BaseItemDto currentlyPlayingItem = getCurrentlyPlayingItem();
+        org.jellyfin.sdk.model.api.BaseItemDto currentlyPlayingItem = getCurrentlyPlayingItem();
         getMasterOverlayFragment().toggleRecording(currentlyPlayingItem);
     }
 
     boolean isRecording() {
-        BaseItemDto currentProgram = getCurrentlyPlayingItem().getCurrentProgram();
+        org.jellyfin.sdk.model.api.BaseItemDto currentProgram = getCurrentlyPlayingItem().getCurrentProgram();
         if (currentProgram == null) {
             return false;
         } else {
@@ -166,7 +164,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
         }
     }
 
-    BaseItemDto getCurrentlyPlayingItem() {
+    org.jellyfin.sdk.model.api.BaseItemDto getCurrentlyPlayingItem() {
         return playbackController.getCurrentlyPlayingItem();
     }
 
@@ -175,8 +173,8 @@ public class VideoPlayerAdapter extends PlayerAdapter {
     }
 
     boolean hasChapters() {
-        BaseItemDto item = getCurrentlyPlayingItem();
-        List<ChapterInfoDto> chapters = item.getChapters();
+        org.jellyfin.sdk.model.api.BaseItemDto item = getCurrentlyPlayingItem();
+        List<ChapterInfo> chapters = item.getChapters();
         return chapters != null && chapters.size() > 0;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.java
@@ -11,7 +11,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.PlaybackManager;
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue;
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
-import org.jellyfin.apiclient.model.entities.MediaStream;
+import org.jellyfin.sdk.model.api.MediaStream;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.List;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -5,10 +5,9 @@ import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import org.jellyfin.androidtv.ui.playback.MediaManager
-import org.jellyfin.apiclient.model.dto.BaseItemDto
-import org.jellyfin.apiclient.model.dto.BaseItemType
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 import timber.log.Timber
@@ -58,16 +57,16 @@ class PlaybackForwardingActivity : FragmentActivity() {
 	private fun findItemId(): UUID? {
 		val extra = intent.getStringExtra(EXTRA_ITEM_ID)?.toUUIDOrNull()
 
-		var first: BaseItemDto? = null
-		var best: BaseItemDto? = null
+		var first: org.jellyfin.sdk.model.api.BaseItemDto? = null
+		var best: org.jellyfin.sdk.model.api.BaseItemDto? = null
 
 		for (item in mediaManager.currentVideoQueue ?: emptyList()) {
 			if (first == null) first = item
-			if (best == null && item.baseItemType !== BaseItemType.Trailer) best = item
+			if (best == null && item.type !== BaseItemKind.TRAILER) best = item
 
 			if (first != null && best != null) break
 		}
 
-		return extra ?: best?.id?.toUUIDOrNull() ?: first?.id?.toUUIDOrNull()
+		return extra ?: best?.id ?: first?.id
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/PaddedLineBackgroundSpan.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/PaddedLineBackgroundSpan.kt
@@ -3,8 +3,8 @@ package org.jellyfin.androidtv.ui.shared
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
-import android.view.Gravity
 import android.text.style.LineBackgroundSpan
+import android.view.Gravity
 import androidx.annotation.ColorInt
 import androidx.annotation.Dimension
 import kotlin.math.roundToInt

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -17,7 +17,6 @@ import org.jellyfin.androidtv.preference.constant.RatingType;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.util.apiclient.StreamHelper;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.jellyfin.sdk.model.api.MediaStream;
@@ -39,7 +38,7 @@ public class InfoLayoutHelper {
         switch (item.getBaseRowType()) {
 
             case BaseItem:
-                addInfoRow(context, ModelCompat.asSdk(item.getBaseItem()), layout, includeRuntime, includeEndtime);
+                addInfoRow(context, item.getBaseItem(), layout, includeRuntime, includeEndtime);
                 break;
             default:
                 addSubText(context, item, layout);

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -295,8 +295,8 @@ public class InfoLayoutHelper {
             case PROGRAM:
             case TV_CHANNEL:
                 if (item.getStartDate() != null && item.getEndDate() != null) {
-                    date.setText(DateFormat.getTimeFormat(context).format(item.getStartDate())
-                            + "-"+ DateFormat.getTimeFormat(context).format(item.getEndDate()));
+                    date.setText(DateFormat.getTimeFormat(context).format(TimeUtils.getDate(item.getStartDate()))
+                            + "-"+ DateFormat.getTimeFormat(context).format(TimeUtils.getDate(item.getEndDate())));
                     layout.addView(date);
                     addSpacer(context, layout, "    ");
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
@@ -8,7 +8,6 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.PlaybackManager;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.EmptyResponse;
-import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.session.PlaybackProgressInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStartInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStopInfo;
@@ -17,38 +16,38 @@ import org.koin.java.KoinJavaComponent;
 import timber.log.Timber;
 
 public class ReportingHelper {
-    public static void reportStopped(BaseItemDto item, StreamInfo streamInfo, long pos) {
+    public static void reportStopped(org.jellyfin.sdk.model.api.BaseItemDto item, StreamInfo streamInfo, long pos) {
         if (item != null && streamInfo != null) {
             PlaybackStopInfo info = new PlaybackStopInfo();
-            info.setItemId(item.getId());
+            info.setItemId(item.getId().toString());
             info.setPositionTicks(pos);
             KoinJavaComponent.<PlaybackManager>get(PlaybackManager.class).reportPlaybackStopped(info, streamInfo, KoinJavaComponent.<ApiClient>get(ApiClient.class), new EmptyResponse());
 
             DataRefreshService dataRefreshService = KoinJavaComponent.<DataRefreshService>get(DataRefreshService.class);
             dataRefreshService.setLastPlayback(System.currentTimeMillis());
-            switch (item.getBaseItemType()) {
-                case Movie:
+            switch (item.getType()) {
+                case MOVIE:
                     dataRefreshService.setLastMoviePlayback(System.currentTimeMillis());
                     break;
-                case Episode:
+                case EPISODE:
                     dataRefreshService.setLastTvPlayback(System.currentTimeMillis());
                     break;
             }
         }
     }
 
-    public static void reportStart(BaseItemDto item, long pos) {
+    public static void reportStart(org.jellyfin.sdk.model.api.BaseItemDto item, long pos) {
         PlaybackStartInfo startInfo = new PlaybackStartInfo();
-        startInfo.setItemId(item.getId());
+        startInfo.setItemId(item.getId().toString());
         startInfo.setPositionTicks(pos);
         KoinJavaComponent.<PlaybackManager>get(PlaybackManager.class).reportPlaybackStart(startInfo, KoinJavaComponent.<ApiClient>get(ApiClient.class), new EmptyResponse());
         Timber.i("Playback of %s started.", item.getName());
     }
 
-    public static void reportProgress(@Nullable PlaybackController playbackController, BaseItemDto item, StreamInfo currentStreamInfo, Long position, boolean isPaused) {
+    public static void reportProgress(@Nullable PlaybackController playbackController, org.jellyfin.sdk.model.api.BaseItemDto item, StreamInfo currentStreamInfo, Long position, boolean isPaused) {
         if (item != null && currentStreamInfo != null) {
             PlaybackProgressInfo info = new PlaybackProgressInfo();
-            info.setItemId(item.getId());
+            info.setItemId(item.getId().toString());
             info.setPositionTicks(position);
             info.setIsPaused(isPaused);
             info.setCanSeek(currentStreamInfo.getRunTimeTicks() != null && currentStreamInfo.getRunTimeTicks() > 0);

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
@@ -71,8 +71,8 @@ fun BaseItemDto.getProgramSubText(context: Context) = buildString {
 	val dateFormat = DateFormat.getTimeFormat(context)
 	append(context.getString(
 		R.string.lbl_time_range,
-		dateFormat.format(startDate),
-		dateFormat.format(endDate)
+		dateFormat.format(TimeUtils.getDate(startDate)),
+		dateFormat.format(TimeUtils.getDate(endDate))
 	))
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
@@ -1,0 +1,43 @@
+@file:JvmName("JavaCompat")
+
+package org.jellyfin.androidtv.util.sdk.compat
+
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.api.MediaStream
+import java.time.LocalDateTime
+import org.jellyfin.apiclient.model.dto.BaseItemDto as LegacyBaseItemdto
+
+fun BaseItemDto.copyWithDisplayPreferencesId(
+	displayPreferencesId: String?
+) = copy(
+	displayPreferencesId = displayPreferencesId,
+)
+
+fun BaseItemDto.copyWithDates(
+	premiereDate: LocalDateTime?,
+	endDate: LocalDateTime?,
+	officialRating: String?,
+	runTimeTicks: Long?,
+) = copy(
+	premiereDate = premiereDate,
+	endDate = endDate,
+	officialRating = officialRating,
+	runTimeTicks = runTimeTicks,
+)
+
+fun BaseItemDto.getResumePositionTicks() = userData?.playbackPositionTicks ?: 0
+
+fun Collection<LegacyBaseItemdto>.mapBaseItemCollection(): List<BaseItemDto> = map { it.asSdk() }
+fun Array<LegacyBaseItemdto>.mapBaseItemArray(): List<BaseItemDto> = map { it.asSdk() }
+
+fun MediaSourceInfo.getVideoStream() = mediaStreams?.firstOrNull {
+	it.type == org.jellyfin.sdk.model.api.MediaStreamType.VIDEO
+}
+
+fun MediaSourceInfo.getDefaultAudioStream(): MediaStream? {
+	val audioStreams = mediaStreams.orEmpty().filter { it.type == org.jellyfin.sdk.model.api.MediaStreamType.AUDIO }
+	return audioStreams.firstOrNull { it.index == defaultAudioStreamIndex }
+		?: audioStreams.firstOrNull { it.isDefault }
+		?: audioStreams.firstOrNull()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
@@ -34,6 +34,7 @@ import org.jellyfin.apiclient.model.entities.SortOrder as LegacySortOrder
 import org.jellyfin.apiclient.model.entities.Video3DFormat as LegacyVideo3DFormat
 import org.jellyfin.apiclient.model.entities.VideoType as LegacyVideoType
 import org.jellyfin.apiclient.model.library.PlayAccess as LegacyPlayAccess
+import org.jellyfin.apiclient.model.livetv.ChannelInfoDto as LegacyChannelInfoDto
 import org.jellyfin.apiclient.model.livetv.ChannelType as LegacyChannelType
 import org.jellyfin.apiclient.model.livetv.DayPattern as LegacyDayPattern
 import org.jellyfin.apiclient.model.livetv.KeepUntil as LegacyKeepUntil
@@ -639,6 +640,24 @@ fun LegacySearchHint.asSdk(): ModernSearchHint = ModernSearchHint(
 	episodeCount = this.episodeCount,
 	channelId = this.channelId.toUUID(),
 	channelName = this.channelName,
+	primaryImageAspectRatio = this.primaryImageAspectRatio,
+)
+
+fun LegacyChannelInfoDto.asSdk() = ModernBaseItemDto(
+	name = this.name,
+	serverId = this.serverId,
+	id = this.id.toUUID(),
+//	externalId = this.externalId,
+	mediaSources = this.mediaSources?.map { it.asSdk() },
+	imageTags = this.imageTags?.asSdk(),
+	number = this.number,
+	playAccess = this.playAccess?.asSdk(),
+//	serviceName = this.serviceName,
+	channelType = this.channelType?.asSdk(),
+	type = BaseItemKind.from(this.type)!!,
+	mediaType = this.mediaType,
+	userData = this.userData?.asSdk(),
+	currentProgram = this.currentProgram?.asSdk(),
 	primaryImageAspectRatio = this.primaryImageAspectRatio,
 )
 


### PR DESCRIPTION
I spend like 5 hours on this

**Changes**
Use BaseItemDto from SDK in BaseRowItem internally and fix everything that (in)directly depends on it... that's quite a lot

Some functions that were added to the BaseItemDto in the legacy apiclient have been copied and rewritten (partially in JavaCompat and sometimes as private methods in Java classes).

This PR should not change behavior.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
