### PR TITLE
Fix BrowseGridFragment focus not restoring when going back

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -188,27 +188,6 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
         // Hide the description because we don't have room for it
         binding.npBug.showDescription(false);
 
-        // NOTE: we only get the 100% correct grid size if we render it once, so hook into it here
-        binding.rowsFragment.post(() -> {
-            if (binding.rowsFragment.getHeight() > 0 && binding.rowsFragment.getWidth() > 0) {
-                if (mGridView == null) {
-                    return;
-                }
-                // prevent adaption on minor size delta's
-                if (Math.abs(mGridHeight - binding.rowsFragment.getHeight()) > MIN_GRIDSIZE_CHANGE_DELTA || Math.abs(mGridWidth - binding.rowsFragment.getWidth()) > MIN_GRIDSIZE_CHANGE_DELTA) {
-                    mGridHeight = Math.round(binding.rowsFragment.getHeight() / getResources().getDisplayMetrics().density);
-                    mGridWidth = Math.round(binding.rowsFragment.getWidth() / getResources().getDisplayMetrics().density);
-                    Timber.d("Auto-Adapting grid size to height <%s> width <%s>", binding.rowsFragment.getHeight(), binding.rowsFragment.getWidth());
-                    mDirty = true;
-                    determiningPosterSize = true;
-                    setAutoCardGridValues();
-                    createGrid();
-                    loadGrid();
-                    determiningPosterSize = false;
-                }
-            }
-        });
-
         return binding.getRoot();
     }
 


### PR DESCRIPTION
TL;DR; removing code fixes issue 🤷 

**Changes**

Because the onCreateView function scheduled a callback for after the first render it caused some problems. The biggest one being that the focused item would not restore when going back and a side-effect was that the grid was kinda slow. When I reviewed the PR that introduced this change I probably missed this code, because it doesn't make sense anyway - you need to use onViewCreated to read measurements etc. and the fragment already does that. So removing this codeblock doesn't introduce any  issues because it was just duplicate code....

**Issues**

Fixes #2363