### PR TITLE
Remove selected photo item from MediaManager and do some more cleaning

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -53,7 +53,6 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
-import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.HorizontalGridPresenter;
 import org.jellyfin.androidtv.util.CoroutineUtils;
@@ -117,7 +116,6 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     private int mGridPaddingTop = 0;
 
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
-    private final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
     private final Lazy<PreferencesRepository> preferencesRepository = inject(PreferencesRepository.class);
     private final Lazy<UserViewsRepository> userViewsRepository = inject(UserViewsRepository.class);
     private final Lazy<UserRepository> userRepository = inject(UserRepository.class);
@@ -203,11 +201,6 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         if (event.getAction() != KeyEvent.ACTION_UP) return false;
-
-        if (keyCode == KeyEvent.KEYCODE_MEDIA_PLAY || keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE) {
-            mediaManager.getValue().setCurrentMediaAdapter(mAdapter);
-            mediaManager.getValue().setCurrentMediaPosition(mCurrentItem.getIndex());
-        }
         return KeyProcessor.HandleKey(keyCode, mCurrentItem, mActivity);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -67,7 +67,6 @@ public class ItemLauncher {
 
     public static void launch(final BaseRowItem rowItem, ItemRowAdapter adapter, int pos, final Activity activity) {
         NavigationRepository navigationRepository = KoinJavaComponent.<NavigationRepository>get(NavigationRepository.class);
-        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentMediaAdapter(adapter);
 
         switch (rowItem.getBaseRowType()) {
             case BaseItem:
@@ -131,13 +130,11 @@ public class ItemLauncher {
                         return;
 
                     case PHOTO:
-                        KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentMediaPosition(pos);
-
                         navigationRepository.navigate(Destinations.INSTANCE.pictureViewer(
-                                mediaManager.getCurrentMediaItem().getBaseItem().getId(),
+                                rowItem.getBaseItem().getId(),
                                 false,
-                                mediaManager.getCurrentMediaAdapter().getSortBy(),
-                                mediaManager.getCurrentMediaAdapter().getSortOrder()
+                                adapter.getSortBy(),
+                                adapter.getSortOrder()
                         ));
                         return;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -62,8 +62,6 @@ import timber.log.Timber;
 
 public class LegacyMediaManager implements MediaManager {
     private Context context;
-    private ItemRowAdapter mCurrentMediaAdapter;
-    private int mCurrentMediaPosition = -1;
 
     private ItemRowAdapter mCurrentAudioQueue;
     private ItemRowAdapter mManagedAudioQueue;
@@ -101,21 +99,7 @@ public class LegacyMediaManager implements MediaManager {
     }
 
     @Override
-    public ItemRowAdapter getCurrentMediaAdapter() {
-        return mCurrentMediaAdapter;
-    }
-    @Override
     public boolean hasAudioQueueItems() { return mCurrentAudioQueue != null && mCurrentAudioQueue.size() > 0; }
-
-    @Override
-    public void setCurrentMediaAdapter(ItemRowAdapter currentMediaAdapter) {
-        this.mCurrentMediaAdapter = currentMediaAdapter;
-    }
-
-    @Override
-    public int getCurrentMediaPosition() {
-        return mCurrentMediaPosition;
-    }
 
     @Override
     public int getCurrentAudioQueueSize() { return mCurrentAudioQueue != null ? mCurrentAudioQueue.size() : 0; }
@@ -197,8 +181,7 @@ public class LegacyMediaManager implements MediaManager {
         Timber.d("Removed event listener.  Total listeners: %d", mAudioEventListeners.size());
     }
 
-    @Override
-    public boolean initAudio() {
+    private boolean initAudio() {
         Timber.d("initializing audio");
         if (mAudioManager == null) mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 
@@ -975,8 +958,7 @@ public class LegacyMediaManager implements MediaManager {
         seek(-userPrefs.getValue().get(UserSettingPreferences.Companion.getSkipBackLength()));
     }
 
-    @Override
-    public void seek(int offset) {
+    private void seek(int offset) {
         if (mCurrentAudioItem != null && isPlayingAudio()) {
             if (nativeMode) {
                 Timber.d("Fast forward %d with ExoPlayer", offset);
@@ -993,21 +975,4 @@ public class LegacyMediaManager implements MediaManager {
             }
         }
     }
-
-    @Override
-    public void setCurrentMediaPosition(int currentMediaPosition) {
-        if (currentMediaPosition < 0) return;
-        if (mCurrentMediaAdapter == null) return;
-        if (mCurrentMediaAdapter != null && currentMediaPosition > mCurrentMediaAdapter.size()) return;
-
-        mCurrentMediaPosition = currentMediaPosition;
-    }
-
-    @Override
-    public BaseRowItem getMediaItem(int pos) {
-        return mCurrentMediaAdapter != null && mCurrentMediaAdapter.size() > pos ? (BaseRowItem) mCurrentMediaAdapter.get(pos) : null;
-    }
-
-    @Override
-    public BaseRowItem getCurrentMediaItem() { return getMediaItem(mCurrentMediaPosition); }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -1,14 +1,11 @@
 package org.jellyfin.androidtv.ui.playback
 
 import android.content.Context
-import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
 import org.jellyfin.sdk.model.api.BaseItemDto
 
 interface MediaManager {
-	var currentMediaAdapter: ItemRowAdapter?
 	fun hasAudioQueueItems(): Boolean
-	var currentMediaPosition: Int
 	val currentAudioQueueSize: Int
 	val currentAudioQueuePosition: Int
 	val currentAudioPosition: Long
@@ -24,7 +21,6 @@ interface MediaManager {
 	fun createManagedAudioQueue()
 	fun addAudioEventListener(listener: AudioEventListener)
 	fun removeAudioEventListener(listener: AudioEventListener)
-	fun initAudio(): Boolean
 	fun saveAudioQueue(context: Context?)
 	fun queueAudioItem(item: BaseItemDto?): Int
 	fun clearAudioQueue()
@@ -49,7 +45,4 @@ interface MediaManager {
 	fun resumeAudio()
 	fun fastForward()
 	fun rewind()
-	fun seek(offset: Int)
-	fun getMediaItem(pos: Int): BaseRowItem?
-	val currentMediaItem: BaseRowItem?
 }


### PR DESCRIPTION
Cleaning some more in the MediaManager interface. It was basically a storage box for all kinds of stuff. Now it's 100% only audio things.

**Changes**
- Remove selected photo item from MediaManager and do some more cleaning
- Remove some unused code from MediaManager
- Remove some unused code from LegacyMediaManager
- Remove some unused code from PlaybackController
- Remove some unused code from BrowseGridFragment
- Smarter picture viewer starting in ItemLauncher

**Issues**

Also a part of #1057 
