### PR TITLE
Avoid clearing all items on ItemRowAdapter load

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -351,4 +351,9 @@ open class BaseRowItem protected constructor(
 			}
 		}
 	}
+
+	override fun equals(other: Any?): Boolean {
+		if (other is BaseRowItem) return other.getItemId() == getItemId()
+		return super.equals(other)
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -849,25 +849,10 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
             public void onResponse(ItemsResult response) {
                 if (response.getItems() != null && response.getItems().length > 0) {
                     setTotalItems(query.getEnableTotalRecordCount() ? response.getTotalRecordCount() : response.getItems().length);
-                    int i = getItemsLoaded();
-                    int prevItems = i == 0 && size() > 0 ? size() : 0;
-                    for (BaseItemDto item : response.getItems()) {
-                        add(new BaseRowItem(i++, item, getPreferParentThumb(), isStaticHeight()));
 
-                    }
-                    setItemsLoaded(i);
-                    if (i == 0) {
-                        removeRow();
-                    } else if (prevItems > 0) {
-                        // remove previous items as we re-retrieved
-                        // this is done this way instead of clearing the adapter to avoid bugs in the framework elements
-                        removeAt(0, prevItems);
-                    }
-                } else {
-                    // no results - don't show us
-                    if (getItemsLoaded() == 0) {
-                        removeRow();
-                    }
+                    ItemRowAdapterHelperKt.setItems(ItemRowAdapter.this, response.getItems(), (item, i) -> new BaseRowItem(i, item, getPreferParentThumb(), isStaticHeight()));
+                } else if (getItemsLoaded() == 0) {
+                    removeRow();
                 }
 
                 notifyRetrieveFinished();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -1,0 +1,30 @@
+package org.jellyfin.androidtv.ui.itemhandling
+
+import timber.log.Timber
+
+fun <T : Any> ItemRowAdapter.setItems(
+	items: Array<T>,
+	transform: (T, Int) -> BaseRowItem,
+) {
+	Timber.d("Creating items from $itemsLoaded existing and ${items.size} new, adapter size is ${size()}")
+
+	val allItems = buildList {
+		// Add current items before loaded items
+		repeat(itemsLoaded) {
+			add(this@setItems.get(it))
+		}
+
+		// Add loaded items
+		items.forEachIndexed { index, item ->
+			add(transform(item, itemsLoaded + index))
+		}
+
+		// Add current items after loaded items
+		repeat(size() - itemsLoaded - items.size) {
+			add(this@setItems.get(it + itemsLoaded + items.size))
+		}
+	}
+
+	replaceAll(allItems)
+	itemsLoaded = allItems.size
+}


### PR DESCRIPTION
_Beta blocker 2 / ~~2~~ 3_

After the fragment migration the grid fragment started to act weird when resuming. The focus would get lost where it previously wouldn't. I had to rewrite a bunch of code to properly refresh existing grid items instead of replacing everything. From my testing it works now as expected, but the code is messy and this should definitely be rewritten at some point.

**Changes**
- Avoid clearing all items on ItemRowAdapter load

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
