### PR TITLE
Fix BaseItemInfoRow not showing for persons

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
@@ -53,7 +53,6 @@ class MyDetailsOverviewRowPresenter(
 
 				binding.fdSummaryText.maxLines = 9
 				binding.fdGenreRow.isVisible = false
-				binding.fdMainInfoRow.isVisible = false
 				binding.leftFrame.updateLayoutParams<RelativeLayout.LayoutParams> {
 					width = 100.dp(view.context)
 				}


### PR DESCRIPTION
Not sure why it was hidden, I guess because the string "Born" is hardcoded but that will be fixed in an upcoming PR where I'm refactoring the InfoLayoutHelper.

**Changes**
- Enable BaseItemInfoRow for persons

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
