### PR TITLE
Add option to enable playback rewrite for audio

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -11,11 +11,20 @@ import org.koin.dsl.module
 
 val playbackModule = module {
 	single { PlaybackManager(get()) }
-	single<MediaManager> { LegacyMediaManager(get()) }
+	single { LegacyMediaManager(get()) }
+
+	factory<MediaManager> {
+		val preferences = get<UserPreferences>()
+		val useRewrite = preferences[UserPreferences.playbackRewriteAudioEnabled] && BuildConfig.DEVELOPMENT
+
+		// TODO Return RewriteMediaManager when merged to master
+		if (useRewrite) get<LegacyMediaManager>()
+		else get<LegacyMediaManager>()
+	}
 
 	factory {
 		val preferences = get<UserPreferences>()
-		val useRewrite = preferences[UserPreferences.playbackRewriteEnabled] && BuildConfig.DEVELOPMENT
+		val useRewrite = preferences[UserPreferences.playbackRewriteVideoEnabled] && BuildConfig.DEVELOPMENT
 
 		if (useRewrite) RewritePlaybackLauncher()
 		else GarbagePlaybackLauncher(get())

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -155,9 +155,14 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var debuggingEnabled = booleanPreference("pref_enable_debug", false)
 
 		/**
-		 * Use playback rewrite module
+		 * Use playback rewrite module for video
 		 */
-		var playbackRewriteEnabled = booleanPreference("playback_new", false)
+		var playbackRewriteVideoEnabled = booleanPreference("playback_new", false)
+
+		/**
+		 * Use playback rewrite module for audio
+		 */
+		var playbackRewriteAudioEnabled = booleanPreference("playback_new_audio", false)
 
 		/**
 		 * When to show the clock.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -24,12 +24,20 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 			}
 
 			// Only show in debug mode
+			// some strings are hardcoded because these options don't show in beta/release builds
 			if (BuildConfig.DEVELOPMENT) {
 				checkbox {
-					setTitle(R.string.enable_playback_module_title)
+					title = "Enable new playback module for video"
 					setContent(R.string.enable_playback_module_description)
 
-					bind(userPreferences, UserPreferences.playbackRewriteEnabled)
+					bind(userPreferences, UserPreferences.playbackRewriteVideoEnabled)
+				}
+
+				checkbox {
+					title = "Enable new playback module for audio"
+					setContent(R.string.enable_playback_module_description)
+
+					bind(userPreferences, UserPreferences.playbackRewriteAudioEnabled)
 				}
 			}
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -397,7 +397,6 @@
     <string name="lbl_one_song">1 Song</string>
     <string name="lbl_name_date">%1$s (%2$s)</string>
     <string name="lbl_time_range">%1$s–%2$s</string>
-    <string name="enable_playback_module_title">Enable new playback module</string>
     <string name="enable_playback_module_description">This is an experimental feature. No support is provided.</string>
     <string name="last_use">Most recently used</string>
     <string name="alphabetical">Alphabetical</string>


### PR DESCRIPTION
Working on integrating playback rewrite module into existing UI.

**Changes**
- Change `playbackRewriteEnabled` to `playbackRewriteVideoEnabled`
- Add playbackRewriteAudioEnabled
- Remove `enable_playback_module_title` string resource (string is unused in beta/release builds)


**Issues**

Part of #1057