### PR TITLE
Fix crash when scaleType is null in AsyncImage

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
@@ -33,7 +33,7 @@ fun AsyncImage(
 		modifier = modifier,
 		factory = { context ->
 			AsyncImageView(context).also { view ->
-				view.scaleType = scaleType
+				view.scaleType = scaleType ?: ImageView.ScaleType.FIT_CENTER
 			}
 		},
 		update = { view ->


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Default to FIT_CENTER when scaleType is not set

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
