### PR TITLE
Add LifecycleAwareResponse

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -51,9 +51,9 @@ import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.MarkdownRenderer;
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
 import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
-import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.jellyfin.sdk.model.constant.CollectionType;
@@ -342,9 +342,11 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                 mCurrentItem.getBaseItemType() != BaseItemKind.MUSIC_ALBUM &&
                 mCurrentItem.getBaseItemType() != BaseItemKind.PLAYLIST
         ) {
-            mCurrentItem.refresh(new EmptyResponse() {
+            mCurrentItem.refresh(new EmptyLifecycleAwareResponse(getLifecycle()) {
                 @Override
                 public void onResponse() {
+                    if (!getActive()) return;
+
                     ItemRowAdapter adapter = (ItemRowAdapter) mCurrentRow.getAdapter();
                     adapter.notifyItemRangeChanged(adapter.indexOf(mCurrentItem), 1);
                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -40,7 +40,7 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter
 import org.jellyfin.androidtv.util.KeyProcessor
-import org.jellyfin.apiclient.interaction.EmptyResponse
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -218,8 +218,10 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 
 			Timber.d("Refresh item ${item.getFullName(requireContext())}")
 
-			item.refresh(object : EmptyResponse() {
+			item.refresh(object : EmptyLifecycleAwareResponse(lifecycle) {
 				override fun onResponse() {
+					if (!active) return
+
 					val adapter = currentRow?.adapter as? ItemRowAdapter
 					adapter?.notifyItemRangeChanged(adapter.indexOf(item), 1)
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -16,11 +16,11 @@ import org.jellyfin.androidtv.data.model.ChapterItemInfo
 import org.jellyfin.androidtv.ui.GridButton
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.TimeUtils
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse
 import org.jellyfin.androidtv.util.apiclient.getSeriesOverview
 import org.jellyfin.androidtv.util.sdk.compat.asSdk
 import org.jellyfin.androidtv.util.sdk.getFullName
 import org.jellyfin.androidtv.util.sdk.getSubName
-import org.jellyfin.apiclient.interaction.EmptyResponse
 import org.jellyfin.apiclient.model.dto.BaseItemDto
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto
 import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto
@@ -329,7 +329,7 @@ open class BaseRowItem protected constructor(
 
 	@JvmOverloads
 	fun refresh(
-		outerResponse: EmptyResponse,
+		outerResponse: EmptyLifecycleAwareResponse,
 		scope: CoroutineScope = ProcessLifecycleOwner.get().lifecycleScope,
 	) {
 		if (baseRowType == BaseRowType.BaseItem) {
@@ -345,7 +345,7 @@ open class BaseRowItem protected constructor(
 				val response by api.userLibraryApi.getItem(itemId = id.toUUID())
 				baseItem = response
 
-				withContext(Dispatchers.Main) {
+				if (outerResponse.active) withContext(Dispatchers.Main) {
 					outerResponse.onResponse()
 				}
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -34,10 +34,10 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.TextItemPresenter;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
@@ -97,7 +97,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     private SortOrder sortOrder;
     private FilterOptions mFilters;
 
-    private EmptyResponse mRetrieveFinishedListener;
+    private EmptyLifecycleAwareResponse mRetrieveFinishedListener;
 
     private ChangeTriggerType[] reRetrieveTriggers = new ChangeTriggerType[]{};
     private Calendar lastFullRetrieve;
@@ -1560,13 +1560,13 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
 
     protected void notifyRetrieveFinished(@Nullable Exception exception) {
         setCurrentlyRetrieving(false);
-        if (mRetrieveFinishedListener != null) {
+        if (mRetrieveFinishedListener != null && mRetrieveFinishedListener.getActive()) {
             if (exception == null) mRetrieveFinishedListener.onResponse();
             else mRetrieveFinishedListener.onError(exception);
         }
     }
 
-    public void setRetrieveFinishedListener(EmptyResponse response) {
+    public void setRetrieveFinishedListener(EmptyLifecycleAwareResponse response) {
         this.mRetrieveFinishedListener = response;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -47,10 +47,10 @@ import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -447,9 +447,11 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
     public void showProgramOptions() {
         if (mSelectedProgram == null) return;
         if (mDetailPopup == null) {
-            mDetailPopup = new LiveProgramDetailPopup(requireActivity(), this, mSummary.getWidth()+20, new EmptyResponse() {
+            mDetailPopup = new LiveProgramDetailPopup(requireActivity(), getLifecycle(), this, mSummary.getWidth()+20, new EmptyLifecycleAwareResponse(getLifecycle()) {
                 @Override
                 public void onResponse() {
+                    if (!getActive()) return;
+
                     PlaybackHelper.retrieveAndPlay(mSelectedProgram.getChannelId(), false, requireContext());
                 }
             });
@@ -494,9 +496,11 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
         mChannels.removeAllViews();
         mChannelStatus.setText("");
         mFilterStatus.setText("");
-        TvManager.getProgramsAsync(mCurrentDisplayChannelStartNdx, mCurrentDisplayChannelEndNdx, mCurrentGuideStart, mCurrentGuideEnd, new EmptyResponse() {
+        TvManager.getProgramsAsync(mCurrentDisplayChannelStartNdx, mCurrentDisplayChannelEndNdx, mCurrentGuideStart, mCurrentGuideEnd, new EmptyLifecycleAwareResponse(getLifecycle()) {
             @Override
             public void onResponse() {
+                if (!getActive()) return;
+
                 Timber.d("*** Programs response");
                 if (mDisplayProgramsTask != null) mDisplayProgramsTask.cancel(true);
                 mDisplayProgramsTask = new DisplayProgramsTask();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -23,8 +23,8 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -152,7 +152,7 @@ public class TvManager {
         return ndx;
     }
 
-    public static void getProgramsAsync(int startNdx, int endNdx, final Calendar start, Calendar endTime, final EmptyResponse outerResponse) {
+    public static void getProgramsAsync(int startNdx, int endNdx, final Calendar start, Calendar endTime, final EmptyLifecycleAwareResponse outerResponse) {
         start.set(Calendar.MINUTE, start.get(Calendar.MINUTE) >= 30 ? 30 : 0);
         start.set(Calendar.SECOND, 1);
         if (forceReload || needLoadTime == null || start.after(needLoadTime) || !mProgramsDict.containsKey(channelIds[startNdx]) || !mProgramsDict.containsKey(channelIds[endNdx])) {
@@ -178,12 +178,12 @@ public class TvManager {
                     buildProgramsDict(response.getItems(), start);
                     Timber.d("*** Programs retrieval finished");
 
-                    outerResponse.onResponse();
+                    if (outerResponse.getActive()) outerResponse.onResponse();
                 }
 
                 @Override
                 public void onError(Exception exception) {
-                    outerResponse.onError(exception);
+                    if (outerResponse.getActive()) outerResponse.onError(exception);
                 }
             });
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -71,10 +71,10 @@ import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TextUtilsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -778,9 +778,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         tvGuideBinding.channelsStatus.setText("");
         tvGuideBinding.filterStatus.setText("");
         final CustomPlaybackOverlayFragment self = this;
-        TvManager.getProgramsAsync(mCurrentDisplayChannelStartNdx, mCurrentDisplayChannelEndNdx, mCurrentGuideStart, mCurrentGuideEnd, new EmptyResponse() {
+        TvManager.getProgramsAsync(mCurrentDisplayChannelStartNdx, mCurrentDisplayChannelEndNdx, mCurrentGuideStart, mCurrentGuideEnd, new EmptyLifecycleAwareResponse(getLifecycle()) {
             @Override
             public void onResponse() {
+                if (!getActive()) return;
+
                 Timber.d("*** Programs response");
                 if (mDisplayProgramsTask != null) mDisplayProgramsTask.cancel(true);
                 mDisplayProgramsTask = new DisplayProgramsTask(self);
@@ -1071,9 +1073,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     public void showProgramOptions() {
         if (mSelectedProgram == null) return;
         if (mDetailPopup == null)
-            mDetailPopup = new LiveProgramDetailPopup(((PlaybackOverlayActivity) requireActivity()), this, Utils.convertDpToPixel(requireContext(), 600), new EmptyResponse() {
+            mDetailPopup = new LiveProgramDetailPopup(requireActivity(), getLifecycle(), this, Utils.convertDpToPixel(requireContext(), 600), new EmptyLifecycleAwareResponse(getLifecycle()) {
                 @Override
                 public void onResponse() {
+                    if (!getActive()) return;
+
                     switchChannel(mSelectedProgram.getChannelId());
                 }
             });
@@ -1185,9 +1189,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private void cancelRecording(org.jellyfin.sdk.model.api.BaseItemDto program, boolean series) {
         if (program != null) {
             if (series) {
-                apiClient.getValue().CancelLiveTvSeriesTimerAsync(program.getSeriesTimerId(), new EmptyResponse() {
+                apiClient.getValue().CancelLiveTvSeriesTimerAsync(program.getSeriesTimerId(), new EmptyLifecycleAwareResponse(getLifecycle()) {
                     @Override
                     public void onResponse() {
+                        if (!getActive()) return;
+
                         Utils.showToast(requireContext(), R.string.msg_recording_cancelled);
                         mPlaybackController.updateTvProgramInfo();
                         TvManager.forceReload();
@@ -1195,13 +1201,17 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     @Override
                     public void onError(Exception ex) {
+                        if (!getActive()) return;
+
                         Utils.showToast(requireContext(), R.string.msg_unable_to_cancel);
                     }
                 });
             } else {
-                apiClient.getValue().CancelLiveTvTimerAsync(program.getTimerId(), new EmptyResponse() {
+                apiClient.getValue().CancelLiveTvTimerAsync(program.getTimerId(), new EmptyLifecycleAwareResponse(getLifecycle()) {
                     @Override
                     public void onResponse() {
+                        if (!getActive()) return;
+
                         Utils.showToast(requireContext(), R.string.msg_recording_cancelled);
                         mPlaybackController.updateTvProgramInfo();
                         TvManager.forceReload();
@@ -1209,6 +1219,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     @Override
                     public void onError(Exception ex) {
+                        if (!getActive()) return;
+
                         Utils.showToast(requireContext(), R.string.msg_unable_to_cancel);
                     }
                 });
@@ -1223,9 +1235,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 public void onResponse(SeriesTimerInfoDto response) {
                     response.setProgramId(program.getId().toString());
                     if (series) {
-                        apiClient.getValue().CreateLiveTvSeriesTimerAsync(response, new EmptyResponse() {
+                        apiClient.getValue().CreateLiveTvSeriesTimerAsync(response, new EmptyLifecycleAwareResponse(getLifecycle()) {
                             @Override
                             public void onResponse() {
+                                if (!getActive()) return;
+
                                 Utils.showToast(requireContext(), R.string.msg_set_to_record);
                                 mPlaybackController.updateTvProgramInfo();
                                 TvManager.forceReload();
@@ -1233,13 +1247,17 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                             @Override
                             public void onError(Exception ex) {
+                                if (!getActive()) return;
+
                                 Utils.showToast(requireContext(), R.string.msg_unable_to_create_recording);
                             }
                         });
                     } else {
-                        apiClient.getValue().CreateLiveTvTimerAsync(response, new EmptyResponse() {
+                        apiClient.getValue().CreateLiveTvTimerAsync(response, new EmptyLifecycleAwareResponse(getLifecycle()) {
                             @Override
                             public void onResponse() {
+                                if (!getActive()) return;
+
                                 Utils.showToast(requireContext(), R.string.msg_set_to_record);
                                 mPlaybackController.updateTvProgramInfo();
                                 TvManager.forceReload();
@@ -1247,6 +1265,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                             @Override
                             public void onError(Exception ex) {
+                                if (!getActive()) return;
+
                                 Utils.showToast(requireContext(), R.string.msg_unable_to_create_recording);
                             }
                         });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchProvider.kt
@@ -23,7 +23,7 @@ class SearchProvider(
 
 	private val rowsAdapter = MutableObjectAdapter<Row>(CustomListRowPresenter())
 	private var previousQuery: String? = null
-	private val searchRunnable = SearchRunnable(context, rowsAdapter)
+	private val searchRunnable = SearchRunnable(context, lifecycle, rowsAdapter)
 	private var searchJob: Job? = null
 
 	override fun getResultsAdapter(): ObjectAdapter = rowsAdapter

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/EmptyLifecycleAwareResponse.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/EmptyLifecycleAwareResponse.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.androidtv.util.apiclient
+
+import androidx.lifecycle.Lifecycle
+import org.jellyfin.apiclient.interaction.EmptyResponse
+
+abstract class EmptyLifecycleAwareResponse(
+	private val lifecycle: Lifecycle,
+) : EmptyResponse() {
+	val active get() = lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)
+
+	override fun triggerInnerResponse() {
+		if (!active) return
+
+		super.triggerInnerResponse()
+	}
+
+	override fun onResponse() {
+		if (!active) return
+
+		super.onResponse()
+	}
+
+	override fun onError(ex: Exception?) {
+		if (!active) return
+
+		super.onError(ex)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/LifecycleAwareResponse.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/LifecycleAwareResponse.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.androidtv.util.apiclient
+
+import androidx.lifecycle.Lifecycle
+import org.jellyfin.apiclient.interaction.Response
+
+abstract class LifecycleAwareResponse<T>(
+	private val lifecycle: Lifecycle,
+) : Response<T>() {
+	val active get() = lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)
+
+	override fun triggerInnerResponse() {
+		if (!active) return
+
+		super.triggerInnerResponse()
+	}
+
+	override fun onResponse(response: T) {
+		if (!active) return
+
+		super.onResponse(response)
+	}
+
+	override fun onError(exception: Exception?) {
+		if (!active) return
+
+		super.onError(exception)
+	}
+}


### PR DESCRIPTION
The lifecycle of an activity/fragment keeps track of whether it's still available or not. In Kotlin we  launch coroutines in the scope of a lifecycle so they automatically cancel. In Java land we just have callback hell.

This PR adds two classes that extend the ApiClient's response classes and uses a lifecycle instance to check whether it's still available or not. Using these new response classes we can avoid running any code in the onResponse() function when a fragment is dead.

This fixes most crashes from #2132. This PR only replaces EmptyResponse with EmptyLifecycleAwareResponse. I did add a LifecycleAwareResponse as well but it's not used (yet).

**Changes**
- Add LifecycleAwareResponse
- Add EmptyLifecycleAwareResponse
  - And use it

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
