### PR TITLE
Split MediaManager into interface and implementation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -19,7 +19,6 @@ import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.navigation.NavigationRepositoryImpl
 import org.jellyfin.androidtv.ui.picture.PictureViewerViewModel
-import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
 import org.jellyfin.androidtv.ui.startup.ServerAddViewModel
@@ -86,8 +85,6 @@ val appModule = module {
 	}
 
 	// Non API related
-	single { MediaManager(get()) }
-
 	single { DataRefreshService() }
 	single { PlaybackControllerContainer() }
 

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -3,14 +3,15 @@ package org.jellyfin.androidtv.di
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.playback.GarbagePlaybackLauncher
+import org.jellyfin.androidtv.ui.playback.LegacyMediaManager
+import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackManager
 import org.jellyfin.androidtv.ui.playback.RewritePlaybackLauncher
 import org.koin.dsl.module
 
 val playbackModule = module {
-	single {
-		PlaybackManager(get())
-	}
+	single { PlaybackManager(get()) }
+	single<MediaManager> { LegacyMediaManager(get()) }
 
 	factory {
 		val preferences = get<UserPreferences>()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -48,7 +48,7 @@ class NowPlayingView @JvmOverloads constructor(
 
 			if (mediaManager.hasAudioQueueItems()) {
 				isVisible = true
-				setInfo(mediaManager.currentAudioItem)
+				setInfo(mediaManager.currentAudioItem!!)
 				setStatus(mediaManager.currentAudioPosition)
 			} else isVisible = false
 		}
@@ -95,7 +95,7 @@ class NowPlayingView @JvmOverloads constructor(
 
 			if (hasQueue) {
 				// may have just added one so update display
-				setInfo(mediaManager.currentAudioItem)
+				setInfo(mediaManager.currentAudioItem!!)
 				setStatus(mediaManager.currentAudioPosition)
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -207,7 +207,6 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
         if (keyCode == KeyEvent.KEYCODE_MEDIA_PLAY || keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE) {
             mediaManager.getValue().setCurrentMediaAdapter(mAdapter);
             mediaManager.getValue().setCurrentMediaPosition(mCurrentItem.getIndex());
-            mediaManager.getValue().setCurrentMediaTitle(mFolder.getName());
         }
         return KeyProcessor.HandleKey(keyCode, mCurrentItem, mActivity);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -430,7 +430,6 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
         public void onItemClicked(final Presenter.ViewHolder itemViewHolder, Object item, RowPresenter.ViewHolder rowViewHolder, Row row) {
             if (!(item instanceof BaseRowItem)) return;
 
-            mediaManager.getValue().setCurrentMediaTitle(row.getHeaderItem().getName());
             ItemLauncher.launch((BaseRowItem) item, (ItemRowAdapter) ((ListRow) row).getAdapter(), ((BaseRowItem) item).getIndex(), getActivity());
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -295,7 +295,7 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
         updateButtons(mediaManager.getValue().isPlayingAudio());
 
         // load the item duration and set the position to 0 since it won't be set elsewhere until playback is initialized
-        if (!mediaManager.getValue().getIsAudioPlayerInitialized())
+        if (!mediaManager.getValue().isAudioPlayerInitialized())
             setCurrentTime(0);
     }
 
@@ -389,7 +389,7 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
             Timber.d("Queue status changed");
             if (hasQueue) {
                 loadItem();
-                if (mediaManager.getValue().getIsAudioPlayerInitialized()) {
+                if (mediaManager.getValue().isAudioPlayerInitialized()) {
                     updateButtons(mediaManager.getValue().isPlayingAudio());
                 }
             } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -61,7 +61,7 @@ import java.util.Random;
 import kotlin.Lazy;
 import timber.log.Timber;
 
-public class MediaManager {
+public class LegacyMediaManager implements MediaManager {
     private Context context;
     private ItemRowAdapter mCurrentMediaAdapter;
     private int mCurrentMediaPosition = -1;
@@ -101,24 +101,30 @@ public class MediaManager {
     private Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private Lazy<UserSettingPreferences> userPrefs = inject(UserSettingPreferences.class);
 
-    public MediaManager(Context context) {
+    public LegacyMediaManager(Context context) {
         this.context = context;
     }
 
+    @Override
     public ItemRowAdapter getCurrentMediaAdapter() {
         return mCurrentMediaAdapter;
     }
+    @Override
     public boolean hasAudioQueueItems() { return mCurrentAudioQueue != null && mCurrentAudioQueue.size() > 0; }
+    @Override
     public boolean hasVideoQueueItems() { return mCurrentVideoQueue != null && mCurrentVideoQueue.size() > 0; }
 
+    @Override
     public void setCurrentMediaAdapter(ItemRowAdapter currentMediaAdapter) {
         this.mCurrentMediaAdapter = currentMediaAdapter;
     }
 
+    @Override
     public int getCurrentMediaPosition() {
         return mCurrentMediaPosition;
     }
 
+    @Override
     public void setCurrentVideoQueue(List<org.jellyfin.sdk.model.api.BaseItemDto> items) {
         if (items == null || items.size() < 1) {
             clearVideoQueue();
@@ -134,23 +140,34 @@ public class MediaManager {
         mCurrentMediaPosition = 0;
     }
 
+    @Override
     public List<org.jellyfin.sdk.model.api.BaseItemDto> getCurrentVideoQueue() { return mCurrentVideoQueue; }
 
+    @Override
     public int getCurrentAudioQueueSize() { return mCurrentAudioQueue != null ? mCurrentAudioQueue.size() : 0; }
+    @Override
     public int getCurrentAudioQueuePosition() { return hasAudioQueueItems() && mCurrentAudioQueuePosition >= 0 ? mCurrentAudioQueuePosition : 0; }
+    @Override
     public long getCurrentAudioPosition() { return mCurrentAudioPosition; }
+    @Override
     public String getCurrentAudioQueueDisplayPosition() { return Integer.toString(getCurrentAudioQueuePosition() + 1); }
+    @Override
     public String getCurrentAudioQueueDisplaySize() { return mCurrentAudioQueue != null ? Integer.toString(mCurrentAudioQueue.size()) : "0"; }
 
+    @Override
     public org.jellyfin.sdk.model.api.BaseItemDto getCurrentAudioItem() { return mCurrentAudioItem != null ? mCurrentAudioItem : hasAudioQueueItems() ? ((BaseRowItem)mCurrentAudioQueue.get(0)).getBaseItem() : null; }
 
+    @Override
     public boolean toggleRepeat() { mRepeat = !mRepeat; return mRepeat; }
+    @Override
     public boolean isRepeatMode() { return mRepeat; }
 
-    public boolean getIsAudioPlayerInitialized() {
+    @Override
+    public boolean isAudioPlayerInitialized() {
         return audioInitialized && (nativeMode ? mExoPlayer != null : mVlcPlayer != null);
     }
 
+    @Override
     public boolean isShuffleMode() {
         if (mUnShuffledAudioQueueIndexes != null) {
             return true;
@@ -162,12 +179,15 @@ public class MediaManager {
         mUnShuffledAudioQueueIndexes = null;
     }
 
+    @Override
     public ItemRowAdapter getCurrentAudioQueue() { return mCurrentAudioQueue; }
+    @Override
     public ItemRowAdapter getManagedAudioQueue() {
         createManagedAudioQueue();
         return mManagedAudioQueue;
     }
 
+    @Override
     public void createManagedAudioQueue() {
         if (mCurrentAudioQueue != null) {
             if (mManagedAudioQueue != null) {
@@ -192,15 +212,18 @@ public class MediaManager {
         }
     }
 
+    @Override
     public void addAudioEventListener(AudioEventListener listener) {
         mAudioEventListeners.add(listener);
         Timber.d("Added event listener.  Total listeners: %d", mAudioEventListeners.size());
     }
+    @Override
     public void removeAudioEventListener(AudioEventListener listener) {
         mAudioEventListeners.remove(listener);
         Timber.d("Removed event listener.  Total listeners: %d", mAudioEventListeners.size());
     }
 
+    @Override
     public boolean initAudio() {
         Timber.d("initializing audio");
         if (mAudioManager == null) mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
@@ -221,7 +244,7 @@ public class MediaManager {
     }
 
     private void reportProgress() {
-        if (mCurrentAudioItem == null || !getIsAudioPlayerInitialized()) {
+        if (mCurrentAudioItem == null || !isAudioPlayerInitialized()) {
             stopProgressLoop();
             return;
         }
@@ -432,14 +455,17 @@ public class MediaManager {
     private static final int TYPE_AUDIO = 0;
     private static final int TYPE_VIDEO = 1;
 
+    @Override
     public void saveAudioQueue(Context context) {
         saveQueue(context, TYPE_AUDIO);
     }
 
+    @Override
     public void saveVideoQueue(Context context) {
         saveQueue(context, TYPE_VIDEO);
     }
 
+    @Override
     public void saveQueue(Context context, final int type) {
         //Get a name and save as playlist
         final EditText name = new EditText(context);
@@ -501,6 +527,7 @@ public class MediaManager {
         return result;
     }
 
+    @Override
     public int queueAudioItem(org.jellyfin.sdk.model.api.BaseItemDto item) {
         if (mCurrentAudioQueue == null) {
             createAudioQueue(new ArrayList<org.jellyfin.sdk.model.api.BaseItemDto>());
@@ -512,6 +539,7 @@ public class MediaManager {
         return mCurrentAudioQueue.size()-1;
     }
 
+    @Override
     public int addToVideoQueue(org.jellyfin.sdk.model.api.BaseItemDto item) {
         if (mCurrentVideoQueue == null) mCurrentVideoQueue = new ArrayList<>();
         mCurrentVideoQueue.add(item);
@@ -529,10 +557,12 @@ public class MediaManager {
         return mCurrentVideoQueue.size()-1;
     }
 
+    @Override
     public void clearAudioQueue() {
         clearAudioQueue(false);
     }
 
+    @Override
     public void clearAudioQueue(boolean releasePlayer) {
         Timber.d("clearing the audio queue");
         stopAudio(releasePlayer);
@@ -548,6 +578,7 @@ public class MediaManager {
         if (mManagedAudioQueue != null) mManagedAudioQueue.clear();
     }
 
+    @Override
     public void addToAudioQueue(List<org.jellyfin.sdk.model.api.BaseItemDto> items) {
         if (mCurrentAudioQueue == null) {
             createAudioQueue(items);
@@ -566,6 +597,7 @@ public class MediaManager {
         Toast.makeText(context, items.size() + (items.size() > 1 ? context.getString(R.string.msg_items_added) : context.getString(R.string.msg_item_added)), Toast.LENGTH_LONG).show();
     }
 
+    @Override
     public void removeFromAudioQueue(int ndx) {
         if (!hasAudioQueueItems() || ndx > getCurrentAudioQueueSize()) return;
 
@@ -604,10 +636,11 @@ public class MediaManager {
         fireQueueStatusChange();
     }
 
-    public boolean isPlayingAudio() { return getIsAudioPlayerInitialized() && (nativeMode ? mExoPlayer.isPlaying() : mVlcPlayer.isPlaying()); }
+    @Override
+    public boolean isPlayingAudio() { return isAudioPlayerInitialized() && (nativeMode ? mExoPlayer.isPlaying() : mVlcPlayer.isPlaying()); }
 
     private boolean ensureInitialized() {
-        if (!audioInitialized || !getIsAudioPlayerInitialized()) {
+        if (!audioInitialized || !isAudioPlayerInitialized()) {
             audioInitialized = initAudio();
         }
 
@@ -618,6 +651,7 @@ public class MediaManager {
         return audioInitialized;
     }
 
+    @Override
     public void playNow(Context context, final List<org.jellyfin.sdk.model.api.BaseItemDto> items, int position, boolean shuffle) {
         if (!ensureInitialized()) return;
 
@@ -640,10 +674,12 @@ public class MediaManager {
             fireQueueReplaced();
     }
 
+    @Override
     public void playNow(Context context, final List<org.jellyfin.sdk.model.api.BaseItemDto> items, boolean shuffle) {
         playNow(context, items, 0, shuffle);
     }
 
+    @Override
     public void playNow(Context context, final org.jellyfin.sdk.model.api.BaseItemDto item) {
         if (!ensureInitialized()) return;
 
@@ -671,6 +707,7 @@ public class MediaManager {
         Toast.makeText(context,items.size() + (items.size() > 1 ? context.getString(R.string.msg_items_added) : context.getString(R.string.msg_item_added)), Toast.LENGTH_LONG).show();
     }
 
+    @Override
     public boolean playFrom(int ndx) {
         if (mCurrentAudioQueue == null || ndx >= mCurrentAudioQueue.size()) return false;
 
@@ -777,6 +814,7 @@ public class MediaManager {
         }
     }
 
+    @Override
     public void shuffleAudioQueue() {
         if (!hasAudioQueueItems()) return;
 
@@ -845,6 +883,7 @@ public class MediaManager {
         fireQueueReplaced();
     }
 
+    @Override
     public org.jellyfin.sdk.model.api.BaseItemDto getNextAudioItem() {
         if (mCurrentAudioQueue == null || mCurrentAudioQueue.size() == 0 || (!mRepeat && mCurrentAudioQueuePosition == mCurrentAudioQueue.size() - 1)) return null;
 
@@ -853,6 +892,7 @@ public class MediaManager {
         return ((BaseRowItem)mCurrentAudioQueue.get(ndx)).getBaseItem();
     }
 
+    @Override
     public org.jellyfin.sdk.model.api.BaseItemDto getPrevAudioItem() {
         if (mCurrentAudioQueue == null || mCurrentAudioQueue.size() == 0 || (!mRepeat && mCurrentAudioQueuePosition == 0)) return null;
 
@@ -861,9 +901,12 @@ public class MediaManager {
         return ((BaseRowItem)mCurrentAudioQueue.get(ndx)).getBaseItem();
     }
 
+    @Override
     public boolean hasNextAudioItem() { return mCurrentAudioQueue != null && mCurrentAudioQueue.size() > 0 && (mRepeat || mCurrentAudioQueuePosition < mCurrentAudioQueue.size()-1); }
+    @Override
     public boolean hasPrevAudioItem() { return mCurrentAudioQueue != null && mCurrentAudioQueue.size() > 0 && (mRepeat || mCurrentAudioQueuePosition > 0); }
 
+    @Override
     public void updateCurrentAudioItemPlaying(boolean playing) {
         if (mCurrentAudioQueuePosition < 0) return;
         BaseRowItem rowItem = (BaseRowItem) mCurrentAudioQueue.get(mCurrentAudioQueuePosition);
@@ -878,6 +921,7 @@ public class MediaManager {
         }
     }
 
+    @Override
     public int nextAudioItem() {
         //turn off indicator for current item
         if (mCurrentAudioQueuePosition >= 0) {
@@ -896,6 +940,7 @@ public class MediaManager {
         return ndx;
     }
 
+    @Override
     public int prevAudioItem() {
         if (mCurrentAudioQueue == null || (!mRepeat && mCurrentAudioQueue.size() == 0)) return -1;
         if (isPlayingAudio() && mCurrentAudioPosition > 10000) {
@@ -920,11 +965,12 @@ public class MediaManager {
     }
 
     private void stop() {
-        if (!getIsAudioPlayerInitialized()) return ;
+        if (!isAudioPlayerInitialized()) return ;
         if (nativeMode) mExoPlayer.stop();
         else mVlcPlayer.stop();
     }
 
+    @Override
     public void stopAudio(boolean releasePlayer) {
         if (mCurrentAudioItem != null) {
             Timber.d("Stopping audio");
@@ -944,11 +990,12 @@ public class MediaManager {
     }
 
     private void pause() {
-        if (!getIsAudioPlayerInitialized()) return;
+        if (!isAudioPlayerInitialized()) return;
         if (nativeMode) mExoPlayer.setPlayWhenReady(false);
         else mVlcPlayer.pause();
     }
 
+    @Override
     public void pauseAudio() {
         if (mCurrentAudioItem != null && isPlayingAudio()) {
             updateCurrentAudioItemPlaying(false);
@@ -961,6 +1008,7 @@ public class MediaManager {
         }
     }
 
+    @Override
     public void playPauseAudio() {
         if (isPaused()) {
             resumeAudio();
@@ -969,8 +1017,9 @@ public class MediaManager {
         }
     }
 
+    @Override
     public void resumeAudio() {
-        if (mCurrentAudioItem != null && getIsAudioPlayerInitialized()) {
+        if (mCurrentAudioItem != null && isAudioPlayerInitialized()) {
             ensureAudioFocus();
             if (nativeMode) mExoPlayer.setPlayWhenReady(true);
             else mVlcPlayer.play();
@@ -986,14 +1035,17 @@ public class MediaManager {
         }
     }
 
+    @Override
     public void fastForward() {
         seek(userPrefs.getValue().get(UserSettingPreferences.Companion.getSkipForwardLength()));
     }
 
+    @Override
     public void rewind() {
         seek(-userPrefs.getValue().get(UserSettingPreferences.Companion.getSkipBackLength()));
     }
 
+    @Override
     public void seek(int offset) {
         if (mCurrentAudioItem != null && isPlayingAudio()) {
             if (nativeMode) {
@@ -1012,6 +1064,7 @@ public class MediaManager {
         }
     }
 
+    @Override
     public void setCurrentMediaPosition(int currentMediaPosition) {
         if (currentMediaPosition < 0) return;
         if (mCurrentMediaAdapter == null && mCurrentVideoQueue == null) return;
@@ -1021,12 +1074,15 @@ public class MediaManager {
         mCurrentMediaPosition = currentMediaPosition;
     }
 
+    @Override
     public BaseRowItem getMediaItem(int pos) {
         return mCurrentMediaAdapter != null && mCurrentMediaAdapter.size() > pos ? (BaseRowItem) mCurrentMediaAdapter.get(pos) : null;
     }
 
+    @Override
     public BaseRowItem getCurrentMediaItem() { return getMediaItem(mCurrentMediaPosition); }
 
+    @Override
     public BaseRowItem nextMedia() {
         if (hasNextMediaItem()) {
             mCurrentMediaPosition++;
@@ -1036,6 +1092,7 @@ public class MediaManager {
         return getCurrentMediaItem();
     }
 
+    @Override
     public BaseRowItem prevMedia() {
         if (hasPrevMediaItem()) {
             mCurrentMediaPosition--;
@@ -1044,33 +1101,42 @@ public class MediaManager {
         return getCurrentMediaItem();
     }
 
+    @Override
     public BaseRowItem peekNextMediaItem() {
         return hasNextMediaItem() ? getMediaItem(mCurrentMediaPosition +1) : null;
     }
 
+    @Override
     public BaseRowItem peekPrevMediaItem() {
         return hasPrevMediaItem() ? getMediaItem(mCurrentMediaPosition -1) : null;
     }
 
+    @Override
     public boolean hasNextMediaItem() { return mCurrentMediaAdapter.size() > mCurrentMediaPosition +1; }
+    @Override
     public boolean hasPrevMediaItem() { return mCurrentMediaPosition > 0; }
 
+    @Override
     public String getCurrentMediaTitle() {
         return currentMediaTitle;
     }
 
+    @Override
     public void setCurrentMediaTitle(String currentMediaTitle) {
         this.currentMediaTitle = currentMediaTitle;
     }
 
+    @Override
     public boolean isVideoQueueModified() {
         return videoQueueModified;
     }
 
+    @Override
     public void setVideoQueueModified(boolean videoQueueModified) {
         this.videoQueueModified = videoQueueModified;
     }
 
+    @Override
     public void clearVideoQueue() {
         mCurrentVideoQueue = new ArrayList<>();
         videoQueueModified = false;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -8,7 +8,6 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 interface MediaManager {
 	var currentMediaAdapter: ItemRowAdapter?
 	fun hasAudioQueueItems(): Boolean
-	fun hasVideoQueueItems(): Boolean
 	var currentMediaPosition: Int
 	var currentVideoQueue: List<BaseItemDto?>?
 	val currentAudioQueueSize: Int
@@ -28,8 +27,6 @@ interface MediaManager {
 	fun removeAudioEventListener(listener: AudioEventListener?)
 	fun initAudio(): Boolean
 	fun saveAudioQueue(context: Context?)
-	fun saveVideoQueue(context: Context?)
-	fun saveQueue(context: Context?, type: Int)
 	fun queueAudioItem(item: BaseItemDto?): Int
 	fun addToVideoQueue(item: BaseItemDto?): Int
 	fun clearAudioQueue()
@@ -58,13 +55,6 @@ interface MediaManager {
 	fun seek(offset: Int)
 	fun getMediaItem(pos: Int): BaseRowItem?
 	val currentMediaItem: BaseRowItem?
-	fun nextMedia(): BaseRowItem?
-	fun prevMedia(): BaseRowItem?
-	fun peekNextMediaItem(): BaseRowItem?
-	fun peekPrevMediaItem(): BaseRowItem?
-	fun hasNextMediaItem(): Boolean
-	fun hasPrevMediaItem(): Boolean
-	var currentMediaTitle: String?
 	var isVideoQueueModified: Boolean
 	fun clearVideoQueue()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -1,0 +1,70 @@
+package org.jellyfin.androidtv.ui.playback
+
+import android.content.Context
+import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem
+import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
+import org.jellyfin.sdk.model.api.BaseItemDto
+
+interface MediaManager {
+	var currentMediaAdapter: ItemRowAdapter?
+	fun hasAudioQueueItems(): Boolean
+	fun hasVideoQueueItems(): Boolean
+	var currentMediaPosition: Int
+	var currentVideoQueue: List<BaseItemDto?>?
+	val currentAudioQueueSize: Int
+	val currentAudioQueuePosition: Int
+	val currentAudioPosition: Long
+	val currentAudioQueueDisplayPosition: String?
+	val currentAudioQueueDisplaySize: String?
+	val currentAudioItem: BaseItemDto?
+	fun toggleRepeat(): Boolean
+	val isRepeatMode: Boolean
+	val isAudioPlayerInitialized: Boolean
+	val isShuffleMode: Boolean
+	val currentAudioQueue: ItemRowAdapter?
+	val managedAudioQueue: ItemRowAdapter?
+	fun createManagedAudioQueue()
+	fun addAudioEventListener(listener: AudioEventListener?)
+	fun removeAudioEventListener(listener: AudioEventListener?)
+	fun initAudio(): Boolean
+	fun saveAudioQueue(context: Context?)
+	fun saveVideoQueue(context: Context?)
+	fun saveQueue(context: Context?, type: Int)
+	fun queueAudioItem(item: BaseItemDto?): Int
+	fun addToVideoQueue(item: BaseItemDto?): Int
+	fun clearAudioQueue()
+	fun clearAudioQueue(releasePlayer: Boolean)
+	fun addToAudioQueue(items: List<BaseItemDto?>?)
+	fun removeFromAudioQueue(ndx: Int)
+	val isPlayingAudio: Boolean
+	fun playNow(context: Context?, items: List<BaseItemDto?>?, position: Int, shuffle: Boolean)
+	fun playNow(context: Context?, items: List<BaseItemDto?>?, shuffle: Boolean)
+	fun playNow(context: Context?, item: BaseItemDto?)
+	fun playFrom(ndx: Int): Boolean
+	fun shuffleAudioQueue()
+	val nextAudioItem: BaseItemDto?
+	val prevAudioItem: BaseItemDto?
+	fun hasNextAudioItem(): Boolean
+	fun hasPrevAudioItem(): Boolean
+	fun updateCurrentAudioItemPlaying(playing: Boolean)
+	fun nextAudioItem(): Int
+	fun prevAudioItem(): Int
+	fun stopAudio(releasePlayer: Boolean)
+	fun pauseAudio()
+	fun playPauseAudio()
+	fun resumeAudio()
+	fun fastForward()
+	fun rewind()
+	fun seek(offset: Int)
+	fun getMediaItem(pos: Int): BaseRowItem?
+	val currentMediaItem: BaseRowItem?
+	fun nextMedia(): BaseRowItem?
+	fun prevMedia(): BaseRowItem?
+	fun peekNextMediaItem(): BaseRowItem?
+	fun peekPrevMediaItem(): BaseRowItem?
+	fun hasNextMediaItem(): Boolean
+	fun hasPrevMediaItem(): Boolean
+	var currentMediaTitle: String?
+	var isVideoQueueModified: Boolean
+	fun clearVideoQueue()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -67,7 +67,7 @@ class PlaybackForwardingActivity : FragmentActivity() {
 
 		for (item in mediaManager.currentVideoQueue ?: emptyList()) {
 			if (first == null) first = item
-			if (best == null && item.type !== BaseItemKind.TRAILER) best = item
+			if (item != null && item.type !== BaseItemKind.TRAILER) best = item
 
 			if (first != null && best != null) break
 		}


### PR DESCRIPTION
Supersedes #2452

Splitting the current MediaManager into an interface will allow for a new implementation of the existing functions with the new playback module as backing.

**Changes**
- Split MediaManager into interface and implementation
- Remove unused properties/functions from MediaManager
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
