### PR TITLE
Fix PictureViewerFragment crashing when opening photo from latest row

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -140,11 +140,11 @@ object Destinations {
 	// Playback
 	val nowPlaying = fragmentDestination<AudioNowPlayingFragment>()
 	val photoPlayer = activityDestination<PhotoPlayerActivity>()
-	fun pictureViewer(item: UUID, autoPlay: Boolean, albumSortBy: String, albumSortOrder: SortOrder) =
+	fun pictureViewer(item: UUID, autoPlay: Boolean, albumSortBy: String?, albumSortOrder: SortOrder?) =
 		fragmentDestination<PictureViewerFragment>(
 			PictureViewerFragment.ARGUMENT_ITEM_ID to item.toString(),
 			PictureViewerFragment.ARGUMENT_ALBUM_SORT_BY to albumSortBy,
-			PictureViewerFragment.ARGUMENT_ALBUM_SORT_ORDER to Json.Default.encodeToString(albumSortOrder),
+			PictureViewerFragment.ARGUMENT_ALBUM_SORT_ORDER to albumSortOrder?.let { Json.Default.encodeToString(it) },
 			PictureViewerFragment.ARGUMENT_AUTO_PLAY to autoPlay,
 		)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
@@ -24,6 +24,7 @@ import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.SortOrder
+import org.jellyfin.sdk.model.constant.ItemSortBy
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
@@ -46,10 +47,10 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 		// Load requested item in viewmodel
 		lifecycleScope.launch {
 			val itemId = requireNotNull(arguments?.getString(ARGUMENT_ITEM_ID)?.toUUIDOrNull())
-			val albumSortBy = requireNotNull(arguments?.getString(ARGUMENT_ALBUM_SORT_BY))
-			val albumSortOrder = requireNotNull(arguments?.getString(ARGUMENT_ALBUM_SORT_ORDER)).let {
+			val albumSortBy = arguments?.getString(ARGUMENT_ALBUM_SORT_BY) ?: ItemSortBy.SortName
+			val albumSortOrder = arguments?.getString(ARGUMENT_ALBUM_SORT_ORDER)?.let {
 				Json.Default.decodeFromString<SortOrder>(it)
-			}
+			} ?: SortOrder.ASCENDING
 			pictureViewerViewModel.loadItem(itemId, albumSortBy, albumSortOrder)
 
 			val autoPlay = arguments?.getBoolean(ARGUMENT_AUTO_PLAY) == true


### PR DESCRIPTION
Sort by and order are not set when opening photo directly instead of via media manager

**Changes**
- Fix PictureViewerFragment crashing when opening photo from latest row
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
