### PR TITLE
Add option to toggle content maturity rating from view

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -176,6 +176,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var defaultRatingType = enumPreference("pref_rating_type", RatingType.RATING_TOMATOES)
 
 		/**
+		 * Sets whether to display content maturity ratings
+		 */
+		var maturityRatingsEnabled = booleanPreference("pref_enable_maturity_ratings", true)
+
+		/**
 		 * Set when watched indicators should show on MyImageCardViews
 		 */
 		var watchedIndicatorBehavior = enumPreference("pref_watched_indicator_behavior", WatchedIndicatorBehavior.ALWAYS)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -60,6 +60,12 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 			}
 
 			checkbox {
+				setTitle(R.string.pref_enable_maturity_ratings)
+				setContent(R.string.pref_enable_maturity_ratings_description)
+				bind(userPreferences, UserPreferences.maturityRatingsEnabled)
+			}
+
+			checkbox {
 				setTitle(R.string.lbl_show_premieres)
 				setContent(R.string.desc_premieres)
 				bind(userPreferences, UserPreferences.premieresEnabled)

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -100,7 +100,8 @@ public class InfoLayoutHelper {
         }
         if (includeRuntime) addRuntime(context, item, layout, includeEndTime);
         addSeriesStatus(context, item, layout);
-        addRatingAndRes(context, item, layout);
+        addMaturityRating(context, item, layout);
+        addMediaResolution(context, item, layout);
         addMediaDetails(context, audioStream, layout);
     }
 
@@ -325,11 +326,17 @@ public class InfoLayoutHelper {
 
     }
 
-    private static void addRatingAndRes(Context context, BaseItemDto item, LinearLayout layout) {
+    private static void addMaturityRating(Context context, BaseItemDto item, LinearLayout layout) {
+        if (!KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getMaturityRatingsEnabled()))
+            return;
+
         if (item.getOfficialRating() != null && !item.getOfficialRating().equals("0")) {
             addBlockText(context, layout, item.getOfficialRating());
             addSpacer(context, layout, "  ");
         }
+    }
+
+    private static void addMediaResolution(Context context, BaseItemDto item, LinearLayout layout) {
         if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0 && item.getMediaStreams().get(0).getWidth() != null && item.getMediaStreams().get(0).getHeight() != null) {
             int width = item.getMediaStreams().get(0).getWidth();
             int height = item.getMediaStreams().get(0).getHeight();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -496,6 +496,8 @@
     <string name="pref_screensaver_inapp_enabled">Use in-app screensaver</string>
     <string name="pref_screensaver_inapp_enabled_description">Show the Jellyfin screensaver while the app is open</string>
     <string name="pref_screensaver_inapp_timeout">Start screensaver after</string>
+    <string name="pref_enable_maturity_ratings">Display content maturity ratings</string>
+    <string name="pref_enable_maturity_ratings_description">Shows maturity ratings whilst browsing content</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
Adds an option to toggle displaying the selected content's maturity rating.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
We use maturity rating (instead of content rating) to remove ambiguity between content rating (critic and audience) and content rating (restrictions on content).

**Issues**
Fixes #2438 