### PR TITLE
Mark LibVLC as experimental

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,7 +259,7 @@
     <string name="pref_theme_emerald">Classic Emerald</string>
     <string name="pref_video_player_auto">Automatically choose</string>
     <string name="pref_video_player_exoplayer">ExoPlayer</string>
-    <string name="pref_video_player_vlc">LibVLC</string>
+    <string name="pref_video_player_vlc">LibVLC (experimental)</string>
     <string name="pref_video_player_external">External app</string>
     <string name="pref_video_player_choose">Always ask</string>
     <string name="pref_about_title">About</string>


### PR DESCRIPTION
There's a lot of crashes when using LibVLC because our implementation is just bad. This PR changes the preference to end with "(experimental)" so users are less likely to use it.

**Changes**
- Mark LibVLC as experimental

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
