### PR TITLE
Revert "Remember button focus on summary page"

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
@@ -13,18 +13,4 @@ class DetailRowView @JvmOverloads constructor(
 	defStyleRes: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 	val binding = ViewRowDetailsBinding.inflate(LayoutInflater.from(context), this, true)
-
-	private var lastFocusedButton: TextUnderButton? = null
-
-	init {
-		// Keep track of the last selected button and reselect it when navigating back to the buttons row
-		binding.root.viewTreeObserver.addOnGlobalFocusChangeListener { oldFocus, newFocus ->
-			if (oldFocus is TextUnderButton && newFocus !is TextUnderButton) {
-				lastFocusedButton = oldFocus
-			} else if (newFocus is TextUnderButton && lastFocusedButton != null) {
-				lastFocusedButton?.requestFocus()
-				lastFocusedButton = null
-			}
-		}
-	}
 }


### PR DESCRIPTION
Reverts jellyfin/jellyfin-androidtv#2297

---

There are two issues with the PR:

1. The global listener isn't removed when the view detaches, this is an easy fix. just store it in a var and add/remove in onAttachedToWindow/onDetachedFromWindow
2. The call `requestFocus()` somehow crashes the app when viewing a person opened via a movie. I have no clue why and I tried to fix it for about 3 hours after giving up. **This is the reason for the revert.**

