### PR TITLE
Fix ItemSortBy.Random

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -154,6 +154,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
             sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), ItemSortBy.CommunityRating + "," + ItemSortBy.SortName, SortOrder.DESCENDING));
             sortOptions.put(5, new SortOption(getString(R.string.lbl_critic_rating), ItemSortBy.CriticRating + "," + ItemSortBy.SortName, SortOrder.DESCENDING));
             sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), ItemSortBy.DatePlayed + "," + ItemSortBy.SortName, SortOrder.DESCENDING));
+            sortOptions.put(7, new SortOption(getString(R.string.lbl_random), ItemSortBy.Random, SortOrder.ASCENDING));
         }
 
         mActivity = getActivity();


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
added sortOptions.put(7, new SortOption(getString(R.string.lbl_random), ItemSortBy.Random, SortOrder.ASCENDING));in jellyfin-androidtv/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java after Line 156 , which is sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), ItemSortBy.DatePlayed + "," + ItemSortBy.SortName, SortOrder.DESCENDING)); 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> 
fixes #2309  
