### PR TITLE
Fix bad version.ref in dependency catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,9 +66,9 @@ android-gradle = { module = "com.android.tools.build:gradle", version.ref = "and
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx.compose" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx.compose" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx.compose" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose" }
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }


### PR DESCRIPTION
**Changes**

- Changed `"androidx.compose"` to `"androidx-compose"`
  - Probably fixes Renovate not updating Compose
  - Using a dot actually worked fine in Gradle but it was still wrong

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
