### PR TITLE
Add androidx.media2 MediaSessionService implementation

### DIFF
--- a/playback/core/src/main/AndroidManifest.xml
+++ b/playback/core/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
-
+        <service
+            android:name="org.jellyfin.playback.core.mediasession.AndroidMediaService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.media2.session.MediaSessionService" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/playback/core/src/main/kotlin/mediasession/AndroidMediaService.kt
+++ b/playback/core/src/main/kotlin/mediasession/AndroidMediaService.kt
@@ -1,0 +1,8 @@
+package org.jellyfin.playback.core.mediasession
+
+import androidx.media2.session.MediaSession
+import androidx.media2.session.MediaSessionService
+
+class AndroidMediaService : MediaSessionService() {
+	override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = sessions.firstOrNull()
+}

--- a/playback/core/src/main/kotlin/queue/QueueService.kt
+++ b/playback/core/src/main/kotlin/queue/QueueService.kt
@@ -23,18 +23,18 @@ class QueueService(
 				Timber.d("Queue changed, setting index to 0")
 				setIndex(0)
 			}
-
-			manager.backendService.addListener(object : PlayerBackendEventListener {
-				override fun onPlayStateChange(state: PlayState) = Unit
-				override fun onVideoSizeChange(width: Int, height: Int) = Unit
-
-				override fun onMediaStreamEnd(mediaStream: MediaStream) {
-					// TODO: Find position based on $mediaStream instead
-					// TODO: This doesn't work as expected
-					coroutineScope.launch { next() }
-				}
-			})
 		}
+
+		manager.backendService.addListener(object : PlayerBackendEventListener {
+			override fun onPlayStateChange(state: PlayState) = Unit
+			override fun onVideoSizeChange(width: Int, height: Int) = Unit
+
+			override fun onMediaStreamEnd(mediaStream: MediaStream) {
+				// TODO: Find position based on $mediaStream instead
+				// TODO: This doesn't work as expected
+				coroutineScope.launch { next() }
+			}
+		})
 	}
 
 	var currentItemPosition = POSITION_NONE


### PR DESCRIPTION
**Changes**
- Add androidx.media2 MediaSessionService implementation

This class is used to allow background playback and controlling playback from launcher / other apps.

- Fix QueueService backend listener registration shouldn't be in coroutine scope

**Issues**

Part of #1057 