### PR TITLE
Always check server id when retrieving user data from AccountManagerStore

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -75,7 +75,7 @@ class AuthenticationRepositoryImpl(
 		// Automatic logic is disabled when the always authenticate preference is enabled
 		if (authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]) return flowOf(RequireSignInState)
 
-		val account = accountManagerStore.getAccount(user.id)
+		val account = accountManagerStore.getAccount(server.id, user.id)
 		// Try login with access token
 		return if (account?.accessToken != null) authenticateToken(server, user.withToken(account.accessToken))
 		// Try login without password
@@ -180,7 +180,7 @@ class AuthenticationRepositoryImpl(
 	}
 
 	private suspend fun setActiveSession(user: User, server: Server): Boolean {
-		val authenticated = sessionRepository.switchCurrentSession(user.id)
+		val authenticated = sessionRepository.switchCurrentSession(server.id, user.id)
 
 		if (authenticated) {
 			// Update last use in store
@@ -197,7 +197,7 @@ class AuthenticationRepositoryImpl(
 	}
 
 	override fun logout(user: User): Boolean {
-		val authInfo = accountManagerStore.getAccount(user.id) ?: return false
+		val authInfo = accountManagerStore.getAccount(user.serverId, user.id) ?: return false
 		return accountManagerStore.removeAccount(authInfo)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerUserRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerUserRepository.kt
@@ -31,7 +31,7 @@ class ServerUserRepositoryImpl(
 ) : ServerUserRepository {
 	override fun getStoredServerUsers(server: Server) = authenticationStore.getUsers(server.id)
 		?.mapNotNull { (userId, userInfo) ->
-			val authInfo = accountManagerStore.getAccount(userId)
+			val authInfo = accountManagerStore.getAccount(server.id, userId)
 			PrivateUser(
 				id = authInfo?.id ?: userId,
 				serverId = authInfo?.server ?: server.id,
@@ -64,7 +64,7 @@ class ServerUserRepositoryImpl(
 		authenticationStore.removeUser(user.serverId, user.id)
 
 		// Remove authentication info from system account manager
-		accountManagerStore.getAccount(user.id)?.let { accountManagerAccount ->
+		accountManagerStore.getAccount(user.serverId, user.id)?.let { accountManagerAccount ->
 			accountManagerStore.removeAccount(accountManagerAccount)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/auth/store/AuthenticationPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/store/AuthenticationPreferences.kt
@@ -14,12 +14,30 @@ class AuthenticationPreferences(context: Context) : SharedPreferenceStore(
 	companion object {
 		// Preferences
 		val autoLoginUserBehavior = enumPreference("auto_login_user_behavior", UserSelectBehavior.LAST_USER)
+		val autoLoginServerId = stringPreference("auto_login_server_id", "")
 		val autoLoginUserId = stringPreference("auto_login_user_id", "")
 
 		val sortBy = enumPreference("sort_by", AuthenticationSortBy.LAST_USE)
 		val alwaysAuthenticate = booleanPreference("always_authenticate", false)
 
 		// Persistent state
+		val lastServerId = stringPreference("last_server_id", "")
 		val lastUserId = stringPreference("last_user_id", "")
+	}
+
+	init {
+		runMigrations {
+			// v0.15.4 to v0.15.5
+			migration(toVersion = 2) {
+				// Unfortunately we cannot migrate the "specific user" login option
+				// so we'll reset the preference to disabled if it was used
+				if (it.getString("auto_login_user_behavior", null) === UserSelectBehavior.SPECIFIC_USER.name) {
+					putString("auto_login_user_id", "")
+					putString("auto_login_user_behavior", UserSelectBehavior.DISABLED.name)
+				}
+
+				putString("last_user_id", "")
+			}
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemUserPicker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemUserPicker.kt
@@ -33,6 +33,7 @@ class OptionsItemUserPicker(
 
 	private fun MutableList<RichListItem<UserSelection>>.add(
 		behavior: UserSelectBehavior,
+		serverId: UUID? = null,
 		userId: UUID? = null,
 		title: String,
 		summary: String
@@ -40,7 +41,8 @@ class OptionsItemUserPicker(
 		RichListOption(
 			UserSelection(
 				behavior = behavior,
-				userId = userId
+				serverId = serverId,
+				userId = userId,
 			),
 			title,
 			summary
@@ -70,6 +72,7 @@ class OptionsItemUserPicker(
 
 			for (user in users) add(
 				behavior = UserSelectBehavior.SPECIFIC_USER,
+				serverId = user.serverId,
 				userId = user.id,
 				title = user.name,
 				summary = context.getString(
@@ -111,7 +114,8 @@ class OptionsItemUserPicker(
 
 	data class UserSelection(
 		val behavior: UserSelectBehavior,
-		val userId: UUID?
+		val serverId: UUID?,
+		val userId: UUID?,
 	)
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/AuthPreferencesScreen.kt
@@ -61,7 +61,8 @@ class AuthPreferencesScreen : OptionsFragment() {
 					from(
 						authenticationPreferences,
 						AuthenticationPreferences.autoLoginUserBehavior,
-						AuthenticationPreferences.autoLoginUserId
+						AuthenticationPreferences.autoLoginServerId,
+						AuthenticationPreferences.autoLoginUserId,
 					)
 				}
 
@@ -117,25 +118,28 @@ class AuthPreferencesScreen : OptionsFragment() {
 	private fun OptionsBinder.Builder<OptionsItemUserPicker.UserSelection>.from(
 		authenticationPreferences: AuthenticationPreferences,
 		userBehaviorPreference: Preference<UserSelectBehavior>,
+		serverIdPreference: Preference<String>,
 		userIdPreference: Preference<String>,
 		onSet: ((OptionsItemUserPicker.UserSelection) -> Unit)? = null,
 	) {
 		get {
 			OptionsItemUserPicker.UserSelection(
 				authenticationPreferences[userBehaviorPreference],
-				authenticationPreferences[userIdPreference].toUUIDOrNull()
+				authenticationPreferences[serverIdPreference].toUUIDOrNull(),
+				authenticationPreferences[userIdPreference].toUUIDOrNull(),
 			)
 		}
 
 		set {
 			authenticationPreferences[userBehaviorPreference] = it.behavior
+			authenticationPreferences[serverIdPreference] = it.serverId?.toString().orEmpty()
 			authenticationPreferences[userIdPreference] = it.userId?.toString().orEmpty()
 
 			onSet?.invoke(it)
 		}
 
 		default {
-			OptionsItemUserPicker.UserSelection(UserSelectBehavior.LAST_USER, null)
+			OptionsItemUserPicker.UserSelection(UserSelectBehavior.LAST_USER, null, null)
 		}
 	}
 


### PR DESCRIPTION
**Side effects**

Unfortunately the changes in this PR have some side effects:

- When the "auto login" option is used and set to a specific user the PR disables it. You need to manually set the user again.
- When the "auto login" option is used and set to use the last active user, you need to select a user once after updating. No further action is required.

**Changes**

- Always check server id when retrieving user data from AccountManagerStore
  - **This fixes a security issue** when 2 servers use a same user id, this should normally not happen but a malicious server could technically do this. There are no known instances of this happening.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
