### PR TITLE
Use plurals for amount of tracks in album / episodes in season

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
@@ -6,6 +6,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.model.ChapterItemInfo
 import org.jellyfin.androidtv.ui.livetv.TvManager
 import org.jellyfin.androidtv.util.TimeUtils
+import org.jellyfin.androidtv.util.getQuantityString
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -114,17 +115,11 @@ fun BaseItemDto.getSubName(context: Context): String? = when (type) {
 		else -> name
 	}
 	BaseItemKind.SEASON -> when {
-		childCount != null && childCount!! > 0 -> when {
-			childCount!! > 1 -> context.getString(R.string.lbl_num_episodes, childCount)
-			else -> context.getString(R.string.lbl_one_episode)
-		}
+		childCount != null && childCount!! > 0 -> context.getQuantityString(R.plurals.episodes, childCount!!)
 		else -> ""
 	}
 	BaseItemKind.MUSIC_ALBUM -> when {
-		childCount != null && childCount!! > 0 -> when {
-			childCount!! > 1 -> context.getString(R.string.lbl_num_songs, childCount)
-			else -> context.getString(R.string.lbl_one_song)
-		}
+		childCount != null && childCount!! > 0 -> context.getQuantityString(R.plurals.tracks, childCount!!)
 		else -> ""
 	}
 	BaseItemKind.AUDIO -> name

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -383,10 +383,6 @@
     <string name="lbl_record_all">Will record all episodes</string>
     <string name="lbl_on_any_channel">On any channel</string>
     <string name="lbl_on_channel">On %1$s</string>
-    <string name="lbl_num_episodes">%1$d episodes</string>
-    <string name="lbl_one_episode">1 episode</string>
-    <string name="lbl_num_songs">%1$d songs</string>
-    <string name="lbl_one_song">1 song</string>
     <string name="lbl_name_date">%1$s (%2$s)</string>
     <string name="lbl_time_range">%1$s–%2$s</string>
     <string name="enable_playback_module_description">This is an experimental feature. No support is provided.</string>
@@ -507,5 +503,13 @@
     <plurals name="hours">
         <item quantity="one">%1$s hour</item>
         <item quantity="other">%1$s hours</item>
+    </plurals>
+    <plurals name="tracks">
+        <item quantity="one">%1$s track</item>
+        <item quantity="other">%1$s tracks</item>
+    </plurals>
+    <plurals name="episodes">
+        <item quantity="one">%1$s episode</item>
+        <item quantity="other">%1$s episodes</item>
     </plurals>
 </resources>


### PR DESCRIPTION
**Changes**
- Use plurals for amount of tracks in album
- Use plurals for amount of episodes in season
- Renames "songs" to "tracks" for consistency with jellyfin-web

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
