### PR TITLE
Allow Opus, FLAC audio in video direct play (#2366, #2359)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -50,7 +50,8 @@ class ExoPlayerProfile(
 		Codec.Audio.TRUEHD,
 		Codec.Audio.PCM_ALAW,
 		Codec.Audio.PCM_MULAW,
-		Codec.Audio.OPUS
+		Codec.Audio.OPUS,
+		Codec.Audio.FLAC
 	)
 
 	init {
@@ -123,7 +124,6 @@ class ExoPlayerProfile(
 			// Audio direct play
 			add(audioDirectPlayProfile(allSupportedAudioCodecs + arrayOf(
 				Codec.Audio.MPA,
-				Codec.Audio.FLAC,
 				Codec.Audio.WAV,
 				Codec.Audio.WMA,
 				Codec.Audio.OGG,

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -50,6 +50,7 @@ class ExoPlayerProfile(
 		Codec.Audio.TRUEHD,
 		Codec.Audio.PCM_ALAW,
 		Codec.Audio.PCM_MULAW,
+		Codec.Audio.OPUS
 	)
 
 	init {
@@ -129,7 +130,6 @@ class ExoPlayerProfile(
 				Codec.Audio.OGA,
 				Codec.Audio.WEBMA,
 				Codec.Audio.APE,
-				Codec.Audio.OPUS,
 			)))
 			// Photo direct play
 			add(photoDirectPlayProfile)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
I added the Opus and FLAC codecs to the supported audio codecs for directly playable videos.
According to the [Android documentation](https://developer.android.com/guide/topics/media/media-formats#core), Opus decoding is natively supported since Android 5.0, the minimum required version of this app; FLAC since 3.1.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2359 #2366 