### PR TITLE
Fix playback rewrite audio queue in UI

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -80,14 +80,7 @@ class RewriteMediaManager(
 		QueryType.StaticAudioQueueItems
 	)
 
-	override val managedAudioQueue = ItemRowAdapter(
-		context,
-		emptyList(),
-		CardPresenter(true, @Suppress("MagicNumber") 140),
-		null,
-		QueryType.StaticAudioQueueItems
-	)
-
+	override val managedAudioQueue get() = currentAudioQueue
 
 	private val audioListeners = mutableListOf<AudioEventListener>()
 	private var audioListenersJob: Job? = null
@@ -142,7 +135,6 @@ class RewriteMediaManager(
 					?: return@collect
 
 				currentAudioQueue.replaceAll(items.map(::BaseRowItem))
-				managedAudioQueue.replaceAll(items)
 
 				notifyListeners { onQueueReplaced() }
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -144,6 +144,7 @@ class RewriteMediaManager(
 					.apply {
 						// Set first as playing
 						if (isNotEmpty()) first().playing = true
+						forEachIndexed { index, item -> item.index = index }
 					}
 
 				// Update item row


### PR DESCRIPTION
**Changes**
- Merge currentAudioQueue & managedAudioQueue (for now)
- Remove everything before currently playing item from currentAudioQueue
- Set "playing" on BaseRowItem for currently playing item
- Set index on BaseRowItem because why

**Issues**

Part of #1057 
