### PR TITLE
Fix missing background in DreamContentLogo

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLogo.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLogo.kt
@@ -1,12 +1,14 @@
 package org.jellyfin.androidtv.integration.dream.composable
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -14,7 +16,9 @@ import org.jellyfin.androidtv.R
 
 @Composable
 fun DreamContentLogo() = Box(
-	modifier = Modifier.fillMaxSize(),
+	modifier = Modifier
+		.fillMaxSize()
+		.background(Color.Black),
 ) {
 	Image(
 		painter = painterResource(R.drawable.app_logo),


### PR DESCRIPTION
When the dream failed to display content and went from a library showcase to the logo it would flicker because there was no background for the logo content during the animation, and when the animation finished the library showcase would suddenly disappear. Adding a background color fixes this issue.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Addmissing background in DreamContentLogo

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
