### PR TITLE
Add workaround for non reproducible baseline profiles in AGP

### DIFF
--- a/app/baselineWorkaround.gradle
+++ b/app/baselineWorkaround.gradle
@@ -1,0 +1,39 @@
+buildscript {
+	repositories {
+		mavenCentral()
+		google()
+	}
+
+	dependencies {
+		classpath libs.android.gradle
+	}
+}
+
+import com.android.tools.profgen.ArtProfileKt
+import com.android.tools.profgen.ArtProfileSerializer
+import com.android.tools.profgen.DexFile
+
+/**
+ * This is a temporary workaround for https://issuetracker.google.com/issues/231837768
+ * which will be fixed in AGP 8.1.0, at which point the workaround may be deleted.
+ */
+project.afterEvaluate {
+	tasks.compileReleaseArtProfile.doLast {
+		outputs.files.each { file ->
+			if (file.toString().endsWith(".profm")) {
+				println("Sorting ${file}")
+				def version = ArtProfileSerializer.valueOf("METADATA_0_0_2")
+				def profile = ArtProfileKt.ArtProfile(file)
+				def keys = new ArrayList(profile.profileData.keySet())
+				def sortedData = new LinkedHashMap()
+				Collections.sort keys, new DexFile.Companion()
+				keys.each { key -> sortedData[key] = profile.profileData[key] }
+				new FileOutputStream(file).with {
+					write(version.magicBytes$profgen)
+					write(version.versionBytes$profgen)
+					version.write$profgen(it, sortedData, "")
+				}
+			}
+		}
+	}
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 	alias(libs.plugins.aboutlibraries)
 }
 
+// Apply workaround
+apply("baselineWorkaround.gradle")
+
 android {
 	namespace = "org.jellyfin.androidtv"
 	compileSdk = 33


### PR DESCRIPTION
**Changes**
- Add the workaround made by @obfusk to fix the reproducibility of the baseline profiles

**Issues**

Now really fixes #1639 (I tested it by making two clean builds locally and comparing them with `diff -r`)