### PR TITLE
Fix EnhancedBrowseFragment registering multiple listeners

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CompositeClickedListener.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CompositeClickedListener.kt
@@ -20,4 +20,6 @@ class CompositeClickedListener : OnItemViewClickedListener {
 			listener.onItemClicked(itemViewHolder, item, rowViewHolder, row)
 		}
 	}
+
+	fun removeListeners() = listeners.clear()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CompositeSelectedListener.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CompositeSelectedListener.kt
@@ -20,4 +20,6 @@ class CompositeSelectedListener : OnItemViewSelectedListener {
 			listener.onItemSelected(itemViewHolder, item, rowViewHolder, row)
 		}
 	}
+
+	fun removeListeners() = listeners.clear()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -12,6 +12,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -146,7 +147,20 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
         setupViews();
         setupQueries(this);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
         setupEventListeners();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mClickedListener.removeListeners();
+        mSelectedListener.removeListeners();
     }
 
     protected void setupQueries(RowLoader rowLoader) {


### PR DESCRIPTION
1. open library
2. open item
3. go back
4. open item

The navigation state is now corrupt because the item was opened twice. This PR fixes that issue.

**Changes**
- Fix EnhancedBrowseFragment registering multiple listeners

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
