### PR TITLE
Change opening menu to ACTION_UP instead of ACTION_DOWN

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -202,7 +202,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
 
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
-        if (event.getAction() != KeyEvent.ACTION_DOWN) return false;
+        if (event.getAction() != KeyEvent.ACTION_UP) return false;
 
         if (keyCode == KeyEvent.KEYCODE_MEDIA_PLAY || keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE) {
             mediaManager.getValue().setCurrentMediaAdapter(mAdapter);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -339,7 +339,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
-        if (event.getAction() != KeyEvent.ACTION_DOWN) return false;
+        if (event.getAction() != KeyEvent.ACTION_UP) return false;
         return KeyProcessor.HandleKey(keyCode, mCurrentItem, requireActivity());
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -162,7 +162,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	}
 
 	override fun onKey(v: View?, keyCode: Int, event: KeyEvent?): Boolean {
-		if (event?.action != KeyEvent.ACTION_DOWN) return false
+		if (event?.action != KeyEvent.ACTION_UP) return false
 		return KeyProcessor.HandleKey(keyCode, currentItem, activity)
 	}
 


### PR DESCRIPTION
This changes the behavior back to what it was in 0.14. Unfortunately Amazon behaves weird when opening the PopupMenu when the keypress starts so this "fixes" that issue.

**Changes**

- Open item menu when keypress ends instead of when it starts
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #2436
