### PR TITLE
Fix crash when stopping playback with back button when refresh rate switching is enabled

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -428,7 +428,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             } else if (mGuideVisible) {
                 hideGuide();
             } else if (!requireActivity().isFinishing()) {
-                requireActivity().finish();
+                onStop();
             }
         }
     };


### PR DESCRIPTION
Race condition magic

**Changes**
- Fix crash when stopping playback with back button when refresh rate switching is enabled
  Calling onStop() releases libvlc and then calls finish()

**Issues**

Fixes #2291
Fixes #1855
Fixes #2060
Fixes #2283