### PR TITLE
Fix acra-core dependency using wrong name

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 aboutlibraries = "10.5.1"
-acra = "5.9.6"
+acra = "5.9.7"
 android-desugar = "1.1.8"
 android-gradle = "7.3.1"
 androidx-activity = "1.6.1"
@@ -108,7 +108,7 @@ glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glide" }
 kenburnsview = { module = "com.flaviofaria:kenburnsview", version.ref = "kenburnsview" }
 
 # Crash Reporting
-acra-core = { module = "ch.acra:acra-toast", version.ref = "acra" }
+acra-core = { module = "ch.acra:acra-core", version.ref = "acra" }
 acra-toast = { module = "ch.acra:acra-toast", version.ref = "acra" }
 
 # Libraries


### PR DESCRIPTION
The acra-toast package depends on acra-core so this doesn't really change much. Just fixes a copy-paste mistake.

**Changes**
- Fix acra-core dependency using wrong name
- Update acra version (closes #2296)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
