### PR TITLE
Fix opening Live TV recordings

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -1,7 +1,11 @@
 package org.jellyfin.androidtv.ui.browsing;
 
+import android.os.Bundle;
 import android.os.Handler;
+import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.leanback.widget.ArrayObjectAdapter;
 import androidx.leanback.widget.HeaderItem;
 import androidx.leanback.widget.ListRow;
@@ -40,9 +44,15 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
     }
 
     @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        mTitle.setText(getString(R.string.lbl_loading_elipses));
+    }
+
+    @Override
     protected void setupQueries(final RowLoader rowLoader) {
         showViews = true;
-        mTitle.setText(getString(R.string.lbl_loading_elipses));
         //Latest Recordings
         RecordingQuery recordings = new RecordingQuery();
         recordings.setFields(new ItemFields[]{
@@ -53,7 +63,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         recordings.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
         recordings.setEnableImages(true);
         recordings.setLimit(40);
-        mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_recent_recordings), recordings, 40));
+        mRows.add(new BrowseRowDef(getString(R.string.lbl_recent_recordings), recordings, 40));
 
         //Movies
         RecordingQuery movies = new RecordingQuery();
@@ -65,7 +75,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         movies.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
         movies.setEnableImages(true);
         movies.setIsMovie(true);
-        BrowseRowDef moviesDef = new BrowseRowDef(mActivity.getString(R.string.lbl_movies), movies, 60);
+        BrowseRowDef moviesDef = new BrowseRowDef(getString(R.string.lbl_movies), movies, 60);
 
         //Shows
         RecordingQuery shows = new RecordingQuery();
@@ -77,7 +87,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         shows.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
         shows.setEnableImages(true);
         shows.setIsSeries(true);
-        BrowseRowDef showsDef = new BrowseRowDef(mActivity.getString(R.string.lbl_tv_series), shows, 60);
+        BrowseRowDef showsDef = new BrowseRowDef(getString(R.string.lbl_tv_series), shows, 60);
 
         mRows.add(showsDef);
         mRows.add(moviesDef);
@@ -92,7 +102,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         sports.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
         sports.setEnableImages(true);
         sports.setIsSports(true);
-        mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_sports), sports, 60));
+        mRows.add(new BrowseRowDef(getString(R.string.lbl_sports), sports, 60));
 
         //Kids
         RecordingQuery kids = new RecordingQuery();
@@ -104,7 +114,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         kids.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
         kids.setEnableImages(true);
         kids.setIsKids(true);
-        mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_kids), kids, 60));
+        mRows.add(new BrowseRowDef(getString(R.string.lbl_kids), kids, 60));
 
         rowLoader.loadRows(mRows);
         addNext24Timers();
@@ -173,7 +183,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
         ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
         gridRowAdapter.add(new GridButton(SCHEDULE, getString(R.string.lbl_schedule), R.drawable.tile_port_time));
-        gridRowAdapter.add(new GridButton(SERIES, mActivity.getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer));
+        gridRowAdapter.add(new GridButton(SERIES, getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer));
         rowAdapter.add(new ListRow(gridHeader, gridRowAdapter));
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -163,6 +163,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     }
 
     protected void setupViews() {
+        if (!getArguments().containsKey(Extras.Folder)) return;
         mFolder = Json.Default.decodeFromString(BaseItemDto.Companion.serializer(), getArguments().getString(Extras.Folder));
         if (mFolder == null) return;
 
@@ -414,7 +415,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                         break;
 
                     case LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID:
-                        navigationRepository.getValue().navigate(Destinations.INSTANCE.libraryBrowser(FakeBaseItem.INSTANCE.getTV_RECORDINGS()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvRecordings());
                         break;
 
                     case LiveTvOption.LIVE_TV_GUIDE_OPTION_ID:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
@@ -52,14 +52,7 @@ class HomeFragmentLiveTVRow(
 		when (item.id) {
 			LiveTvOption.LIVE_TV_GUIDE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvGuide)
 			LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSchedule)
-			LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID -> {
-				val folder = BaseItemDto(
-					id = UUID.randomUUID(),
-					type = BaseItemKind.FOLDER,
-					name = activity.getString(R.string.lbl_recorded_tv),
-				)
-				navigationRepository.navigate(Destinations.libraryBrowser(folder))
-			}
+			LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvRecordings)
 			LiveTvOption.LIVE_TV_SERIES_OPTION_ID -> {
 				val folder = BaseItemDto(
 					id = UUID.randomUUID(),

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -313,11 +313,7 @@ public class ItemLauncher {
                         break;
 
                     case LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID:
-                        BaseItemDto folder = new BaseItemDto();
-                        folder.setId(UUID.randomUUID().toString());
-                        folder.setBaseItemType(BaseItemType.Folder);
-                        folder.setName(activity.getString(R.string.lbl_recorded_tv));
-                        navigationRepository.navigate(Destinations.INSTANCE.libraryBrowser(ModelCompat.asSdk(folder)));
+                        navigationRepository.navigate(Destinations.INSTANCE.getLiveTvRecordings());
                         break;
 
                     case LiveTvOption.LIVE_TV_SERIES_OPTION_ID:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.constant.Extras
 import org.jellyfin.androidtv.ui.browsing.BrowseGridFragment
+import org.jellyfin.androidtv.ui.browsing.BrowseRecordingsFragment
 import org.jellyfin.androidtv.ui.browsing.BrowseScheduleFragment
 import org.jellyfin.androidtv.ui.browsing.BrowseViewFragment
 import org.jellyfin.androidtv.ui.browsing.ByGenreFragment
@@ -133,6 +134,7 @@ object Destinations {
 	// Live TV
 	val liveTvGuide = fragmentDestination<LiveTvGuideFragment>()
 	val liveTvSchedule = fragmentDestination<BrowseScheduleFragment>()
+	val liveTvRecordings = fragmentDestination<BrowseRecordingsFragment>()
 	val liveTvGuideFilterPreferences = preferenceDestination<GuideFiltersScreen>()
 	val liveTvGuideOptionPreferences = preferenceDestination<GuideOptionsScreen>()
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
@@ -64,10 +64,4 @@ object FakeBaseItem {
 		type = BaseItemKind.FOLDER,
 		collectionType = "SeriesTimers",
 	)
-
-	val TV_RECORDINGS_ID = UUID.fromString("11111111-0000-0000-0000-000000000003")
-	val TV_RECORDINGS = BaseItemDto(
-		id = TV_RECORDINGS_ID,
-		type = BaseItemKind.FOLDER,
-	)
 }


### PR DESCRIPTION
Something went wrong during the nav migration and it no longer used the dedicated fragment, which was also broken.

**Changes**
- Add BrowseRecordingsFragment to destinations
- Fix opening Live TV recordings

**Issues**

Partially fixes #2281 
