### PR TITLE
Add dismissible notification for beta releases

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/model/AppNotification.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/model/AppNotification.kt
@@ -2,4 +2,5 @@ package org.jellyfin.androidtv.data.model
 
 data class AppNotification(
 	val message: String,
+	val dismiss: () -> Unit,
 )

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -93,7 +93,7 @@ val appModule = module {
 
 	single<UserRepository> { UserRepositoryImpl() }
 	single<UserViewsRepository> { UserViewsRepositoryImpl(get()) }
-	single<NotificationsRepository> { NotificationsRepositoryImpl(get(), get()) }
+	single<NotificationsRepository> { NotificationsRepositoryImpl(get(), get(), get()) }
 	single<ItemMutationRepository> { ItemMutationRepositoryImpl(get(), get()) }
 	single<CustomMessageRepository> { CustomMessageRepositoryImpl() }
 	single<NavigationRepository> { NavigationRepositoryImpl(Destinations.home) }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
@@ -64,5 +64,10 @@ class SystemPreferences(context: Context) : SharedPreferenceStore(
 		 * Chosen player for play with button. Changes every time user chooses a player with "play with" button.
 		 */
 		var chosenPlayer = enumPreference("chosen_player", PreferredVideoPlayer.VLC)
+
+		/**
+		 * The version name for the latest dismissed beta notification or empty if none.
+		 */
+		val dismissedBetaNotificationVersion = stringPreference("dismissed_beta_notification_version", "")
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,4 +497,5 @@
     <string name="crash_report_toast">Oops! Something went wrong, a crash report was sent to your Jellyfin server.</string>
     <string name="server_setup_incomplete">The setup of this server has not been completed. Open Jellyfin in a web browser to finish setup before signing in.</string>
     <string name="episode_name_special">special</string>
+    <string name="app_notification_beta">App updated to %1$s\nThank you for participating in the Jellyfin beta program</string>
 </resources>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2305178/201429925-371b942d-1c2c-47ef-aab0-9209fcac0ae9.png)
_Will obviously show "0.15.0-beta.1" on actual beta release_

**Changes**

Add a notification that shows after each beta update. Pressing it will dismiss it until the next beta version. It does not show for development or stable builds (it searches for the "beta" string in the version name).

We have 2000+ beta participants on Google Play, but the beta program is only meant for users that actively report issues. Adding this notification will remind users that they participate in the beta program.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
