### PR TITLE
Fix LegacyImageCardView scaling on non-1080p devices

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -141,8 +141,9 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
 
         // init with some working defaults
         DisplayMetrics display = requireContext().getResources().getDisplayMetrics();
-        mGridHeight = display.heightPixels - (int) Math.round(display.density * 130.6); // top + bottom in dp, elements scale with density so adjust accordingly
-        mGridWidth = display.widthPixels;
+        // top + bottom in dp, elements scale with density so adjust accordingly
+        mGridHeight = Math.round(display.heightPixels / getResources().getDisplayMetrics().density - 130.6f);
+        mGridWidth = Math.round(display.widthPixels / getResources().getDisplayMetrics().density);
 
         sortOptions = new HashMap<>();
         {
@@ -195,8 +196,8 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                 }
                 // prevent adaption on minor size delta's
                 if (Math.abs(mGridHeight - binding.rowsFragment.getHeight()) > MIN_GRIDSIZE_CHANGE_DELTA || Math.abs(mGridWidth - binding.rowsFragment.getWidth()) > MIN_GRIDSIZE_CHANGE_DELTA) {
-                    mGridHeight = binding.rowsFragment.getHeight();
-                    mGridWidth = binding.rowsFragment.getWidth();
+                    mGridHeight = Math.round(binding.rowsFragment.getHeight() / getResources().getDisplayMetrics().density);
+                    mGridWidth = Math.round(binding.rowsFragment.getWidth() / getResources().getDisplayMetrics().density);
                     Timber.d("Auto-Adapting grid size to height <%s> width <%s>", binding.rowsFragment.getHeight(), binding.rowsFragment.getWidth());
                     mDirty = true;
                     determiningPosterSize = true;
@@ -645,7 +646,8 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
             //Re-retrieve anything that needs it but delay slightly so we don't take away gui landing
             if (mAdapter != null) {
                 mHandler.postDelayed(() -> {
-                    if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+                    if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED))
+                        return;
 
                     if (mAdapter != null && mAdapter.size() > 0) {
                         if (!mAdapter.ReRetrieveIfNeeded()) {
@@ -730,7 +732,8 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                 if (mAdapter.getTotalItems() == 0) {
                     binding.toolBar.requestFocus();
                     mHandler.postDelayed(() -> {
-                        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+                        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED))
+                            return;
 
                         binding.title.setText(mFolder.getName());
                     }, 500);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -222,10 +222,10 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
     public void loadRows(List<BrowseRowDef> rows) {
         mRowsAdapter = new MutableObjectAdapter<Row>(new PositionableListRowPresenter());
-        mCardPresenter = new CardPresenter(false, 280);
+        mCardPresenter = new CardPresenter(false, 140);
         ClassPresenterSelector ps = new ClassPresenterSelector();
         ps.addClassPresenter(BaseRowItem.class, mCardPresenter);
-        ps.addClassPresenter(GridButton.class, new GridButtonPresenter(false, 310, 280));
+        ps.addClassPresenter(GridButton.class, new GridButtonPresenter(false, 155, 140));
 
         for (BrowseRowDef def : rows) {
             HeaderItem header = new HeaderItem(def.getHeaderText());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -83,12 +83,12 @@ public class LegacyImageCardView extends BaseCardView {
 
     public void setMainImageDimensions(int width, int height) {
         ViewGroup.LayoutParams lp = binding.mainImage.getLayoutParams();
-        lp.width = width;
-        lp.height = height;
+        lp.width = Math.round(width * getResources().getDisplayMetrics().density);
+        lp.height = Math.round(height * getResources().getDisplayMetrics().density);
         binding.mainImage.setLayoutParams(lp);
-        if (mBanner != null) mBanner.setX(width - BANNER_SIZE);
+        if (mBanner != null) mBanner.setX(lp.width - BANNER_SIZE);
         ViewGroup.LayoutParams lp2 = binding.resumeProgress.getLayoutParams();
-        lp2.width = width;
+        lp2.width = lp.width;
         binding.resumeProgress.setLayoutParams(lp2);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -550,7 +550,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 //Cast/Crew
                 if (mBaseItem.getPeople() != null && mBaseItem.getPeople().length > 0) {
-                    ItemRowAdapter castAdapter = new ItemRowAdapter(requireContext(), ModelCompat.asSdk(mBaseItem.getPeople()), new CardPresenter(true, 260), adapter);
+                    ItemRowAdapter castAdapter = new ItemRowAdapter(requireContext(), ModelCompat.asSdk(mBaseItem.getPeople()), new CardPresenter(true, 130), adapter);
                     addItemRow(adapter, castAdapter, 1, getString(R.string.lbl_cast_crew));
                 }
 
@@ -567,7 +567,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 //Chapters
                 if (mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
                     List<ChapterItemInfo> chapters = BaseItemExtensionsKt.buildChapterItems(ModelCompat.asSdk(mBaseItem), api.getValue());
-                    ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), chapters, new CardPresenter(true, 240), adapter);
+                    ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), chapters, new CardPresenter(true, 120), adapter);
                     addItemRow(adapter, chapterAdapter, 2, getString(R.string.lbl_chapters));
                 }
 
@@ -590,7 +590,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 //Cast/Crew
                 if (mBaseItem.getPeople() != null && mBaseItem.getPeople().length > 0) {
-                    ItemRowAdapter castAdapter = new ItemRowAdapter(requireContext(), ModelCompat.asSdk(mBaseItem.getPeople()), new CardPresenter(true, 260), adapter);
+                    ItemRowAdapter castAdapter = new ItemRowAdapter(requireContext(), ModelCompat.asSdk(mBaseItem.getPeople()), new CardPresenter(true, 130), adapter);
                     addItemRow(adapter, castAdapter, 0, getString(R.string.lbl_cast_crew));
                 }
 
@@ -675,7 +675,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                         ItemFields.PrimaryImageAspectRatio,
                         ItemFields.ChildCount
                 });
-                ItemRowAdapter nextUpAdapter = new ItemRowAdapter(requireContext(), nextUpQuery, false, new CardPresenter(true, 260), adapter);
+                ItemRowAdapter nextUpAdapter = new ItemRowAdapter(requireContext(), nextUpQuery, false, new CardPresenter(true, 130), adapter);
                 addItemRow(adapter, nextUpAdapter, 0, getString(R.string.lbl_next_up));
 
                 SeasonQuery seasons = new SeasonQuery();
@@ -700,7 +700,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 addItemRow(adapter, upcomingAdapter, 2, getString(R.string.lbl_upcoming));
 
                 if (mBaseItem.getPeople() != null && mBaseItem.getPeople().length > 0) {
-                    ItemRowAdapter seriesCastAdapter = new ItemRowAdapter(requireContext(), ModelCompat.asSdk(mBaseItem.getPeople()), new CardPresenter(true, 260), adapter);
+                    ItemRowAdapter seriesCastAdapter = new ItemRowAdapter(requireContext(), ModelCompat.asSdk(mBaseItem.getPeople()), new CardPresenter(true, 130), adapter);
                     addItemRow(adapter, seriesCastAdapter, 3, getString(R.string.lbl_cast_crew));
 
                 }
@@ -725,7 +725,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     nextEpisodes.setIncludeItemTypes(new String[]{"Episode"});
                     nextEpisodes.setStartIndex(mBaseItem.getIndexNumber()); // query index is zero-based but episode no is not
                     nextEpisodes.setLimit(20);
-                    ItemRowAdapter nextAdapter = new ItemRowAdapter(requireContext(), nextEpisodes, 0 , false, true, new CardPresenter(true, 240), adapter);
+                    ItemRowAdapter nextAdapter = new ItemRowAdapter(requireContext(), nextEpisodes, 0 , false, true, new CardPresenter(true, 120), adapter);
                     addItemRow(adapter, nextAdapter, 5, getString(R.string.lbl_next_episode));
                 }
 
@@ -736,7 +736,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                         if (person.getType() == PersonType.GuestStar) guests.add(person);
                     }
                     if (guests.size() > 0) {
-                        ItemRowAdapter castAdapter = new ItemRowAdapter(requireContext(), guests.toArray(new BaseItemPerson[guests.size()]), new CardPresenter(true, 260), adapter);
+                        ItemRowAdapter castAdapter = new ItemRowAdapter(requireContext(), guests.toArray(new BaseItemPerson[guests.size()]), new CardPresenter(true, 130), adapter);
                         addItemRow(adapter, castAdapter, 0, getString(R.string.lbl_guest_stars));
                     }
                 }
@@ -744,7 +744,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 //Chapters
                 if (mBaseItem.getChapters() != null && mBaseItem.getChapters().size() > 0) {
                     List<ChapterItemInfo> chapters = BaseItemExtensionsKt.buildChapterItems(ModelCompat.asSdk(mBaseItem), api.getValue());
-                    ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), chapters, new CardPresenter(true, 240), adapter);
+                    ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), chapters, new CardPresenter(true, 120), adapter);
                     addItemRow(adapter, chapterAdapter, 1, getString(R.string.lbl_chapters));
                 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1377,7 +1377,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         if (chapters != null && !chapters.isEmpty()) {
             // create chapter row for later use
-            ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), BaseItemExtensionsKt.buildChapterItems(item, api.getValue()), new CardPresenter(true, 220), new MutableObjectAdapter<Row>());
+            ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), BaseItemExtensionsKt.buildChapterItems(item, api.getValue()), new CardPresenter(true, 110), new MutableObjectAdapter<Row>());
             chapterAdapter.Retrieve();
             if (mChapterRow != null) mPopupRowAdapter.remove(mChapterRow);
             mChapterRow = new ListRow(new HeaderItem(requireContext().getString(R.string.chapters)), chapterAdapter);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -179,7 +179,7 @@ public class MediaManager {
                 for (int i = getCurrentAudioQueuePosition(); i < mCurrentAudioQueue.size(); i++) {
                     managedItems.add(((BaseRowItem)mCurrentAudioQueue.get(i)).getBaseItem());
                 }
-                mManagedAudioQueue = new ItemRowAdapter(context, managedItems, new CardPresenter(true, Utils.convertDpToPixel(context, 150)), null, QueryType.StaticAudioQueueItems);
+                mManagedAudioQueue = new ItemRowAdapter(context, managedItems, new CardPresenter(true, 150), null, QueryType.StaticAudioQueueItems);
                 mManagedAudioQueue.Retrieve();
             }
             if (mManagedAudioQueue.size() > 0 && isPlayingAudio()) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class CardPresenter extends Presenter {
     public static final double ASPECT_RATIO_BANNER = 1000.0 / 185.0;
 
-    private int mStaticHeight = 300;
+    private int mStaticHeight = 150;
     private ImageType mImageType = ImageType.POSTER;
     private double aspect;
 
@@ -67,8 +67,8 @@ public class CardPresenter extends Presenter {
     }
 
     class ViewHolder extends Presenter.ViewHolder {
-        private int cardWidth = 230;
-        private int cardHeight = 280;
+        private int cardWidth = 115;
+        private int cardHeight = 140;
 
         private BaseRowItem mItem;
         private LegacyImageCardView mCardView;
@@ -88,7 +88,7 @@ public class CardPresenter extends Presenter {
         }
 
         public void setItem(BaseRowItem m) {
-            setItem(m, ImageType.POSTER, 260, 300, 300);
+            setItem(m, ImageType.POSTER, 130, 150, 150);
         }
 
         public void setItem(BaseRowItem m, ImageType imageType, int lHeight, int pHeight, int sHeight) {
@@ -192,8 +192,8 @@ public class CardPresenter extends Presenter {
                     }
                     cardHeight = !m.getStaticHeight() ? (aspect > 1 ? lHeight : pHeight) : sHeight;
                     cardWidth = (int) (aspect * cardHeight);
-                    if (cardWidth < 10) {
-                        cardWidth = 230;  //Guard against zero size images causing picasso to barf
+                    if (cardWidth < 5) {
+                        cardWidth = 115;  //Guard against zero size images causing picasso to barf
                     }
                     if (itemDto.getLocationType() == LocationType.OFFLINE) {
                         mCardView.setBanner(R.drawable.banner_edge_offline);
@@ -232,8 +232,8 @@ public class CardPresenter extends Presenter {
                         Utils.getSafeValue(channel.getPrimaryImageAspectRatio(), 1.0);
                     cardHeight = !m.getStaticHeight() ? tvAspect > 1 ? lHeight : pHeight : sHeight;
                     cardWidth = (int) ((tvAspect) * cardHeight);
-                    if (cardWidth < 10) {
-                        cardWidth = 230;  //Guard against zero size images causing picasso to barf
+                    if (cardWidth < 5) {
+                        cardWidth = 115;  //Guard against zero size images causing picasso to barf
                     }
                     mCardView.setMainImageDimensions(cardWidth, cardHeight);
                     // Channel logos should fit within the view
@@ -251,8 +251,8 @@ public class CardPresenter extends Presenter {
                     }
                     cardHeight = !m.getStaticHeight() ? programAspect > 1 ? lHeight : pHeight : sHeight;
                     cardWidth = (int) ((programAspect) * cardHeight);
-                    if (cardWidth < 10) {
-                        cardWidth = 230;  //Guard against zero size images causing picasso to barf
+                    if (cardWidth < 5) {
+                        cardWidth = 115;  //Guard against zero size images causing picasso to barf
                     }
                     switch (program.getLocationType()) {
                         case FILE_SYSTEM:
@@ -275,8 +275,8 @@ public class CardPresenter extends Presenter {
                     double recordingAspect = imageType.equals(ImageType.BANNER) ? ASPECT_RATIO_BANNER : (imageType.equals(ImageType.THUMB) ? ImageUtils.ASPECT_RATIO_16_9 : Utils.getSafeValue(recording.getPrimaryImageAspectRatio(), ImageUtils.ASPECT_RATIO_7_9));
                     cardHeight = !m.getStaticHeight() ? recordingAspect > 1 ? lHeight : pHeight : sHeight;
                     cardWidth = (int) ((recordingAspect) * cardHeight);
-                    if (cardWidth < 10) {
-                        cardWidth = 230;  //Guard against zero size images causing picasso to barf
+                    if (cardWidth < 5) {
+                        cardWidth = 115;  //Guard against zero size images causing picasso to barf
                     }
                     mCardView.setMainImageDimensions(cardWidth, cardHeight);
                     mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_tv);
@@ -371,7 +371,7 @@ public class CardPresenter extends Presenter {
         BaseRowItem rowItem = (BaseRowItem) item;
 
         ViewHolder holder = (ViewHolder) viewHolder;
-        holder.setItem(rowItem, mImageType, 260, 300, mStaticHeight);
+        holder.setItem(rowItem, mImageType, 130, 150, mStaticHeight);
 
         holder.mCardView.setTitleText(rowItem.getCardName(holder.mCardView.getContext()));
         holder.mCardView.setContentText(rowItem.getSubText(holder.mCardView.getContext()));
@@ -420,8 +420,9 @@ public class CardPresenter extends Presenter {
             }
         }
 
+        float maxHeight = holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, holder.getCardHeight()),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
@@ -9,8 +9,8 @@ import org.jellyfin.androidtv.ui.card.LegacyImageCardView
 
 class GridButtonPresenter @JvmOverloads constructor(
 	private val showinfo: Boolean = true,
-	private val width: Int = 220,
-	private val height: Int = 220,
+	private val width: Int = 110,
+	private val height: Int = 110,
 ) : Presenter() {
 	class ViewHolder(
 		private val cardView: LegacyImageCardView,


### PR DESCRIPTION
Found this one a few days ago when I created a new emulator to test something on an old Android TV version and I chose a 720p display instead of 1080p.

**Changes**

Properly scale LegacyCardView with the screen density instead of hardcoding 2x. This fixes the scaling for pretty much all cards in app to be a consistent size across different display sizes. Previously only devices that rendered UI at 1080p (like most 4k/1080p devices) showed as intended.

AFAIk this bug was present in all previous app versions and actually makes the app unusable on 720p devices because the cards are way to big. A single episode card in the home screen would cover about 85% of the display.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
