### PR TITLE
Add (experimental) reactive homepage

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -219,6 +219,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Timeout before showing the screensaver in app, depends on [screensaverInAppEnabled].
 		 */
 		var screensaverInAppTimeout = longPreference("screensaver_inapp_timeout", 5.minutes.inWholeMilliseconds)
+
+		/**
+		 * Enable reactive homepage
+		 */
+		var homeReactive = booleanPreference("home_reactive", false)
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -23,6 +23,12 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.debuggingEnabled)
 			}
 
+			checkbox {
+				setTitle(R.string.enable_reactive_homepage)
+				setContent(R.string.enable_playback_module_description)
+				bind(userPreferences, UserPreferences.homeReactive)
+			}
+
 			// Only show in debug mode
 			// some strings are hardcoded because these options don't show in beta/release builds
 			if (BuildConfig.DEVELOPMENT) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,6 +488,7 @@
     <string name="pref_screensaver_inapp_enabled">Use in-app screensaver</string>
     <string name="pref_screensaver_inapp_enabled_description">Show the Jellyfin screensaver while the app is open</string>
     <string name="pref_screensaver_inapp_timeout">Start screensaver after</string>
+    <string name="enable_reactive_homepage">Enable reactive homepage</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Add (experimental) reactive homepage

When enabled, the home fragment will watch for updates from the server and reload **all** rows. The rows that use the ItemRowAdapterHelper will update their items while others will flicker. This functionality will do stuff like "live" reload the "next up" row when an episode is added to the server or watched on another device.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
