### PR TITLE
Use ItemRowAdapterHelper.setItems for more row types

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -4,7 +4,7 @@ import timber.log.Timber
 
 fun <T : Any> ItemRowAdapter.setItems(
 	items: Array<T>,
-	transform: (T, Int) -> BaseRowItem,
+	transform: (T, Int) -> BaseRowItem?,
 ) {
 	Timber.d("Creating items from $itemsLoaded existing and ${items.size} new, adapter size is ${size()}")
 
@@ -15,13 +15,14 @@ fun <T : Any> ItemRowAdapter.setItems(
 		}
 
 		// Add loaded items
-		items.forEachIndexed { index, item ->
-			add(transform(item, itemsLoaded + index))
+		val mappedItems = items.mapIndexedNotNull { index, item ->
+			transform(item, itemsLoaded + index)
 		}
+		mappedItems.forEach { add(it) }
 
 		// Add current items after loaded items
-		repeat(size() - itemsLoaded - items.size) {
-			add(this@setItems.get(it + itemsLoaded + items.size))
+		repeat(size() - itemsLoaded - mappedItems.size) {
+			add(this@setItems.get(it + itemsLoaded + mappedItems.size))
 		}
 	}
 


### PR DESCRIPTION
When resuming a fragment with an paged adapter that had an item focused after the first page the leanback library would try to focus an item that wasn't ready yet. I fixed this in #2246 for ItemQuery but we also use pages for artists and a few other types.

**Changes**
- Use ItemRowAdapterHelper.setItems for artists
- Use ItemRowAdapterHelper.setItems for views
- Use ItemRowAdapterHelper.setItems for search results
- Use ItemRowAdapterHelper.setItems for latest items
- Filter out null values in ItemRowAdapterHelper.setItems

**Issues**

Fixes #2260