### PR TITLE
Remove playlist creation from NowPlaying screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -63,7 +63,6 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
     private ImageButton mShuffleButton;
     private ImageButton mAlbumButton;
     private ImageButton mArtistButton;
-    private ImageButton mSaveButton;
     private ClockUserView mClock;
     private TextView mCounter;
     private ScrollView mScrollView;
@@ -190,21 +189,6 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
             }
         });
         mRepeatButton.setOnFocusChangeListener(mainAreaFocusListener);
-
-        mSaveButton = binding.saveBtn;
-        mSaveButton.setContentDescription(getString(R.string.lbl_save_as_playlist));
-        mSaveButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (ssActive) {
-                    stopScreenSaver();
-                } else {
-                    mediaManager.getValue().saveAudioQueue(requireActivity());
-                }
-                lastUserInteraction = System.currentTimeMillis();
-            }
-        });
-        mSaveButton.setOnFocusChangeListener(mainAreaFocusListener);
 
         mShuffleButton = binding.shuffleBtn;
         mShuffleButton.setContentDescription(getString(R.string.lbl_shuffle_queue));
@@ -466,7 +450,6 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
                     mPlayPauseButton.setContentDescription(getString(R.string.lbl_pause));
                 }
                 mRepeatButton.setActivated(mediaManager.getValue().isRepeatMode());
-                mSaveButton.setEnabled(mediaManager.getValue().getCurrentAudioQueueSize() > 1);
                 mPrevButton.setEnabled(mediaManager.getValue().hasPrevAudioItem());
                 mNextButton.setEnabled(mediaManager.getValue().hasNextAudioItem());
                 mShuffleButton.setEnabled(mediaManager.getValue().getCurrentAudioQueueSize() > 1);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -2,15 +2,11 @@ package org.jellyfin.androidtv.ui.playback;
 
 import static org.koin.java.KoinJavaComponent.inject;
 
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
-import android.text.InputType;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import com.google.android.exoplayer2.ExoPlayer;
@@ -22,7 +18,6 @@ import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 
 import org.jellyfin.androidtv.R;
-import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.compat.AudioOptions;
 import org.jellyfin.androidtv.data.compat.StreamInfo;
@@ -43,11 +38,8 @@ import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.dlna.DeviceProfile;
-import org.jellyfin.apiclient.model.playlists.PlaylistCreationRequest;
-import org.jellyfin.apiclient.model.playlists.PlaylistCreationResult;
 import org.jellyfin.sdk.model.DeviceInfo;
 import org.jellyfin.sdk.model.api.BaseItemKind;
-import org.jellyfin.sdk.model.constant.MediaType;
 import org.koin.java.KoinJavaComponent;
 import org.videolan.libvlc.LibVLC;
 import org.videolan.libvlc.Media;
@@ -406,56 +398,6 @@ public class LegacyMediaManager implements MediaManager {
         mCurrentAudioQueue.Retrieve();
         mManagedAudioQueue = null;
         fireQueueStatusChange();
-    }
-
-    @Override
-    public void saveAudioQueue(Context context) {
-        //Get a name and save as playlist
-        final EditText name = new EditText(context);
-        name.setInputType(InputType.TYPE_TEXT_FLAG_CAP_WORDS);
-        new AlertDialog.Builder(context)
-                .setTitle(R.string.lbl_save_as_playlist)
-                .setMessage(R.string.lbl_new_playlist_name)
-                .setView(name)
-                .setPositiveButton(R.string.btn_done, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        final String text = name.getText().toString();
-                        PlaylistCreationRequest request = new PlaylistCreationRequest();
-                        request.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
-                        request.setMediaType(MediaType.Audio);
-                        request.setName(text);
-                        request.setItemIdList(getCurrentAudioQueueItemIds());
-                        KoinJavaComponent.<ApiClient>get(ApiClient.class).CreatePlaylist(request, new Response<PlaylistCreationResult>() {
-                            @Override
-                            public void onResponse(PlaylistCreationResult response) {
-                                Toast.makeText(context, context.getString(R.string.msg_queue_saved, text), Toast.LENGTH_LONG).show();
-                                DataRefreshService dataRefreshService = KoinJavaComponent.<DataRefreshService>get(DataRefreshService.class);
-                                dataRefreshService.setLastLibraryChange(System.currentTimeMillis());
-                            }
-
-                            @Override
-                            public void onError(Exception exception) {
-                                Timber.e(exception, "Exception creating playlist");
-                            }
-                        });
-                    }
-                })
-                .show();
-
-    }
-
-    private ArrayList<String> getCurrentAudioQueueItemIds() {
-        ArrayList<String> result = new ArrayList<>();
-
-        if (mCurrentAudioQueue != null) {
-            for (int i = 0; i < mCurrentAudioQueue.size(); i++) {
-                AudioQueueItem item = (AudioQueueItem) mCurrentAudioQueue.get(i);
-                result.add(item.getItemId());
-            }
-        }
-
-        return result;
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -20,7 +20,6 @@ interface MediaManager {
 	val managedAudioQueue: ItemRowAdapter?
 	fun addAudioEventListener(listener: AudioEventListener)
 	fun removeAudioEventListener(listener: AudioEventListener)
-	fun saveAudioQueue(context: Context?)
 	fun queueAudioItem(item: BaseItemDto?): Int
 	fun clearAudioQueue()
 	fun clearAudioQueue(releasePlayer: Boolean)

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -182,13 +182,6 @@
                         android:src="@drawable/ic_shuffle" />
 
                     <ImageButton
-                        android:id="@+id/saveBtn"
-                        style="@style/Button.Icon"
-                        android:layout_width="28sp"
-                        android:layout_height="28sp"
-                        android:src="@drawable/ic_save" />
-
-                    <ImageButton
                         android:id="@+id/albumBtn"
                         style="@style/Button.Icon"
                         android:layout_width="28sp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,7 +174,6 @@
     <string name="lbl_remove_from_queue">Remove from Queue</string>
     <string name="lbl_goto_now_playing">Go to Now Playing</string>
     <string name="lbl_instant_mix">Instant Mix</string>
-    <string name="lbl_save_as_playlist">Save as Playlist</string>
     <string name="lbl_delete">Delete</string>
     <string name="msg_item_added">" item added"</string>
     <string name="desc_automatic_fav_songs">Automatic playlist of favorite songs</string>
@@ -291,7 +290,6 @@
     <string name="episode_missing">Episode Missing</string>
     <string name="episode_missing_message">This episode is missing from your library.  Would you like to skip it and continue to the next one?</string>
     <string name="episode_missing_message_2">This episode is missing from your library.  Playback will stop.</string>
-    <string name="lbl_new_playlist_name">Enter a name for the new playlist</string>
     <string name="lbl_load_guide_data">Load Guide Data</string>
     <string name="msg_live_tv_next">Load next %1$d hours?"</string>
     <string name="msg_live_tv_prev">Load prev %1$d hours?"</string>
@@ -300,7 +298,6 @@
     <string name="too_many_errors">Too many errors. Giving up</string>
     <string name="subtitle_error">Unable to select subtitle</string>
     <string name="msg_no_items">No items to play</string>
-    <string name="msg_queue_saved">Queue saved as new playlist: %1$s</string>
     <string name="msg_added_to_video">%1$s added to video queue. Ends: %2$s</string>
     <string name="audio_error">Unable to play audio %1$s</string>
     <string name="turn_off">Turn this option off</string>


### PR DESCRIPTION
Apparently this function is broken (I guess something with the 10.7 API migration?) and the implementation was bad anyway. Playlist managing will make a return when we revamp the UI.

**Changes**

- Remove saveAudioQueue from MediaManager

**Issues**

Fixes #2500
