### PR TITLE
Fix rare picture viewer crash when album is empty

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
@@ -40,6 +40,13 @@ class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
 		)
 		album = albumResponse.items.orEmpty()
 		albumIndex = album.indexOfFirst { it.id == id }
+
+		// In some rare cases the album of the image might be empty when the
+		// files are considered invalid by the server
+		if (album.isEmpty()) {
+			album = listOf(itemResponse)
+			albumIndex = 0
+		}
 	}
 
 	// Album actions


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

- Fix rare picture viewer crash when album is empty

**Issues**

Fixes #2456 on the client
