### PR TITLE
Use fragment arguments instead of activity intent

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserPreferences.Companion.clockBehavior
@@ -47,9 +48,8 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 		super.onCreate(savedInstanceState)
 
 		// Parse intent
-		val intent = requireActivity().intent
-		folder = Json.decodeFromString<BaseItemDto>(intent.getStringExtra(GroupedItemsActivity.EXTRA_FOLDER)!!)
-		includeType = intent.getStringExtra(GroupedItemsActivity.EXTRA_INCLUDE_TYPE)
+		folder = Json.decodeFromString<BaseItemDto>(arguments?.getString(GroupedItemsActivity.EXTRA_FOLDER)!!)
+		includeType = arguments?.getString(GroupedItemsActivity.EXTRA_INCLUDE_TYPE)
 
 		// Attach background service
 		backgroundService.attach(requireActivity())
@@ -124,10 +124,10 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 		val showClock = userPreferences[clockBehavior]
 		if (showClock !== ClockBehavior.ALWAYS && showClock !== ClockBehavior.IN_MENUS) return
 
-		val root = requireActivity().findViewById<ViewGroup>(android.R.id.content)
+		val root = requireActivity().findViewById<ViewGroup>(R.id.content_view)
 
 		// Move the title to the left to make way for the clock
-		val titleView = root.findViewById<TextView>(org.jellyfin.androidtv.R.id.title_text)
+		val titleView = root.findViewById<TextView>(R.id.title_text)
 		if (titleView != null) {
 			val layoutParams = titleView.layoutParams as FrameLayout.LayoutParams
 			layoutParams.rightMargin = convertDpToPixel(root.context, 120)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -155,7 +155,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
         if (getActivity() instanceof BaseActivity) mActivity = (BaseActivity) getActivity();
         backgroundService.getValue().attach(requireActivity());
 
-        mFolder = Json.Default.decodeFromString(BaseItemDto.Companion.serializer(), requireActivity().getIntent().getStringExtra(Extras.Folder));
+        mFolder = Json.Default.decodeFromString(BaseItemDto.Companion.serializer(), getArguments().getString(Extras.Folder));
         mParentId = mFolder.getId();
         mainTitle = mFolder.getName();
         libraryPreferences = preferencesRepository.getValue().getLibraryPreferences(Objects.requireNonNull(mFolder.getDisplayPreferencesId()));
@@ -588,7 +588,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                     break;
                 case CollectionType.Music:
                     //Special queries needed for album artists
-                    String includeType = requireActivity().getIntent().getStringExtra(Extras.IncludeType);
+                    String includeType = getArguments().getString(Extras.IncludeType);
                     if ("AlbumArtist".equals(includeType)) {
                         ArtistsQuery albumArtists = new ArtistsQuery();
                         albumArtists.setUserId(userRepository.getValue().getCurrentUser().getValue().getId().toString());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsActivity.kt
@@ -13,7 +13,7 @@ class BrowseRecordingsActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<BrowseRecordingsFragment>(R.id.content_view)
+			replace<BrowseRecordingsFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleActivity.kt
@@ -13,7 +13,7 @@ class BrowseScheduleActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<BrowseScheduleFragment>(R.id.content_view)
+			replace<BrowseScheduleFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionActivity.kt
@@ -13,7 +13,7 @@ class CollectionActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<CollectionFragment>(R.id.content_view)
+			replace<CollectionFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -161,7 +161,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     }
 
     protected void setupViews() {
-        mFolder = serializer.getValue().DeserializeFromString(requireActivity().getIntent().getStringExtra(Extras.Folder), BaseItemDto.class);
+        mFolder = serializer.getValue().DeserializeFromString(getArguments().getString(Extras.Folder), BaseItemDto.class);
         if (mFolder == null) return;
 
         if (mFolder.getCollectionType() != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderActivity.kt
@@ -13,7 +13,7 @@ class GenericFolderActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<GenericFolderFragment>(R.id.content_view)
+			replace<GenericFolderFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericGridActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericGridActivity.kt
@@ -13,7 +13,7 @@ class GenericGridActivity : FragmentActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			add<BrowseGridFragment>(R.id.content_view)
+			add<BrowseGridFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GroupedItemsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GroupedItemsActivity.kt
@@ -4,8 +4,9 @@ import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import org.jellyfin.androidtv.R
 
-class GroupedItemsActivity : FragmentActivity() {
+class GroupedItemsActivity : FragmentActivity(R.layout.fragment_content_view) {
 	private val groupingType get() = intent.extras?.getString(EXTRA_GROUPING_TYPE)?.let { GroupingType.valueOf(it) }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,8 +14,8 @@ class GroupedItemsActivity : FragmentActivity() {
 
 		supportFragmentManager.commit {
 			when (requireNotNull(groupingType)) {
-				GroupingType.GENRE -> replace<ByGenreFragment>(android.R.id.content)
-				GroupingType.LETTER -> replace<ByLetterFragment>(android.R.id.content)
+				GroupingType.GENRE -> replace<ByGenreFragment>(R.id.content_view, args = intent.extras)
+				GroupingType.LETTER -> replace<ByLetterFragment>(R.id.content_view, args = intent.extras)
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -20,8 +20,8 @@ class MainActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<HomeToolbarFragment>(R.id.content_view)
-			add<HomeFragment>(R.id.content_view)
+			replace<HomeToolbarFragment>(R.id.content_view, args = intent.extras)
+			add<HomeFragment>(R.id.content_view, args = intent.extras)
 		}
 
 		backgroundService.attach(this)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesActivity.kt
@@ -13,7 +13,7 @@ class SuggestedMoviesActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<SuggestedMoviesFragment>(R.id.content_view)
+			replace<SuggestedMoviesFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/UserViewActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/UserViewActivity.kt
@@ -13,7 +13,7 @@ class UserViewActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			replace<BrowseViewFragment>(R.id.content_view)
+			replace<BrowseViewFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsActivity.kt
@@ -13,7 +13,7 @@ class FullDetailsActivity : BaseActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			add<FullDetailsFragment>(R.id.content_view)
+			add<FullDetailsFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -182,13 +182,13 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
         mDorPresenter = new MyDetailsOverviewRowPresenter(markdownRenderer.getValue());
 
-        mItemId = requireActivity().getIntent().getStringExtra("ItemId");
-        mChannelId = requireActivity().getIntent().getStringExtra("ChannelId");
-        String programJson = requireActivity().getIntent().getStringExtra("ProgramInfo");
+        mItemId = getArguments().getString("ItemId");
+        mChannelId = getArguments().getString("ChannelId");
+        String programJson = getArguments().getString("ProgramInfo");
         if (programJson != null) {
             mProgramInfo = serializer.getValue().DeserializeFromString(programJson, BaseItemDto.class);
         }
-        String timerJson = requireActivity().getIntent().getStringExtra("SeriesTimer");
+        String timerJson = getArguments().getString("SeriesTimer");
         if (timerJson != null) {
             mSeriesTimerInfo = serializer.getValue().DeserializeFromString(timerJson, SeriesTimerInfoDto.class);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListActivity.kt
@@ -13,7 +13,7 @@ class ItemListActivity : FragmentActivity(R.layout.fragment_content_view) {
 		super.onCreate(savedInstanceState)
 
 		supportFragmentManager.commit {
-			add<ItemListFragment>(R.id.content_view)
+			add<ItemListFragment>(R.id.content_view, args = intent.extras)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -156,7 +156,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
 
         backgroundService.getValue().attach(requireActivity());
 
-        mItemId = requireActivity().getIntent().getStringExtra("ItemId");
+        mItemId = getArguments().getString("ItemId");
         loadItem(mItemId);
 
         return binding.getRoot();
@@ -365,7 +365,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
                             ItemFields.Genres,
                             ItemFields.ChildCount
                     });
-                    favSongs.setParentId(requireActivity().getIntent().getStringExtra("ParentId"));
+                    favSongs.setParentId(getArguments().getString("ParentId"));
                     favSongs.setIncludeItemTypes(new String[] {"Audio"});
                     favSongs.setRecursive(true);
                     favSongs.setFilters(new ItemFilter[]{ItemFilter.IsFavoriteOrLikes});

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -306,9 +306,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         requireActivity().getOnBackPressedDispatcher().addCallback(backPressedCallback);
 
-
-        Intent intent = requireActivity().getIntent();
-        int startPos = intent.getIntExtra("Position", 0);
+        int startPos = getArguments().getInt("Position", 0);
 
         // start playing
         mPlaybackController.play(startPos);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
@@ -8,13 +8,16 @@ import android.view.View
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.shared.BaseActivity
 import org.koin.android.ext.android.inject
 
 /**
  * PlaybackOverlayActivity for video playback that loads PlaybackOverlayFragment
  */
-class PlaybackOverlayActivity : BaseActivity() {
+class PlaybackOverlayActivity : BaseActivity(R.layout.fragment_content_view) {
 	private val playbackControllerContainer by inject<PlaybackControllerContainer>()
 	var keyListener: View.OnKeyListener? = null
 
@@ -27,15 +30,14 @@ class PlaybackOverlayActivity : BaseActivity() {
 
 		// Hide system bars
 		WindowCompat.setDecorFitsSystemWindows(window, false)
-		WindowInsetsControllerCompat(window, findViewById(android.R.id.content)).apply {
+		WindowInsetsControllerCompat(window, findViewById(R.id.content_view)).apply {
 			hide(WindowInsetsCompat.Type.systemBars())
 			systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 		}
 
-		supportFragmentManager
-			.beginTransaction()
-			.replace(android.R.id.content, CustomPlaybackOverlayFragment())
-			.commit()
+		supportFragmentManager.commit {
+			add<CustomPlaybackOverlayFragment>(R.id.content_view, args = intent.extras)
+		}
 	}
 
 	override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.playback.PlaybackOverlayActivity
@@ -14,7 +15,7 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class NextUpActivity : FragmentActivity() {
+class NextUpActivity : FragmentActivity(R.layout.fragment_content_view) {
 	companion object {
 		const val EXTRA_ID = "id"
 		const val EXTRA_USE_EXTERNAL_PLAYER = "useExternalPlayer"
@@ -55,7 +56,7 @@ class NextUpActivity : FragmentActivity() {
 		// Add fragment
 		supportFragmentManager
 			.beginTransaction()
-			.add(android.R.id.content, NextUpFragment())
+			.add(R.id.content_view, NextUpFragment())
 			.commit()
 
 		// Load item info

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesActivity.kt
@@ -3,9 +3,10 @@ package org.jellyfin.androidtv.ui.preference
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
 
-class PreferencesActivity : FragmentActivity() {
+class PreferencesActivity : FragmentActivity(R.layout.fragment_content_view) {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
@@ -14,7 +15,7 @@ class PreferencesActivity : FragmentActivity() {
 
 		supportFragmentManager
 			.beginTransaction()
-			.replace(android.R.id.content, PreferencesFragment().apply {
+			.replace(R.id.content_view, PreferencesFragment().apply {
 				// Set screen
 				arguments = bundleOf(
 					PreferencesFragment.EXTRA_SCREEN to screen,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchActivity.kt
@@ -6,8 +6,9 @@ import android.os.Bundle
 import android.speech.SpeechRecognizer
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import org.jellyfin.androidtv.R
 
-class SearchActivity : FragmentActivity() {
+class SearchActivity : FragmentActivity(R.layout.fragment_content_view) {
 	private val isSpeechEnabled by lazy {
 		SpeechRecognizer.isRecognitionAvailable(this)
 			&& ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_DENIED
@@ -25,7 +26,7 @@ class SearchActivity : FragmentActivity() {
 		// Add fragment
 		supportFragmentManager
 			.beginTransaction()
-			.replace(android.R.id.content, searchFragment)
+			.replace(R.id.content_view, searchFragment)
 			.commit()
 	}
 


### PR DESCRIPTION
We should now be able to start moving to a single activity architecture. There are still a few activities that might need some changes (moving logic to fragment) but overall I think it should be fairly easy now.

**Changes**
- Use fragment arguments instead of activity intent
- Always use our own fragment layout

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
