### PR TITLE
Always reset navigation in StartupActivity

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -134,7 +134,7 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 			else -> null
 		}
 
-		if (destination != null) navigationRepository.reset(destination)
+		navigationRepository.reset(destination)
 
 		val intent = Intent(this, MainActivity::class.java)
 		// Clear navigation history


### PR DESCRIPTION
fixes some edge cases where the wrong destination would open and it became impossible to go to the home screen again.

**Changes**
- Always reset navigation in StartupActivity

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
