### PR TITLE
#2314 surround works with LibVLC 

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -318,7 +318,6 @@ public class MediaManager {
                 if(!Utils.downMixAudio(context)) {
                     mVlcPlayer.setAudioDigitalOutputEnabled(true);
                 } else {
-                    mVlcPlayer.setAudioOutput("opensles_android");
                     mVlcPlayer.setAudioOutputDevice("hdmi");
                 }
 


### PR DESCRIPTION
Seems like mentioned in a earlier issue (https://github.com/jellyfin/jellyfin-androidtv/issues/786) that specifying 'setAudioOutput' prevents passtrough/auto codec selection. With this line gone 5.1 works with LibVLC in audio direct modus.

I don't know what the line I deleted was supposed to do, but it works great without. Maybe someone else knows what this was supposed to do.