### PR TITLE
Load fresh item data in AudioTrackQueue

### DIFF
--- a/playback/jellyfin/src/main/kotlin/queue/AudioTrackQueue.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioTrackQueue.kt
@@ -4,6 +4,7 @@ import org.jellyfin.playback.core.queue.PagedQueue
 import org.jellyfin.playback.core.queue.item.QueueEntry
 import org.jellyfin.playback.jellyfin.queue.item.BaseItemDtoUserQueueEntry
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 
@@ -19,6 +20,7 @@ class AudioTrackQueue(
 		// We only have a single item
 		if (offset > 0) return emptyList()
 
+		val item by api.userLibraryApi.getItem(itemId = item.id)
 		return listOf(BaseItemDtoUserQueueEntry.build(api, item))
 	}
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Always load item data from API in AudioTrackQueue.
  This fixes an issue where an apiclient item converted to SDK item would have lost some data causing playback to fail.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
