### PR TITLE
Show keyboard on right on text search fragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,13 +23,14 @@
     <uses-permission
         android:name="android.permission.ACCESS_WIFI_STATE"
         tools:ignore="LeanbackUsesWifi" />
+
+    <!-- Search permissions (voice to text) -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <!-- Device feature requirements -->
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />
-
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
@@ -48,10 +49,9 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:roundIcon="@drawable/app_icon_round"
+        android:supportsRtl="true"
         android:theme="@style/Theme.Jellyfin"
-        android:usesCleartextTraffic="true"
-        android:supportsRtl="true">
-
+        android:usesCleartextTraffic="true">
         <service
             android:name=".auth.service.AuthenticatorService"
             android:exported="false">
@@ -63,6 +63,7 @@
                 android:resource="@xml/authenticator" />
         </service>
 
+        <!-- Screensaver -->
         <service
             android:name=".integration.dream.LibraryDreamService"
             android:exported="true"
@@ -100,10 +101,7 @@
             android:exported="true"
             android:initOrder="10" />
 
-        <activity
-            android:name=".ui.browsing.MainActivity"
-            android:screenOrientation="landscape" />
-
+        <!-- Authentication -->
         <activity
             android:name=".ui.startup.StartupActivity"
             android:exported="true"
@@ -122,18 +120,24 @@
                 android:name="android.app.searchable"
                 android:resource="@xml/searchable" />
         </activity>
-
         <activity-alias
             android:name=".startup.StartupActivity"
             android:targetActivity=".ui.startup.StartupActivity" />
 
+        <!-- Main application -->
         <activity
-            android:name=".ui.playback.PlaybackOverlayActivity"
-            android:screenOrientation="landscape" />
+            android:name=".ui.browsing.MainActivity"
+            android:screenOrientation="landscape"
+            android:windowSoftInputMode="adjustNothing" />
 
         <activity
             android:name=".ui.preference.PreferencesActivity"
             android:theme="@style/Theme.Jellyfin.Preferences" />
+
+        <!-- Playback related activities -->
+        <activity
+            android:name=".ui.playback.PlaybackOverlayActivity"
+            android:screenOrientation="landscape" />
 
         <activity android:name=".ui.playback.ExternalPlayerActivity" />
 

--- a/app/src/main/res/layout/fragment_search_text.xml
+++ b/app/src/main/res/layout/fragment_search_text.xml
@@ -41,6 +41,7 @@
         android:imeOptions="actionSearch"
         android:importantForAutofill="no"
         android:inputType="text"
+        android:privateImeOptions="horizontalAlignment=right"
         app:layout_constraintBottom_toBottomOf="@id/logo"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/search_icon"


### PR DESCRIPTION
Moving the keyboard (gboard, android tv only) to the right makes it easier to see results.

**Changes**
- Show keyboard on right on text search fragment
- Add `android:windowSoftInputMode="adjustNothing"` to main activity for search
- Reorder android manifest

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
