### PR TITLE
Fix TimeUtils.getDate not using UTC for offset

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
@@ -8,6 +8,7 @@ import org.jellyfin.androidtv.R;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -162,8 +163,12 @@ public class TimeUtils {
     }
 
     public static Date getDate(LocalDateTime date) {
+        return getDate(date, ZoneOffset.UTC);
+    }
+
+    public static Date getDate(LocalDateTime date, ZoneId zone) {
         if (date == null) return null;
 
-        return Date.from(date.atZone(ZoneId.systemDefault()).toInstant());
+        return Date.from(date.atZone(zone).toInstant());
     }
 }


### PR DESCRIPTION
The SDK uses java.time but the old apiclient uses java.util.Date. The latter doesn't support timezones that great and guess what, the function that converted Date->java.time didn't either!

**Changes**
- Fix TimeUtils.getDate not using UTC for offset causing displayed dates to be offset

**Issues**

Fixes #2279