### PR TITLE
Remove watched indicator from empty series

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -205,7 +205,7 @@ public class CardPresenter extends Presenter {
                     if (showWatched && userData != null) {
                         WatchedIndicatorBehavior showIndicator = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getWatchedIndicatorBehavior());
                         if (userData.getPlayed()) {
-                            if (showIndicator != WatchedIndicatorBehavior.NEVER && (showIndicator != WatchedIndicatorBehavior.EPISODES_ONLY || itemDto.getType() == BaseItemKind.EPISODE))
+                            if (showIndicator != WatchedIndicatorBehavior.NEVER && (showIndicator != WatchedIndicatorBehavior.EPISODES_ONLY || itemDto.getType() == BaseItemKind.EPISODE) && userData.getPlayCount() > 0)
                                 mCardView.setUnwatchedCount(0);
                             else
                                 mCardView.setUnwatchedCount(-1);


### PR DESCRIPTION
When an item is empty (e.g. series without any seasons or season without any episodes) the server returns the following userData:

```json
{
	"UserData": {
		"UnplayedItemCount": 0,
		"PlaybackPositionTicks": 0,
		"PlayCount": 0,
		"IsFavorite": false,
		"Played": true,
		"Key": "57125afe-ff17-942b-760d-3ab3185e9aff"
	}
}
```

This is stupid because obviously the item cannot be "played" when there are no items. The app would always show a checkmark because `Played==true`, this is the same behavior as jellyfin-web but IMO the completely wrong behavior. Ideally this behavior would be changed on the server side but until that's a thing, here's a fix for the ATV app.

**Changes**
- Don't show watched indicator when item (series/season/other) is empty 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
