### PR TITLE
Ignore missing notification permission from Glide

### DIFF
--- a/android-lint.xml
+++ b/android-lint.xml
@@ -13,6 +13,9 @@
     <issue id="MangledCRLF" severity="warning" />
     <issue id="NegativeMargin" severity="warning" />
     <issue id="NoHardKeywords" severity="warning" />
+    <issue id="NotificationPermission">
+        <ignore regexp="com.bumptech.glide.request.target.NotificationTarget" />
+    </issue>
     <issue id="Registered" severity="warning" />
     <issue id="RequiredSize" severity="error" />
     <issue id="Typos" severity="ignore" />


### PR DESCRIPTION
Ignores the missing `android.permission.POST_NOTIFICATIONS` permission caused by some Glide class that's not used in this project. There's a issue already raised but it hasn't been actioned yet: https://github.com/bumptech/glide/issues/4940

This should allow upgrading AGP to 7.4.0 without any issues.