### PR TITLE
Save accounts to account manager by address

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/AccountManagerAccount.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/AccountManagerAccount.kt
@@ -4,6 +4,7 @@ import java.util.UUID
 
 data class AccountManagerAccount(
 	val id: UUID,
+	val address: String,
 	val server: UUID,
 	val name: String,
 	val accessToken: String? = null,

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -175,7 +175,13 @@ class AuthenticationRepositoryImpl(
 		)
 		authenticationStore.putUser(server.id, userInfo.id, updatedUser)
 
-		val accountManagerAccount = AccountManagerAccount(userInfo.id, server.id, updatedUser.name, accessToken)
+		val accountManagerAccount = AccountManagerAccount(
+			id = userInfo.id,
+			address = "${updatedUser.name}@${server.address}",
+			server = server.id,
+			name = updatedUser.name,
+			accessToken = accessToken,
+		)
 		accountManagerStore.putAccount(accountManagerAccount)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/store/AccountManagerStore.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/store/AccountManagerStore.kt
@@ -32,6 +32,7 @@ class AccountManagerStore(
 
 	private fun getAccountData(account: Account): AccountManagerAccount = AccountManagerAccount(
 		id = accountManager.getUserData(account, ACCOUNT_DATA_ID).toUUID(),
+		address = account.name,
 		server = accountManager.getUserData(account, ACCOUNT_DATA_SERVER).toUUID(),
 		name = accountManager.getUserData(account, ACCOUNT_DATA_NAME),
 		accessToken = accountManager.peekAuthToken(account, ACCOUNT_ACCESS_TOKEN_TYPE)
@@ -44,7 +45,7 @@ class AccountManagerStore(
 
 		// Update credentials
 		if (androidAccount == null) {
-			androidAccount = Account(accountManagerAccount.name, ACCOUNT_TYPE)
+			androidAccount = Account(accountManagerAccount.address, ACCOUNT_TYPE)
 
 			accountManager.addAccountExplicitly(
 				androidAccount,
@@ -55,9 +56,14 @@ class AccountManagerStore(
 		}
 
 		// Update name
-		if (androidAccount.name != accountManagerAccount.name) {
+		if (androidAccount.name != accountManagerAccount.address) {
 			androidAccount = suspendCoroutine { continuation ->
-				accountManager.renameAccount(androidAccount, accountManagerAccount.name, { continuation.resume(it.result) }, null)
+				accountManager.renameAccount(
+					androidAccount,
+					accountManagerAccount.address,
+					{ continuation.resume(it.result) },
+					null,
+				)
 			}
 		}
 


### PR DESCRIPTION
Previously we would only use the username. Unfortunately this username should be unique per app. So if you have multiple servers with the same username the app would (accidentally) always overwrite the existing account when signing in. This PR updates the name we send to the account manager by appending the server URL.

The changes in this PR do not affect existing logins, it will update the name the next time you authenticate (so not on account use). We don't use those account manager names ourselves because we store our values in the user data.

**Changes**
- Use the combination of username+server address when storing users to the account manager
  ![image](https://user-images.githubusercontent.com/2305178/224830660-f231d928-2785-4f3a-ba9d-4634819c175a.png)


**Issues**

Fixes #2586
