### PR TITLE
Refactor CustomPlaybackTransportControlGlue to extract logic into actions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -305,7 +305,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     public void onCustomActionClicked(Action action, View view) {
         // Handle custom action clicks which require a popup menu
         if (action instanceof CustomAction){
-            ((CustomAction) action).handleClickAction(playbackController, getPlayerAdapter(), getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
+            ((CustomAction) action).handleClickAction(playbackController, getPlayerAdapter(), getContext(), view);
         }
 
         if (action == playbackSpeedAction) {
@@ -391,10 +391,10 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
         VideoPlayerAdapter playerAdapter = getPlayerAdapter();
 
         if (playerAdapter.hasSubs() && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutSubtitleTrack())) {
-            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter(), getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
+            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter(), getContext(), v);
         }
         if (playerAdapter.hasMultiAudio() && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutAudioTrack())) {
-            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter(), getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
+            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter(), getContext(), v);
         }
         return super.onKey(v, keyCode, event);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -28,17 +28,23 @@ import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.ClockBehavior;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.PlaybackManager;
+import org.jellyfin.androidtv.ui.playback.overlay.action.AndroidAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ChannelBarChannelAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ChapterAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ClosedCaptionsAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.CustomAction;
+import org.jellyfin.androidtv.ui.playback.overlay.action.FastForwardAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.GuideAction;
+import org.jellyfin.androidtv.ui.playback.overlay.action.PlayPauseAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.PlaybackSpeedAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.PreviousLiveTvChannelAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.RecordAction;
+import org.jellyfin.androidtv.ui.playback.overlay.action.RewindAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.SelectAudioAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.SelectQualityAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.SettingAction;
+import org.jellyfin.androidtv.ui.playback.overlay.action.SkipNextAction;
+import org.jellyfin.androidtv.ui.playback.overlay.action.SkipPreviousAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ZoomAction;
 import org.koin.java.KoinJavaComponent;
 
@@ -47,11 +53,11 @@ import java.util.Calendar;
 public class CustomPlaybackTransportControlGlue extends PlaybackTransportControlGlue<VideoPlayerAdapter> {
 
     // Normal playback actions
-    private PlaybackControlsRow.PlayPauseAction playPauseAction;
-    private PlaybackControlsRow.RewindAction rewindAction;
-    private PlaybackControlsRow.FastForwardAction fastForwardAction;
-    private PlaybackControlsRow.SkipPreviousAction skipPreviousAction;
-    private PlaybackControlsRow.SkipNextAction skipNextAction;
+    private PlayPauseAction playPauseAction;
+    private RewindAction rewindAction;
+    private FastForwardAction fastForwardAction;
+    private SkipPreviousAction skipPreviousAction;
+    private SkipNextAction skipNextAction;
     private SelectAudioAction selectAudioAction;
     private ClosedCaptionsAction closedCaptionsAction;
     private SelectQualityAction selectQualityAction;
@@ -175,11 +181,11 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     }
 
     private void initActions(Context context) {
-        playPauseAction = new PlaybackControlsRow.PlayPauseAction(context);
-        rewindAction = new PlaybackControlsRow.RewindAction(context);
-        fastForwardAction = new PlaybackControlsRow.FastForwardAction(context);
-        skipPreviousAction = new PlaybackControlsRow.SkipPreviousAction(context);
-        skipNextAction = new PlaybackControlsRow.SkipNextAction(context);
+        playPauseAction = new PlayPauseAction(context);
+        rewindAction = new RewindAction(context);
+        fastForwardAction = new FastForwardAction(context);
+        skipPreviousAction = new SkipPreviousAction(context);
+        skipNextAction = new SkipNextAction(context);
         selectAudioAction = new SelectAudioAction(context, this, KoinJavaComponent.get(PlaybackManager.class));
         selectAudioAction.setLabels(new String[]{context.getString(R.string.lbl_audio_track)});
         closedCaptionsAction = new ClosedCaptionsAction(context, this);
@@ -282,22 +288,8 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     @Override
     public void onActionClicked(Action action) {
-        if (action == playPauseAction) {
-            if (playPauseAction.getIndex() == PlaybackControlsRow.PlayPauseAction.INDEX_PAUSE) {
-                getPlayerAdapter().pause();
-                playPauseAction.setIndex(PlaybackControlsRow.PlayPauseAction.INDEX_PLAY);
-            } else if (playPauseAction.getIndex() == PlaybackControlsRow.PlayPauseAction.INDEX_PLAY) {
-                getPlayerAdapter().play();
-                playPauseAction.setIndex(PlaybackControlsRow.PlayPauseAction.INDEX_PAUSE);
-            }
-        } else if (action == rewindAction) {
-            getPlayerAdapter().rewind();
-        } else if (action == fastForwardAction) {
-            getPlayerAdapter().fastForward();
-        } else if (action == skipPreviousAction) {
-            getPlayerAdapter().previous();
-        } else if (action == skipNextAction) {
-            getPlayerAdapter().next();
+        if (action instanceof AndroidAction) {
+            ((AndroidAction) action).onActionClicked(getPlayerAdapter());
         }
         notifyActionChanged(action);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -296,7 +296,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     public void onCustomActionClicked(Action action, View view) {
         // Handle custom action clicks which require a popup menu
-        if (action instanceof CustomAction){
+        if (action instanceof CustomAction) {
             ((CustomAction) action).handleClickAction(playbackController, getPlayerAdapter(), getContext(), view);
         }
 
@@ -375,7 +375,7 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
-        if (event.getAction() != KeyEvent.ACTION_UP){
+        if (event.getAction() != KeyEvent.ACTION_UP) {
             // The below actions are only handled on key up
             return super.onKey(v, keyCode, event);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -26,12 +26,12 @@ import androidx.leanback.widget.RowPresenter;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.ClockBehavior;
-import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.PlaybackManager;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ChannelBarChannelAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ChapterAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.ClosedCaptionsAction;
+import org.jellyfin.androidtv.ui.playback.overlay.action.CustomAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.GuideAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.PlaybackSpeedAction;
 import org.jellyfin.androidtv.ui.playback.overlay.action.PreviousLiveTvChannelAction;
@@ -226,53 +226,54 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
         // Primary Items
         primaryActionsAdapter.add(playPauseAction);
+        VideoPlayerAdapter playerAdapter = getPlayerAdapter();
 
-        if (canSeek()) {
+        if (playerAdapter.canSeek()) {
             primaryActionsAdapter.add(rewindAction);
             primaryActionsAdapter.add(fastForwardAction);
         }
 
-        if (hasSubs()) {
+        if (playerAdapter.hasSubs()) {
             primaryActionsAdapter.add(closedCaptionsAction);
         }
 
-        if (hasMultiAudio()) {
+        if (playerAdapter.hasMultiAudio()) {
             primaryActionsAdapter.add(selectAudioAction);
         }
 
-        if (isLiveTv()) {
+        if (playerAdapter.isLiveTv()) {
             primaryActionsAdapter.add(channelBarChannelAction);
             primaryActionsAdapter.add(guideAction);
         }
 
         // Secondary Items
-        if (isLiveTv()) {
+        if (playerAdapter.isLiveTv()) {
             secondaryActionsAdapter.add(previousLiveTvChannelAction);
-            if (canRecordLiveTv()) {
+            if (playerAdapter.canRecordLiveTv()) {
                 secondaryActionsAdapter.add(recordAction);
                 recordingStateChanged();
             }
         }
 
-        if (hasPreviousItem()) {
+        if (playerAdapter.hasPreviousItem()) {
             secondaryActionsAdapter.add(skipPreviousAction);
         }
 
-        if (hasNextItem()) {
+        if (playerAdapter.hasNextItem()) {
             secondaryActionsAdapter.add(skipNextAction);
         }
 
-        if (hasChapters()) {
+        if (playerAdapter.hasChapters()) {
             secondaryActionsAdapter.add(chapterAction);
         }
 
-        if (!isLiveTv()) {
+        if (!playerAdapter.isLiveTv()) {
             secondaryActionsAdapter.add(playbackSpeedAction);
             secondaryActionsAdapter.add(selectQualityAction);
         }
 
 
-        if (!isNativeMode()) {
+        if (!playerAdapter.isNativeMode()) {
             secondaryActionsAdapter.add(settingAction);
         } else {
             secondaryActionsAdapter.add(zoomAction);
@@ -303,43 +304,15 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     public void onCustomActionClicked(Action action, View view) {
         // Handle custom action clicks which require a popup menu
-        if (action == selectAudioAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
-            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
-        } else if (action == closedCaptionsAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
-            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
-        } else if (action == settingAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
-            settingAction.setSubtitlesPresent(hasSubs());
-            settingAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
-        } else if (action == playbackSpeedAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
-            playbackSpeedAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
+        if (action instanceof CustomAction){
+            ((CustomAction) action).handleClickAction(playbackController, getPlayerAdapter(), getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
+        }
+
+        if (action == playbackSpeedAction) {
             // Post a callback to calculate the new time, since Exoplayer updates this in an async fashion.
             // This is a hack, we should instead have onPlaybackParametersChanged call out to this
             // class to notify rather than poll. But communication is unidirectional at the moment:
             mHandler.postDelayed(mRefreshEndTime, 5000);  // 5 seconds
-        }  else if (action == selectQualityAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
-            selectQualityAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
-        } else if (action == zoomAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().setFading(false);
-            zoomAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), view);
-        } else if (action == chapterAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().hideOverlay();
-            getPlayerAdapter().getMasterOverlayFragment().showChapterSelector();
-        } else if (action == previousLiveTvChannelAction) {
-            getPlayerAdapter().getMasterOverlayFragment().switchChannel(TvManager.getPrevLiveTvChannel());
-        } else if (action == channelBarChannelAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().hideOverlay();
-            getPlayerAdapter().getMasterOverlayFragment().showQuickChannelChanger();
-        } else if (action == guideAction) {
-            getPlayerAdapter().getLeanbackOverlayFragment().hideOverlay();
-            getPlayerAdapter().getMasterOverlayFragment().showGuide();
-        } else if (action == recordAction) {
-            getPlayerAdapter().toggleRecording();
-            // Icon will be updated via callback recordingStateChanged
         }
     }
 
@@ -369,42 +342,6 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
     void setInitialPlaybackDrawable() {
         playPauseAction.setIndex(PlaybackControlsRow.PlayPauseAction.INDEX_PAUSE);
         notifyActionChanged(playPauseAction);
-    }
-
-    private boolean hasSubs() {
-        return getPlayerAdapter().hasSubs();
-    }
-
-    private boolean hasMultiAudio() {
-        return getPlayerAdapter().hasMultiAudio();
-    }
-
-    private boolean hasNextItem() {
-        return getPlayerAdapter().hasNextItem();
-    }
-
-    private boolean hasPreviousItem() {
-        return getPlayerAdapter().hasPreviousItem();
-    }
-
-    private boolean isNativeMode() {
-        return getPlayerAdapter().isNativeMode();
-    }
-
-    private boolean canSeek() {
-        return getPlayerAdapter().canSeek();
-    }
-
-    private boolean isLiveTv() {
-        return getPlayerAdapter().isLiveTv();
-    }
-
-    private boolean canRecordLiveTv() {
-        return getPlayerAdapter().canRecordLiveTv();
-    }
-
-    private boolean hasChapters() {
-        return getPlayerAdapter().hasChapters();
     }
 
     void invalidatePlaybackControls() {
@@ -446,11 +383,18 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
-        if (hasSubs() && event.getAction() == KeyEvent.ACTION_UP && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutSubtitleTrack())) {
-            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
+        if (event.getAction() != KeyEvent.ACTION_UP){
+            // The below actions are only handled on key up
+            return super.onKey(v, keyCode, event);
         }
-        if (hasMultiAudio() && event.getAction() == KeyEvent.ACTION_UP && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutAudioTrack())) {
-            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
+
+        VideoPlayerAdapter playerAdapter = getPlayerAdapter();
+
+        if (playerAdapter.hasSubs() && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutSubtitleTrack())) {
+            closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter(), getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
+        }
+        if (playerAdapter.hasMultiAudio() && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutAudioTrack())) {
+            selectAudioAction.handleClickAction(playbackController, getPlayerAdapter(), getPlayerAdapter().getLeanbackOverlayFragment(), getContext(), v);
         }
         return super.onKey(v, keyCode, event);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.ui.playback.overlay;
 
+import androidx.annotation.NonNull;
 import androidx.leanback.media.PlayerAdapter;
 
 import org.jellyfin.androidtv.auth.repository.UserRepository;
@@ -130,10 +131,12 @@ public class VideoPlayerAdapter extends PlayerAdapter {
         this.customPlaybackOverlayFragment = customPlaybackOverlayFragment;
     }
 
+    @NonNull
     public CustomPlaybackOverlayFragment getMasterOverlayFragment() {
         return customPlaybackOverlayFragment;
     }
 
+    @NonNull
     public LeanbackOverlayFragment getLeanbackOverlayFragment() {
         return leanbackOverlayFragment;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -134,7 +134,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
         return customPlaybackOverlayFragment;
     }
 
-    LeanbackOverlayFragment getLeanbackOverlayFragment() {
+    public LeanbackOverlayFragment getLeanbackOverlayFragment() {
         return leanbackOverlayFragment;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -98,11 +98,11 @@ public class VideoPlayerAdapter extends PlayerAdapter {
         getCallback().onDurationChanged(this);
     }
 
-    boolean hasSubs() {
+    public boolean hasSubs() {
         return StreamHelper.getSubtitleStreams(playbackController.getCurrentMediaSource()).size() > 0;
     }
 
-    boolean hasMultiAudio() {
+    public boolean hasMultiAudio() {
         return StreamHelper.getAudioStreams(playbackController.getCurrentMediaSource()).size() > 1;
     }
 
@@ -130,7 +130,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
         this.customPlaybackOverlayFragment = customPlaybackOverlayFragment;
     }
 
-    CustomPlaybackOverlayFragment getMasterOverlayFragment() {
+    public CustomPlaybackOverlayFragment getMasterOverlayFragment() {
         return customPlaybackOverlayFragment;
     }
 
@@ -150,7 +150,7 @@ public class VideoPlayerAdapter extends PlayerAdapter {
                 && Utils.canManageRecordings(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue());
     }
 
-    void toggleRecording() {
+    public void toggleRecording() {
         org.jellyfin.sdk.model.api.BaseItemDto currentlyPlayingItem = getCurrentlyPlayingItem();
         getMasterOverlayFragment().toggleRecording(currentlyPlayingItem);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/AndroidAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/AndroidAction.kt
@@ -1,0 +1,9 @@
+package org.jellyfin.androidtv.ui.playback.overlay.action
+
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+
+interface AndroidAction {
+	fun onActionClicked(
+		videoPlayerAdapter: VideoPlayerAdapter
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChannelBarChannelAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChannelBarChannelAction.kt
@@ -20,11 +20,10 @@ class ChannelBarChannelAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
-		leanbackOverlayFragment.hideOverlay()
+		videoPlayerAdapter.leanbackOverlayFragment.hideOverlay()
 		videoPlayerAdapter.masterOverlayFragment.showQuickChannelChanger();
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChannelBarChannelAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChannelBarChannelAction.kt
@@ -21,7 +21,7 @@ class ChannelBarChannelAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.hideOverlay()
 		videoPlayerAdapter.masterOverlayFragment.showQuickChannelChanger();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChannelBarChannelAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChannelBarChannelAction.kt
@@ -1,8 +1,12 @@
 package org.jellyfin.androidtv.ui.playback.overlay.action
 
 import android.content.Context
+import android.view.View
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
+import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class ChannelBarChannelAction(
 	context: Context,
@@ -10,5 +14,17 @@ class ChannelBarChannelAction(
 ) : CustomAction(context, customPlaybackTransportControlGlue) {
 	init {
 		initializeWithIcon(R.drawable.ic_channel_bar)
+	}
+
+	@Override
+	override fun handleClickAction(
+		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
+		leanbackOverlayFragment: LeanbackOverlayFragment,
+		context: Context,
+		view: View
+	) {
+		leanbackOverlayFragment.hideOverlay()
+		videoPlayerAdapter.masterOverlayFragment.showQuickChannelChanger();
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChapterAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChapterAction.kt
@@ -20,11 +20,10 @@ class ChapterAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
-		leanbackOverlayFragment.hideOverlay()
+		videoPlayerAdapter.leanbackOverlayFragment.hideOverlay()
 		videoPlayerAdapter.masterOverlayFragment.showChapterSelector();
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChapterAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChapterAction.kt
@@ -21,7 +21,7 @@ class ChapterAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.hideOverlay()
 		videoPlayerAdapter.masterOverlayFragment.showChapterSelector();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChapterAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ChapterAction.kt
@@ -1,8 +1,12 @@
 package org.jellyfin.androidtv.ui.playback.overlay.action
 
 import android.content.Context
+import android.view.View
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
+import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class ChapterAction(
 	context: Context,
@@ -10,5 +14,17 @@ class ChapterAction(
 ) : CustomAction(context, customPlaybackTransportControlGlue) {
 	init {
 		initializeWithIcon(R.drawable.ic_select_chapter)
+	}
+
+	@Override
+	override fun handleClickAction(
+		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
+		leanbackOverlayFragment: LeanbackOverlayFragment,
+		context: Context,
+		view: View
+	) {
+		leanbackOverlayFragment.hideOverlay()
+		videoPlayerAdapter.masterOverlayFragment.showChapterSelector();
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
@@ -23,7 +23,6 @@ class ClosedCaptionsAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
@@ -33,7 +32,7 @@ class ClosedCaptionsAction(
 			return
 		}
 
-		leanbackOverlayFragment.setFading(false)
+		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		PopupMenu(context, view, Gravity.END).apply {
 			with(menu) {
 				for (sub in playbackController.subtitleStreams) {
@@ -48,7 +47,7 @@ class ClosedCaptionsAction(
 
 				setGroupCheckable(0, true, false)
 			}
-			setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+			setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 			setOnMenuItemClickListener { item ->
 				playbackController.switchSubtitleStream(item.itemId)
 				true

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
@@ -24,7 +24,7 @@ class ClosedCaptionsAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		if (playbackController.currentStreamInfo == null) {
 			Timber.w("StreamInfo null trying to obtain subtitles")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 import timber.log.Timber
 
 class ClosedCaptionsAction(
@@ -21,9 +22,10 @@ class ClosedCaptionsAction(
 
 	override fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
-		view: View,
+		view: View
 	) {
 		if (playbackController.currentStreamInfo == null) {
 			Timber.w("StreamInfo null trying to obtain subtitles")
@@ -31,6 +33,7 @@ class ClosedCaptionsAction(
 			return
 		}
 
+		leanbackOverlayFragment.setFading(false)
 		PopupMenu(context, view, Gravity.END).apply {
 			with(menu) {
 				for (sub in playbackController.subtitleStreams) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/CustomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/CustomAction.kt
@@ -27,7 +27,6 @@ abstract class CustomAction(
 	open fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View,
 	) {}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/CustomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/CustomAction.kt
@@ -8,6 +8,7 @@ import androidx.leanback.widget.PlaybackControlsRow
 import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 abstract class CustomAction(
 	private val context: Context,
@@ -25,6 +26,7 @@ abstract class CustomAction(
 
 	open fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/FastForwardAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/FastForwardAction.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.androidtv.ui.playback.overlay.action
+
+import android.content.Context
+import androidx.leanback.widget.PlaybackControlsRow
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+
+class FastForwardAction(context: Context) : PlaybackControlsRow.FastForwardAction(context),
+	AndroidAction {
+	override fun onActionClicked(videoPlayerAdapter: VideoPlayerAdapter) =
+		videoPlayerAdapter.fastForward()
+}
+

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/GuideAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/GuideAction.kt
@@ -21,7 +21,7 @@ class GuideAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.hideOverlay()
 		videoPlayerAdapter.masterOverlayFragment.showGuide()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/GuideAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/GuideAction.kt
@@ -1,8 +1,12 @@
 package org.jellyfin.androidtv.ui.playback.overlay.action
 
 import android.content.Context
+import android.view.View
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
+import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class GuideAction(
 	context: Context,
@@ -10,5 +14,17 @@ class GuideAction(
 ) : CustomAction(context, customPlaybackTransportControlGlue) {
 	init {
 		initializeWithIcon(R.drawable.ic_guide)
+	}
+
+	@Override
+	override fun handleClickAction(
+		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
+		leanbackOverlayFragment: LeanbackOverlayFragment,
+		context: Context,
+		view: View
+	) {
+		leanbackOverlayFragment.hideOverlay()
+		videoPlayerAdapter.masterOverlayFragment.showGuide()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/GuideAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/GuideAction.kt
@@ -20,11 +20,10 @@ class GuideAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
-		leanbackOverlayFragment.hideOverlay()
+		videoPlayerAdapter.leanbackOverlayFragment.hideOverlay()
 		videoPlayerAdapter.masterOverlayFragment.showGuide()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlayPauseAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlayPauseAction.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.androidtv.ui.playback.overlay.action
+
+import android.content.Context
+import androidx.leanback.widget.PlaybackControlsRow
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+
+class PlayPauseAction(context: Context) : PlaybackControlsRow.PlayPauseAction(context),
+	AndroidAction {
+	override fun onActionClicked(videoPlayerAdapter: VideoPlayerAdapter) =
+		when (this.index) {
+			INDEX_PLAY -> {
+				videoPlayerAdapter.play()
+				this.index = INDEX_PAUSE
+			}
+
+			INDEX_PAUSE -> {
+				videoPlayerAdapter.pause()
+				this.index = INDEX_PLAY
+			}
+
+			else -> {}
+		}
+
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.VideoSpeedController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 import java.util.Locale
 
 class PlaybackSpeedAction(
@@ -25,10 +26,12 @@ class PlaybackSpeedAction(
 
 	override fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View,
 	) {
+		leanbackOverlayFragment.setFading(false)
 		val speedMenu = populateMenu(context, view, speedController)
 
 		speedMenu.setOnDismissListener { leanbackOverlayFragment.setFading(true) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
@@ -28,7 +28,7 @@ class PlaybackSpeedAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		val speedMenu = populateMenu(context, view, speedController)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PlaybackSpeedAction.kt
@@ -27,14 +27,13 @@ class PlaybackSpeedAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
-		view: View,
+		view: View
 	) {
-		leanbackOverlayFragment.setFading(false)
+		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		val speedMenu = populateMenu(context, view, speedController)
 
-		speedMenu.setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+		speedMenu.setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 
 		speedMenu.setOnMenuItemClickListener { menuItem ->
 			speedController.currentSpeed = speeds[menuItem.itemId]

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PreviousLiveTvChannelAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PreviousLiveTvChannelAction.kt
@@ -21,7 +21,6 @@ class PreviousLiveTvChannelAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PreviousLiveTvChannelAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PreviousLiveTvChannelAction.kt
@@ -22,7 +22,7 @@ class PreviousLiveTvChannelAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.masterOverlayFragment.switchChannel(TvManager.getPrevLiveTvChannel())
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PreviousLiveTvChannelAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/PreviousLiveTvChannelAction.kt
@@ -1,8 +1,13 @@
 package org.jellyfin.androidtv.ui.playback.overlay.action
 
 import android.content.Context
+import android.view.View
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.livetv.TvManager
+import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
+import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter as VideoPlayerAdapter
 
 class PreviousLiveTvChannelAction(
 	context: Context,
@@ -10,5 +15,16 @@ class PreviousLiveTvChannelAction(
 ) : CustomAction(context, customPlaybackTransportControlGlue) {
 	init {
 		initializeWithIcon(R.drawable.ic_previous_episode)
+	}
+
+	@Override
+	override fun handleClickAction(
+		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
+		leanbackOverlayFragment: LeanbackOverlayFragment,
+		context: Context,
+		view: View
+	) {
+		videoPlayerAdapter.masterOverlayFragment.switchChannel(TvManager.getPrevLiveTvChannel())
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.kt
@@ -29,7 +29,6 @@ class RecordAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.kt
@@ -1,9 +1,13 @@
 package org.jellyfin.androidtv.ui.playback.overlay.action
 
 import android.content.Context
+import android.view.View
 import androidx.core.content.ContextCompat
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
+import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class RecordAction(
 	context: Context,
@@ -19,5 +23,16 @@ class RecordAction(
 		val recordActive = ContextCompat.getDrawable(context, R.drawable.ic_record_red)
 
 		setDrawables(arrayOf(recordInactive, recordActive))
+	}
+
+	@Override
+	override fun handleClickAction(
+		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
+		leanbackOverlayFragment: LeanbackOverlayFragment,
+		context: Context,
+		view: View
+	) {
+		videoPlayerAdapter.toggleRecording()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RecordAction.kt
@@ -30,7 +30,7 @@ class RecordAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.toggleRecording()
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RewindAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/RewindAction.kt
@@ -1,0 +1,10 @@
+package org.jellyfin.androidtv.ui.playback.overlay.action
+
+import android.content.Context
+import androidx.leanback.widget.PlaybackControlsRow
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+
+class RewindAction(context: Context) : PlaybackControlsRow.RewindAction(context), AndroidAction {
+	override fun onActionClicked(videoPlayerAdapter: VideoPlayerAdapter) =
+		videoPlayerAdapter.rewind()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.PlaybackManager
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class SelectAudioAction(
 	context: Context,
@@ -21,10 +22,12 @@ class SelectAudioAction(
 
 	override fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
-		view: View,
+		view: View
 	) {
+		leanbackOverlayFragment.setFading(false)
 		val audioTracks = playbackManager.getInPlaybackSelectableAudioStreams(playbackController.currentStreamInfo)
 			?: return
 		val currentAudioIndex = playbackController.audioStreamIndex

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
@@ -24,7 +24,7 @@ class SelectAudioAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		val audioTracks = playbackManager.getInPlaybackSelectableAudioStreams(playbackController.currentStreamInfo)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
@@ -23,11 +23,10 @@ class SelectAudioAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
-		leanbackOverlayFragment.setFading(false)
+		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		val audioTracks = playbackManager.getInPlaybackSelectableAudioStreams(playbackController.currentStreamInfo)
 			?: return
 		val currentAudioIndex = playbackController.audioStreamIndex
@@ -42,7 +41,7 @@ class SelectAudioAction(
 				setGroupCheckable(0, true, false)
 			}
 
-			setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+			setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 			setOnMenuItemClickListener { item ->
 				playbackController.switchAudioStream(item.itemId)
 				true

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
@@ -11,6 +11,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.VideoQualityController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class SelectQualityAction(
 	context: Context,
@@ -27,9 +28,12 @@ class SelectQualityAction(
 
 	override fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
-		context: Context, view: View
+		context: Context,
+		view: View
 	) {
+		leanbackOverlayFragment.setFading(false)
 		PopupMenu(context, view, Gravity.END).apply {
 			qualityProfiles.values.forEachIndexed { i, selected ->
 				menu.add(0, i, i, selected)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
@@ -29,11 +29,10 @@ class SelectQualityAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
-		leanbackOverlayFragment.setFading(false)
+		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		PopupMenu(context, view, Gravity.END).apply {
 			qualityProfiles.values.forEachIndexed { i, selected ->
 				menu.add(0, i, i, selected)
@@ -44,7 +43,7 @@ class SelectQualityAction(
 				item.isChecked = true
 			}
 
-			setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+			setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 			setOnMenuItemClickListener { menuItem ->
 				qualityController.currentQuality = qualityProfiles.keys.elementAt(menuItem.itemId)
 				playbackController.refreshStream()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
@@ -30,7 +30,7 @@ class SelectQualityAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		PopupMenu(context, view, Gravity.END).apply {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SettingAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SettingAction.kt
@@ -7,6 +7,7 @@ import org.jellyfin.androidtv.ui.SettingsPopup
 import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class SettingAction(
 	context: Context,
@@ -20,17 +21,22 @@ class SettingAction(
 
 	override fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
-	) = SettingsPopup(context, view,
-		{ value -> playbackController.audioDelay = value },
-		{ value -> playbackController.subtitleDelay = value }
-	).apply {
-		popupWindow.setOnDismissListener { leanbackOverlayFragment.setFading(true) }
-	}.show(
-		subtitlesPresent,
-		playbackController.audioDelay,
-		playbackController.subtitleDelay
-	)
+	) {
+		subtitlesPresent = videoPlayerAdapter.hasSubs()
+		leanbackOverlayFragment.setFading(false)
+		return SettingsPopup(context, view,
+			{ value -> playbackController.audioDelay = value },
+			{ value -> playbackController.subtitleDelay = value }
+		).apply {
+			popupWindow.setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+		}.show(
+			subtitlesPresent,
+			playbackController.audioDelay,
+			playbackController.subtitleDelay
+		)
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SettingAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SettingAction.kt
@@ -22,17 +22,16 @@ class SettingAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
 		subtitlesPresent = videoPlayerAdapter.hasSubs()
-		leanbackOverlayFragment.setFading(false)
+		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		return SettingsPopup(context, view,
 			{ value -> playbackController.audioDelay = value },
 			{ value -> playbackController.subtitleDelay = value }
 		).apply {
-			popupWindow.setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+			popupWindow.setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 		}.show(
 			subtitlesPresent,
 			playbackController.audioDelay,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SettingAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SettingAction.kt
@@ -23,7 +23,7 @@ class SettingAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		subtitlesPresent = videoPlayerAdapter.hasSubs()
 		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SkipNextAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SkipNextAction.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.androidtv.ui.playback.overlay.action
+
+import android.content.Context
+import androidx.leanback.widget.PlaybackControlsRow
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+
+class SkipNextAction(context: Context) : PlaybackControlsRow.SkipNextAction(context),
+	AndroidAction {
+	override fun onActionClicked(videoPlayerAdapter: VideoPlayerAdapter) =
+		videoPlayerAdapter.next()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SkipPreviousAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SkipPreviousAction.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.androidtv.ui.playback.overlay.action
+
+import android.content.Context
+import androidx.leanback.widget.PlaybackControlsRow
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+
+class SkipPreviousAction(context: Context) : PlaybackControlsRow.SkipPreviousAction(context),
+	AndroidAction {
+	override fun onActionClicked(videoPlayerAdapter: VideoPlayerAdapter) =
+		videoPlayerAdapter.previous()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
@@ -22,11 +22,10 @@ class ZoomAction(
 	override fun handleClickAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
-		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
 		view: View
 	) {
-		leanbackOverlayFragment.setFading(false)
+		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		return PopupMenu(context, view, Gravity.END).apply {
 			with(menu) {
 				add(
@@ -59,7 +58,7 @@ class ZoomAction(
 				setGroupCheckable(0, true, false)
 			}
 
-			setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+			setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 			setOnMenuItemClickListener { item ->
 				playbackController.setZoom(item.itemId)
 				true

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
@@ -23,7 +23,7 @@ class ZoomAction(
 		playbackController: PlaybackController,
 		videoPlayerAdapter: VideoPlayerAdapter,
 		context: Context,
-		view: View
+		view: View,
 	) {
 		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		return PopupMenu(context, view, Gravity.END).apply {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.VideoManager
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
+import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
 
 class ZoomAction(
 	context: Context,
@@ -20,45 +21,49 @@ class ZoomAction(
 
 	override fun handleClickAction(
 		playbackController: PlaybackController,
+		videoPlayerAdapter: VideoPlayerAdapter,
 		leanbackOverlayFragment: LeanbackOverlayFragment,
 		context: Context,
-		view: View,
-	) = PopupMenu(context, view, Gravity.END).apply {
-		with(menu) {
-			add(
-				0,
-				VideoManager.ZOOM_AUTO_CROP,
-				VideoManager.ZOOM_AUTO_CROP,
-				context.getString(R.string.lbl_auto_crop)
-			).apply {
-				isChecked = playbackController.zoomMode == VideoManager.ZOOM_AUTO_CROP
+		view: View
+	) {
+		leanbackOverlayFragment.setFading(false)
+		return PopupMenu(context, view, Gravity.END).apply {
+			with(menu) {
+				add(
+					0,
+					VideoManager.ZOOM_AUTO_CROP,
+					VideoManager.ZOOM_AUTO_CROP,
+					context.getString(R.string.lbl_auto_crop)
+				).apply {
+					isChecked = playbackController.zoomMode == VideoManager.ZOOM_AUTO_CROP
+				}
+
+				add(
+					0,
+					VideoManager.ZOOM_FIT,
+					VideoManager.ZOOM_FIT,
+					context.getString(R.string.lbl_fit)
+				).apply {
+					isChecked = playbackController.zoomMode == VideoManager.ZOOM_FIT
+				}
+
+				add(
+					0,
+					VideoManager.ZOOM_STRETCH,
+					VideoManager.ZOOM_STRETCH,
+					context.getString(R.string.lbl_stretch)
+				).apply {
+					isChecked = playbackController.zoomMode == VideoManager.ZOOM_STRETCH
+				}
+
+				setGroupCheckable(0, true, false)
 			}
 
-			add(
-				0,
-				VideoManager.ZOOM_FIT,
-				VideoManager.ZOOM_FIT,
-				context.getString(R.string.lbl_fit)
-			).apply {
-				isChecked = playbackController.zoomMode == VideoManager.ZOOM_FIT
+			setOnDismissListener { leanbackOverlayFragment.setFading(true) }
+			setOnMenuItemClickListener { item ->
+				playbackController.setZoom(item.itemId)
+				true
 			}
-
-			add(
-				0,
-				VideoManager.ZOOM_STRETCH,
-				VideoManager.ZOOM_STRETCH,
-				context.getString(R.string.lbl_stretch)
-			).apply {
-				isChecked = playbackController.zoomMode == VideoManager.ZOOM_STRETCH
-			}
-
-			setGroupCheckable(0, true, false)
-		}
-
-		setOnDismissListener { leanbackOverlayFragment.setFading(true) }
-		setOnMenuItemClickListener { item ->
-			playbackController.setZoom(item.itemId)
-			true
-		}
-	}.show()
+		}.show()
+	}
 }


### PR DESCRIPTION
**Changes**
Refactors the `CustomPlaybackTransportControlGlue` by:
- Removing static dispatch for custom actions and built-in actions
- Encapsulating the logic for each action into the action class

This will make it much easier to unit test actions, because we only need to inject the mocks for the method signature rather than everything the glue class could possibly need.

I've done this with as minimal changes to `videoAdapter` to not interfere with any playback rewrites going on. It's not perfect but (hopefully) it creates so better separation of concerns that will allow us to write tests at a later date.

In the future I want to shift as much logic out of the glue class into the relevant actions, but this diff is already quite large...

**To Test**
- Check all buttons work whilst playing media.
- Double check live TV buttons (as I don't have access to those options locally)
