### PR TITLE
Fix setExoPlayerTrack exception when allStreams is empty

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -542,7 +542,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     }
 
     public boolean setExoPlayerTrack(int index, @Nullable org.jellyfin.sdk.model.api.MediaStreamType streamType, @Nullable List<org.jellyfin.sdk.model.api.MediaStream> allStreams) {
-        if (!nativeMode || !isInitialized() || allStreams == null || streamType != org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE && streamType != org.jellyfin.sdk.model.api.MediaStreamType.AUDIO)
+        if (!nativeMode || !isInitialized() || allStreams == null || allStreams.isEmpty() || streamType != org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE && streamType != org.jellyfin.sdk.model.api.MediaStreamType.AUDIO)
             return false;
 
         int chosenTrackType = streamType == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE ? C.TRACK_TYPE_TEXT : C.TRACK_TYPE_AUDIO;


### PR DESCRIPTION
```
2022-08-30 23:42:05.406   772-772   AndroidRuntime          org.jellyfin.androidtv.debug         E  FATAL EXCEPTION: main
                                                                                                    Process: org.jellyfin.androidtv.debug, PID: 772
                                                                                                    java.lang.IndexOutOfBoundsException: Index: 1, Size: 0
                                                                                                    	at java.util.ArrayList.get(ArrayList.java:437)
                                                                                                    	at org.jellyfin.androidtv.ui.playback.VideoManager.setExoPlayerTrack(VideoManager.java:549)
                                                                                                    	at org.jellyfin.androidtv.ui.playback.PlaybackController.switchAudioStream(PlaybackController.java:955)
                                                                                                    	at org.jellyfin.androidtv.ui.playback.PlaybackController.onPrepared(PlaybackController.java:1491)
                                                                                                    	at org.jellyfin.androidtv.ui.playback.VideoManager$1.onIsPlayingChanged(VideoManager.java:134)
                                                                                                    	at com.google.android.exoplayer2.ExoPlayerImpl.lambda$updatePlaybackInfo$24(ExoPlayerImpl.java:1944)
                                                                                                    	at com.google.android.exoplayer2.ExoPlayerImpl$$ExternalSyntheticLambda3.invoke(Unknown Source:4)
                                                                                                    	at com.google.android.exoplayer2.util.ListenerSet$ListenerHolder.invoke(ListenerSet.java:281)
                                                                                                    	at com.google.android.exoplayer2.util.ListenerSet.lambda$queueEvent$0(ListenerSet.java:190)
                                                                                                    	at com.google.android.exoplayer2.util.ListenerSet$$ExternalSyntheticLambda1.run(Unknown Source:6)
                                                                                                    	at com.google.android.exoplayer2.util.ListenerSet.flushEvents(ListenerSet.java:211)
                                                                                                    	at com.google.android.exoplayer2.ExoPlayerImpl.updatePlaybackInfo(ExoPlayerImpl.java:1955)
                                                                                                    	at com.google.android.exoplayer2.ExoPlayerImpl.handlePlaybackInfo(ExoPlayerImpl.java:1787)
                                                                                                    	at com.google.android.exoplayer2.ExoPlayerImpl.lambda$new$1$com-google-android-exoplayer2-ExoPlayerImpl(ExoPlayerImpl.java:309)
                                                                                                    	at com.google.android.exoplayer2.ExoPlayerImpl$$ExternalSyntheticLambda24.run(Unknown Source:4)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:938)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:201)
                                                                                                    	at android.os.Looper.loop(Looper.java:288)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:7839)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

**Changes**
- Fix setExoPlayerTrack exception when allStreams is empty
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Probably fixes #2163