### PR TITLE
Always use getQuantityString() for time units

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopup.java
@@ -26,6 +26,7 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.constant.CustomMessage;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
+import org.jellyfin.androidtv.util.ContextExtensionsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
@@ -81,14 +82,14 @@ public class RecordPopup {
 
         mPaddingDisplayOptions = new ArrayList<>(Arrays.asList(
                 mActivity.getString(R.string.lbl_on_schedule),
-                "1  " + mActivity.getString(R.string.lbl_minute),
-                "5  " + mActivity.getString(R.string.lbl_minutes),
-                "15 " + mActivity.getString(R.string.lbl_minutes),
-                "30 " + mActivity.getString(R.string.lbl_minutes),
-                "60 " + mActivity.getString(R.string.lbl_minutes),
-                "90 " + mActivity.getString(R.string.lbl_minutes),
-                "2  " + mActivity.getString(R.string.lbl_hours),
-                "3  " + mActivity.getString(R.string.lbl_hours)
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.minutes, 1),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.minutes, 5),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.minutes, 15),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.minutes, 30),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.minutes, 60),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.minutes, 90),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.hours, 2),
+                ContextExtensionsKt.getQuantityString(activity, R.plurals.hours, 3)
         ));
 
         LayoutInflater inflater = (LayoutInflater) mActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);

--- a/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TimeUtils.java
@@ -52,33 +52,13 @@ public class TimeUtils {
     }
 
     public static String formatSeconds(Context context, int seconds) {
-        // Seconds
         if (seconds < SECS_PER_MIN) {
-            return seconds + " " + context.getString(R.string.lbl_seconds);
-        }
-
-        StringBuilder builder = new StringBuilder();
-        // Minutes
-        if (seconds < SECS_PER_HR) {
-            builder.append(seconds / SECS_PER_MIN)
-                    .append(" ");
-            if (seconds < 2 * SECS_PER_MIN) {
-                builder.append(context.getString(R.string.lbl_minute));
-            } else {
-                builder.append(context.getString(R.string.lbl_minutes));
-            }
-            return builder.toString();
-        }
-
-        // Hours
-        builder.append(seconds / SECS_PER_HR)
-                .append(" ");
-        if (seconds < 2 * SECS_PER_HR) {
-            builder.append(context.getString(R.string.lbl_hour));
+            return ContextExtensionsKt.getQuantityString(context, R.plurals.seconds, seconds);
+        } else if (seconds < SECS_PER_HR) {
+            return ContextExtensionsKt.getQuantityString(context, R.plurals.minutes, seconds / SECS_PER_MIN);
         } else {
-            builder.append(context.getString(R.string.lbl_hours));
+            return ContextExtensionsKt.getQuantityString(context, R.plurals.hours, seconds / SECS_PER_HR);
         }
-        return builder.toString();
     }
 
     public static Date convertToLocalDate(Date utcDate) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,11 +216,6 @@
     <string name="lbl_save">Save</string>
     <string name="lbl_series_recordings">Series Recordings</string>
     <string name="lbl_at_any_time">At Any Time</string>
-    <string name="lbl_seconds">Seconds</string>
-    <string name="lbl_minutes">Minutes</string>
-    <string name="lbl_hour">Hour</string>
-    <string name="lbl_minute">Minute</string>
-    <string name="lbl_hours">Hours</string>
     <string name="lbl_on_schedule">On Schedule</string>
     <string name="lbl_guest_stars">Guest Stars</string>
     <string name="lbl_premiere">Premiere</string>


### PR DESCRIPTION
I introduced plurals in #2539 and they work great in Weblate. This allows different locales to use their own way of displaying time units.

**Changes**
- Rewrite `TimeUtils.formatSeconds` to use plurals
- Remove old strings for seconds,minute(s) and hour(s)
  - Replaced usages with `getQuantityString()`

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
