### PR TITLE
Fix scaling of album images in audio queue on now playing screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -421,7 +421,7 @@ public class MediaManager {
     }
 
     private void createAudioQueue(List<org.jellyfin.sdk.model.api.BaseItemDto> items) {
-        mCurrentAudioQueue = new ItemRowAdapter(context, items, new CardPresenter(true, Utils.convertDpToPixel(context, 140)), null, QueryType.StaticAudioQueueItems);
+        mCurrentAudioQueue = new ItemRowAdapter(context, items, new CardPresenter(true, 140), null, QueryType.StaticAudioQueueItems);
         mCurrentAudioQueue.Retrieve();
         mManagedAudioQueue = null;
         fireQueueStatusChange();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix scaling of album images in audio queue on now playing screen

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
