### PR TITLE
Accept KEYCODE_ENTER as alt to KEYCODE_CENTER

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -300,6 +300,7 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
 
     private boolean onKeyDown(int keyCode, KeyEvent event) {
         switch (keyCode){
+            case KeyEvent.KEYCODE_ENTER:
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 event.startTracking();
                 return true;
@@ -309,6 +310,7 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
 
     private boolean onKeyLongPress(int keyCode) {
         switch (keyCode){
+            case KeyEvent.KEYCODE_ENTER:
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 if (mSelectedProgramView instanceof ProgramGridCell)
                     showProgramOptions();
@@ -325,6 +327,7 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
                 // bring up filter selection
                 showFilterOptions();
                 break;
+            case KeyEvent.KEYCODE_ENTER:
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
                     Date curUTC = TimeUtils.convertToUtcDate(new Date());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -595,7 +595,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                             }
                         }
 
-                        if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER && mPlaybackController.canSeek()) {
+                        if ((keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)
+                                && mPlaybackController.canSeek()) {
                             // if the player is playing and the overlay is hidden, this will pause
                             // if the player is paused and then 'back' is pressed to hide the overlay, this will play
                             mPlaybackController.playPause();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayActivity.kt
@@ -57,7 +57,7 @@ class PlaybackOverlayActivity : FragmentActivity(R.layout.fragment_content_view)
 		if (keyListener?.onKey(currentFocus, keyCode, event) == true)
 			return true
 
-		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
 			val frag = supportFragmentManager.fragments[0]
 			if (frag is CustomPlaybackOverlayFragment) {
 				frag.onKeyUp(keyCode, event)
@@ -83,7 +83,7 @@ class PlaybackOverlayActivity : FragmentActivity(R.layout.fragment_content_view)
 	}
 
 	override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
 			event?.startTracking()
 			return true
 		}
@@ -92,7 +92,7 @@ class PlaybackOverlayActivity : FragmentActivity(R.layout.fragment_content_view)
 	}
 
 	override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
-		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+		if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
 			val frag = supportFragmentManager.fragments[0]
 			if (frag is CustomPlaybackOverlayFragment) {
 				frag.onKeyLongPress(keyCode, event)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Adds KEYCODE_ENTER wherever we accept KEYCODE_DPAD_CENTER. This was reported in #2526 where third-party remotes will use the former instead of the latter value.

I've added this to all places we accept CENTER, since our most of our Kotlin code already accepts this as an alternative and I can't forsee a case where we would want these to accept different things.

This was tested in the emulator to ensure we've not broken the existing mapping, but short of using the enter key (which works) I can't verify this fixes the original issue.

**Issues**
(Hopefully) Fixes: #2526 
