### PR TITLE
Show resumable episodes in smart screen for shows

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -133,6 +133,24 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
             case CollectionType.TvShows:
                 itemTypeString = "Series";
 
+                //Resume
+                StdItemQuery resumeEpisodes = new StdItemQuery(new ItemFields[]{
+                        ItemFields.PrimaryImageAspectRatio,
+                        ItemFields.Overview,
+                        ItemFields.ChildCount,
+                        ItemFields.MediaSources,
+                        ItemFields.MediaStreams
+                });
+                resumeEpisodes.setIncludeItemTypes(new String[]{"Episode"});
+                resumeEpisodes.setLimit(50);
+                resumeEpisodes.setParentId(mFolder.getId().toString());
+                resumeEpisodes.setRecursive(true);
+                resumeEpisodes.setImageTypeLimit(1);
+                resumeEpisodes.setFilters(new ItemFilter[]{ItemFilter.IsResumable});
+                resumeEpisodes.setSortBy(new String[]{ItemSortBy.DatePlayed});
+                resumeEpisodes.setSortOrder(SortOrder.Descending);
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_continue_watching), resumeEpisodes, 0, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
+
                 //Next up
                 NextUpQuery nextUpQuery = new NextUpQuery();
                 nextUpQuery.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());


### PR DESCRIPTION
**Changes**
Add another row to the smart screen of show libraries displaying resumable episodes (similar to the implemenation for movies).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2275 
