### PR TITLE
Allow all supported audio codecs in ExoPlayer transcoding profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -39,18 +39,19 @@ class ExoPlayerProfile(
 	 * Returns all audio codecs used commonly in video containers.
 	 * This does not include containers / codecs found in audio files
 	 */
-	private val allSupportedAudioCodecs = downmixSupportedAudioCodecs + arrayOf(
-		Codec.Audio.AAC_LATM,
-		Codec.Audio.ALAC,
-		Codec.Audio.AC3,
-		Codec.Audio.EAC3,
-		Codec.Audio.DCA,
-		Codec.Audio.DTS,
-		Codec.Audio.MLP,
-		Codec.Audio.TRUEHD,
-		Codec.Audio.PCM_ALAW,
-		Codec.Audio.PCM_MULAW,
-	)
+	private val allSupportedAudioCodecs = buildList {
+		addAll(downmixSupportedAudioCodecs)
+		add(Codec.Audio.AAC_LATM)
+		add(Codec.Audio.ALAC)
+		if (isAC3Enabled) add(Codec.Audio.AC3)
+		if (isAC3Enabled) add(Codec.Audio.EAC3)
+		add(Codec.Audio.DCA)
+		add(Codec.Audio.DTS)
+		add(Codec.Audio.MLP)
+		add(Codec.Audio.TRUEHD)
+		add(Codec.Audio.PCM_ALAW)
+		add(Codec.Audio.PCM_MULAW)
+	}.toTypedArray()
 
 	init {
 		name = "AndroidTV-ExoPlayer"
@@ -65,10 +66,9 @@ class ExoPlayerProfile(
 					if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
 					add(Codec.Video.H264)
 				}.joinToString(",")
-				audioCodec = buildList {
-					if (isAC3Enabled) add(Codec.Audio.AC3)
-					add(Codec.Audio.AAC)
-					add(Codec.Audio.MP3)
+				audioCodec = when {
+					Utils.downMixAudio(context) -> downmixSupportedAudioCodecs
+					else -> allSupportedAudioCodecs
 				}.joinToString(",")
 				protocol = "hls"
 				copyTimestamps = false


### PR DESCRIPTION
I've only tested this one a single video item that needed transcoding for subs but also transcoded the audio. Not sure why the transcoding profile didn't allow all audio codecs.

**Changes**
- Allow all supported audio codecs in ExoPlayer transcoding profile

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
