### PR TITLE
Enable nonTransitiveRClass

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/FriendlyDateButton.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/FriendlyDateButton.java
@@ -39,7 +39,7 @@ public class FriendlyDateButton extends FrameLayout {
         super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
 
         if (gainFocus) {
-            setBackgroundColor(getResources().getColor(R.color.lb_default_brand_color));
+            setBackgroundColor(getResources().getColor(androidx.leanback.R.color.lb_default_brand_color));
         } else {
             setBackgroundColor(0);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
@@ -82,7 +82,7 @@ public class ProgramGridCell extends RelativeLayout implements RecordingIndicato
         }
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowRepeatIndicator()) && Utils.isTrue(program.getIsRepeat())) {
-            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_repeat), 10, Color.GRAY, R.color.lb_default_brand_color);
+            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_repeat), 10, Color.GRAY, androidx.leanback.R.color.lb_default_brand_color);
         }
 
         if (program.getOfficialRating() != null && !program.getOfficialRating().equals("0")) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.Extras
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -122,10 +121,10 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 		val showClock = userPreferences[clockBehavior]
 		if (showClock !== ClockBehavior.ALWAYS && showClock !== ClockBehavior.IN_MENUS) return
 
-		val root = requireActivity().findViewById<ViewGroup>(R.id.browse_frame)
+		val root = requireActivity().findViewById<ViewGroup>(androidx.leanback.R.id.browse_frame)
 
 		// Move the title to the left to make way for the clock
-		val titleView = root.findViewById<TextView>(R.id.title_text)
+		val titleView = root.findViewById<TextView>(androidx.leanback.R.id.title_text)
 		if (titleView != null) {
 			val layoutParams = titleView.layoutParams as FrameLayout.LayoutParams
 			layoutParams.rightMargin = convertDpToPixel(root.context, 120)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/LegacyImageCardView.java
@@ -35,7 +35,7 @@ public class LegacyImageCardView extends BaseCardView {
     private NumberFormat nf = NumberFormat.getInstance();
 
     public LegacyImageCardView(Context context, boolean showInfo) {
-        super(context, null, R.attr.imageCardViewStyle);
+        super(context, null, androidx.leanback.R.attr.imageCardViewStyle);
 
         if (!showInfo) {
             setCardType(CARD_TYPE_MAIN_ONLY);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -274,10 +274,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         }
 
         //pre-load animations
-        fadeOut = AnimationUtils.loadAnimation(requireContext(), R.anim.abc_fade_out);
+        fadeOut = AnimationUtils.loadAnimation(requireContext(), androidx.leanback.R.anim.abc_fade_out);
         fadeOut.setAnimationListener(hideAnimationListener);
-        slideDown = AnimationUtils.loadAnimation(requireContext(), R.anim.abc_slide_in_top);
-        slideUp = AnimationUtils.loadAnimation(requireContext(), R.anim.abc_slide_in_bottom);
+        slideDown = AnimationUtils.loadAnimation(requireContext(), androidx.leanback.R.anim.abc_slide_in_top);
+        slideUp = AnimationUtils.loadAnimation(requireContext(), androidx.leanback.R.anim.abc_slide_in_bottom);
         slideDown.setAnimationListener(showAnimationListener);
         setupPopupAnimations();
 
@@ -345,7 +345,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     private void setupPopupAnimations() {
-        showPopup = AnimationUtils.loadAnimation(requireContext(), R.anim.abc_slide_in_bottom);
+        showPopup = AnimationUtils.loadAnimation(requireContext(), androidx.leanback.R.anim.abc_slide_in_bottom);
         showPopup.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {
@@ -361,7 +361,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             public void onAnimationRepeat(Animation animation) {
             }
         });
-        hidePopup = AnimationUtils.loadAnimation(requireContext(), R.anim.abc_fade_out);
+        hidePopup = AnimationUtils.loadAnimation(requireContext(), androidx.leanback.R.anim.abc_fade_out);
         hidePopup.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
@@ -68,7 +68,7 @@ class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		val styledContext = ContextThemeWrapper(activity, R.style.PreferenceThemeOverlayLeanback)
+		val styledContext = ContextThemeWrapper(activity, androidx.leanback.preference.R.style.PreferenceThemeOverlayLeanback)
 		val styledInflater = inflater.cloneInContext(styledContext)
 		binding = PreferenceButtonRemapBinding.inflate(styledInflater, container, false)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ColorPickerDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ColorPickerDialogFragment.kt
@@ -43,7 +43,7 @@ class ColorPickerDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		val styledContext = ContextThemeWrapper(activity, R.style.PreferenceThemeOverlayLeanback)
+		val styledContext = ContextThemeWrapper(activity, androidx.leanback.preference.R.style.PreferenceThemeOverlayLeanback)
 		val styledInflater = inflater.cloneInContext(styledContext)
 		binding = PreferenceColorListBinding.inflate(styledInflater, container, false)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/DurationSeekBarPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/DurationSeekBarPreference.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.widget.TextView
 import androidx.preference.PreferenceViewHolder
 import androidx.preference.SeekBarPreference
-import org.jellyfin.androidtv.R
 
 class DurationSeekBarPreference @JvmOverloads constructor(
 	context: Context,
@@ -21,7 +20,7 @@ class DurationSeekBarPreference @JvmOverloads constructor(
 	override fun onBindViewHolder(view: PreferenceViewHolder) {
 		super.onBindViewHolder(view)
 
-		val textView = view.findViewById(R.id.seekbar_value) as TextView
+		val textView = view.findViewById(androidx.leanback.preference.R.id.seekbar_value) as TextView
 		textView.transformationMethod = object : TransformationMethod {
 			override fun onFocusChanged(view: View, sourceText: CharSequence?, focused: Boolean, direction: Int, previouslyFocusedRect: Rect) {}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListDialogFragment.kt
@@ -49,7 +49,7 @@ class RichListDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 	}
 
 	public override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		val styledContext = ContextThemeWrapper(activity, R.style.PreferenceThemeOverlayLeanback)
+		val styledContext = ContextThemeWrapper(activity, androidx.leanback.preference.R.style.PreferenceThemeOverlayLeanback)
 		val styledInflater = inflater.cloneInContext(styledContext)
 		binding = PreferenceRichListBinding.inflate(styledInflater, container, false)
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -176,11 +176,11 @@ public class InfoLayoutHelper {
             addBlockText(context, layout, context.getString(R.string.lbl_new), 12, Color.GRAY, R.drawable.dark_green_gradient);
             addSpacer(context, layout, "  ");
         } else if (Utils.isTrue(item.isSeries()) && !Utils.isTrue(item.isNews())) {
-            addBlockText(context, layout, context.getString(R.string.lbl_repeat), 12, Color.GRAY, R.color.lb_default_brand_color);
+            addBlockText(context, layout, context.getString(R.string.lbl_repeat), 12, Color.GRAY, androidx.leanback.R.color.lb_default_brand_color);
             addSpacer(context, layout, "  ");
         }
         if (Utils.isTrue(item.isLive())) {
-            addBlockText(context, layout, context.getString(R.string.lbl_live), 12, Color.GRAY, R.color.lb_default_brand_color);
+            addBlockText(context, layout, context.getString(R.string.lbl_live), 12, Color.GRAY, androidx.leanback.R.color.lb_default_brand_color);
             addSpacer(context, layout, "  ");
 
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -489,6 +489,7 @@
     <string name="pref_screensaver_inapp_enabled_description">Show the Jellyfin screensaver while the app is open</string>
     <string name="pref_screensaver_inapp_timeout">Start screensaver after</string>
     <string name="enable_reactive_homepage">Enable reactive homepage</string>
+    <string name="not_set">Not set</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,6 @@ sdk.version=default
 
 # Android
 android.useAndroidX=true
-# FIXME: Remove this once all uses of R have correct imports
-android.nonTransitiveRClass=false
 
 # Enable LeakCanary
 leakcanary.enable=false


### PR DESCRIPTION
AGP 8 enables the nonTransitiveRClass by default. We had to temporarily disable it again because our code wasn't migrated yet. This PR fixes that, this should result in a small performance increase during compilation.

**Changes**
- Enable nonTransitiveRClass
  Mostly done by adding the android/androidx.leanback packages, but one string that we used from the leanback library is now added to our own string file.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
