### PR TITLE
Remove most deprecation annotations

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/AudioOptions.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/AudioOptions.java
@@ -6,12 +6,6 @@ import org.jellyfin.sdk.model.api.MediaSourceInfo;
 
 import java.util.List;
 
-/**
- * Class AudioOptions.
- *
- * @deprecated
- */
-@Deprecated
 public class AudioOptions {
     public AudioOptions() {
         setContext(EncodingContext.Streaming);

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/PlaybackException.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/PlaybackException.java
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.data.compat;
 
 import org.jellyfin.apiclient.model.dlna.PlaybackErrorCode;
 
-@Deprecated
 public class PlaybackException extends RuntimeException {
     private PlaybackErrorCode ErrorCode = PlaybackErrorCode.values()[0];
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamBuilder.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamBuilder.java
@@ -6,7 +6,6 @@ import org.jellyfin.apiclient.model.dlna.SubtitleProfile;
 import org.jellyfin.apiclient.model.entities.MediaStream;
 import org.jellyfin.apiclient.model.session.PlayMethod;
 
-@Deprecated
 public class StreamBuilder
 {
     public static SubtitleProfile GetSubtitleProfile(org.jellyfin.sdk.model.api.MediaStream subtitleStream, SubtitleProfile[] subtitleProfiles, PlayMethod playMethod)

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -16,12 +16,6 @@ import org.jellyfin.sdk.model.api.MediaStreamType;
 
 import java.util.ArrayList;
 
-/**
- * Class StreamInfo.
- *
- * @deprecated
- */
-@Deprecated
 public class StreamInfo {
     private static final String START_TIME_TICKS = "StartTimeTicks";
     private static final String SUBTITLE_STREAM_INDEX = "SubtitleStreamIndex";

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/SubtitleStreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/SubtitleStreamInfo.java
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.data.compat;
 
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 
-@Deprecated
 public class SubtitleStreamInfo {
     private String Url;
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/VideoOptions.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/VideoOptions.java
@@ -1,11 +1,5 @@
 package org.jellyfin.androidtv.data.compat;
 
-/**
- * Class VideoOptions.
- *
- * @deprecated
- */
-@Deprecated
 public class VideoOptions extends AudioOptions {
     private Integer AudioStreamIndex;
     private Integer SubtitleStreamIndex;

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.model.Server
 import org.jellyfin.androidtv.preference.UserPreferences
-import org.jellyfin.androidtv.util.sdk.compat.asSdk
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.imageApi
@@ -41,7 +40,6 @@ import org.jellyfin.sdk.model.serializer.toUUID
 import timber.log.Timber
 import java.util.UUID
 import java.util.concurrent.ExecutionException
-import org.jellyfin.apiclient.model.dto.BaseItemDto as LegacyBaseItemDto
 
 class BackgroundService(
 	private val context: Context,
@@ -144,15 +142,6 @@ class BackgroundService(
 			)
 		}
 	}
-
-	/**
-	 * Use all available backdrops from [baseItem] as background.
-	 */
-	@Deprecated(
-		"Use the SDK instead of the legacy apiclient",
-		ReplaceWith("setBackground(baseItem?.asSdk())", "org.jellyfin.androidtv.util.sdk.compat.asSdk")
-	)
-	fun setBackground(baseItem: LegacyBaseItemDto?) = setBackground(baseItem?.asSdk())
 
 	/**
 	 * Use all available backdrops from [baseItem] as background.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.java
@@ -507,7 +507,7 @@ public class FullDetailsActivity extends BaseActivity implements RecordingIndica
 
     public void setBaseItem(BaseItemDto item) {
         mBaseItem = item;
-        backgroundService.getValue().setBackground(item);
+        backgroundService.getValue().setBackground(ModelCompat.asSdk(item));
         if (mBaseItem != null) {
             if (mChannelId != null) {
                 mBaseItem.setParentId(mChannelId);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.java
@@ -608,6 +608,6 @@ public class ItemListActivity extends FragmentActivity {
         if(item.getBackdropCount() == 0 && mItems != null && mItems.size() >= 1)
             item = mItems.get(new Random().nextInt(mItems.size()));
 
-        backgroundService.getValue().setBackground(item);
+        backgroundService.getValue().setBackground(ModelCompat.asSdk(item));
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
@@ -20,7 +20,6 @@ import org.jellyfin.sdk.model.DeviceInfo;
 
 import java.util.ArrayList;
 
-@Deprecated
 public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
     private PlaybackManager playbackManager;
     private final DeviceInfo deviceInfo;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -18,12 +18,6 @@ import org.jellyfin.sdk.model.api.MediaStream;
 
 import java.util.ArrayList;
 
-/**
- * Reimplementation of the PlaybackManager class from the apiclient with local item support removed.
- *
- * @deprecated
- */
-@Deprecated
 public class PlaybackManager {
     private final org.jellyfin.sdk.api.client.ApiClient api;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/StopTranscodingResponse.java
@@ -9,7 +9,6 @@ import org.jellyfin.sdk.model.DeviceInfo;
 
 import timber.log.Timber;
 
-@Deprecated
 public class StopTranscodingResponse extends EmptyResponse {
     private PlaybackManager playbackManager;
     private final DeviceInfo deviceInfo;


### PR DESCRIPTION

**Changes**
- Remove deprecated setBackground function in BackgroundService - updated the call side
- Remove `@deprecated` annotations from legacy playback code - yes it's deprecated and we shouldn't use it, but no there is no need to add that annotation when we still need to use it.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
