### PR TITLE
Don't show "invalid credentials" message when authentication fails with an SDK exception

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/LoginState.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/LoginState.kt
@@ -1,8 +1,11 @@
 package org.jellyfin.androidtv.auth.model
 
+import org.jellyfin.sdk.api.client.exception.ApiClientException
+
 sealed class LoginState
 object AuthenticatingState : LoginState()
 object RequireSignInState : LoginState()
 object ServerUnavailableState : LoginState()
 data class ServerVersionNotSupported(val server: Server) : LoginState()
+data class ApiClientErrorLoginState(val error: ApiClientException) : LoginState()
 object AuthenticatedState : LoginState()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.model.ApiClientErrorLoginState
 import org.jellyfin.androidtv.auth.model.AuthenticatedState
 import org.jellyfin.androidtv.auth.model.AuthenticatingState
 import org.jellyfin.androidtv.auth.model.PrivateUser
@@ -80,7 +81,8 @@ class ServerFragment : Fragment() {
 							UserLoginFragment.ARG_USERNAME to user.name,
 						))
 						// Errors
-						ServerUnavailableState -> Toast.makeText(context, R.string.server_connection_failed, Toast.LENGTH_LONG).show()
+						ServerUnavailableState,
+						is ApiClientErrorLoginState-> Toast.makeText(context, R.string.server_connection_failed, Toast.LENGTH_LONG).show()
 						is ServerVersionNotSupported -> Toast.makeText(
 							context,
 							getString(R.string.server_unsupported, state.server.version, ServerRepository.minimumServerVersion.toString()),

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.model.ApiClientErrorLoginState
 import org.jellyfin.androidtv.auth.model.AuthenticatedState
 import org.jellyfin.androidtv.auth.model.AuthenticatingState
 import org.jellyfin.androidtv.auth.model.RequireSignInState
@@ -72,7 +73,8 @@ class UserLoginCredentialsFragment : Fragment() {
 					))
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)
 					RequireSignInState -> binding.error.setText(R.string.login_invalid_credentials)
-					ServerUnavailableState -> binding.error.setText(R.string.login_server_unavailable)
+					ServerUnavailableState,
+					is ApiClientErrorLoginState -> binding.error.setText(R.string.login_server_unavailable)
 					// Do nothing because the activity will respond to the new session
 					AuthenticatedState -> Unit
 					// Not initialized

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.model.ApiClientErrorLoginState
 import org.jellyfin.androidtv.auth.model.AuthenticatedState
 import org.jellyfin.androidtv.auth.model.AuthenticatingState
 import org.jellyfin.androidtv.auth.model.ConnectedQuickConnectState
@@ -66,7 +67,8 @@ class UserLoginQuickConnectFragment : Fragment() {
 					))
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)
 					RequireSignInState -> binding.error.setText(R.string.login_invalid_credentials)
-					ServerUnavailableState -> binding.error.setText(R.string.login_server_unavailable)
+					ServerUnavailableState,
+					is ApiClientErrorLoginState -> binding.error.setText(R.string.login_server_unavailable)
 					// Do nothing because the activity will respond to the new session
 					AuthenticatedState -> Unit
 					// Not initialized


### PR DESCRIPTION
Right now when signing in goes wrong with an SDK exception we return `RequireSignInState`, which will show the "Invalid username and/or password" message. This is misleading because the credentials are most likely correct. This PR adds a new `ApiClientErrorLoginState` which re-uses the "Unable to connect to server" message.

Ideally the message should be different but we can't add strings in .z releases so that will be in another PR.

**Changes**
- Add `ApiClientErrorLoginState` when SDK exception happens during authentication
- Listen for TimeoutException in some more places

**Issues**

Related #2503
