### PR TITLE
Add PlaySessionService to playback rewrite

### DIFF
--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -1,0 +1,15 @@
+package org.jellyfin.playback.jellyfin
+
+import org.jellyfin.playback.core.plugin.playbackPlugin
+import org.jellyfin.playback.jellyfin.playsession.PlaySessionService
+import org.jellyfin.playback.jellyfin.playsession.PlaySessionSocketService
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.sockets.SocketInstance
+
+fun jellyfinPlugin(
+	api: ApiClient,
+	socketInstance: SocketInstance,
+) = playbackPlugin {
+	provide(PlaySessionService(api))
+	provide(PlaySessionSocketService(socketInstance))
+}

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
@@ -1,0 +1,127 @@
+package org.jellyfin.playback.jellyfin.playsession
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.item.QueueEntry
+import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.playback.jellyfin.queue.item.BaseItemDtoUserQueueEntry
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.playStateApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.PlayMethod
+import org.jellyfin.sdk.model.api.PlaybackProgressInfo
+import org.jellyfin.sdk.model.api.PlaybackStartInfo
+import org.jellyfin.sdk.model.api.PlaybackStopInfo
+import org.jellyfin.sdk.model.api.QueueItem
+import org.jellyfin.sdk.model.api.RepeatMode
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
+class PlaySessionService(
+	private val api: ApiClient,
+) : PlayerService() {
+	var reportedItem: BaseItemDto? = null
+
+	override suspend fun onInitialize() {
+		coroutineScope.launch {
+			state.currentEntry.collect { entry ->
+				onItemChange(entry)
+			}
+		}
+
+		coroutineScope.launch {
+			state.playState.collect { playState ->
+				when (playState) {
+					PlayState.PLAYING -> onStart()
+					PlayState.STOPPED -> onStop()
+					PlayState.PAUSED -> onPause()
+					PlayState.ERROR -> onStop()
+				}
+			}
+		}
+	}
+
+	private fun onItemChange(item: QueueEntry?) {
+		if (item !is BaseItemDtoUserQueueEntry) return
+		reportedItem = item.baseItem
+		onStart()
+	}
+
+	private fun onStart() {
+		coroutineScope.launch {
+			if (reportedItem != null) startBaseItem(reportedItem!!)
+		}
+	}
+
+	private fun onStop() {
+		coroutineScope.launch {
+			if (reportedItem != null) {
+				stopBaseItem(reportedItem!!)
+			}
+		}
+	}
+
+	private fun onPause() {
+		coroutineScope.launch {
+			if (reportedItem != null) updateBaseItem(reportedItem!!)
+		}
+	}
+
+	private suspend fun getQueue(): List<QueueItem> {
+		// The queues are lazy loaded so we only load a small amount of items to set as queue on the
+		// backend.
+		return manager.queue
+			?.peekNext(15)
+			.orEmpty()
+			.filterIsInstance<BaseItemDtoUserQueueEntry>()
+			.map { QueueItem(id = it.baseItem.id, playlistItemId = it.baseItem.playlistItemId) }
+	}
+
+	private suspend fun startBaseItem(item: BaseItemDto) {
+		api.playStateApi.reportPlaybackStart(PlaybackStartInfo(
+			itemId = item.id,
+			playlistItemId = item.playlistItemId,
+			canSeek = true,
+			isMuted = false,
+			isPaused = state.playState.value != PlayState.PLAYING,
+			aspectRatio = state.videoSize.value.aspectRatio.toString(),
+			positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },
+			playMethod = PlayMethod.DIRECT_PLAY,
+			repeatMode = RepeatMode.REPEAT_NONE,
+			nowPlayingQueue = getQueue(),
+		))
+	}
+
+	private suspend fun updateBaseItem(item: BaseItemDto) {
+		api.playStateApi.reportPlaybackProgress(PlaybackProgressInfo(
+			itemId = item.id,
+			playlistItemId = item.playlistItemId,
+			canSeek = true,
+			isMuted = false,
+			isPaused = state.playState.value != PlayState.PLAYING,
+			aspectRatio = state.videoSize.value.aspectRatio.toString(),
+			positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },
+			playMethod = PlayMethod.DIRECT_PLAY,
+			repeatMode = RepeatMode.REPEAT_NONE,
+			nowPlayingQueue = getQueue(),
+		))
+	}
+
+	private suspend fun stopBaseItem(item: BaseItemDto) {
+		api.playStateApi.reportPlaybackStopped(PlaybackStopInfo(
+			itemId = item.id,
+			playlistItemId = item.playlistItemId,
+			positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },
+			failed = false,
+			nowPlayingQueue = getQueue(),
+		))
+	}
+
+	/**
+	 * The value of this duration expressed as a [Long] number of ticks.
+	 */
+	private val Duration.inWholeTicks: Long get() = toLong(DurationUnit.NANOSECONDS).div(100L)
+}

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionSocketService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionSocketService.kt
@@ -1,0 +1,60 @@
+package org.jellyfin.playback.jellyfin.playsession
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.sdk.api.sockets.SocketInstance
+import org.jellyfin.sdk.api.sockets.addPlayStateCommandsListener
+import org.jellyfin.sdk.api.sockets.listener.SocketListener
+import org.jellyfin.sdk.model.api.PlaystateCommand
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+
+class PlaySessionSocketService(
+	private val socketInstance: SocketInstance,
+) : PlayerService() {
+	private var listeners = mutableListOf<SocketListener>()
+
+	override suspend fun onInitialize() {
+		listeners += socketInstance.addPlayStateCommandsListener { message ->
+			coroutineScope.launch(Dispatchers.Main) {
+				when (message.request.command) {
+					PlaystateCommand.STOP -> state.stop()
+					PlaystateCommand.PAUSE -> state.pause()
+					PlaystateCommand.UNPAUSE -> state.unpause()
+					PlaystateCommand.NEXT_TRACK -> manager.queue?.next()
+					PlaystateCommand.PREVIOUS_TRACK -> manager.queue?.previous()
+					PlaystateCommand.SEEK -> {
+						val to = message.request.seekPositionTicks?.ticks ?: Duration.ZERO
+						state.seek(to)
+					}
+					PlaystateCommand.REWIND -> state.rewind()
+					PlaystateCommand.FAST_FORWARD -> state.fastForward()
+					PlaystateCommand.PLAY_PAUSE -> when (state.playState.value) {
+						PlayState.PLAYING -> state.pause()
+						else -> state.unpause()
+					}
+				}
+			}
+		}
+
+		coroutineScope.launch {
+			try {
+				awaitCancellation()
+			} finally {
+				listeners.removeAll { listener ->
+					listener.stop()
+					true
+				}
+			}
+		}
+	}
+
+	/**
+	 * Convert ticks to duration
+	 */
+	private val Long.ticks get() = div(100L).nanoseconds
+}


### PR DESCRIPTION
There we go, the second third big PR for the playback rewrite! This one adds play session support which is pretty essential for Jellyfin.

**Changes**
- Add JellyfinPlugin
  - Adds all Jellyfin specific stuff like PlaySession, Media resolving, QuickConnect etc.
- Add PlaySessionService
  - Reports media progress to the backend
  - This is what makes the dashboard show what a user is playing
  - There might be some bugs in this implementation because our API isn't documented greatly
  - Needs jellyfin/jellyfin#8971 to function properly
- Add PlaySessionSocketService
  - Listens for PlayState commands on the WebSocket connection
  - This is what allows for remote control
  - Currently doesn't support playing queues yet
    - This will come after video support is added and we can determine the queue type etc.
  - Works quite well with jellyfin-web :)

**Issues**

Part of #1057