### PR TITLE
Add MediaSessionPlugin to playback rewrite

### DIFF
--- a/playback/core/build.gradle.kts
+++ b/playback/core/build.gradle.kts
@@ -13,6 +13,10 @@ android {
 		targetSdk = 33
 	}
 
+	compileOptions {
+		isCoreLibraryDesugaringEnabled = true
+	}
+
 	lint {
 		lintConfig = file("$rootDir/android-lint.xml")
 		abortOnError = false
@@ -41,6 +45,9 @@ dependencies {
 
 	// Logging
 	implementation(libs.timber)
+
+	// Compatibility (desugaring)
+	coreLibraryDesugaring(libs.android.desugar)
 
 	// Testing
 	testImplementation(libs.kotest.runner.junit5)

--- a/playback/core/src/main/kotlin/mediasession/MediaSessionOptions.kt
+++ b/playback/core/src/main/kotlin/mediasession/MediaSessionOptions.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.playback.core.mediasession
+
+import android.app.PendingIntent
+import androidx.annotation.DrawableRes
+
+data class MediaSessionOptions(
+	val channelId: String,
+	val notificationId: Int,
+	@DrawableRes val iconSmall: Int,
+	val openIntent: PendingIntent,
+)

--- a/playback/core/src/main/kotlin/mediasession/MediaSessionPlayerGlue.kt
+++ b/playback/core/src/main/kotlin/mediasession/MediaSessionPlayerGlue.kt
@@ -1,0 +1,137 @@
+package org.jellyfin.playback.core.mediasession
+
+import androidx.media.AudioAttributesCompat
+import androidx.media2.common.MediaItem
+import androidx.media2.common.MediaMetadata
+import androidx.media2.common.SessionPlayer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.guava.future
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.jellyfin.playback.core.model.PlayState
+
+// The base class of PlayerResult is marked as restricted causing a
+// false-positive in the Android linter
+@Suppress("RestrictedApi")
+internal class MediaSessionPlayerGlue(
+	private val scope: CoroutineScope,
+	private val state: org.jellyfin.playback.core.PlayerState,
+) : SessionPlayer() {
+	private val callbackMutex = Mutex()
+	fun notifyCallbacks(body: PlayerCallback.() -> Unit) {
+		for (pair in callbacks) {
+			val executor = pair.second!!
+			val callback = pair.first!!
+
+			scope.launch {
+				callbackMutex.withLock {
+					executor.execute {
+						callback.body()
+					}
+				}
+			}
+		}
+	}
+
+	private var _currentMediaItem: MediaItem? = null
+
+	fun setCurrentMediaItem(item: MediaItem?) {
+		_currentMediaItem = item
+	}
+
+	override fun getCurrentMediaItem(): MediaItem? = _currentMediaItem
+
+	override fun getDuration(): Long = runBlocking(Dispatchers.Main) {
+		state.positionInfo.duration.inWholeMilliseconds
+	}
+
+	override fun setMediaItem(item: MediaItem) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun updatePlaylistMetadata(metadata: MediaMetadata?) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun setPlaybackSpeed(playbackSpeed: Float) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun getPlaylist(): MutableList<MediaItem> = listOfNotNull(currentMediaItem).toMutableList()
+
+	override fun getCurrentPosition(): Long = runBlocking(Dispatchers.Main) {
+		state.positionInfo.active.inWholeMilliseconds
+	}
+
+	override fun play() = scope.future {
+		state.unpause()
+		PlayerResult(PlayerResult.RESULT_SUCCESS, currentMediaItem)
+	}
+
+	override fun skipToPreviousPlaylistItem() = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun getShuffleMode(): Int = SHUFFLE_MODE_NONE
+
+	override fun getRepeatMode(): Int = REPEAT_MODE_NONE
+
+	override fun getPlayerState(): Int = when (state.playState.value) {
+		PlayState.STOPPED -> PLAYER_STATE_IDLE
+		PlayState.PLAYING -> PLAYER_STATE_PLAYING
+		PlayState.PAUSED -> PLAYER_STATE_PAUSED
+		PlayState.ERROR -> PLAYER_STATE_ERROR
+	}
+
+	override fun setPlaylist(list: MutableList<MediaItem>, metadata: MediaMetadata?) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun getPlaybackSpeed(): Float = state.speed.value
+
+	override fun setShuffleMode(shuffleMode: Int) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun skipToNextPlaylistItem() = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun getBufferedPosition(): Long = state.positionInfo.buffer.inWholeMilliseconds
+
+	override fun replacePlaylistItem(index: Int, item: MediaItem) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun getNextMediaItemIndex(): Int = 1
+
+	override fun addPlaylistItem(index: Int, item: MediaItem) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun seekTo(position: Long) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun getBufferingState(): Int = BUFFERING_STATE_BUFFERING_AND_PLAYABLE
+
+	override fun removePlaylistItem(index: Int) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun setRepeatMode(repeatMode: Int) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun skipToPlaylistItem(index: Int) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun prepare() = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+
+	override fun pause() = scope.future {
+		state.pause()
+		PlayerResult(PlayerResult.RESULT_SUCCESS, currentMediaItem)
+	}
+
+	override fun getPlaylistMetadata(): MediaMetadata? = null
+
+	override fun getPreviousMediaItemIndex(): Int = INVALID_ITEM_INDEX
+
+	override fun setAudioAttributes(attributes: AudioAttributesCompat) = scope.future { PlayerResult(PlayerResult.RESULT_ERROR_NOT_SUPPORTED, null) }
+
+	override fun getAudioAttributes(): AudioAttributesCompat? = AudioAttributesCompat.Builder().build()
+
+	override fun getCurrentMediaItemIndex(): Int = 1
+}

--- a/playback/core/src/main/kotlin/mediasession/MediaSessionPlugin.kt
+++ b/playback/core/src/main/kotlin/mediasession/MediaSessionPlugin.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.playback.core.mediasession
+
+import android.content.Context
+import org.jellyfin.playback.core.plugin.playbackPlugin
+
+fun mediaSessionPlugin(
+	androidContext: Context,
+	options: MediaSessionOptions,
+) = playbackPlugin {
+	provide(MediaSessionService(androidContext, options))
+}

--- a/playback/core/src/main/kotlin/mediasession/MediaSessionService.kt
+++ b/playback/core/src/main/kotlin/mediasession/MediaSessionService.kt
@@ -1,0 +1,97 @@
+package org.jellyfin.playback.core.mediasession
+
+import android.content.Context
+import android.support.v4.media.session.PlaybackStateCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.media.app.NotificationCompat.MediaStyle
+import androidx.media.session.MediaButtonReceiver
+import androidx.media2.common.VideoSize
+import androidx.media2.session.MediaSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.item.QueueEntry
+
+class MediaSessionService(
+	private val androidContext: Context,
+	private val options: MediaSessionOptions,
+) : PlayerService() {
+	private val notificationManager = NotificationManagerCompat.from(androidContext)
+	private var notifiedNotificationId: Int? = null
+
+	override suspend fun onInitialize() {
+		val glue = MediaSessionPlayerGlue(CoroutineScope(coroutineScope.coroutineContext), state)
+		val callback = SessionCallback()
+		val session = MediaSession.Builder(androidContext, glue).apply {
+			setSessionCallback(Dispatchers.IO.asExecutor(), callback)
+			setId(options.notificationId.toString())
+			setSessionActivity(options.openIntent)
+		}.build()
+
+		coroutineScope.launch {
+			state.playState.collect {
+				glue.notifyCallbacks { onPlayerStateChanged(glue, glue.playerState) }
+			}
+		}
+
+		coroutineScope.launch {
+			state.videoSize.collect { videoSize ->
+				glue.notifyCallbacks { onVideoSizeChanged(glue, VideoSize(videoSize.width, videoSize.height)) }
+			}
+		}
+
+		coroutineScope.launch {
+			state.currentEntry.collect { item ->
+				val mediaItem = withContext(Dispatchers.IO) { item?.metadata?.toMediaItemWithBitmaps() }
+				glue.currentMediaItem = mediaItem
+				glue.notifyCallbacks { onCurrentMediaItemChanged(glue, mediaItem) }
+
+				if (item != null) session.updateNotification(item)
+				else if (notifiedNotificationId != null) {
+					notificationManager.cancel(notifiedNotificationId!!)
+					notifiedNotificationId = null
+				}
+			}
+		}
+	}
+
+	private fun MediaSession.updateNotification(item: QueueEntry) {
+		val stopIntent = MediaButtonReceiver.buildMediaButtonPendingIntent(androidContext, PlaybackStateCompat.ACTION_STOP)
+		val notification = NotificationCompat.Builder(androidContext, options.channelId).apply {
+			// Set metadata
+			setContentTitle(item.metadata.title)
+			setContentText(item.metadata.artist)
+			setSubText(item.metadata.displayDescription)
+
+			// Set actions
+			setContentIntent(options.openIntent)
+			setDeleteIntent(stopIntent)
+
+			// Make visible on lock screen
+			setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+
+			// Add branding
+			setSmallIcon(options.iconSmall)
+
+			// Use MediaStyle
+			setStyle(MediaStyle().also { style ->
+				style.setMediaSession(sessionCompatToken)
+
+				style.setShowCancelButton(true)
+				style.setCancelButtonIntent(stopIntent)
+			})
+		}.build()
+
+		if (notifiedNotificationId == null) notifiedNotificationId = options.notificationId
+
+		// POST_NOTIFICATIONS permission is not required for media notifications
+		@Suppress("MissingPermission")
+		notificationManager.notify(notifiedNotificationId!!, notification)
+	}
+
+	inner class SessionCallback : MediaSession.SessionCallback()
+}

--- a/playback/core/src/main/kotlin/mediasession/MetadataExtensions.kt
+++ b/playback/core/src/main/kotlin/mediasession/MetadataExtensions.kt
@@ -1,0 +1,54 @@
+package org.jellyfin.playback.core.mediasession
+
+import android.graphics.BitmapFactory
+import androidx.media2.common.MediaItem
+import androidx.media2.common.MediaMetadata
+import kotlinx.coroutines.coroutineScope
+import org.jellyfin.playback.core.queue.item.QueueEntryMetadata
+import java.net.URL
+
+private fun QueueEntryMetadata.toMediaMetadataBuilder() = MediaMetadata.Builder().apply {
+	if (album != null) putString(MediaMetadata.METADATA_KEY_ALBUM, album)
+	if (albumArtist != null) putString(MediaMetadata.METADATA_KEY_ALBUM_ARTIST, albumArtist)
+	if (albumArtUri != null) putString(MediaMetadata.METADATA_KEY_ALBUM_ART_URI, albumArtUri)
+	if (artist != null) putString(MediaMetadata.METADATA_KEY_ARTIST, artist)
+	if (artUri != null) putString(MediaMetadata.METADATA_KEY_ART_URI, artUri)
+	if (author != null) putString(MediaMetadata.METADATA_KEY_AUTHOR, author)
+	if (compilation != null) putString(MediaMetadata.METADATA_KEY_COMPILATION, compilation)
+	if (composer != null) putString(MediaMetadata.METADATA_KEY_COMPOSER, composer)
+	if (date != null) putString(MediaMetadata.METADATA_KEY_DATE, date.toString())
+	if (discNumber != null) putLong(MediaMetadata.METADATA_KEY_DISC_NUMBER, discNumber)
+	if (displayDescription != null) putString(MediaMetadata.METADATA_KEY_DISPLAY_DESCRIPTION, displayDescription)
+	if (displayIconUri != null) putString(MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI, displayIconUri)
+	if (displaySubtitle != null) putString(MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE, displaySubtitle)
+	if (displayTitle != null) putString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE, displayTitle)
+	if (duration != null) putLong(MediaMetadata.METADATA_KEY_DURATION, duration.inWholeMilliseconds)
+	if (genre != null) putString(MediaMetadata.METADATA_KEY_GENRE, genre)
+	if (mediaId != null) putString(MediaMetadata.METADATA_KEY_MEDIA_ID, mediaId)
+	if (mediaUri != null) putString(MediaMetadata.METADATA_KEY_MEDIA_URI, mediaUri)
+	if (numTracks != null) putLong(MediaMetadata.METADATA_KEY_NUM_TRACKS, numTracks)
+	if (title != null) putString(MediaMetadata.METADATA_KEY_TITLE, title)
+	if (trackNumber != null) putLong(MediaMetadata.METADATA_KEY_TRACK_NUMBER, trackNumber)
+	if (writer != null) putString(MediaMetadata.METADATA_KEY_WRITER, writer)
+	if (year != null) putLong(MediaMetadata.METADATA_KEY_YEAR, year.value.toLong())
+}
+
+private suspend fun MediaMetadata.Builder.putBitmap(key: String, url: String): MediaMetadata.Builder = coroutineScope {
+	putBitmap(key, BitmapFactory.decodeStream(URL(url).openStream()))
+}
+
+suspend fun QueueEntryMetadata.toMediaMetadataBuilderWithBitmaps() = toMediaMetadataBuilder().apply {
+	if (albumArtUri != null) putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, albumArtUri)
+	if (artUri != null) putBitmap(MediaMetadata.METADATA_KEY_ART, artUri)
+	if (displayIconUri != null) putBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON, displayIconUri)
+}
+
+fun QueueEntryMetadata.toMediaMetadata() = toMediaMetadataBuilder().build()
+fun QueueEntryMetadata.toMediaItem() = MediaItem.Builder().apply {
+	setMetadata(toMediaMetadata())
+}.build()
+
+suspend fun QueueEntryMetadata.toMediaMetadataWithBitmaps() = toMediaMetadataBuilderWithBitmaps().build()
+suspend fun QueueEntryMetadata.toMediaItemWithBitmaps() = MediaItem.Builder().apply {
+	setMetadata(toMediaMetadataWithBitmaps())
+}.build()


### PR DESCRIPTION
We're slowly getting a usable playback module! This PR adds [MediaSession](https://developer.android.com/guide/topics/media-apps/working-with-a-media-session) support. A media session is what enables stuff like the media notification, google assistant integration, controlling media from other apps / tv remote and more. It's quite a big deal.

For some reason, the default Android TV launcher doesn't load the images from URL (mobile Android does) so we need to fetch the bitmaps and put them in the data as well. We should also proxy the image requests via our own ImageProvider at some point to allow authenticated image requests. But this should probably be initiated from the BaseItemDtoUserQueueEntry builder.

**Changes**

- Add initial media session plugin

**Issues**

Part of #1057
