### PR TITLE
Fix race condition in ItemListFragment causing favorite music screen to crash

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -159,11 +159,15 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         });
 
         backgroundService.getValue().attach(requireActivity());
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         mItemId = getArguments().getString("ItemId");
         loadItem(mItemId);
-
-        return binding.getRoot();
     }
 
     @Override


### PR DESCRIPTION
**Changes**
- Load requested item after the view is created because the `loadItem()` function calls `setBaseItem()` which updates the UI, it needs to be inflated before it can be used.

**Issues**
Fixes #2349
