### PR TITLE
Add Jetpack Compose support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,10 +26,15 @@ android {
 
 	buildFeatures {
 		viewBinding = true
+		compose = true
 	}
 
 	compileOptions {
 		isCoreLibraryDesugaringEnabled = true
+	}
+
+	composeOptions {
+		kotlinCompilerExtensionVersion = libs.versions.androidx.compose.compiler.get()
 	}
 
 	buildTypes {
@@ -128,6 +133,7 @@ dependencies {
 	implementation(libs.androidx.window)
 	implementation(libs.androidx.cardview)
 	implementation(libs.androidx.startup)
+	implementation(libs.bundles.androidx.compose)
 
 	// Dependency Injection
 	implementation(libs.bundles.koin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ android-gradle = "7.3.1"
 androidx-activity = "1.6.0"
 androidx-appcompat = "1.5.1"
 androidx-cardview = "1.0.0"
+androidx-compose = "1.2.1"
+androidx-compose-compiler = "1.3.2"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.9.0"
 androidx-fragment = "1.5.3"
@@ -29,6 +31,7 @@ jellyfin-sdk = "1.3.6"
 junit = "4.13.2"
 kenburnsview = "1.0.7"
 koin = "3.2.3"
+koin-compose = "3.2.1"
 kotest = "5.5.1"
 kotlin = "1.7.20"
 kotlin-ksp = "1.7.20-1.0.7"
@@ -63,6 +66,9 @@ android-gradle = { module = "com.android.tools.build:gradle", version.ref = "and
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx.compose" }
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx.compose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx.compose" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
@@ -83,6 +89,7 @@ androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref
 # Dependency Injection
 koin-android-compat = { module = "io.insert-koin:koin-android-compat", version.ref = "koin" }
 koin-android-core = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin-compose" }
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin" }
 
 # GSON
@@ -130,6 +137,11 @@ acra = [
     "acra-core",
     "acra-toast",
 ]
+androidx-compose = [
+    "androidx-compose-foundation",
+    "androidx-compose-material",
+    "androidx-compose-ui-tooling"
+]
 androidx-lifecycle = [
     "androidx-lifecycle-process",
     "androidx-lifecycle-runtime",
@@ -140,6 +152,7 @@ koin = [
     "koin-android-compat",
     "koin-android-core",
     "koin-androidx-workmanager",
+    "koin-androidx-compose",
 ]
 markwon = [
     "markwon-core",


### PR DESCRIPTION
Creating UI with compose is a billion time easier to do. We're already using it on our mobile app and I've used it for some of my own already. This PR is a starter that just adds the dependencies and build configuration to allow usage of compose in the Android TV app.

Of course because we're a television app there are some issues, like with everything Android TV:
- Compose is not officially supported for TV (yet)
- There is no default focus
- Using compose mixed in Android views is supported, but it doesn't work properly with dpad controls (needs one additional keypress after focusing the compose view)

With these caveats we can't switch our interactive UI (everything that supports dpad controls) but we can rewrite stuff like the backgroundmanager, screensaver, audio now playing screensaver etc.
Google is also working on compose support for tv with the new androidx.tv library. So hopefully we can  use compose in more places soon.

**Changes**

- Enable Jetpack Compose

**Try compose**
I have a second branch that migrates the now playing widget that shows up when playing music. This highlights the focus issue but also shows how easy compose is to work with:
https://github.com/nielsvanvelzen/jellyfin-androidtv/tree/compose-nowplayingview

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
