### PR TITLE
Rewrite GridButton with Compose

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/GridButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/GridButton.kt
@@ -2,10 +2,10 @@ package org.jellyfin.androidtv.ui
 
 import androidx.annotation.DrawableRes
 
-open class GridButton(
+open class GridButton @JvmOverloads constructor(
 	val id: Int,
 	val text: String,
-	@DrawableRes val imageRes: Int,
+	@DrawableRes val imageRes: Int? = null,
 ) {
 	override fun toString() = text
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -182,8 +182,8 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
 
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
         ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
-        gridRowAdapter.add(new GridButton(SCHEDULE, getString(R.string.lbl_schedule), R.drawable.tile_port_time));
-        gridRowAdapter.add(new GridButton(SERIES, getString(R.string.lbl_series_recordings), R.drawable.tile_port_series_timer));
+        gridRowAdapter.add(new GridButton(SCHEDULE, getString(R.string.lbl_schedule)));
+        gridRowAdapter.add(new GridButton(SERIES, getString(R.string.lbl_series_recordings)));
         rowAdapter.add(new ListRow(gridHeader, gridRowAdapter));
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -493,27 +493,11 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
             GridButtonPresenter mGridPresenter = new GridButtonPresenter();
             ArrayObjectAdapter gridRowAdapter = new ArrayObjectAdapter(mGridPresenter);
-            gridRowAdapter.add(new GridButton(
-                LiveTvOption.LIVE_TV_GUIDE_OPTION_ID,
-                getString(R.string.lbl_live_tv_guide),
-                R.drawable.tile_port_guide
-            ));
-            gridRowAdapter.add(new GridButton(
-                LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID,
-                getString(R.string.lbl_recorded_tv),
-                R.drawable.tile_port_record
-            ));
+            gridRowAdapter.add(new GridButton(LiveTvOption.LIVE_TV_GUIDE_OPTION_ID, getString(R.string.lbl_live_tv_guide)));
+            gridRowAdapter.add(new GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, getString(R.string.lbl_recorded_tv)));
             if (Utils.canManageRecordings(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue())) {
-                gridRowAdapter.add(new GridButton(
-                    LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID,
-                    getString(R.string.lbl_schedule),
-                    R.drawable.tile_port_time
-                ));
-                gridRowAdapter.add(new GridButton(
-                    LiveTvOption.LIVE_TV_SERIES_OPTION_ID,
-                    getString(R.string.lbl_series),
-                    R.drawable.tile_port_series_timer
-                ));
+                gridRowAdapter.add(new GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, getString(R.string.lbl_schedule)));
+                gridRowAdapter.add(new GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, getString(R.string.lbl_series)));
             }
 
             mRowsAdapter.add(new ListRow(gridHeader, gridRowAdapter));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -223,7 +223,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
         mCardPresenter = new CardPresenter(false, 140);
         ClassPresenterSelector ps = new ClassPresenterSelector();
         ps.addClassPresenter(BaseRowItem.class, mCardPresenter);
-        ps.addClassPresenter(GridButton.class, new GridButtonPresenter(false, 155, 140));
+        ps.addClassPresenter(GridButton.class, new GridButtonPresenter(155, 140));
 
         for (BrowseRowDef def : rows) {
             HeaderItem header = new HeaderItem(def.getHeaderText());
@@ -295,15 +295,15 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
         switch (itemTypeString) {
             case "Movie":
-                gridRowAdapter.add(new GridButton(SUGGESTED, getString(R.string.lbl_suggested), R.drawable.tile_suggestions));
+                gridRowAdapter.add(new GridButton(SUGGESTED, getString(R.string.lbl_suggested)));
                 addStandardViewButtons(gridRowAdapter);
                 break;
 
             case "MusicAlbum":
-                gridRowAdapter.add(new GridButton(ALBUMS, getString(R.string.lbl_albums), R.drawable.tile_audio));
-                gridRowAdapter.add(new GridButton(ALBUM_ARTISTS, getString(R.string.lbl_album_artists), R.drawable.tile_album_artists));
-                gridRowAdapter.add(new GridButton(ARTISTS, getString(R.string.lbl_artists), R.drawable.tile_artists));
-                gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres));
+                gridRowAdapter.add(new GridButton(ALBUMS, getString(R.string.lbl_albums)));
+                gridRowAdapter.add(new GridButton(ALBUM_ARTISTS, getString(R.string.lbl_album_artists)));
+                gridRowAdapter.add(new GridButton(ARTISTS, getString(R.string.lbl_artists)));
+                gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres)));
                 break;
 
             default:
@@ -315,11 +315,11 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     }
 
     protected void addStandardViewButtons(ArrayObjectAdapter gridRowAdapter) {
-        gridRowAdapter.add(new GridButton(GRID, getString(R.string.lbl_all_items), R.drawable.tile_port_grid));
-        gridRowAdapter.add(new GridButton(BY_LETTER, getString(R.string.lbl_by_letter), R.drawable.tile_letters));
-        gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres), R.drawable.tile_genres));
+        gridRowAdapter.add(new GridButton(GRID, getString(R.string.lbl_all_items)));
+        gridRowAdapter.add(new GridButton(BY_LETTER, getString(R.string.lbl_by_letter)));
+        gridRowAdapter.add(new GridButton(GENRES, getString(R.string.lbl_genres)));
         // Disabled because the screen doesn't behave properly
-        // gridRowAdapter.add(new GridButton(PERSONS, getString(R.string.lbl_performers), R.drawable.tile_actors));
+        // gridRowAdapter.add(new GridButton(PERSONS, getString(R.string.lbl_performers)));
     }
 
     protected void setupEventListeners() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
@@ -31,14 +31,14 @@ class HomeFragmentLiveTVRow(
 		val adapter = ArrayObjectAdapter(GridButtonPresenter())
 
 		// Live TV Guide button
-		adapter.add(GridButton(LiveTvOption.LIVE_TV_GUIDE_OPTION_ID, activity.getString(R.string.lbl_live_tv_guide), R.drawable.tile_port_guide))
+		adapter.add(GridButton(LiveTvOption.LIVE_TV_GUIDE_OPTION_ID, activity.getString(R.string.lbl_live_tv_guide)))
 		// Live TV Recordings button
-		adapter.add(GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, activity.getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record))
+		adapter.add(GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, activity.getString(R.string.lbl_recorded_tv)))
 		if (Utils.canManageRecordings(userRepository.currentUser.value)) {
 			// Recording Schedule button
-			adapter.add(GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, activity.getString(R.string.lbl_schedule), R.drawable.tile_port_time))
+			adapter.add(GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, activity.getString(R.string.lbl_schedule)))
 			// Recording Series button
-			adapter.add(GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, activity.getString(R.string.lbl_series), R.drawable.tile_port_series_timer))
+			adapter.add(GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, activity.getString(R.string.lbl_series)))
 		}
 
 		rowsAdapter.add(ListRow(header, adapter))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -172,7 +172,7 @@ open class BaseRowItem protected constructor(
 		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, maxHeight)
 		BaseRowType.Chapter -> chapterInfo?.imagePath
 		BaseRowType.LiveTvChannel -> ImageUtils.getPrimaryImageUrl(baseItem!!)
-		BaseRowType.GridButton -> ImageUtils.getResourceUrl(context, gridButton!!.imageRes)
+		BaseRowType.GridButton -> gridButton?.imageRes?.let { ImageUtils.getResourceUrl(context, it) }
 		BaseRowType.SeriesTimer -> ImageUtils.getResourceUrl(context, R.drawable.tile_land_series_timer)
 		BaseRowType.SearchHint -> when {
 			!searchHint?.primaryImageTag.isNullOrBlank() -> ImageUtils.getImageUrl(searchHint!!.itemId.toString(), org.jellyfin.apiclient.model.entities.ImageType.Primary, searchHint.primaryImageTag!!)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -1242,14 +1242,14 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
                     int prevItems = Math.max(adapter.size(), 0);
                     if (adapter.chunkSize == 0) {
                         // and recordings as first item if showing all
-                        adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, context.getString(R.string.lbl_recorded_tv), R.drawable.tile_port_record)));
+                        adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, context.getString(R.string.lbl_recorded_tv))));
                         i++;
                         if (Utils.canManageRecordings(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue())) {
                             // and schedule
-                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, context.getString(R.string.lbl_schedule), R.drawable.tile_port_time)));
+                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, context.getString(R.string.lbl_schedule))));
                             i++;
                             // and series
-                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, context.getString(R.string.lbl_series), R.drawable.tile_port_series_timer)));
+                            adapter.add(new BaseRowItem(new GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, context.getString(R.string.lbl_series))));
                             i++;
                         }
                     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
@@ -1,50 +1,83 @@
 package org.jellyfin.androidtv.ui.presentation
 
-import android.util.TypedValue
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.leanback.widget.Presenter
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.GridButton
-import org.jellyfin.androidtv.ui.card.LegacyImageCardView
 
 class GridButtonPresenter @JvmOverloads constructor(
-	private val showinfo: Boolean = true,
 	private val width: Int = 110,
-	private val height: Int = 110,
+	private val imageHeight: Int = 110,
 ) : Presenter() {
-	class ViewHolder(
-		private val cardView: LegacyImageCardView,
-	) : Presenter.ViewHolder(cardView) {
-		var item: GridButton? = null
-			set(value) {
-				field = value
-
-				if (value != null) cardView.mainImageView.setImageResource(value.imageRes)
-
-				cardView.setTitleText(value?.text)
-				cardView.setOverlayText(value?.text)
-			}
-	}
-
-	override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
-		val typedValue = TypedValue()
-		parent.context.theme.resolveAttribute(R.attr.cardViewBackground, typedValue, true)
-
-		val view = LegacyImageCardView(parent.context, showinfo).apply {
-			isFocusable = true
-			isFocusableInTouchMode = true
-			setBackgroundColor(typedValue.data)
+	private class ComposeViewWrapper(composeView: ComposeView) : FrameLayout(composeView.context) {
+		init {
+			addView(composeView)
 		}
-		view.setMainImageDimensions(width, height)
 
-		return ViewHolder(view)
+		// Hack to prevent Compose crash with leanback presenters
+		override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+			if (isAttachedToWindow) super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+			else setMeasuredDimension(widthMeasureSpec, heightMeasureSpec)
+		}
 	}
+
+	inner class ViewHolder(
+		private val composeView: ComposeView,
+	) : Presenter.ViewHolder(ComposeViewWrapper(composeView)) {
+		fun bind(value: GridButton) = composeView.setContent {
+			Box(
+				modifier = Modifier
+					.width(width.dp)
+					.clip(RoundedCornerShape(4.dp))
+					.background(colorResource(R.color.button_default_normal_background))
+			) {
+				if (value.imageRes != null) {
+					Image(
+						painter = painterResource(value.imageRes),
+						contentDescription = value.text,
+						contentScale = ContentScale.Crop,
+						modifier = Modifier.size(width.dp, imageHeight.dp)
+					)
+				}
+
+				Text(
+					text = value.text,
+					style = TextStyle(
+						color = colorResource(R.color.button_default_normal_text),
+						fontSize = 12.sp
+					),
+					modifier = Modifier
+						.padding(15.dp, 10.dp)
+						.align(Alignment.BottomStart)
+				)
+			}
+		}
+	}
+
+	override fun onCreateViewHolder(parent: ViewGroup): ViewHolder =
+		ViewHolder(ComposeView(parent.context))
 
 	override fun onBindViewHolder(viewHolder: Presenter.ViewHolder?, item: Any?) {
-		if (item !is GridButton) return
-		if (viewHolder !is ViewHolder) return
-
-		viewHolder.item = item
+		if (viewHolder is ViewHolder && item is GridButton) viewHolder.bind(item)
 	}
 
 	override fun onUnbindViewHolder(viewHolder: Presenter.ViewHolder?) = Unit


### PR DESCRIPTION
**Changes**
- Rewrite GridButton with Compose
- Add image-less grid button
- Use image-less grid button for everything except the "favorites" playlist in the music smart screen

Unfortunately the "active" effect cannot be changed for specific items without rewriting a lot of code so for now it uses the zoom effect instead of our regular background color change with buttons. This can be fixed when we convert even more stuff to compose.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

**Screenshots**
![image](https://user-images.githubusercontent.com/2305178/232323339-aca051c1-f6a0-4078-910c-9a92ebbb2142.png)

top: music favorite button
bottom: image-less grid button