### PR TITLE
Move package declaration to Gradle build files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.jellyfin.androidtv"
     android:installLocation="auto">
 
     <!-- Android TV Integration -->

--- a/playback/core/build.gradle.kts
+++ b/playback/core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+	namespace = "org.jellyfin.playback.core"
 	compileSdk = 33
 
 	defaultConfig {

--- a/playback/core/src/main/AndroidManifest.xml
+++ b/playback/core/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jellyfin.playback.core">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
 

--- a/playback/exoplayer/build.gradle.kts
+++ b/playback/exoplayer/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+	namespace = "org.jellyfin.playback.exoplayer"
 	compileSdk = 33
 
 	defaultConfig {

--- a/playback/exoplayer/src/main/AndroidManifest.xml
+++ b/playback/exoplayer/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jellyfin.playback.exoplayer" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/playback/jellyfin/build.gradle.kts
+++ b/playback/jellyfin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+	namespace = "org.jellyfin.playback.jellyfin"
 	compileSdk = 33
 
 	defaultConfig {

--- a/playback/jellyfin/src/main/AndroidManifest.xml
+++ b/playback/jellyfin/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jellyfin.playback.jellyfin" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/playback/ui/build.gradle.kts
+++ b/playback/ui/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+	namespace = "org.jellyfin.playback.ui"
 	compileSdk = 33
 
 	defaultConfig {

--- a/playback/ui/src/main/AndroidManifest.xml
+++ b/playback/ui/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jellyfin.playback.ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
 

--- a/preference/build.gradle.kts
+++ b/preference/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+	namespace = "org.jellyfin.preference"
 	compileSdk = 33
 
 	defaultConfig {

--- a/preference/src/main/AndroidManifest.xml
+++ b/preference/src/main/AndroidManifest.xml
@@ -1,7 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jellyfin.preference">
-
-    <application>
-
-    </application>
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
The package attribute in the manifest XML is deprecated.

**Changes**
- Move package declaration to Gradle build files

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
