### PR TITLE
Explicitly use JDK 17 through gradle toolchains

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,18 @@
 plugins {
 	alias(libs.plugins.detekt)
+	java
 }
 
 buildscript {
 	dependencies {
 		classpath(libs.android.gradle)
 		classpath(libs.kotlin.gradle)
+	}
+}
+
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of("17"))
 	}
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
 	`kotlin-dsl`
 }
 
+kotlin {
+	jvmToolchain {
+		languageVersion.set(JavaLanguageVersion.of("17"))
+	}
+}
+
 repositories {
 	mavenCentral()
 }


### PR DESCRIPTION
**Changes**
Pins the implicit JDK version to 17 (based on our CI settings) to avoid gradle sync errors with 8.x
This is because Gradle has bumped the DSL to 1.8 with version 8.x, so it highlighted the implicit mismatch going on

**Issues**
Fixes #2495 
