### PR TITLE
Split MediaManager into MediaManager and VideoQueueManager

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -7,10 +7,12 @@ import org.jellyfin.androidtv.ui.playback.LegacyMediaManager
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackManager
 import org.jellyfin.androidtv.ui.playback.RewritePlaybackLauncher
+import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.koin.dsl.module
 
 val playbackModule = module {
 	single { PlaybackManager(get()) }
+	single { VideoQueueManager() }
 	single { LegacyMediaManager(get()) }
 
 	factory<MediaManager> {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -915,15 +915,6 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     }
 
     private void refreshCurrentItem() {
-        if (mediaManager.getValue().getCurrentMediaPosition() >= 0) {
-            mCurrentItem = mediaManager.getValue().getCurrentMediaItem();
-
-            if (mGridPresenter instanceof HorizontalGridPresenter)
-                ((HorizontalGridPresenter) mGridPresenter).setPosition(mediaManager.getValue().getCurrentMediaPosition());
-            // Don't do anything for vertical grids as the presenter does not allow setting the position
-
-            mediaManager.getValue().setCurrentMediaPosition(-1); // re-set so it doesn't mess with parent views
-        }
         if (mCurrentItem != null && mCurrentItem.getBaseItemType() != BaseItemKind.PHOTO && mCurrentItem.getBaseItemType() != BaseItemKind.PHOTO_ALBUM
                 && mCurrentItem.getBaseItemType() != BaseItemKind.MUSIC_ARTIST && mCurrentItem.getBaseItemType() != BaseItemKind.MUSIC_ALBUM) {
             Timber.d("Refresh item \"%s\"", mCurrentItem.getFullName(requireContext()));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -66,6 +66,7 @@ import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
+import org.jellyfin.androidtv.ui.playback.VideoQueueManager;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.CustomListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.InfoCardPresenter;
@@ -166,6 +167,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     private Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private Lazy<VideoQueueManager> videoQueueManager = inject(VideoQueueManager.class);
     private Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
@@ -869,8 +871,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             } else {
                 mediaManager.getValue().addToAudioQueue(Arrays.asList(baseItem));
             }
-        } else {
-            mediaManager.getValue().addToVideoQueue(baseItem);
         }
     }
 
@@ -1533,7 +1533,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                             if (ModelCompat.asSdk(mBaseItem).getType() == BaseItemKind.MUSIC_ARTIST) {
                                 mediaManager.getValue().playNow(requireContext(), response, false);
                             } else {
-                                mediaManager.getValue().setCurrentVideoQueue(response);
+                                videoQueueManager.getValue().setCurrentVideoQueue(response);
                                 navigationRepository.getValue().navigate(Destinations.INSTANCE.externalPlayer(0));
                             }
                         }
@@ -1697,7 +1697,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 if (ModelCompat.asSdk(item).getType() == BaseItemKind.MUSIC_ARTIST) {
                     mediaManager.getValue().playNow(requireContext(), response, shuffle);
                 } else {
-                    mediaManager.getValue().setCurrentVideoQueue(response);
+                    videoQueueManager.getValue().setCurrentVideoQueue(response);
                     Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(ModelCompat.asSdk(item).getType(), pos);
                     navigationRepository.getValue().navigate(destination);
                 }
@@ -1709,7 +1709,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     protected void play(final BaseItemDto[] items, final int pos, final boolean shuffle) {
         List<BaseItemDto> itemsToPlay = Arrays.asList(items);
         if (shuffle) Collections.shuffle(itemsToPlay);
-        mediaManager.getValue().setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(itemsToPlay));
+        videoQueueManager.getValue().setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(itemsToPlay));
         Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(ModelCompat.asSdk(items[0]).getType(), pos);
         navigationRepository.getValue().navigate(destination);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -14,6 +14,7 @@ import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
+import org.jellyfin.androidtv.ui.playback.VideoQueueManager;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
@@ -165,7 +166,7 @@ public class ItemLauncher {
                                 PlaybackHelper.getItemsToPlay(baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<org.jellyfin.sdk.model.api.BaseItemDto>>() {
                                     @Override
                                     public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
-                                        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(response);
+                                        KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
                                         Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(itemType, 0);
                                         navigationRepository.navigate(destination);
                                     }
@@ -189,7 +190,7 @@ public class ItemLauncher {
                     public void onResponse(BaseItemDto response) {
                         List<BaseItemDto> items = new ArrayList<>();
                         items.add(response);
-                        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
+                        KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
                         Long start = chapter.getStartPositionTicks() / 10000;
                         Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(ModelCompat.asSdk(response).getType(), start.intValue());
                         navigationRepository.navigate(destination);
@@ -243,7 +244,7 @@ public class ItemLauncher {
                                 public void onResponse(BaseItemDto response) {
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
-                                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
+                                    KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
                                     Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(ModelCompat.asSdk(response).getType(), 0);
                                     navigationRepository.navigate(destination);
 
@@ -264,7 +265,7 @@ public class ItemLauncher {
                         PlaybackHelper.getItemsToPlay(ModelCompat.asSdk(response), false, false, new Response<List<org.jellyfin.sdk.model.api.BaseItemDto>>() {
                             @Override
                             public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
-                                KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(response);
+                                KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
                                 Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(channel.getType(), 0);
                                 navigationRepository.navigate(destination);
                             }
@@ -287,7 +288,7 @@ public class ItemLauncher {
                                 public void onResponse(BaseItemDto response) {
                                     List<BaseItemDto> items = new ArrayList<>();
                                     items.add(response);
-                                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
+                                    KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(JavaCompat.mapBaseItemCollection(items));
                                     Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(rowItem.getBaseItemType(), 0);
                                     navigationRepository.navigate(destination);
                                 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -156,6 +156,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<ApiClient> apiClient = inject(ApiClient.class);
     private final Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private final Lazy<VideoQueueManager> videoQueueManager = inject(VideoQueueManager.class);
     private final Lazy<PlaybackControllerContainer> playbackControllerContainer = inject(PlaybackControllerContainer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
 
@@ -176,14 +177,14 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         requireActivity().setVolumeControlStream(AudioManager.STREAM_MUSIC);
         ((PlaybackOverlayActivity) requireActivity()).setKeyListener(keyListener);
 
-        mItemsToPlay = mediaManager.getValue().getCurrentVideoQueue();
+        mItemsToPlay = videoQueueManager.getValue().getCurrentVideoQueue();
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
             Utils.showToast(getContext(), getString(R.string.msg_no_playable_items));
             requireActivity().finish();
             return;
         }
 
-        int mediaPosition = mediaManager.getValue().getCurrentMediaPosition();
+        int mediaPosition = videoQueueManager.getValue().getCurrentMediaPosition();
 
         playbackControllerContainer.getValue().setPlaybackController(new PlaybackController(mItemsToPlay, this, mediaPosition));
         mPlaybackController = playbackControllerContainer.getValue().getPlaybackController();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -65,6 +65,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
     private Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private Lazy<VideoQueueManager> videoQueueManager = inject(VideoQueueManager.class);
     private Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private Lazy<PlaybackControllerContainer> playbackControllerContainer = inject(PlaybackControllerContainer.class);
 
@@ -106,7 +107,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
 
         backgroundService.getValue().attach(this);
 
-        mItemsToPlay = mediaManager.getValue().getCurrentVideoQueue();
+        mItemsToPlay = videoQueueManager.getValue().getCurrentVideoQueue();
 
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
             Utils.showToast(this, getString(R.string.msg_no_playable_items));
@@ -189,8 +190,8 @@ public class ExternalPlayerActivity extends FragmentActivity {
                         .setNegativeButton(R.string.lbl_no, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                if (!mediaManager.getValue().isVideoQueueModified()) {
-                                    mediaManager.getValue().clearVideoQueue();
+                                if (!videoQueueManager.getValue().isVideoQueueModified()) {
+                                    videoQueueManager.getValue().clearVideoQueue();
                                 } else {
                                     mItemsToPlay.remove(0);
                                 }
@@ -214,8 +215,8 @@ public class ExternalPlayerActivity extends FragmentActivity {
     }
 
     private void handlePlayerError() {
-        if (!mediaManager.getValue().isVideoQueueModified())
-            mediaManager.getValue().clearVideoQueue();
+        if (!videoQueueManager.getValue().isVideoQueueModified())
+            videoQueueManager.getValue().clearVideoQueue();
 
         new AlertDialog.Builder(this)
                 .setTitle(R.string.no_player)
@@ -273,7 +274,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
         if (mItemsToPlay.size() > 0) {
             if (userPreferences.getValue().get(UserPreferences.Companion.getNextUpBehavior()) != NextUpBehavior.DISABLED) {
                 // Set to "modified" so the queue won't be cleared
-                mediaManager.getValue().setVideoQueueModified(true);
+                videoQueueManager.getValue().setVideoQueueModified(true);
 
                 Intent intent = new Intent(this, NextUpActivity.class);
                 intent.putExtra(NextUpActivity.EXTRA_ID, mItemsToPlay.get(mCurrentNdx).getId());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -9,7 +9,6 @@ interface MediaManager {
 	var currentMediaAdapter: ItemRowAdapter?
 	fun hasAudioQueueItems(): Boolean
 	var currentMediaPosition: Int
-	var currentVideoQueue: List<BaseItemDto?>?
 	val currentAudioQueueSize: Int
 	val currentAudioQueuePosition: Int
 	val currentAudioPosition: Long
@@ -23,27 +22,25 @@ interface MediaManager {
 	val currentAudioQueue: ItemRowAdapter?
 	val managedAudioQueue: ItemRowAdapter?
 	fun createManagedAudioQueue()
-	fun addAudioEventListener(listener: AudioEventListener?)
-	fun removeAudioEventListener(listener: AudioEventListener?)
+	fun addAudioEventListener(listener: AudioEventListener)
+	fun removeAudioEventListener(listener: AudioEventListener)
 	fun initAudio(): Boolean
 	fun saveAudioQueue(context: Context?)
 	fun queueAudioItem(item: BaseItemDto?): Int
-	fun addToVideoQueue(item: BaseItemDto?): Int
 	fun clearAudioQueue()
 	fun clearAudioQueue(releasePlayer: Boolean)
-	fun addToAudioQueue(items: List<BaseItemDto?>?)
+	fun addToAudioQueue(items: List<BaseItemDto>)
 	fun removeFromAudioQueue(ndx: Int)
 	val isPlayingAudio: Boolean
-	fun playNow(context: Context?, items: List<BaseItemDto?>?, position: Int, shuffle: Boolean)
-	fun playNow(context: Context?, items: List<BaseItemDto?>?, shuffle: Boolean)
-	fun playNow(context: Context?, item: BaseItemDto?)
+	fun playNow(context: Context?, items: List<BaseItemDto>, position: Int, shuffle: Boolean)
+	fun playNow(context: Context?, items: List<BaseItemDto>, shuffle: Boolean)
+	fun playNow(context: Context?, item: BaseItemDto)
 	fun playFrom(ndx: Int): Boolean
 	fun shuffleAudioQueue()
 	val nextAudioItem: BaseItemDto?
 	val prevAudioItem: BaseItemDto?
 	fun hasNextAudioItem(): Boolean
 	fun hasPrevAudioItem(): Boolean
-	fun updateCurrentAudioItemPlaying(playing: Boolean)
 	fun nextAudioItem(): Int
 	fun prevAudioItem(): Int
 	fun stopAudio(releasePlayer: Boolean)
@@ -55,6 +52,4 @@ interface MediaManager {
 	fun seek(offset: Int)
 	fun getMediaItem(pos: Int): BaseRowItem?
 	val currentMediaItem: BaseRowItem?
-	var isVideoQueueModified: Boolean
-	fun clearVideoQueue()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
@@ -1,0 +1,32 @@
+package org.jellyfin.androidtv.ui.playback
+
+import org.jellyfin.sdk.model.api.BaseItemDto
+
+class VideoQueueManager {
+	private var _currentVideoQueue: List<BaseItemDto> = emptyList()
+	private var _currentMediaPosition = -1
+	var isVideoQueueModified: Boolean = false
+
+	fun setCurrentVideoQueue(items: List<BaseItemDto>?) {
+		if (items.isNullOrEmpty()) return clearVideoQueue()
+
+		_currentVideoQueue = items.toMutableList()
+		_currentMediaPosition = 0
+	}
+
+	fun getCurrentVideoQueue(): List<BaseItemDto> = _currentVideoQueue
+
+	fun setCurrentMediaPosition(currentMediaPosition: Int) {
+		if (currentMediaPosition !in 0.._currentVideoQueue.size) return
+
+		_currentMediaPosition = currentMediaPosition
+	}
+
+	fun getCurrentMediaPosition() = _currentMediaPosition
+
+	fun clearVideoQueue() {
+		_currentVideoQueue = emptyList()
+		isVideoQueueModified = false
+		_currentMediaPosition = -1
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackForwardingActivity.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
-import org.jellyfin.androidtv.ui.playback.MediaManager
+import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -21,7 +21,7 @@ class PlaybackForwardingActivity : FragmentActivity() {
 		const val EXTRA_ITEM_ID: String = "item_id"
 	}
 
-	private val mediaManager by inject<MediaManager>()
+	private val videoQueueManager by inject<VideoQueueManager>()
 	private val api by inject<ApiClient>()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,11 +65,11 @@ class PlaybackForwardingActivity : FragmentActivity() {
 		var first: org.jellyfin.sdk.model.api.BaseItemDto? = null
 		var best: org.jellyfin.sdk.model.api.BaseItemDto? = null
 
-		for (item in mediaManager.currentVideoQueue ?: emptyList()) {
+		for (item in videoQueueManager.getCurrentVideoQueue()) {
 			if (first == null) first = item
-			if (item != null && item.type !== BaseItemKind.TRAILER) best = item
+			if (item.type !== BaseItemKind.TRAILER) best = item
 
-			if (first != null && best != null) break
+			if (best != null) break
 		}
 
 		return extra ?: best?.id ?: first?.id

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -106,7 +106,6 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 				} else {
 					// Clear audio queue in case left over from last run
 					mediaManager.clearAudioQueue()
-					mediaManager.clearVideoQueue()
 
 					val server = startupViewModel.getLastServer()
 					if (server != null) showServer(server.id)

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -7,7 +7,6 @@ import android.view.MenuItem;
 import android.widget.PopupMenu;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.constant.CustomMessage;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
@@ -21,7 +20,6 @@ import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
 import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.entities.SortOrder;
@@ -332,32 +330,17 @@ public class KeyProcessor {
                     }
                     return true;
                 case MENU_ADD_QUEUE:
-                    if (isMusic) {
-                        PlaybackHelper.getItemsToPlay(mCurrentItem, false, false, new Response<List<BaseItemDto>>() {
-                            @Override
-                            public void onResponse(List<BaseItemDto> response) {
-                                KoinJavaComponent.<MediaManager>get(MediaManager.class).addToAudioQueue(response);
-                            }
+                    PlaybackHelper.getItemsToPlay(mCurrentItem, false, false, new Response<List<BaseItemDto>>() {
+                        @Override
+                        public void onResponse(List<BaseItemDto> response) {
+                            KoinJavaComponent.<MediaManager>get(MediaManager.class).addToAudioQueue(response);
+                        }
 
-                            @Override
-                            public void onError(Exception exception) {
-                                Utils.showToast(mCurrentActivity, R.string.msg_cannot_play_time);
-                            }
-                        });
-
-                    } else {
-                        KoinJavaComponent.<ApiClient>get(ApiClient.class).GetItemAsync(mCurrentItemId, KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new Response<org.jellyfin.apiclient.model.dto.BaseItemDto>() {
-                            @Override
-                            public void onResponse(org.jellyfin.apiclient.model.dto.BaseItemDto response) {
-                                KoinJavaComponent.<MediaManager>get(MediaManager.class).addToVideoQueue(ModelCompat.asSdk(response));
-                            }
-
-                            @Override
-                            public void onError(Exception exception) {
-                                Utils.showToast(mCurrentActivity, R.string.msg_cannot_play_time);
-                            }
-                        });
-                    }
+                        @Override
+                        public void onError(Exception exception) {
+                            Utils.showToast(mCurrentActivity, R.string.msg_cannot_play_time);
+                        }
+                    });
                     return true;
                 case MENU_PLAY_FIRST_UNWATCHED:
                     StdItemQuery query = new StdItemQuery();

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -5,11 +5,11 @@ import android.content.Context;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.SessionRepository;
 import org.jellyfin.androidtv.preference.UserPreferences;
-import org.jellyfin.androidtv.ui.itemdetail.ItemListFragment;
 import org.jellyfin.androidtv.ui.navigation.Destination;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
+import org.jellyfin.androidtv.ui.playback.VideoQueueManager;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
@@ -50,7 +50,6 @@ public class PlaybackHelper {
             case EPISODE:
                 items.add(mainItem);
                 if (KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getMediaQueuingEnabled())) {
-                    KoinJavaComponent.<MediaManager>get(MediaManager.class).setVideoQueueModified(false); // we are automatically creating new queue
                     //add subsequent episodes
                     if (mainItem.getSeriesId() != null && mainItem.getId() != null) {
                         EpisodeQuery episodeQuery = new EpisodeQuery();
@@ -285,7 +284,7 @@ public class PlaybackHelper {
                             KoinJavaComponent.<MediaManager>get(MediaManager.class).playNow(activity, response, shuffle);
                         } else {
                             BaseItemKind itemType = response.size() > 0 ? response.get(0).getType() : null;
-                            KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(response);
+                            KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
                             Destination destination = playbackLauncher.getPlaybackDestination(itemType, pos);
                             navigationRepository.navigate(destination);
                         }
@@ -297,7 +296,7 @@ public class PlaybackHelper {
                         break;
 
                     default:
-                        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentVideoQueue(response);
+                        KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
                         Destination destination = playbackLauncher.getPlaybackDestination(item.getType(), pos);
                         navigationRepository.navigate(destination);
                 }


### PR DESCRIPTION
Working on a MediaManager implementation for rewrite. Didn't want to implement the stuff for video twice so here is the PR splitting that.

Ignore everything that looks hacky, just a part of the migration process :(

I tested this for like 30 seconds and nothing crashed.. yet

**Changes**
- Fix some nullability stuff in MadiaManager
- Add VideoQueueManager
  - Does stuff that video queue managers do

**Issues**

everything I do these days is part of #1057 
