### PR TITLE
Fix crash when media info contains a data stream

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
@@ -456,11 +456,13 @@ fun LegacyMediaStream.asSdk(): ModernMediaStream = ModernMediaStream(
 	isAnamorphic = this.isAnamorphic,
 )
 
-fun LegacyMediaStreamType.asSdk(): ModernMediaStreamType = when (this) {
+fun LegacyMediaStreamType?.asSdk(): ModernMediaStreamType = when (this) {
 	LegacyMediaStreamType.Audio -> ModernMediaStreamType.AUDIO
 	LegacyMediaStreamType.Video -> ModernMediaStreamType.VIDEO
 	LegacyMediaStreamType.Subtitle -> ModernMediaStreamType.SUBTITLE
 	LegacyMediaStreamType.EmbeddedImage -> ModernMediaStreamType.EMBEDDED_IMAGE
+	// Note: The apiclient doesn't have the DATA member and defaults to "null"
+	null -> ModernMediaStreamType.DATA
 }
 
 fun LegacySubtitleDeliveryMethod.asSdk(): ModernSubtitleDeliveryMethod = when (this) {


### PR DESCRIPTION
I have not verified this fix as I'm unable to find any media files with data streams. Looking at the reported crash logs I suspect the legacy apiclient falls back to a "null" value when it encounters an unknown enum value so I mapped null to the DATA member type in ModelCompat.

Depends on #2095 (when backporting)

**Changes**
- Fix crash when media info contains a data stream

**Issues**

Fixes #2125
