### PR TITLE
adds "shuffle with" button if "always ask" is selected as preferred player.

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -981,7 +981,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             });
             mDetailsOverviewRow.addAction(playButton);
 
-            if (mBaseItem.getIsFolderItem() || baseItem.getType() == BaseItemKind.MUSIC_ARTIST) {
+            if (mBaseItem.getIsFolderItem()) {
                 shuffleButton = TextUnderButton.create(requireContext(), R.drawable.ic_shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -1523,34 +1523,32 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         }
     };
 
-    private PopupMenu.OnMenuItemClickListener playWithMenuListener = new PopupMenu.OnMenuItemClickListener() {
+    private final PopupMenu.OnMenuItemClickListener playWithMenuListener = new PopupMenu.OnMenuItemClickListener() {
         @Override
         public boolean onMenuItemClick(MenuItem item) {
             return playWithItemMenu(item, false);
         }
     };
 
-    private PopupMenu.OnMenuItemClickListener shuffleWithMenuListener = new PopupMenu.OnMenuItemClickListener() {
+    private final PopupMenu.OnMenuItemClickListener shuffleWithMenuListener = new PopupMenu.OnMenuItemClickListener() {
         @Override
         public boolean onMenuItemClick(MenuItem item) {
             return playWithItemMenu(item, true);
         }
     };
 
-    private boolean playWithItemMenu(MenuItem item, boolean shuffle){
-        switch (item.getItemId()) {
-
-            case R.id.play_with_vlc:
-                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.VLC);
+    private boolean playWithItemMenu(MenuItem item, boolean shuffle) {
+            if (item.getItemId() == R.id.play_with_vlc) {
+                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(), PreferredVideoPlayer.VLC);
                 play(mBaseItem, 0, shuffle);
                 return true;
-            case R.id.play_with_exo:
-                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.EXOPLAYER);
+            } else if (item.getItemId() == R.id.play_with_exo) {
+                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(), PreferredVideoPlayer.EXOPLAYER);
                 play(mBaseItem, 0, shuffle);
                 return true;
-            case R.id.play_with_external:
-                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.EXTERNAL);
-                PlaybackHelper.getItemsToPlay(ModelCompat.asSdk(mBaseItem), false , shuffle, new LifecycleAwareResponse<List<org.jellyfin.sdk.model.api.BaseItemDto>>(getLifecycle()) {
+            } else if (item.getItemId() == R.id.play_with_external) {
+                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(), PreferredVideoPlayer.EXTERNAL);
+                PlaybackHelper.getItemsToPlay(ModelCompat.asSdk(mBaseItem), false, shuffle, new LifecycleAwareResponse<List<org.jellyfin.sdk.model.api.BaseItemDto>>(getLifecycle()) {
                     @Override
                     public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
                         if (!getActive()) return;
@@ -1564,8 +1562,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     }
                 });
                 return true;
-
-        }
+            }
         return false;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -980,6 +980,19 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 }
             });
             mDetailsOverviewRow.addAction(playButton);
+
+            if (mBaseItem.getIsFolderItem() || baseItem.getType() == BaseItemKind.MUSIC_ARTIST) {
+                shuffleButton = TextUnderButton.create(requireContext(), R.drawable.ic_shuffle, buttonSize, 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        PopupMenu more = new PopupMenu(requireContext(), view);
+                        more.inflate(R.menu.menu_details_play_with);
+                        more.setOnMenuItemClickListener(shuffleWithMenuListener);
+                        more.show();
+                    }
+                });
+                mDetailsOverviewRow.addAction(shuffleButton);
+            }
         } else { //here playButton is only a play button
             if (BaseItemExtensionsKt.canPlay(baseItem)) {
                 mDetailsOverviewRow.addAction(mResumeButton);
@@ -1513,37 +1526,48 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     private PopupMenu.OnMenuItemClickListener playWithMenuListener = new PopupMenu.OnMenuItemClickListener() {
         @Override
         public boolean onMenuItemClick(MenuItem item) {
-            switch (item.getItemId()) {
-
-                case R.id.play_with_vlc:
-                    systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.VLC);
-                    play(mBaseItem, 0, false);
-                    return true;
-                case R.id.play_with_exo:
-                    systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.EXOPLAYER);
-                    play(mBaseItem, 0, false);
-                    return true;
-                case R.id.play_with_external:
-                    systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.EXTERNAL);
-                    PlaybackHelper.getItemsToPlay(ModelCompat.asSdk(mBaseItem), false , false, new LifecycleAwareResponse<List<org.jellyfin.sdk.model.api.BaseItemDto>>(getLifecycle()) {
-                        @Override
-                        public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
-                            if (!getActive()) return;
-
-                            if (ModelCompat.asSdk(mBaseItem).getType() == BaseItemKind.MUSIC_ARTIST) {
-                                mediaManager.getValue().playNow(requireContext(), response, false);
-                            } else {
-                                videoQueueManager.getValue().setCurrentVideoQueue(response);
-                                navigationRepository.getValue().navigate(Destinations.INSTANCE.externalPlayer(0));
-                            }
-                        }
-                    });
-                    return true;
-
-            }
-            return false;
+            return playWithItemMenu(item, false);
         }
     };
+
+    private PopupMenu.OnMenuItemClickListener shuffleWithMenuListener = new PopupMenu.OnMenuItemClickListener() {
+        @Override
+        public boolean onMenuItemClick(MenuItem item) {
+            return playWithItemMenu(item, true);
+        }
+    };
+
+    private boolean playWithItemMenu(MenuItem item, boolean shuffle){
+        switch (item.getItemId()) {
+
+            case R.id.play_with_vlc:
+                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.VLC);
+                play(mBaseItem, 0, shuffle);
+                return true;
+            case R.id.play_with_exo:
+                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.EXOPLAYER);
+                play(mBaseItem, 0, shuffle);
+                return true;
+            case R.id.play_with_external:
+                systemPreferences.getValue().set(SystemPreferences.Companion.getChosenPlayer(),PreferredVideoPlayer.EXTERNAL);
+                PlaybackHelper.getItemsToPlay(ModelCompat.asSdk(mBaseItem), false , shuffle, new LifecycleAwareResponse<List<org.jellyfin.sdk.model.api.BaseItemDto>>(getLifecycle()) {
+                    @Override
+                    public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
+                        if (!getActive()) return;
+
+                        if (ModelCompat.asSdk(mBaseItem).getType() == BaseItemKind.MUSIC_ARTIST) {
+                            mediaManager.getValue().playNow(requireContext(), response, false);
+                        } else {
+                            videoQueueManager.getValue().setCurrentVideoQueue(response);
+                            navigationRepository.getValue().navigate(Destinations.INSTANCE.externalPlayer(0));
+                        }
+                    }
+                });
+                return true;
+
+        }
+        return false;
+    }
 
     RecordPopup mRecordPopup;
     public void showRecordingOptions(String id, final org.jellyfin.sdk.model.api.BaseItemDto program, final boolean recordSeries) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Shows the "shuffle" button when video player is set to "always ask". Selecting the shuffle button prompts the player types to be selected.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Implements #2321

**Some questions for the reviewers**

- The button is now labelled: "Shuffle" not "shuffle with". is that desired?
- I'm not used to java: I've created a seperate function: `playWithItemMenu` which is used within shuffleMenu and PlayMenu. Is this the correct way to implement such a feature?
- There are some other functions that are also hidden if "always ask" is selected. Would you like me to implement those too? If yes: should that be in this PR or seperate PR's per "feature"?
- What is the conversion policy for when/how to convert to Kotlin?