### PR TITLE
Live TV program end time & recording page fixes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
@@ -262,7 +262,7 @@ public class RecordPopup {
         timelineRow.removeAllViews();
         if (program.getStartDate() == null) return;
 
-        Date local = TimeUtils.convertToLocalDate(TimeUtils.getDate(program.getStartDate()));
+        Date local = TimeUtils.getDate(program.getStartDate());
         TextView on = new TextView(mActivity);
         on.setText(mActivity.getString(R.string.lbl_on));
         timelineRow.addView(on);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -401,7 +401,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             item.setId(mSeriesTimerInfo.getId());
             item.setBaseItemType(BaseItemType.Folder);
             item.setSeriesTimerId(mSeriesTimerInfo.getId());
-            item.setBaseItemType(BaseItemType.SeriesTimer);
             item.setName(mSeriesTimerInfo.getName());
             item.setOverview(BaseItemUtils.getSeriesOverview(mSeriesTimerInfo, requireContext()));
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -110,6 +110,7 @@ import org.jellyfin.sdk.model.constant.PersonType;
 import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
 import org.koin.java.KoinJavaComponent;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -522,7 +523,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             if (mChannelId != null) {
                 mBaseItem.setParentId(mChannelId);
                 mBaseItem.setPremiereDate(TimeUtils.getDate(mProgramInfo.getStartDate()));
-                mBaseItem.setEndDate(TimeUtils.getDate(mProgramInfo.getEndDate()));
+                mBaseItem.setEndDate(TimeUtils.getDate(mProgramInfo.getEndDate(), ZoneId.systemDefault()));
                 mBaseItem.setRunTimeTicks(mProgramInfo.getRunTimeTicks());
             }
             new BuildDorTask().execute(item);


### PR DESCRIPTION
Need testers for the second fix, please check if 1) you can open a recording and 2) the UI is the same as in 0.14.z.

**Changes**

- Fix Live TV program end time in FullDetailsFragment
- Fix opening Live TV recordings in FullDetailsFragment
- Fix Live TV program time in RecordPopup

**Issues**

Fixes #2311
Fixes #2312
Fixes #2319