### PR TITLE
Fix app crash when playing trailers

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1457,6 +1457,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     return true;
                 case R.id.playTrailers:
                     playTrailers();
+                    return true;
                 case R.id.gotoSeries:
                     gotoSeries();
                     return true;


### PR DESCRIPTION
The app crashed because `gotoSeries()` was called when it shouldn't due to 
a missing return statement.

**Changes**
- Add missing return statement in FullDetailsFragment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
