### PR TITLE
Fix SearchFragment not restoring properly

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.speech.SpeechRecognizer
-import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import org.jellyfin.androidtv.R
@@ -15,8 +14,8 @@ class SearchFragment : Fragment(R.layout.fragment_content_view) {
 			&& ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_DENIED
 	}
 
-	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-		super.onViewCreated(view, savedInstanceState)
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
 
 		// Determine fragment to use
 		val searchFragment = when {


### PR DESCRIPTION
**Changes**
- Fix an issue where the behavior of SearchFragment updating the child fragment in onViewCreated caused state restoration to fail.

**Issues**

Closes #2561 