### PR TITLE
Remove mActivity from EnhancedBrowseFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseScheduleFragment.java
@@ -15,12 +15,6 @@ public class BrowseScheduleFragment extends EnhancedBrowseFragment {
     @Override
     protected void setupQueries(final RowLoader rowLoader) {
         TvManager.getScheduleRowsAsync(requireContext(), new TimerQuery(), new CardPresenter(true), mRowsAdapter, new LifecycleAwareResponse<Integer>(getLifecycle()) {
-            @Override
-            public void onResponse(Integer response) {
-                if (!getActive()) return;
-
-                if (response == 0) mActivity.setTitle("No Scheduled Recordings");
-            }
         });
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -376,7 +376,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                                     });
                                     recordings.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
                                     recordings.setEnableImages(true);
-                                    mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_recent_recordings), recordings, 50));
+                                    mRows.add(new BrowseRowDef(getString(R.string.lbl_recent_recordings), recordings, 50));
                                     rowLoader.loadRows(mRows);
 
                                     //Now insert our smart rows
@@ -427,7 +427,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 break;
 
             case "seriestimers":
-                mRows.add(new BrowseRowDef(mActivity.getString(R.string.lbl_series_recordings), new SeriesTimerQuery()));
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_series_recordings), new SeriesTimerQuery()));
                 rowLoader.loadRows(mRows);
                 break;
             default:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -15,7 +15,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
 import androidx.leanback.widget.ClassPresenterSelector;
@@ -68,8 +67,6 @@ import kotlin.Lazy;
 import kotlinx.serialization.json.Json;
 
 public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.OnKeyListener {
-    protected FragmentActivity mActivity;
-
     protected TextView mTitle;
     private LinearLayout mInfoRow;
     private TextView mSummary;
@@ -121,8 +118,6 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         EnhancedDetailBrowseBinding binding = EnhancedDetailBrowseBinding.inflate(inflater, container, false);
-
-        mActivity = getActivity();
 
         mTitle = binding.title;
         mInfoRow = binding.infoRow;
@@ -345,7 +340,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         if (event.getAction() != KeyEvent.ACTION_DOWN) return false;
-        return KeyProcessor.HandleKey(keyCode, mCurrentItem, mActivity);
+        return KeyProcessor.HandleKey(keyCode, mCurrentItem, requireActivity());
     }
 
     private void refreshCurrentItem() {
@@ -423,7 +418,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                         break;
 
                     default:
-                        Toast.makeText(getActivity(), item.toString() + getString(R.string.msg_not_implemented), Toast.LENGTH_SHORT).show();
+                        Toast.makeText(requireContext(), item.toString() + getString(R.string.msg_not_implemented), Toast.LENGTH_SHORT).show();
                         break;
                 }
             }


### PR DESCRIPTION
**Changes**
- Remove mActivity from EnhancedBrowseFragment
  - Use requireContext() or requireActivity() instead
- Remove onResponse handler in BrowseScheduleFragment (changing the activity title doesn't do anything on Android TV)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
