### PR TITLE
Always use repeatOnLifecycle instead of launchWhenX functions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeToolbarFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeToolbarFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomViewTarget
 import com.bumptech.glide.request.transition.Transition
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
@@ -53,7 +54,7 @@ class HomeToolbarFragment : Fragment() {
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 		super.onViewCreated(view, savedInstanceState)
 
-		viewLifecycleOwner.lifecycleScope.launchWhenCreated {
+		viewLifecycleOwner.lifecycleScope.launch {
 			viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
 				userRepository.currentUser.collect { user ->
 					if (user != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity
@@ -27,7 +28,7 @@ class NextUpActivity : FragmentActivity() {
 		val useExternalPlayer = intent.getBooleanExtra(EXTRA_USE_EXTERNAL_PLAYER, false)
 
 		// Observe state
-		lifecycleScope.launchWhenCreated {
+		lifecycleScope.launch {
 			repeatOnLifecycle(Lifecycle.State.STARTED) {
 				viewModel.state.collect { state ->
 					when (state) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -3,7 +3,10 @@ package org.jellyfin.androidtv.ui.playback.rewrite
 import android.os.Bundle
 import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
@@ -37,20 +40,22 @@ class PlaybackForwardingActivity : FragmentActivity() {
 			return
 		}
 
-		lifecycleScope.launchWhenCreated {
-			// Get fresh info from API in SDK format
-			val item by api.userLibraryApi.getItem(itemId = itemId)
+		lifecycleScope.launch {
+			lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+				// Get fresh info from API in SDK format
+				val item by api.userLibraryApi.getItem(itemId = itemId)
 
-			// Log info
-			Toast.makeText(
-				this@PlaybackForwardingActivity,
-				"Found item of type ${item.type} - ${item.name} (${item.id}",
-				Toast.LENGTH_LONG
-			).show()
-			Timber.i(item.toString())
+				// Log info
+				Toast.makeText(
+					this@PlaybackForwardingActivity,
+					"Found item of type ${item.type} - ${item.name} (${item.id}",
+					Toast.LENGTH_LONG
+				).show()
+				Timber.i(item.toString())
 
-			// TODO: Create queue, send to new playback manager, start new player UI
-			finishAfterTransition()
+				// TODO: Create queue, send to new playback manager, start new player UI
+				finishAfterTransition()
+			}
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -108,9 +108,11 @@ class ServerFragment : Fragment() {
 
 		onServerChange(server)
 
-		lifecycleScope.launchWhenCreated {
-			val updated = startupViewModel.updateServer(server)
-			if (updated) startupViewModel.getServer(server.id)?.let(::onServerChange)
+		lifecycleScope.launch {
+			lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+				val updated = startupViewModel.updateServer(server)
+				if (updated) startupViewModel.getServer(server.id)?.let(::onServerChange)
+			}
 		}
 
 		return binding.root


### PR DESCRIPTION
The launchWhenX functions have a performance penalty, using repeatOnLifecycle is the recommended function to use.

**Changes**
- Always use repeatOnLifecycle instead of launchWhenX functions
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
