### PR TITLE
Remember button focus on details screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
@@ -3,6 +3,8 @@ package org.jellyfin.androidtv.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.View
+import android.view.View.OnFocusChangeListener
 import android.widget.FrameLayout
 import org.jellyfin.androidtv.databinding.ViewRowDetailsBinding
 
@@ -13,4 +15,38 @@ class DetailRowView @JvmOverloads constructor(
 	defStyleRes: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 	val binding = ViewRowDetailsBinding.inflate(LayoutInflater.from(context), this, true)
+
+	/**
+	 * Keeps track of the last selected button and reselect it when navigating back to the buttons row.
+	 */
+	private val buttonsHierarchyChangeListener = object : OnHierarchyChangeListener {
+
+		private var lastFocusedButton: View? = null
+
+		private val focusChangeListener = OnFocusChangeListener { view, hasFocus ->
+			// Restore last focused button when navigating back to button row
+			if (hasFocus && lastFocusedButton != null) {
+				lastFocusedButton?.requestFocus()
+				lastFocusedButton = null
+			}
+			view.post {
+				// Store last focused button when navigating away from button row
+				if (binding.fdButtonRow.focusedChild == null) {
+					lastFocusedButton = view
+				}
+			}
+		}
+
+		override fun onChildViewAdded(parent: View?, child: View?) {
+			child?.onFocusChangeListener = focusChangeListener
+		}
+
+		override fun onChildViewRemoved(parent: View?, child: View?) {
+			child?.onFocusChangeListener = null
+		}
+	}
+
+	init {
+		binding.fdButtonRow.setOnHierarchyChangeListener(buttonsHierarchyChangeListener)
+	}
 }


### PR DESCRIPTION
**Changes**
Reworked #2297 in way that does not cause regressions.

The previous implementation added a global focus listener that worked even if the buttons row was offscreen. The linked bug happened because a "last button" was stored when navigating to the movie screen and then when navigating to the person screen, that same button would request focus even if was offscreen. Detaching the listener when navigating between screens was not sufficient because it would always be called too late, ie. after the incorrect focus request happened. TIL global focus listener is very dangerous.

The rework involves a targeted focus listener for each button which does not operate while offscreen. The last focused button is only stored when navigating away from the buttons row, and only restored when coming back to that same row.

**Issues**
N/A
