### PR TITLE
Fix "null" on Live TV guide "load channels" button

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GuidePagingButton.java
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
 import android.util.AttributeSet;
@@ -23,14 +22,14 @@ public class GuidePagingButton extends RelativeLayout {
         super(context, attrs);
     }
 
-    public GuidePagingButton(final Activity activity, final LiveTvGuide guide, int start, String label) {
-        super(activity);
+    public GuidePagingButton(Context context, final LiveTvGuide guide, int start, String label) {
+        super(context);
 
-        LayoutInflater inflater = LayoutInflater.from(activity);
+        LayoutInflater inflater = LayoutInflater.from(context);
         ProgramGridCellBinding binding = ProgramGridCellBinding.inflate(inflater, this, true);
         binding.programName.setText(label);
 
-        setBackgroundColor(Utils.getThemeColor(activity, R.attr.buttonDefaultNormalBackground));
+        setBackgroundColor(Utils.getThemeColor(context, R.attr.buttonDefaultNormalBackground));
         setFocusable(true);
         setOnClickListener(v -> guide.displayChannels(start, LiveTvGuideFragment.PAGE_SIZE));
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -46,6 +46,7 @@ import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
+import org.jellyfin.androidtv.util.TextUtilsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
@@ -541,7 +542,8 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
                 mChannels.addView(placeHolder);
                 displayedChannels = 0;
 
-                mProgramRows.addView(new GuidePagingButton(requireActivity(), LiveTvGuideFragment.this, pageUpStart, getString(R.string.lbl_load_channels)+mAllChannels.get(pageUpStart).getNumber() + " - "+mAllChannels.get(mCurrentDisplayChannelStartNdx-1).getNumber()));
+                String label = TextUtilsKt.getLoadChannelsLabel(requireContext(), mAllChannels.get(pageUpStart).getNumber(), mAllChannels.get(mCurrentDisplayChannelStartNdx - 1).getNumber());
+                mProgramRows.addView(new GuidePagingButton(requireActivity(), LiveTvGuideFragment.this, pageUpStart, label));
             }
         }
 
@@ -609,7 +611,8 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
                 placeHolder.setHeight(guideRowHeightPx);
                 mChannels.addView(placeHolder);
 
-                mProgramRows.addView(new GuidePagingButton(requireActivity(), LiveTvGuideFragment.this, mCurrentDisplayChannelEndNdx + 1, getString(R.string.lbl_load_channels)+mAllChannels.get(mCurrentDisplayChannelEndNdx+1).getNumber() + " - "+mAllChannels.get(pageDnEnd).getNumber()));
+                String label = TextUtilsKt.getLoadChannelsLabel(requireContext(), mAllChannels.get(mCurrentDisplayChannelEndNdx + 1).getNumber(), mAllChannels.get(pageDnEnd).getNumber());
+                mProgramRows.addView(new GuidePagingButton(requireActivity(), LiveTvGuideFragment.this, mCurrentDisplayChannelEndNdx + 1, label));
             }
 
             mChannelStatus.setText(displayedChannels+" of "+mAllChannels.size()+" channels");

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -846,7 +846,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 tvGuideBinding.channels.addView(placeHolder);
                 displayedChannels = 0;
 
-                tvGuideBinding.programRows.addView(new GuidePagingButton(requireActivity(), guide, pageUpStart, getString(R.string.lbl_load_channels) + mAllChannels.get(pageUpStart).getNumber() + " - " + mAllChannels.get(mCurrentDisplayChannelStartNdx - 1).getNumber()));
+                String label = TextUtilsKt.getLoadChannelsLabel(requireContext(), mAllChannels.get(pageUpStart).getNumber(), mAllChannels.get(mCurrentDisplayChannelStartNdx - 1).getNumber());
+                tvGuideBinding.programRows.addView(new GuidePagingButton(requireActivity(), guide, pageUpStart, label));
             }
         }
 
@@ -907,7 +908,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 placeHolder.setHeight(Utils.convertDpToPixel(getContext(), LiveTvGuideFragment.GUIDE_ROW_HEIGHT_DP));
                 tvGuideBinding.channels.addView(placeHolder);
 
-                tvGuideBinding.programRows.addView(new GuidePagingButton(requireActivity(), guide, mCurrentDisplayChannelEndNdx + 1, getString(R.string.lbl_load_channels) + mAllChannels.get(mCurrentDisplayChannelEndNdx + 1).getNumber() + " - " + mAllChannels.get(pageDnEnd).getNumber()));
+                String label = TextUtilsKt.getLoadChannelsLabel(requireContext(), mAllChannels.get(mCurrentDisplayChannelEndNdx + 1).getNumber(), mAllChannels.get(pageDnEnd).getNumber());
+                tvGuideBinding.programRows.addView(new GuidePagingButton(requireActivity(), guide, mCurrentDisplayChannelEndNdx + 1, label));
             }
 
             tvGuideBinding.channelsStatus.setText(getResources().getString(R.string.lbl_tv_channel_status, displayedChannels, mAllChannels.size()));

--- a/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/TextUtils.kt
@@ -1,9 +1,20 @@
 package org.jellyfin.androidtv.util
 
+import android.content.Context
 import android.text.Spanned
 import androidx.core.text.HtmlCompat
+import org.jellyfin.androidtv.R
 
 /**
  * Convert string with HTML to a [Spanned]. Uses the [HtmlCompat.FROM_HTML_MODE_COMPACT] flag.
  */
 fun String.toHtmlSpanned(): Spanned = HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)
+
+/**
+ * Utility to get the string for the "Load channels" button in the Live TV guide.
+ */
+fun getLoadChannelsLabel(context: Context, startNumber: String? = null, endNumber: String? = null) = buildString {
+	append(context.getString(R.string.lbl_load_channels))
+
+	if (!startNumber.isNullOrBlank() && !endNumber.isNullOrBlank()) append("$startNumber - $endNumber")
+}


### PR DESCRIPTION
**Changes**
- Fix "null" on Live TV guide "load channels" button
  Sometimes a channel doesn't have a number so we need to check for that. Ideally the text would be replaced with something like "load **more** channels" but string changes cannot be backported.

**Issues**

Fixes #2633