### PR TITLE
Add ExoPlayer backend to playback rewrite

### DIFF
--- a/playback/exoplayer/build.gradle.kts
+++ b/playback/exoplayer/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
 	// ExoPlayer
 	implementation(libs.exoplayer)
+	implementation(libs.jellyfin.exoplayer.ffmpegextension)
 
 	// Logging
 	implementation(libs.timber)

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -1,0 +1,109 @@
+package org.jellyfin.playback.exoplayer
+
+import android.content.Context
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.DefaultRenderersFactory
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.PlaybackException
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.video.VideoSize
+import org.jellyfin.playback.core.backend.BasePlayerBackend
+import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.PositionInfo
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
+
+class ExoPlayerBackend(
+	private val context: Context,
+) : BasePlayerBackend() {
+	override fun getPositionInfo(): PositionInfo = PositionInfo(
+		active = exoPlayer.currentPosition.milliseconds,
+		buffer = exoPlayer.bufferedPosition.milliseconds,
+		duration = if (exoPlayer.duration == C.TIME_UNSET) ZERO else exoPlayer.duration.milliseconds,
+	)
+
+	private val exoPlayer by lazy {
+		val renderersFactory = DefaultRenderersFactory(context).apply {
+			setEnableDecoderFallback(true)
+			setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+		}
+		ExoPlayer.Builder(context, renderersFactory)
+			.build()
+			.also { player -> player.addListener(PlayerListener()) }
+	}
+
+	inner class PlayerListener : Player.Listener {
+		override fun onIsPlayingChanged(isPlaying: Boolean) {
+			val state = when {
+				isPlaying -> PlayState.PLAYING
+				exoPlayer.playbackState == Player.STATE_IDLE || exoPlayer.playbackState == Player.STATE_ENDED -> PlayState.STOPPED
+				else -> PlayState.PAUSED
+			}
+			listener?.onPlayStateChange(state)
+		}
+
+		override fun onPlayerError(error: PlaybackException) {
+			listener?.onPlayStateChange(PlayState.ERROR)
+		}
+
+		override fun onVideoSizeChanged(size: VideoSize) {
+			listener?.onVideoSizeChange(size.width, size.height)
+		}
+
+		override fun onPlaybackStateChanged(playbackState: Int) {
+			onIsPlayingChanged(exoPlayer.isPlaying)
+		}
+	}
+
+	override fun prepareStream(stream: MediaStream) {
+		val mediaItem = MediaItem.Builder().apply {
+			setMediaId(stream.hashCode().toString())
+			setUri(stream.url)
+		}.build()
+
+		if (exoPlayer.mediaItemCount == 0) {
+			exoPlayer.setMediaItem(mediaItem)
+		} else {
+			// Remove old items
+			while (exoPlayer.mediaItemCount > 1) exoPlayer.removeMediaItem(0)
+			// Add new item
+			exoPlayer.addMediaItem(mediaItem)
+		}
+
+		exoPlayer.prepare()
+	}
+
+	override fun playStream(stream: MediaStream) {
+		var streamIsPrepared = false
+		repeat(exoPlayer.mediaItemCount) { index ->
+			streamIsPrepared = streamIsPrepared || exoPlayer.getMediaItemAt(index).mediaId == stream.hashCode().toString()
+		}
+
+		if (!streamIsPrepared) prepareStream(stream)
+
+		exoPlayer.play()
+	}
+
+	override fun play() {
+		exoPlayer.play()
+	}
+
+	override fun pause() {
+		exoPlayer.pause()
+	}
+
+	override fun stop() {
+		exoPlayer.stop()
+	}
+
+	override fun seekTo(position: Duration) {
+		exoPlayer.seekTo(position.inWholeMilliseconds)
+	}
+
+	override fun setSpeed(speed: Float) {
+		exoPlayer.setPlaybackSpeed(speed)
+	}
+}

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -64,14 +64,10 @@ class ExoPlayerBackend(
 			setUri(stream.url)
 		}.build()
 
-		if (exoPlayer.mediaItemCount == 0) {
-			exoPlayer.setMediaItem(mediaItem)
-		} else {
-			// Remove old items
-			while (exoPlayer.mediaItemCount > 1) exoPlayer.removeMediaItem(0)
-			// Add new item
-			exoPlayer.addMediaItem(mediaItem)
-		}
+		// Remove any old preloaded items (skips the first which is the playing item)
+		while (exoPlayer.mediaItemCount > 1) exoPlayer.removeMediaItem(0)
+		// Add new item
+		exoPlayer.addMediaItem(mediaItem)
 
 		exoPlayer.prepare()
 	}

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerPlugin.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerPlugin.kt
@@ -1,0 +1,8 @@
+package org.jellyfin.playback.exoplayer
+
+import android.content.Context
+import org.jellyfin.playback.core.plugin.playbackPlugin
+
+fun exoPlayerPlugin(androidContext: Context) = playbackPlugin {
+	provide(ExoPlayerBackend(androidContext))
+}


### PR DESCRIPTION
There we go, the third big PR for the playback rewrite! Well actually not that big but it adds an important part. This PR is a follow up on #2401 where I didn't include the ExoPlayer backend intentionally.

**Changes**

- Add ExoPlayerBackend
  - Supports all current features
  - This will be the only backend in the forseeable future, multi-backend support and smart-backend selection are a low priority for now (but will likely be high priority when video support is added)
  - Some features related to video are removed from this PR

**Issues**

Part of #1057