### PR TITLE
Remember button focus on summary page

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
@@ -13,4 +13,18 @@ class DetailRowView @JvmOverloads constructor(
 	defStyleRes: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 	val binding = ViewRowDetailsBinding.inflate(LayoutInflater.from(context), this, true)
+
+	private var lastFocusedButton: TextUnderButton? = null
+
+	init {
+		// Keep track of the last selected button and reselect it when navigating back to the buttons row
+		binding.root.viewTreeObserver.addOnGlobalFocusChangeListener { oldFocus, newFocus ->
+			if (oldFocus is TextUnderButton && newFocus !is TextUnderButton) {
+				lastFocusedButton = oldFocus
+			} else if (newFocus is TextUnderButton && lastFocusedButton != null) {
+				lastFocusedButton?.requestFocus()
+				lastFocusedButton = null
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes remembering the last selected button so that it's reselected when coming back to the buttons row. As far as I can tell from other places in the app and other TV apps in general, this seems to be standard behaviour.

Side note: big fan of Jellyfin, keep up the good work 👍 