### PR TITLE
Replace Response<> usages with LifecycleAwareResponse<> in fragments

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -16,8 +16,8 @@ import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.entities.LocationType;
@@ -113,9 +113,11 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
     private void addNext24Timers() {
         final TimerQuery scheduled = new TimerQuery();
         final long ticks24 = 1000 * 60 * 60 * 24;
-        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetLiveTvTimersAsync(scheduled, new Response<TimerInfoDtoResult>() {
+        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetLiveTvTimersAsync(scheduled, new LifecycleAwareResponse<TimerInfoDtoResult>(getLifecycle()) {
             @Override
             public void onResponse(TimerInfoDtoResult response) {
+                if (!getActive()) return;
+
                 List<BaseItemDto> nearTimers = new ArrayList<>();
                 long next24 = System.currentTimeMillis() + ticks24;
                 //Get scheduled items for next 24 hours
@@ -156,8 +158,10 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
             @Override
             public void onError(Exception exception) {
-                    Utils.showToast(getContext(), exception.getLocalizedMessage());
-                    }
+                if (!getActive()) return;
+
+                Utils.showToast(getContext(), exception.getLocalizedMessage());
+            }
 
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleFragment.java
@@ -2,7 +2,7 @@ package org.jellyfin.androidtv.ui.browsing;
 
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
-import org.jellyfin.apiclient.interaction.Response;
+import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse;
 import org.jellyfin.apiclient.model.livetv.TimerQuery;
 
 public class BrowseScheduleFragment extends EnhancedBrowseFragment {
@@ -14,9 +14,11 @@ public class BrowseScheduleFragment extends EnhancedBrowseFragment {
 
     @Override
     protected void setupQueries(final RowLoader rowLoader) {
-        TvManager.getScheduleRowsAsync(requireContext(), new TimerQuery(), new CardPresenter(true), mRowsAdapter, new Response<Integer>() {
+        TvManager.getScheduleRowsAsync(requireContext(), new TimerQuery(), new CardPresenter(true), mRowsAdapter, new LifecycleAwareResponse<Integer>(getLifecycle()) {
             @Override
             public void onResponse(Integer response) {
+                if (!getActive()) return;
+
                 if (response == 0) mActivity.setTitle("No Scheduled Recordings");
             }
         });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.java
@@ -6,8 +6,8 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
+import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse;
 import org.jellyfin.apiclient.interaction.ApiClient;
-import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.entities.SortOrder;
 import org.jellyfin.apiclient.model.querying.ItemFields;
@@ -34,9 +34,11 @@ public class SuggestedMoviesFragment extends EnhancedBrowseFragment {
         lastPlayed.setLimit(8);
         lastPlayed.setRecursive(true);
 
-        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemsAsync(lastPlayed, new Response<ItemsResult>() {
+        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemsAsync(lastPlayed, new LifecycleAwareResponse<ItemsResult>(getLifecycle()) {
             @Override
             public void onResponse(ItemsResult response) {
+                if (!getActive()) return;
+
                 for (BaseItemDto item : response.getItems()) {
                     SimilarItemsQuery similar = new SimilarItemsQuery();
                     similar.setId(item.getId());


### PR DESCRIPTION
Same as #2148 but for responses with generic in fragments. Still some usages left in custom views and other places.

**Changes**
- Replace Response<> usages with LifecycleAwareResponse<> in fragments

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
