### PR TITLE
Add main preferences screen in Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,7 +133,11 @@ dependencies {
 	implementation(libs.androidx.window)
 	implementation(libs.androidx.cardview)
 	implementation(libs.androidx.startup)
-	implementation(libs.bundles.androidx.compose)
+	val composeBom = platform(libs.androidx.compose.bom)
+	implementation(composeBom)
+	implementation(libs.androidx.compose.material)
+	implementation(libs.androidx.compose.ui.tooling.preview)
+	debugImplementation(libs.androidx.compose.ui.tooling)
 
 	// Dependency Injection
 	implementation(libs.bundles.koin)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,9 +133,13 @@ dependencies {
 	implementation(libs.androidx.window)
 	implementation(libs.androidx.cardview)
 	implementation(libs.androidx.startup)
+	implementation(libs.androidx.tv.foundation)
+	implementation(libs.androidx.tv.material)
 	val composeBom = platform(libs.androidx.compose.bom)
 	implementation(composeBom)
+	implementation(libs.androidx.compose.activity)
 	implementation(libs.androidx.compose.material)
+	implementation(libs.androidx.compose.material3)
 	implementation(libs.androidx.compose.ui.tooling.preview)
 	debugImplementation(libs.androidx.compose.ui.tooling)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/MainPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/MainPreferencesScreen.kt
@@ -1,0 +1,137 @@
+package org.jellyfin.androidtv.ui.preference
+
+import android.os.Build
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.foundation.ExperimentalTvFoundationApi
+import androidx.tv.foundation.lazy.list.TvLazyColumn
+import org.jellyfin.androidtv.BuildConfig
+import org.jellyfin.androidtv.R
+
+@OptIn(ExperimentalTvFoundationApi::class)
+@Composable
+internal fun MainPreferencesScreen(
+	modifier: Modifier = Modifier,
+) {
+	val focusRequester = remember { FocusRequester() }
+	TvLazyColumn(
+		modifier = modifier,
+		contentPadding = PaddingValues(bottom = 26.dp),
+	) {
+		stickyHeader {
+			PreferencesHeader(
+				modifier = Modifier
+					.padding(bottom = 26.dp),
+				text = stringResource(id = R.string.settings_title),
+			)
+		}
+		item {
+			PreferenceItem(
+				modifier = Modifier
+					.focusRequester(focusRequester),
+				iconRes = R.drawable.ic_users,
+				title = stringResource(id = R.string.pref_login),
+				description = stringResource(id = R.string.pref_login_description),
+				onClick = {
+					// TODO
+				},
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_adjust,
+				title = stringResource(id = R.string.pref_customization),
+				description = stringResource(id = R.string.pref_customization_description),
+				onClick = {
+					// TODO
+				},
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_next,
+				title = stringResource(id = R.string.pref_playback),
+				description = stringResource(id = R.string.pref_playback_description),
+				onClick = {
+					// TODO
+				},
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_error,
+				title = stringResource(id = R.string.pref_telemetry_category),
+				description = stringResource(id = R.string.pref_telemetry_description),
+				onClick = {
+					// TODO
+				},
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_flask,
+				title = stringResource(id = R.string.pref_developer_link),
+				description = stringResource(id = R.string.pref_developer_link_description),
+				onClick = {
+					// TODO
+				},
+			)
+		}
+
+		// About
+		item {
+			PreferenceCategory(
+				title = stringResource(id = R.string.pref_about_title),
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_jellyfin,
+				title = "Jellyfin app version",
+				description = "jellyfin-androidtv ${BuildConfig.VERSION_NAME} ${BuildConfig.BUILD_TYPE}",
+				onClick = {
+					// No action
+				},
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_tv,
+				title = stringResource(id = R.string.pref_device_model),
+				description = "${Build.MANUFACTURER} ${Build.MODEL}",
+				onClick = {
+					// No action
+				},
+			)
+		}
+		item {
+			PreferenceItem(
+				iconRes = R.drawable.ic_guide,
+				title = stringResource(id = R.string.licenses_link),
+				description = stringResource(id = R.string.licenses_link_description),
+				onClick = {
+					// TODO
+				},
+			)
+		}
+	}
+
+	LaunchedEffect(Unit) {
+		focusRequester.requestFocus()
+	}
+}
+
+@Preview
+@Composable
+private fun Preview() {
+	MainPreferencesScreen()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferenceCategory.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferenceCategory.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.androidtv.ui.preference
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import org.jellyfin.androidtv.R
+
+private val categoryTitleTextStyle = TextStyle(
+	fontFamily = FontFamily.SansSerif,
+	fontSize = 12.sp,
+	fontWeight = FontWeight.Medium,
+)
+
+@Composable
+internal fun PreferenceCategory(
+	modifier: Modifier = Modifier,
+	title: String,
+) {
+	Text(
+		modifier = modifier
+			.fillMaxWidth()
+			.padding(horizontal = 24.dp, vertical = 12.dp),
+		text = title,
+		style = categoryTitleTextStyle,
+		color = Color(ContextCompat.getColor(LocalContext.current, R.color.default_preference_color_accent)),
+	)
+}
+
+@Preview(
+	showBackground = true,
+	backgroundColor = 0xFF1b1c1e,
+)
+@Composable
+private fun Preview() {
+	PreferenceCategory(
+		title = stringResource(id = R.string.pref_about_title),
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferenceItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferenceItem.kt
@@ -1,0 +1,100 @@
+package org.jellyfin.androidtv.ui.preference
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.DeviceFontFamilyName
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jellyfin.androidtv.R
+
+private val FontFamily.Companion.SansSerifCondensed by lazy {
+	FontFamily(Font(DeviceFontFamilyName("sans-serif-condensed")))
+}
+
+private val titleTextStyle = TextStyle(
+	fontSize = 14.sp,
+)
+
+private val descriptionTextStyle = TextStyle(
+	fontFamily = FontFamily.SansSerifCondensed,
+	fontSize = 12.sp,
+)
+
+@Composable
+internal fun PreferenceItem(
+	modifier: Modifier = Modifier,
+	@DrawableRes iconRes: Int,
+	title: String,
+	description: String? = null,
+	onClick: () -> Unit,
+) {
+	Row(
+		modifier = modifier
+			.fillMaxWidth()
+			.heightIn(min = 64.dp)
+			.clickable(onClick = onClick)
+			.focusable(),
+		verticalAlignment = Alignment.CenterVertically,
+	) {
+		Icon(
+			modifier = Modifier
+				.padding(start = 24.dp, end = 16.dp)
+				.padding(vertical = 16.dp),
+			painter = painterResource(id = iconRes),
+			contentDescription = null,
+			tint = Color.White,
+		)
+		Column(
+			modifier = Modifier,
+			verticalArrangement = Arrangement.Center,
+		) {
+			Text(
+				text = title,
+				style = titleTextStyle,
+				color = Color.White,
+			)
+			if (description != null) {
+				Text(
+					modifier = Modifier
+						.padding(top = 2.dp),
+					text = description,
+					style = descriptionTextStyle,
+					color = Color.White.copy(alpha = 0.6f),
+				)
+			}
+		}
+	}
+}
+
+@Preview(
+	showBackground = true,
+	backgroundColor = 0xFF1b1c1e,
+)
+@Composable
+private fun Preview() {
+	PreferenceItem(
+		iconRes = R.drawable.ic_users,
+		title = stringResource(id = R.string.pref_login),
+		description = stringResource(id = R.string.pref_login_description),
+		onClick = { },
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesActivity.kt
@@ -1,28 +1,44 @@
 package org.jellyfin.androidtv.ui.preference
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
 
 class PreferencesActivity : FragmentActivity(R.layout.fragment_content_view) {
+
+	private val shouldUseCompose = false
+
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
-		val screen = intent.extras?.getString(EXTRA_SCREEN) ?: UserPreferencesScreen::class.qualifiedName
-		val screenArgs = intent.extras?.getBundle(EXTRA_SCREEN_ARGS) ?: bundleOf()
+		if (shouldUseCompose) {
+			window.setWindowAnimations(0)
 
-		supportFragmentManager
-			.beginTransaction()
-			.replace(R.id.content_view, PreferencesFragment().apply {
-				// Set screen
-				arguments = bundleOf(
-					PreferencesFragment.EXTRA_SCREEN to screen,
-					PreferencesFragment.EXTRA_SCREEN_ARGS to screenArgs
+			setContent {
+				PreferencesScreen(
+					onClose = {
+						finish()
+					},
 				)
-			}, FRAGMENT_TAG)
-			.commit()
+			}
+		} else {
+			val screen = intent.extras?.getString(EXTRA_SCREEN) ?: UserPreferencesScreen::class.qualifiedName
+			val screenArgs = intent.extras?.getBundle(EXTRA_SCREEN_ARGS) ?: bundleOf()
+
+			supportFragmentManager
+				.beginTransaction()
+				.replace(R.id.content_view, PreferencesFragment().apply {
+					// Set screen
+					arguments = bundleOf(
+						PreferencesFragment.EXTRA_SCREEN to screen,
+						PreferencesFragment.EXTRA_SCREEN_ARGS to screenArgs
+					)
+				}, FRAGMENT_TAG)
+				.commit()
+		}
 	}
 
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesDrawer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesDrawer.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.androidtv.ui.preference
+
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PreferencesDrawer(
+	modifier: Modifier = Modifier,
+	drawerState: DrawerState = rememberDrawerState(DrawerValue.Open),
+	content: @Composable () -> Unit,
+) {
+	// Reverse layout direction so that the drawer opens from the right side
+	val layoutDirectionDefault = LocalLayoutDirection.current
+	val layoutDirectionReversed = when (layoutDirectionDefault) {
+		LayoutDirection.Ltr -> LayoutDirection.Rtl
+		LayoutDirection.Rtl -> LayoutDirection.Ltr
+	}
+	val rippleIndication = rememberRipple(color = Color.White)
+	CompositionLocalProvider(
+		LocalLayoutDirection provides layoutDirectionReversed,
+		LocalIndication provides rippleIndication,
+	) {
+		ModalNavigationDrawer(
+			modifier = modifier,
+			drawerState = drawerState,
+			drawerContent = {
+				CompositionLocalProvider(
+					LocalLayoutDirection provides layoutDirectionDefault,
+				) {
+					content()
+				}
+			},
+			content = {
+				// No content
+			},
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesHeader.kt
@@ -1,0 +1,56 @@
+package org.jellyfin.androidtv.ui.preference
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jellyfin.androidtv.R
+
+private val headerTextStyle = TextStyle(
+	color = Color.White,
+	fontSize = 20.sp,
+)
+
+@Composable
+internal fun PreferencesHeader(
+	modifier: Modifier = Modifier,
+	text: String,
+) {
+	Surface(
+		modifier = modifier,
+		shadowElevation = 2.dp,
+		color = Color(0xFF1b1c1e),
+	) {
+		Box(
+			modifier = Modifier
+				.fillMaxWidth()
+				.height(90.dp)
+				.padding(start = 24.dp, bottom = 18.dp),
+			contentAlignment = Alignment.BottomStart,
+		) {
+			Text(
+				text = text,
+				style = headerTextStyle,
+				fontWeight = FontWeight.Bold,
+			)
+		}
+	}
+}
+
+@Preview
+@Composable
+private fun Preview() {
+	PreferencesHeader(text = stringResource(id = R.string.settings_title))
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesScreen.kt
@@ -1,0 +1,70 @@
+package org.jellyfin.androidtv.ui.preference
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PreferencesScreen(
+	modifier: Modifier = Modifier,
+	onClose: () -> Unit,
+) {
+	MaterialTheme(
+		colorScheme = darkColorScheme(),
+	) {
+		val coroutineScope = rememberCoroutineScope()
+		val drawerState = rememberDrawerState(DrawerValue.Closed)
+
+		// Open on launch for a nice animation
+		LaunchedEffect(Unit) {
+			coroutineScope.launch {
+				drawerState.open()
+			}
+		}
+
+		// Invoke the close lambda when the drawer is closing
+		LaunchedEffect(drawerState.targetValue) {
+			if (drawerState.isOpen && drawerState.targetValue == DrawerValue.Closed) {
+				onClose()
+			}
+		}
+
+		PreferencesDrawer(
+			modifier = modifier,
+			drawerState = drawerState,
+		) {
+			ModalDrawerSheet(
+				drawerShape = RectangleShape,
+				drawerContainerColor = Color(
+					ContextCompat.getColor(
+						LocalContext.current,
+						R.color.default_preference_window_background
+					)
+				),
+			) {
+				BackHandler(drawerState.isOpen) {
+					coroutineScope.launch {
+						drawerState.close()
+					}
+				}
+
+				MainPreferencesScreen()
+			}
+		}
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,10 +6,8 @@ android-gradle = "7.4.2"
 androidx-activity = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-cardview = "1.0.0"
+androidx-compose-bom = "2023.03.00"
 androidx-compose-compiler = "1.4.4"
-androidx-compose-foundation = "1.4.0"
-androidx-compose-material = "1.4.0"
-androidx-compose-ui = "1.4.0"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.9.0"
 androidx-fragment = "1.5.6"
@@ -67,10 +65,11 @@ android-gradle = { module = "com.android.tools.build:gradle", version.ref = "and
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose-ui" }
+androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
@@ -134,11 +133,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 acra = [
     "acra-core",
     "acra-toast",
-]
-androidx-compose = [
-    "androidx-compose-foundation",
-    "androidx-compose-material",
-    "androidx-compose-ui-tooling"
 ]
 androidx-lifecycle = [
     "androidx-lifecycle-process",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ androidx-media2 = "1.2.1"
 androidx-preference = "1.2.0"
 androidx-recyclerview = "1.3.0"
 androidx-startup = "1.1.1"
+androidx-tv = "1.0.0-alpha05"
 androidx-tvprovider = "1.1.0-alpha01"
 androidx-window = "1.0.0"
 androidx-work = "2.8.1"
@@ -65,9 +66,11 @@ android-gradle = { module = "com.android.tools.build:gradle", version.ref = "and
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
+androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
@@ -83,6 +86,8 @@ androidx-media2-session = { module = "androidx.media2:media2-session", version.r
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
+androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "androidx-tv" }
+androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "androidx-tv" }
 androidx-tvprovider = { module = "androidx.tvprovider:tvprovider", version.ref = "androidx-tvprovider" }
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }


### PR DESCRIPTION
I noticed there is a [task](https://github.com/jellyfin/jellyfin-androidtv/projects/15#card-82973332) to convert the preferences screens to Compose as an experiment towards rewriting more of the app. I gave this a shot and converted the main preferences screen just to get an idea of what people think.

**Changes**
- Replaced the Compose dependency bundle with a dependency on the [BOM](https://developer.android.com/jetpack/compose/bom/bom) as this should make it easier to add new compose libs.
- Added a Compose variant of the main preferences screen that matches the original almost perfectly.
  - Can only be turned on in development builds by setting `shouldUseCompose` to true.
  - Added the core UI components used to build preferences. They match their leanback counterparts as closely as I could get it.
  - Uses the latest alpha version of the [Compose TV library](https://developer.android.com/jetpack/androidx/releases/tv).

I thought this would be a fun experiment to modernize the app a bit more so please let me know what you think. If people are happy with this, I'm definitely keen on continuing this refactoring.

**Screenshot**

![Screenshot_1679770789](https://user-images.githubusercontent.com/139957/227736336-00e8b61d-0df9-4ca7-ab92-8fb8d0a23d05.png)
