### PR TITLE
Apply subtitle delay to external subs

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1532,7 +1532,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 updateTvProgramInfo();
             }
             if (mFragment != null && finishedInitialSeek)
-                mFragment.updateSubtitles(mCurrentPosition);
+                mFragment.updateSubtitles(mCurrentPosition - getSubtitleDelay());
         }
         if (mFragment != null)
             mFragment.setCurrentTime(mCurrentPosition);


### PR DESCRIPTION
**Changes**
Subtract the subtitle delay from the playback position that is used to calculate when to show/hide external subtitles.

I have tested changing the subtitle delay on:
* a video with embedded subtitles
* a video with external subtitles

Both of them behaved as expected in my limited testing.

**Issues**
Fixes #2200