### PR TITLE
Improved server unavailability handling during startup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,10 @@ dependencies {
 	implementation(libs.kotlinx.coroutines)
 	implementation(libs.kotlinx.serialization.json)
 
+	// Arrow
+	implementation(platform("io.arrow-kt:arrow-stack:1.1.2"))
+	implementation("io.arrow-kt:arrow-core")
+
 	// Android(x)
 	implementation(libs.androidx.core)
 	implementation(libs.androidx.activity)

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -171,7 +171,7 @@ class AuthenticationRepositoryImpl(
 	}
 
 	private suspend fun setActiveSession(user: User, server: Server): Boolean {
-		val authenticated = sessionRepository.switchCurrentSession(user.id)
+		val authenticated = sessionRepository.switchCurrentSession(user.id).isRight()
 
 		if (authenticated) {
 			// Update last use in store

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -40,7 +40,9 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
 		}
 
 		binding.switchUsers.setOnClickListener {
-			switchUser()
+			lifecycleScope.launch {
+				switchUser()
+			}
 		}
 
 		binding.search.setOnClickListener {
@@ -89,7 +91,7 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
 			})
 	}
 
-	private fun switchUser() {
+	private suspend fun switchUser() {
 		sessionRepository.destroyCurrentSession()
 
 		// Open login activity

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -96,7 +96,7 @@ class AuthPreferencesScreen : OptionsFragment() {
 
 		// Disallow changing the "always authenticate" option from the login screen
 		// because that would allow a kid to disable the function to access a parent's account
-		if (sessionRepository.currentSession.value != null) {
+		if (sessionRepository.currentSession.value.isRight()) {
 			category {
 				setTitle(R.string.advanced_settings)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/AuthenticatedUserCallbacks.kt
@@ -39,7 +39,7 @@ class AuthenticatedUserCallbacks(
 
 		if (name in ignoredClassNames) {
 			Timber.i("Activity $name is ignored")
-		} else if (sessionRepository.currentSession.value == null) {
+		} else if (sessionRepository.currentSession.value.isLeft()) {
 			Timber.w("Activity $name started without a session, bouncing to StartupActivity")
 			startActivity(Intent(this, StartupActivity::class.java))
 			finish()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SplashFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SplashFragment.kt
@@ -6,22 +6,81 @@ import android.view.ViewGroup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import arrow.core.Either
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.repository.SessionRepository
+import org.koin.androidx.compose.get
 
 @Composable
-fun SplashScreen() {
+fun SplashScreen(
+	onSwitchServer: () -> Unit,
+	sessionRepository: SessionRepository = get()
+) {
+	val currentSessionState = sessionRepository.currentSession.collectAsState()
+	val coroutineScope = rememberCoroutineScope()
+	val screenState = when (currentSessionState.value) {
+		is Either.Left -> SplashScreenState.ConnectionFailed(10, {
+			// TODO: Is this sane or could this then be cancelled mid-restoration?
+			coroutineScope.launch {
+				sessionRepository.restoreSession()
+			}
+		}, onSwitchServer)
+		is Either.Right -> SplashScreenState.Empty
+	}
+
+	SplashScreenContent(screenState)
+}
+
+open class SplashScreenState {
+	object Empty : SplashScreenState()
+	data class ConnectionFailed(
+		val nextRetrySeconds: Int,
+		val onRetryRequest: () -> Unit,
+		val onSwitchServer: () -> Unit
+	) : SplashScreenState()
+}
+
+class PreviewProvider: PreviewParameterProvider<SplashScreenState> {
+	override val values: Sequence<SplashScreenState> = sequenceOf(
+		SplashScreenState.Empty,
+		SplashScreenState.ConnectionFailed(30, {}, {})
+	)
+
+}
+
+@Preview(device = Devices.TABLET)
+@Composable
+fun SplashScreenContent(
+	@PreviewParameter(PreviewProvider::class) state: SplashScreenState
+) {
 	Surface(
 		color = colorResource(id = R.color.not_quite_black),
 	) {
@@ -35,6 +94,58 @@ fun SplashScreen() {
 				contentDescription = stringResource(R.string.app_name),
 				modifier = Modifier.width(400.dp)
 			)
+			if (state is SplashScreenState.ConnectionFailed) {
+				Spacer(modifier = Modifier.height(40.dp))
+
+				ConnectionFailureDisplay(
+					modifier = Modifier.width(400.dp),
+					state.nextRetrySeconds,
+					state.onRetryRequest,
+					state.onSwitchServer
+				)
+			}
+		}
+	}
+}
+
+@Composable
+fun ConnectionFailureDisplay(
+	modifier: Modifier,
+	nextRetrySeconds: Int,
+	onRetryRequest: () -> Unit,
+	onSwitchServer: () -> Unit
+) {
+	Column(
+		modifier = modifier
+	) {
+		Row() {
+			Image(
+				painter = painterResource(id = R.drawable.ic_baseline_error_24),
+				contentDescription = "Error icon",
+				modifier = Modifier
+					.height(48.dp)
+					.width(48.dp)
+			)
+			Spacer(modifier = Modifier.width(8.dp))
+			Column(modifier = Modifier.fillMaxWidth()) {
+				Text(
+					text = "Failed to connect to server",
+					color = Color.White,
+				)
+				Text(
+					text = "Reconnecting in $nextRetrySeconds Seconds",
+					color = Color.White
+				)
+			}
+		}
+		Row() {
+			Button(onClick = onRetryRequest) {
+				Text(text = "Retry now")
+			}
+
+			Button(onClick = onSwitchServer) {
+				Text(text = "Switch server")
+			}
 		}
 	}
 }
@@ -46,7 +157,7 @@ class SplashFragment : Fragment() {
 		savedInstanceState: Bundle?
 	) = ComposeView(requireContext()).apply {
 		setContent {
-			SplashScreen()
+			SplashScreen({setFragmentResult("showServerSelection", bundleOf())})
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -41,7 +41,7 @@ public class PlaybackHelper {
     private static final int ITEM_QUERY_LIMIT = 150; // limit the number of items retrieved for playback
 
     public static void getItemsToPlay(final org.jellyfin.sdk.model.api.BaseItemDto mainItem, boolean allowIntros, final boolean shuffle, final Response<List<org.jellyfin.sdk.model.api.BaseItemDto>> outerResponse) {
-        UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().getUserId();
+        UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().orNull().getUserId();
 
         final List<org.jellyfin.sdk.model.api.BaseItemDto> items = new ArrayList<>();
         ItemQuery query = new ItemQuery();
@@ -319,7 +319,7 @@ public class PlaybackHelper {
     }
 
     public static void retrieveAndPlay(String id, final boolean shuffle, final Long position, final Context activity) {
-        UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().getUserId();
+        UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().orNull().getUserId();
         KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(id, userId.toString(), new Response<BaseItemDto>() {
             @Override
             public void onResponse(BaseItemDto response) {
@@ -353,7 +353,7 @@ public class PlaybackHelper {
     }
 
     public static void getInstantMixAsync(String seedId, final Response<BaseItemDto[]> outerResponse) {
-        UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().getUserId();
+        UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().orNull().getUserId();
         SimilarItemsQuery query = new SimilarItemsQuery();
         query.setId(seedId);
         query.setUserId(userId.toString());
@@ -379,7 +379,7 @@ public class PlaybackHelper {
         items.add(mainItem);
         if (mainItem.getPartCount() != null && mainItem.getPartCount() > 1) {
             // get additional parts
-            UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().getUserId();
+            UUID userId = KoinJavaComponent.<SessionRepository>get(SessionRepository.class).getCurrentSession().getValue().orNull().getUserId();
             KoinJavaComponent.<ApiClient>get(ApiClient.class).GetAdditionalParts(mainItem.getId().toString(), userId.toString(), new Response<ItemsResult>() {
                 @Override
                 public void onResponse(ItemsResult response) {

--- a/app/src/main/res/drawable/ic_baseline_error_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_error_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
+</vector>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
This PR changes large parts of the SessionRepository to make its current session an Arrow `Either<A,B>` of either an Error or a valid Session. This can then be used by other components to know why the session is currently unset and allows them to give the user more information on the error. The StartupActivity as well as a modified SplashScreen use this additional information to show the user an information when the server is unavailable.

This draft is in many locations still rough and unfinished (TODOs, ugly draft UI, etc.), but I'm submitting it early to get feedback on whether it's okay to introduce Arrow and the use of its `Either<>` type.
