### PR TITLE
Add IncludeType param when sending number query

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.kt
@@ -15,6 +15,7 @@ class ByLetterFragment : BrowseFolderFragment() {
 		val numbersQuery = StdItemQuery().apply {
 			parentId = folder?.id?.toString()
 			sortBy = arrayOf(ItemSortBy.SortName)
+			includeType?.let { includeItemTypes = arrayOf(it) }
 			nameLessThan = letters.substring(0, 1)
 			recursive = true
 		}


### PR DESCRIPTION
**Changes**
to match the same parameters in both queries, which seems to solve the problem by displaying the content with the numerical title in the "By letter" screen.

**Issues**
Fixes #2403