### PR TITLE
Increase amount of logs added to crash reports

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
@@ -32,6 +32,7 @@ object TelemetryService {
 			buildConfigClass = BuildConfig::class.java
 			sharedPreferencesName = TelemetryPreferences.SHARED_PREFERENCES_NAME
 			pluginLoader = AcraPluginLoader(AcraReportSenderFactory::class.java)
+			applicationLogFileLines = 250
 
 			toast {
 				text = context.getString(R.string.crash_report_toast)


### PR DESCRIPTION
Some stacktraces with Kotlin coroutines can get big. Right now we have 100 lines and this often is not enough to see what happened before the exception. Increasing the count to 250 should hopefully fix that.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Increase amount of logs added to crash reports
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
