### PR TITLE
Fix notification card not focusable on older Android versions

### DIFF
--- a/app/src/main/res/layout/view_card_notification.xml
+++ b/app/src/main/res/layout/view_card_notification.xml
@@ -4,6 +4,8 @@
     android:layout_width="280dp"
     android:layout_height="90dp"
     android:background="@color/cardview_dark_background"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     android:padding="12dp">
 
     <TextView


### PR DESCRIPTION
Just Android things

**Changes**
- Fix notification card not focusable on older Android versions

**Issues**
Fixes #2298