### PR TITLE
Add separate buttons for artists and album artists in music smart screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.kt
@@ -20,6 +20,7 @@ enum class QueryType {
 	StaticItems,
 	Persons,
 	StaticAudioQueueItems,
+	Artists,
 	AlbumArtists,
 	AudioPlaylists,
 	LatestItems,

--- a/app/src/main/java/org/jellyfin/androidtv/data/querying/AlbumArtistsQuery.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/querying/AlbumArtistsQuery.kt
@@ -1,0 +1,5 @@
+package org.jellyfin.androidtv.data.querying
+
+import org.jellyfin.apiclient.model.querying.ArtistsQuery
+
+class AlbumArtistsQuery : ArtistsQuery()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -38,6 +38,7 @@ import org.jellyfin.androidtv.constant.ImageType;
 import org.jellyfin.androidtv.constant.PosterSize;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.model.FilterOptions;
+import org.jellyfin.androidtv.data.querying.AlbumArtistsQuery;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
 import org.jellyfin.androidtv.data.querying.ViewQuery;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
@@ -564,7 +565,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                     //Special queries needed for album artists
                     String includeType = getArguments().getString(Extras.IncludeType);
                     if ("AlbumArtist".equals(includeType)) {
-                        ArtistsQuery albumArtists = new ArtistsQuery();
+                        AlbumArtistsQuery albumArtists = new AlbumArtistsQuery();
                         albumArtists.setUserId(userRepository.getValue().getCurrentUser().getValue().getId().toString());
                         albumArtists.setFields(new ItemFields[]{
                                 ItemFields.PrimaryImageAspectRatio,
@@ -573,6 +574,17 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                         });
                         albumArtists.setParentId(mParentId.toString());
                         setRowDef(new BrowseRowDef("", albumArtists, CHUNK_SIZE_MINIMUM, new ChangeTriggerType[]{}));
+                        return;
+                    } else if ("Artist".equals(includeType)) {
+                        ArtistsQuery artists = new ArtistsQuery();
+                        artists.setUserId(userRepository.getValue().getCurrentUser().getValue().getId().toString());
+                        artists.setFields(new ItemFields[]{
+                                ItemFields.PrimaryImageAspectRatio,
+                                ItemFields.ItemCounts,
+                                ItemFields.ChildCount
+                        });
+                        artists.setParentId(mParentId.toString());
+                        setRowDef(new BrowseRowDef("", artists, CHUNK_SIZE_MINIMUM, new ChangeTriggerType[]{}));
                         return;
                     }
                     query.setIncludeItemTypes(new String[]{includeType != null ? includeType : "MusicAlbum"});
@@ -675,8 +687,11 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
             case LiveTvRecording:
                 mAdapter = new ItemRowAdapter(requireContext(), mRowDef.getRecordingQuery(), chunkSize, mCardPresenter, null);
                 break;
-            case AlbumArtists:
+            case Artists:
                 mAdapter = new ItemRowAdapter(requireContext(), mRowDef.getArtistsQuery(), chunkSize, mCardPresenter, null);
+                break;
+            case AlbumArtists:
+                mAdapter = new ItemRowAdapter(requireContext(), mRowDef.getAlbumArtistsQuery(), chunkSize, mCardPresenter, null);
                 break;
             default:
                 mAdapter = new ItemRowAdapter(requireContext(), mRowDef.getQuery(), chunkSize, mRowDef.getPreferParentThumb(), mRowDef.isStaticHeight(), mCardPresenter, null);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui.browsing;
 
 import org.jellyfin.androidtv.constant.ChangeTriggerType;
 import org.jellyfin.androidtv.constant.QueryType;
+import org.jellyfin.androidtv.data.querying.AlbumArtistsQuery;
 import org.jellyfin.androidtv.data.querying.ViewQuery;
 import org.jellyfin.apiclient.model.livetv.LiveTvChannelQuery;
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery;
@@ -32,6 +33,7 @@ public class BrowseRowDef {
     private SeriesTimerQuery seriesTimerQuery;
 
     private ArtistsQuery artistsQuery;
+    private AlbumArtistsQuery albumArtistsQuery;
     private SeasonQuery seasonQuery;
     private QueryType queryType;
 
@@ -79,9 +81,16 @@ public class BrowseRowDef {
         headerText = header;
         this.artistsQuery = query;
         this.chunkSize = chunkSize;
+        this.queryType = QueryType.Artists;
+        this.changeTriggers = changeTriggers;
+    }
+
+    public BrowseRowDef(String header, AlbumArtistsQuery query, int chunkSize, ChangeTriggerType[] changeTriggers) {
+        headerText = header;
+        this.albumArtistsQuery = query;
+        this.chunkSize = chunkSize;
         this.queryType = QueryType.AlbumArtists;
         this.changeTriggers = changeTriggers;
-
     }
 
     public BrowseRowDef(String header, NextUpQuery query) {
@@ -227,6 +236,7 @@ public class BrowseRowDef {
     }
 
     public ArtistsQuery getArtistsQuery() { return artistsQuery; }
+    public AlbumArtistsQuery getAlbumArtistsQuery() { return albumArtistsQuery; }
 
     public SeriesTimerQuery getSeriesTimerQuery() { return seriesTimerQuery; }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -79,6 +79,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     public static final int FAVSONGS = 9;
     protected static final int SCHEDULE = 10;
     protected static final int SERIES = 11;
+    protected static final int ALBUM_ARTISTS = 12;
     protected BaseItemDto mFolder;
     protected String itemTypeString;
     protected boolean showViews = true;
@@ -300,6 +301,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
             case "MusicAlbum":
                 gridRowAdapter.add(new GridButton(ALBUMS, getString(R.string.lbl_albums), R.drawable.tile_audio));
+                gridRowAdapter.add(new GridButton(ALBUM_ARTISTS, getString(R.string.lbl_album_artists), R.drawable.tile_album_artists));
                 gridRowAdapter.add(new GridButton(ARTISTS, getString(R.string.lbl_artists), R.drawable.tile_artists));
                 gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres));
                 break;
@@ -374,10 +376,16 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                         navigationRepository.getValue().navigate(Destinations.INSTANCE.libraryBrowser(mFolder, "MusicAlbum"));
                         break;
 
-                    case ARTISTS:
+                    case ALBUM_ARTISTS:
                         mFolder = JavaCompat.copyWithDisplayPreferencesId(mFolder, mFolder.getId() + "AR");
 
                         navigationRepository.getValue().navigate(Destinations.INSTANCE.libraryBrowser(mFolder, "AlbumArtist"));
+                        break;
+
+                    case ARTISTS:
+                        mFolder = JavaCompat.copyWithDisplayPreferencesId(mFolder, mFolder.getId() + "AR");
+
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.libraryBrowser(mFolder, "Artist"));
                         break;
 
                     case BY_LETTER:

--- a/app/src/main/res/drawable/tile_album_artists.xml
+++ b/app/src/main/res/drawable/tile_album_artists.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size
+                android:width="256dp"
+                android:height="256dp" />
+            <solid android:color="?attr/tile_artists_bg" />
+        </shape>
+    </item>
+
+    <item
+        android:bottom="60dp"
+        android:drawable="@drawable/ic_artist"
+        android:left="60dp"
+        android:right="60dp"
+        android:top="60dp" />
+</layer-list>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,6 +490,7 @@
     <string name="pref_screensaver_inapp_timeout">Start screensaver after</string>
     <string name="enable_reactive_homepage">Enable reactive homepage</string>
     <string name="not_set">Not set</string>
+    <string name="lbl_album_artists">Album artists</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION

**Changes**
- Add separate buttons for artists and album artists in music smart screen
- Old "Artists" is renamed to "Album artists"
- Newly added "Artists" shows artists

Also adds some garbage because we couldn't retrieve artists from the ItemRowAdapter yet.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
