### PR TITLE
Disable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ org.gradle.jvmargs=-Xmx2048m
 sdk.version=default
 
 # Android
-android.enableJetifier=true
 android.useAndroidX=true
 
 # Enable LeakCanary


### PR DESCRIPTION
We don't need it as all our dependencies already use androidx. This should give a very small performance boost.

**Changes**
- Disable jetifier

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
