### PR TITLE
Revert "Update dependency com.android.tools:desugar_jdk_libs to v2.0.1"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutlibraries = "10.5.2"
 acra = "5.9.7"
-android-desugar = "2.0.1"
+android-desugar = "2.0.0"
 android-gradle = "7.4.1"
 androidx-activity = "1.6.1"
 androidx-appcompat = "1.6.0"


### PR DESCRIPTION
Reverts jellyfin/jellyfin-androidtv#2466

Update caused immediate crashes when starting the app. Bug is already fixed by Google and should be releases soonish in 2.0.2: https://issuetracker.google.com/issues/267483394