### PR TITLE
Remove direct GSON dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,9 +138,6 @@ dependencies {
 	// Dependency Injection
 	implementation(libs.bundles.koin)
 
-	// GSON
-	implementation(libs.gson)
-
 	// Media players
 	implementation(libs.exoplayer)
 	implementation(libs.jellyfin.exoplayer.ffmpegextension)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,9 +92,6 @@ koin-android-core = { module = "io.insert-koin:koin-android", version.ref = "koi
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin-compose" }
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin" }
 
-# GSON
-gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-
 # Media players
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 jellyfin-exoplayer-ffmpegextension = { group = "org.jellyfin.exoplayer", name = "exoplayer-ffmpeg-extension", version.ref = "jellyfin-exoplayer-ffmpegextension" }


### PR DESCRIPTION
We don't use it in the app anymore, it's still added indirectly because the old apiclient uses it.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Remove direct GSON dependency
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Closes #2207
