### PR TITLE
Replace sharedViewModel with activityViewModel

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
@@ -29,7 +29,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.constant.ItemSortBy
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import kotlin.time.Duration.Companion.seconds
 
 class PictureViewerFragment : Fragment(), View.OnKeyListener {
@@ -41,7 +41,7 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 		private val AUTO_HIDE_ACTIONS_DURATION = 4.seconds
 	}
 
-	private val pictureViewerViewModel by sharedViewModel<PictureViewerViewModel>()
+	private val pictureViewerViewModel by activityViewModel<PictureViewerViewModel>()
 	private val api by inject<ApiClient>()
 	private lateinit var binding: FragmentPictureViewerBinding
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -14,10 +14,10 @@ import org.jellyfin.androidtv.databinding.FragmentNextUpBinding
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class NextUpFragment : Fragment() {
-	private val viewModel: NextUpViewModel by sharedViewModel()
+	private val viewModel: NextUpViewModel by activityViewModel()
 	private lateinit var binding: FragmentNextUpBinding
 	private val backgroundService: BackgroundService by inject()
 	private val userPreferences: UserPreferences by inject()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -30,11 +30,11 @@ import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.util.ListAdapter
 import org.jellyfin.androidtv.util.MenuBuilder
 import org.jellyfin.androidtv.util.getSummary
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class SelectServerFragment : Fragment() {
 	private lateinit var binding: FragmentSelectServerBinding
-	private val startupViewModel: StartupViewModel by sharedViewModel()
+	private val startupViewModel: StartupViewModel by activityViewModel()
 
 	@Suppress("LongMethod")
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -40,14 +40,14 @@ import org.jellyfin.androidtv.util.ListAdapter
 import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class ServerFragment : Fragment() {
 	companion object {
 		const val ARG_SERVER_ID = "server_id"
 	}
 
-	private val startupViewModel: StartupViewModel by sharedViewModel()
+	private val startupViewModel: StartupViewModel by activityViewModel()
 	private val markdownRenderer: MarkdownRenderer by inject()
 	private val authenticationRepository: AuthenticationRepository by inject()
 	private val serverUserRepository: ServerUserRepository by inject()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
@@ -17,10 +17,10 @@ import org.jellyfin.androidtv.auth.model.ServerVersionNotSupported
 import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.databinding.FragmentUserLoginCredentialsBinding
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class UserLoginCredentialsFragment : Fragment() {
-	private val userLoginViewModel: UserLoginViewModel by sharedViewModel()
+	private val userLoginViewModel: UserLoginViewModel by activityViewModel()
 	private lateinit var binding: FragmentUserLoginCredentialsBinding
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginFragment.kt
@@ -18,7 +18,7 @@ import org.jellyfin.androidtv.databinding.FragmentUserLoginBinding
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class UserLoginFragment : Fragment() {
 	companion object {
@@ -28,7 +28,7 @@ class UserLoginFragment : Fragment() {
 		const val TAG_LOGIN_METHOD = "login_method"
 	}
 
-	private val userLoginViewModel: UserLoginViewModel by sharedViewModel()
+	private val userLoginViewModel: UserLoginViewModel by activityViewModel()
 	private val backgroundService: BackgroundService by inject()
 	private lateinit var binding: FragmentUserLoginBinding
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
@@ -21,10 +21,10 @@ import org.jellyfin.androidtv.auth.model.UnknownQuickConnectState
 import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.databinding.FragmentUserLoginQuickConnectBinding
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class UserLoginQuickConnectFragment : Fragment() {
-	private val userLoginViewModel: UserLoginViewModel by sharedViewModel()
+	private val userLoginViewModel: UserLoginViewModel by activityViewModel()
 	private lateinit var binding: FragmentUserLoginQuickConnectBinding
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditServerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditServerScreen.kt
@@ -9,13 +9,13 @@ import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import java.text.DateFormat
 import java.util.Date
 import java.util.UUID
 
 class EditServerScreen : OptionsFragment() {
-	private val startupViewModel: StartupViewModel by sharedViewModel()
+	private val startupViewModel: StartupViewModel by activityViewModel()
 	private val serverUserRepository: ServerUserRepository by inject()
 
 	override val rebuildOnResume = true

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditUserScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/preference/EditUserScreen.kt
@@ -8,11 +8,11 @@ import org.jellyfin.androidtv.ui.preference.dsl.action
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import java.util.UUID
 
 class EditUserScreen : OptionsFragment() {
-	private val startupViewModel: StartupViewModel by sharedViewModel()
+	private val startupViewModel: StartupViewModel by activityViewModel()
 	private val authenticationRepository by inject<AuthenticationRepository>()
 	private val serverUserRepository: ServerUserRepository by inject()
 


### PR DESCRIPTION
The sharedViewModel is deprecated in Koin and is basically an alias for activityViewModel right now.

**Changes**
- Replace sharedViewModel with activityViewModel
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
