### PR TITLE
Add ImageProvider for retrieval of images in platform integration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,12 @@
             android:exported="true"
             android:initOrder="10" />
 
+        <provider
+            android:name=".integration.provider.ImageProvider"
+            android:authorities="${applicationId}.integration.provider.ImageProvider"
+            android:exported="true"
+            android:initOrder="10" />
+
         <!-- Authentication -->
         <activity
             android:name=".ui.startup.StartupActivity"

--- a/app/src/main/java/org/jellyfin/androidtv/integration/MediaContentProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/MediaContentProvider.kt
@@ -12,6 +12,7 @@ import android.provider.BaseColumns
 import kotlinx.coroutines.runBlocking
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.sdk.isUsable
 import org.jellyfin.sdk.api.client.ApiClient
@@ -102,9 +103,8 @@ class MediaContentProvider : ContentProvider(), KoinComponent {
 
 		MatrixCursor(columns).also { cursor ->
 			searchResult?.items?.forEach { item ->
-				// Note: Image loading might fail if the image is served over HTTP
 				val imageUri = if (item.imageTags?.contains(ImageType.PRIMARY) == true)
-					api.imageApi.getItemImageUrl(item.id, ImageType.PRIMARY)
+					ImageProvider.getImageUri(api.imageApi.getItemImageUrl(item.id, ImageType.PRIMARY))
 				else
 					ImageUtils.getResourceUrl(context, R.drawable.tile_land_tv)
 

--- a/app/src/main/java/org/jellyfin/androidtv/integration/provider/ImageProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/provider/ImageProvider.kt
@@ -1,0 +1,69 @@
+package org.jellyfin.androidtv.integration.provider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import androidx.core.net.toUri
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.BuildConfig
+
+class ImageProvider : ContentProvider() {
+	override fun onCreate(): Boolean = true
+
+	override fun getType(uri: Uri) = null
+	override fun query(uri: Uri, projection: Array<out String>?, selection: String?, selectionArgs: Array<out String>?, sortOrder: String?) = null
+	override fun insert(uri: Uri, values: ContentValues?) = null
+	override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?) = 0
+	override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?) = 0
+
+	override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
+		val src = requireNotNull(uri.getQueryParameter("src")).toUri()
+
+		val (read, write) = ParcelFileDescriptor.createPipe()
+		val outputStream = ParcelFileDescriptor.AutoCloseOutputStream(write)
+
+		ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.IO) {
+			Glide.with(context!!)
+				.asBitmap()
+				.load(src)
+				.into(object : CustomTarget<Bitmap>() {
+					override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
+						@Suppress("DEPRECATION")
+						val format = when {
+							Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> Bitmap.CompressFormat.WEBP_LOSSY
+							else -> Bitmap.CompressFormat.WEBP
+						}
+						resource.compress(format, 95, outputStream)
+						outputStream.close()
+					}
+
+					override fun onLoadCleared(placeholder: Drawable?) = outputStream.close()
+				})
+		}
+
+		return read
+	}
+
+	companion object {
+		/**
+		 * Get a [Uri] that uses the [ImageProvider] to load an image. The input should be a valid
+		 * Jellyfin image URL created using the SDK.
+		 */
+		fun getImageUri(src: String): Uri = Uri.Builder()
+			.scheme("content")
+			.authority("${BuildConfig.APPLICATION_ID}.integration.provider.ImageProvider")
+			.appendQueryParameter("src", src)
+			.appendQueryParameter("v", BuildConfig.VERSION_NAME)
+			.build()
+	}
+}


### PR DESCRIPTION
This PR adds a content provider to act as a proxy when serving images to platform integrations. This resolves an issue where the Google Assistant rejects http urls and allows us to authenticate the image calls at some point.

One important implemenation detail is that we actually expose the content provider so it also works with third party launchers. Some other apps (\*cough*nvidia) don't do that and use a whitelist instead making it impossible for third party launchers to retrieve the images.

**Changes**
- Add ImageProvider for retrieval of images in platform integration
- Use ImageProvider in LeanbackChannelWorker
- Use ImageProvider in MediaContentProvider

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
