### PR TITLE
Add blurHashPainter composable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -12,21 +12,20 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.vanniktech.blurhash.BlurHash
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
 import org.jellyfin.androidtv.ui.composable.AsyncImage
+import org.jellyfin.androidtv.ui.composable.blurHashPainter
 import org.jellyfin.androidtv.ui.composable.overscan
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.imageApi
@@ -49,16 +48,11 @@ fun DreamContentNowPlaying(
 		(item.albumId != null && item.albumPrimaryImageTag != null) -> item.albumId to item.albumPrimaryImageTag
 		else -> null to null
 	}
+
 	val imageBlurHash = imageTag?.let { tag -> item.imageBlurHashes?.get(ImageType.PRIMARY)?.get(tag) }
-
-	val imageBlurHashBitmap = remember {
-		if (imageBlurHash != null) BlurHash.decode(imageBlurHash, 32, 32)?.asImageBitmap()
-		else null
-	}
-
-	if (imageBlurHashBitmap != null) {
+	if (imageBlurHash != null) {
 		Image(
-			bitmap = imageBlurHashBitmap,
+			painter = blurHashPainter(imageBlurHash, IntSize(32, 32)),
 			contentDescription = null,
 			alignment = Alignment.Center,
 			contentScale = ContentScale.Crop,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
@@ -8,7 +8,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.viewinterop.AndroidView
+import com.vanniktech.blurhash.BlurHash
 import org.jellyfin.androidtv.ui.AsyncImageView
 
 private data class AsyncImageState(
@@ -51,4 +56,20 @@ fun AsyncImage(
 			}
 		},
 	)
+}
+
+@Composable
+fun blurHashPainter(
+	blurHash: String,
+	size: IntSize,
+	punch: Float = 1f,
+): Painter = remember(blurHash, size, punch) {
+	val bitmap = BlurHash.decode(
+		blurHash = blurHash,
+		width = size.width,
+		height = size.height,
+		punch = punch,
+	)
+
+	BitmapPainter(requireNotNull(bitmap).asImageBitmap())
 }


### PR DESCRIPTION
**Changes**
- Add a `blurHashPainter` composable function to create a painter for blur hashes. This allows the use of the blur hash in the Image composable or other composables that use a painter.

I've added this function to the AsyncImage file because eventually AsyncImage will use it.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
