### PR TITLE
Add Video Codec Tag

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -345,7 +345,10 @@ public class InfoLayoutHelper {
                 addBlockText(context, layout, "8K");
             }
 
-            addSpacer(context, layout, "  ");
+            addSpacer(context, layout, " ");
+
+            addVideoCodecDetails(context, layout, item.getMediaStreams().get(0));
+
         }
         if (Utils.isTrue(item.getHasSubtitles())) {
             addBlockText(context, layout, "CC");
@@ -360,6 +363,16 @@ public class InfoLayoutHelper {
             String status = continuing ? context.getString(R.string.lbl__continuing) : context.getString(R.string.lbl_ended);
             addBlockText(context, layout, status, textSize-4, Color.LTGRAY, continuing ? R.drawable.green_gradient : R.drawable.red_gradient);
             addSpacer(context, layout, "  ");
+        }
+    }
+
+    private static void addVideoCodecDetails(Context context, LinearLayout layout, MediaStream stream) {
+        if (stream != null) {
+            if (stream.getCodec() != null && stream.getCodec().trim().length() > 0) {
+                String codec = stream.getCodec().toUpperCase();
+                addBlockText(context, layout, codec);
+                addSpacer(context, layout, "  ");
+            }
         }
     }
 


### PR DESCRIPTION
Add Video Codec Tag to Item View Page

**Changes**
Adds an additional tag to Created `addVideoCodecDetails` function to InfoLayoutHelper.java. The function is called by `addRatingAndRes` in the same file to add a tag with the codec name after the resolution tag.

**Issues**
Fixes  #2244