### PR TITLE
Add AV1 direct play support.

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
@@ -62,6 +62,7 @@ object Codec {
 		const val MPEG2VIDEO = "mpeg2video"
 		const val VP8 = "vp8"
 		const val VP9 = "vp9"
+		const val AV1 = "av1"
 	}
 
 	object Subtitle {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -5,6 +5,7 @@ import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAV1CodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
@@ -114,7 +115,8 @@ class ExoPlayerProfile(
 						Codec.Video.VP8,
 						Codec.Video.VP9,
 						Codec.Video.MPEG,
-						Codec.Video.MPEG2VIDEO
+						Codec.Video.MPEG2VIDEO,
+						Codec.Video.AV1
 					).joinToString(",")
 
 					audioCodec = when {
@@ -190,6 +192,8 @@ class ExoPlayerProfile(
 			})
 			// HEVC profile
 			add(deviceHevcCodecProfile)
+			// AV1 profile
+			add(deviceAV1CodecProfile)
 			// Limit video resolution support for older devices
 			if (!DeviceUtils.has4kVideoSupport()) {
 				add(CodecProfile().apply {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -3,10 +3,21 @@ package org.jellyfin.androidtv.util.profile
 import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
 import android.media.MediaFormat
+import android.os.Build
 import timber.log.Timber
 
 class MediaCodecCapabilitiesTest {
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
+
+	fun supportsAV1(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+		hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AV1)
+
+	fun supportsAV1Main10(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+		hasDecoder(
+			MediaFormat.MIMETYPE_VIDEO_AV1,
+			CodecProfileLevel.AV1ProfileMain10,
+			CodecProfileLevel.AV1Level5
+		)
 
 	fun supportsHevc(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_HEVC)
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -21,6 +21,48 @@ object ProfileHelper {
 
 	private val MediaTest by lazy { MediaCodecCapabilitiesTest() }
 
+	val deviceAV1CodecProfile by lazy {
+		CodecProfile().apply {
+			type = CodecType.Video
+			codec = Codec.Video.AV1
+
+			conditions = when {
+				!MediaTest.supportsAV1() -> {
+					// The following condition is a method to exclude all AV1
+					Timber.i("*** Does NOT support AV1")
+					arrayOf(
+						ProfileCondition(
+							ProfileConditionType.Equals,
+							ProfileConditionValue.VideoProfile,
+							"none"
+						)
+					)
+				}
+				!MediaTest.supportsAV1Main10() -> {
+					Timber.i("*** Does NOT support AV1 10 bit")
+					arrayOf(
+						ProfileCondition(
+							ProfileConditionType.NotEquals,
+							ProfileConditionValue.VideoProfile,
+							"Main 10"
+						)
+					)
+				}
+				else -> {
+					// supports all AV1
+					Timber.i("*** Supports AV1 10 bit")
+					arrayOf(
+						ProfileCondition(
+							ProfileConditionType.NotEquals,
+							ProfileConditionValue.VideoProfile,
+							"none"
+						)
+					)
+				}
+			}
+		}
+	}
+
 	val deviceHevcCodecProfile by lazy {
 		CodecProfile().apply {
 			type = CodecType.Video


### PR DESCRIPTION
**Changes**
This adds the ability for ExoPlayer to play AV1 without transcoding on API level 29 and up.

**Issues**
There's a few issues that reference AV1 support, but nothing really specific to ExoPlayer. LibVLC still appears to just black screen attempting to play AV1, but it doesn't appear to be related to the profiles stuff that was modified here.

There may be more/better ways of doing this, in theory ExoPlayer supports AV1 at even lower API levels, this might not correctly detect/advertise 10-bit support, but the only device I have available to test this on works correctly. This PR is bringing attention to this missing feature and to get the ball rolling on it.

Tested on: Chromecast with Google TV **HD** (which has hardware AV1 support; Chromecast with Google TV _4K_ does not do hardware AV1 but it might do software?).