### PR TITLE
Fix missing checkboxes in player audio, subtitle and zoom menu

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
@@ -33,8 +33,6 @@ class ClosedCaptionsAction(
 
 		PopupMenu(context, view, Gravity.END).apply {
 			with(menu) {
-				setGroupCheckable(0, true, false)
-
 				for (sub in playbackController.subtitleStreams) {
 					add(0, sub.index, sub.index, sub.displayTitle).apply {
 						isChecked = sub.index == playbackController.subtitleStreamIndex
@@ -44,6 +42,8 @@ class ClosedCaptionsAction(
 				add(0, -1, 0, context.getString(R.string.lbl_none)).apply {
 					isChecked = playbackController.subtitleStreamIndex == -1
 				}
+
+				setGroupCheckable(0, true, false)
 			}
 			setOnDismissListener { leanbackOverlayFragment.setFading(true) }
 			setOnMenuItemClickListener { item ->

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
@@ -31,12 +31,12 @@ class SelectAudioAction(
 
 		PopupMenu(context, view, Gravity.END).apply {
 			with(menu) {
-				setGroupCheckable(0, true, false)
 				for (track in audioTracks) {
 					add(0, track.index, track.index, track.displayTitle).apply {
 						isChecked = currentAudioIndex == track.index
 					}
 				}
+				setGroupCheckable(0, true, false)
 			}
 
 			setOnDismissListener { leanbackOverlayFragment.setFading(true) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
@@ -30,7 +30,7 @@ class SelectQualityAction(
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context, view: View
 	) {
-		val qualityMenu = PopupMenu(context, view, Gravity.END).apply {
+		PopupMenu(context, view, Gravity.END).apply {
 			qualityProfiles.values.forEachIndexed { i, selected ->
 				menu.add(0, i, i, selected)
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
@@ -25,8 +25,6 @@ class ZoomAction(
 		view: View,
 	) = PopupMenu(context, view, Gravity.END).apply {
 		with(menu) {
-			setGroupCheckable(0, true, false)
-
 			add(
 				0,
 				VideoManager.ZOOM_AUTO_CROP,
@@ -53,6 +51,8 @@ class ZoomAction(
 			).apply {
 				isChecked = playbackController.zoomMode == VideoManager.ZOOM_STRETCH
 			}
+
+			setGroupCheckable(0, true, false)
 		}
 
 		setOnDismissListener { leanbackOverlayFragment.setFading(true) }


### PR DESCRIPTION
`setGroupCheckable` should be called after adding items to the menu, not before adding them.

**Changes**
- Fix missing checkboxes in player audio, subtitle and zoom menu

**Issues**

Fixes #2253
