### PR TITLE
Use HEADER_ACCEPT from SDK as Glide Accept header value

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
+import org.jellyfin.sdk.api.client.ApiClient
 import kotlin.math.round
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -77,7 +78,7 @@ class AsyncImageView @JvmOverloads constructor(
 				}.into(this@AsyncImageView)
 			} else {
 				val glideUrl = GlideUrl(url, LazyHeaders.Builder().apply {
-					setHeader("Accept", "*/*")
+					setHeader("Accept", ApiClient.HEADER_ACCEPT)
 				}.build())
 
 				Glide.with(this@AsyncImageView).load(glideUrl).apply {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -10,6 +10,8 @@ import androidx.core.view.doOnAttach
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.model.GlideUrl
+import com.bumptech.glide.load.model.LazyHeaders
 import com.vanniktech.blurhash.BlurHash
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -69,15 +71,23 @@ class AsyncImageView @JvmOverloads constructor(
 			}
 
 			// Start loading image or placeholder
-			Glide.with(this@AsyncImageView)
-				.load(url ?: placeholder).apply {
+			if (url == null) {
+				Glide.with(this@AsyncImageView).load(placeholder).apply {
+					if (circleCrop) circleCrop()
+				}.into(this@AsyncImageView)
+			} else {
+				val glideUrl = GlideUrl(url, LazyHeaders.Builder().apply {
+					setHeader("Accept", "*/*")
+				}.build())
+
+				Glide.with(this@AsyncImageView).load(glideUrl).apply {
 					placeholder(placeholderOrBlurHash)
 					error(placeholder)
 					if (circleCrop) circleCrop()
 					// FIXME: Glide is unable to scale the image when transitions are enabled
 					//transition(DrawableTransitionOptions.withCrossFade(crossFadeDuration.inWholeMilliseconds.toInt()))
-				}
-				.into(this@AsyncImageView)
+				}.into(this@AsyncImageView)
+			}
 		}
 	}
 }


### PR DESCRIPTION
By default Glide did not set an `Accept` header. The SDK now provides one that includes both `image/*` and `*/*` as values. This fixes an issue where the server would fail to check which image types are supported.

**Changes**
- Use HEADER_ACCEPT from SDK as Glide Accept header value
  
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
