### PR TITLE
Dim screensaver and static elements

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.asImageBitmap
@@ -35,7 +36,7 @@ fun DreamContentLibraryShowcase(
 			contentDescription = null,
 			alignment = Alignment.Center,
 			contentScale = ContentScale.Crop,
-			modifier = Modifier.fillMaxSize()
+			modifier = Modifier.fillMaxSize().alpha(0.7f)
 		)
 	}
 
@@ -55,6 +56,8 @@ fun DreamContentLibraryShowcase(
 					blurRadius = 2f,
 				)
 			),
+			// The alpha needs to be higher than the backdrop so it's still readable
+			modifier = Modifier.alpha(0.85f)
 		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLogo.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLogo.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -18,6 +19,7 @@ import org.jellyfin.androidtv.R
 fun DreamContentLogo() = Box(
 	modifier = Modifier
 		.fillMaxSize()
+		.alpha(0.5f)
 		.background(Color.Black),
 ) {
 	Image(

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.platform.LocalContext
@@ -30,6 +31,8 @@ fun DreamHeader(
 	showLogo: Boolean,
 	showClock: Boolean,
 ) {
+	// Alpha to avoid burn in on OLED screens
+	val alpha = 0.7f
 	Row(
 		horizontalArrangement = Arrangement.SpaceBetween,
 		modifier = Modifier
@@ -41,11 +44,14 @@ fun DreamHeader(
 			visible = showLogo,
 			enter = fadeIn(),
 			exit = fadeOut(),
-			modifier = Modifier.height(41.dp),
+			modifier = Modifier.height(41.dp).alpha(alpha),
 		) {
 			Image(
 				painter = painterResource(R.drawable.app_logo),
 				contentDescription = stringResource(R.string.app_name),
+				// We also set the alpha for the non-header logo, as this can
+				// be displayed as a fallback
+				modifier = Modifier.alpha(alpha)
 			)
 		}
 
@@ -71,6 +77,7 @@ fun DreamHeader(
 						blurRadius = 2f,
 					)
 				),
+				modifier = Modifier.alpha(alpha)
 			)
 		}
 	}


### PR DESCRIPTION
**Changes**
~Adds an option to remove static elements, specifically the clock and logo, from the screensaver. This should reduce the chances of burn-in on the screensaver.~

Reduces the alpha on various static elements. This not only reduces the burn-in effect on OLED devices, but it also is quite satisfying as the TV feels like it "wakes up" or "dims down" switching into the screen saver. The alpha values have been hand picked to balance between readability and impact. But I'm happy to tweak them based on testing with real devices.

I've also applied it to the Logo backdrop, as any images that fail to load will automatically show that now.

Screenshots:

![image](https://user-images.githubusercontent.com/1817032/232862226-5163cf86-fe81-4aa9-ab10-35a2fe35459c.png)


![image](https://user-images.githubusercontent.com/1817032/232861844-b0114eab-bc3c-44a5-aa78-d102d2ac0a0d.png)




**Issues**
Fixes: #1888 