### PR TITLE
Fix theme not applied before creating views

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -35,11 +35,11 @@ class MainActivity : FragmentActivity(R.layout.fragment_content_view) {
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
+		applyTheme()
+
 		super.onCreate(savedInstanceState)
 
 		if (!validateAuthentication()) return
-
-		applyTheme()
 
 		backgroundService.attach(this)
 		onBackPressedDispatcher.addCallback(this, backPressedCallback)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
@@ -24,11 +24,11 @@ class PlaybackOverlayActivity : FragmentActivity(R.layout.fragment_content_view)
 	var keyListener: View.OnKeyListener? = null
 
 	public override fun onCreate(savedInstanceState: Bundle?) {
+		applyTheme()
+
 		super.onCreate(savedInstanceState)
 
 		if (!validateAuthentication()) return
-
-		applyTheme()
 
 		// Workaround for Sony Bravia devices that show a "grey" background on HDR videos
 		// Note: Should NOT be applied to the decorView as this introduces artifacts

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpActivity.kt
@@ -27,11 +27,11 @@ class NextUpActivity : FragmentActivity(R.layout.fragment_content_view) {
 	private val navigationRepository: NavigationRepository by inject()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
+		applyTheme()
+
 		super.onCreate(savedInstanceState)
 
 		if (!validateAuthentication()) return
-
-		applyTheme()
 
 		val useExternalPlayer = intent.getBooleanExtra(EXTRA_USE_EXTERNAL_PLAYER, false)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -70,9 +70,9 @@ class StartupActivity : FragmentActivity(R.layout.fragment_content_view) {
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
-
 		applyTheme()
+
+		super.onCreate(savedInstanceState)
 
 		backgroundService.attach(this)
 


### PR DESCRIPTION
Some theme properties, like the background, need to be applied before inflating the layout.

**Changes**
- Call applyTheme() before inflating layout

**Issues**

Fixes #2541 (together with #2542)