### PR TITLE
Fix NPE in ExternalPlayerActivity when getMediaSource() returns null

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -298,6 +298,8 @@ public class StreamInfo {
         long startPositionTicks = getPlayMethod() == PlayMethod.Transcode ? getStartPositionTicks() : 0;
 
         if (!includeSelectedTrackOnly) {
+            if (getMediaSource() == null) return list;
+
             for (org.jellyfin.sdk.model.api.MediaStream stream : getMediaSource().getMediaStreams()) {
                 if (stream.getType() == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE) {
                     addSubtitleProfiles(list, stream, enableAllProfiles, baseUrl, accessToken, startPositionTicks);


### PR DESCRIPTION
Untested but should fix the NPE from the logs in the issue.

**Changes**
- Check null value in StreamInfo.getSubtitleProfiles

**Issues**

Fixes #2269
