### PR TITLE
Add media management preference

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/model/DataRefreshService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/model/DataRefreshService.kt
@@ -1,9 +1,10 @@
 package org.jellyfin.androidtv.data.model
 
 import org.jellyfin.sdk.model.api.BaseItemDto
+import java.util.UUID
 
 class DataRefreshService {
-	var lastDeletedItemId: String? = null
+	var lastDeletedItemId: UUID? = null
 	var lastPlayback: Long = 0
 	var lastMoviePlayback: Long = 0
 	var lastTvPlayback: Long = 0

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -52,6 +52,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var premieresEnabled = booleanPreference("pref_enable_premieres", false)
 
+		/**
+		 * Enable management of media like deleting items when the user has sufficient permisisons.
+		 */
+		var mediaManagementEnabled = booleanPreference("enable_media_management", false)
+
 		/* Playback - General*/
 		/**
 		 * Maximum bitrate in megabit for playback. A value of [MAX_BITRATE_AUTO] is used when

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -190,7 +190,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
         // React to deletion
         DataRefreshService dataRefreshService = KoinJavaComponent.<DataRefreshService>get(DataRefreshService.class);
-        if (mCurrentRow != null && mCurrentItem != null && mCurrentItem.getItemId() != null && mCurrentItem.getItemId().equals(dataRefreshService.getLastDeletedItemId())) {
+        if (mCurrentRow != null && mCurrentItem != null && mCurrentItem.getItemId() != null && mCurrentItem.getBaseItem().getId().equals(dataRefreshService.getLastDeletedItemId())) {
             ((ItemRowAdapter) mCurrentRow.getAdapter()).remove(mCurrentItem);
             dataRefreshService.setLastDeletedItemId(null);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -170,8 +170,9 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 		super.onResume()
 
 		//React to deletion
-		if (currentRow != null && currentItem != null && currentItem!!.getItemId() != null && currentItem!!.getItemId().equals(dataRefreshService.lastDeletedItemId)) {
+		if (currentRow != null && currentItem != null && currentItem?.baseItem != null && currentItem!!.baseItem!!.id == dataRefreshService.lastDeletedItemId) {
 			(currentRow!!.adapter as ItemRowAdapter).remove(currentItem)
+			currentItem = null
 			dataRefreshService.lastDeletedItemId = null
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -1,0 +1,42 @@
+package org.jellyfin.androidtv.ui.itemdetail
+
+import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.model.DataRefreshService
+import org.jellyfin.androidtv.ui.navigation.Destinations
+import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.exception.ApiClientException
+import org.jellyfin.sdk.api.client.extensions.libraryApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import timber.log.Timber
+
+fun FullDetailsFragment.deleteItem(
+	api: ApiClient,
+	item: BaseItemDto,
+	dataRefreshService: DataRefreshService,
+	navigationRepository: NavigationRepository,
+) = lifecycleScope.launch {
+	Timber.i("Deleting item ${item.name} (id=${item.id})")
+
+	try {
+		withContext(Dispatchers.IO) {
+			api.libraryApi.deleteItem(item.id)
+		}
+	} catch (error: ApiClientException) {
+		Timber.e(error, "Failed to delete item ${item.name} (id=${item.id})")
+		Toast.makeText(context, getString(R.string.item_deletion_failed, item.name), Toast.LENGTH_LONG).show()
+		return@launch
+	}
+
+	dataRefreshService.lastDeletedItemId = item.id
+
+	if (navigationRepository.canGoBack) navigationRepository.goBack()
+	else navigationRepository.navigate(Destinations.home)
+
+	Toast.makeText(context, getString(R.string.item_deleted, item.name), Toast.LENGTH_LONG).show()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -60,6 +60,12 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 				setContent(R.string.desc_premieres)
 				bind(userPreferences, UserPreferences.premieresEnabled)
 			}
+
+			checkbox {
+				setTitle(R.string.pref_enable_media_management)
+				setContent(R.string.pref_enable_media_management_description)
+				bind(userPreferences, UserPreferences.mediaManagementEnabled)
+			}
 		}
 
 		category {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,4 +495,10 @@
     <string name="server_setup_incomplete">The setup of this server has not been completed. Open Jellyfin in a web browser to finish setup before signing in.</string>
     <string name="episode_name_special">special</string>
     <string name="app_notification_beta">App updated to %1$s\nThank you for participating in the Jellyfin beta program</string>
+    <string name="item_deleted">%1$s deleted</string>
+    <string name="item_deletion_failed">Unable to delete %1$s</string>
+    <string name="pref_enable_media_management">Enable media management</string>
+    <string name="pref_enable_media_management_description">Show option to manage media while browsing</string>
+    <string name="item_delete_confirm_title">Delete item</string>
+    <string name="item_delete_confirm_message">Are you sure you want to delete this item? This action cannot be undone.</string>
 </resources>


### PR DESCRIPTION
This new preference shows a delete option for items when the user has permissions to delete the displaying item. This is a rewritten implementation of the previous delete option that was removed in 0.15.

**Changes**
- Add preference "enable media management"
- Add "delete" option to item details screen (when management is enabled)
  - Only shows when the user has permission to delete the item
    - Also checks per-library delete permission now
  - Catches issues and shows a toast for it, to prevent crashes when deletion fails
- Change DataRefreshService.lastDeletedItemId to UUID
- Item deleted toast is now translatable

**Issues**

Fixes #2368