### PR TITLE
Remove experimental audio codecs from transcoding profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -53,6 +53,10 @@ class ExoPlayerProfile(
 		add(Codec.Audio.PCM_MULAW)
 	}.toTypedArray()
 
+	private val allSupportedAudioCodecsWithoutFFmpegExperimental = allSupportedAudioCodecs
+		.filterNot { it == Codec.Audio.DCA || it == Codec.Audio.TRUEHD }
+		.toTypedArray()
+
 	init {
 		name = "AndroidTV-ExoPlayer"
 
@@ -68,7 +72,7 @@ class ExoPlayerProfile(
 				}.joinToString(",")
 				audioCodec = when {
 					Utils.downMixAudio(context) -> downmixSupportedAudioCodecs
-					else -> allSupportedAudioCodecs
+					else -> allSupportedAudioCodecsWithoutFFmpegExperimental
 				}.joinToString(",")
 				protocol = "hls"
 				copyTimestamps = false


### PR DESCRIPTION
Regression from #2381

**Changes**
- Remove DCA / TrueHD from ExoPlayer transcoding profile

**Issues**

Client-side fix for #2396
