### PR TITLE
Fix offsetStreamIndex when selecting last track

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -464,7 +464,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         }
         index += indexStartsAtOne ? (adjustByAdding ? -1 : 1) : 0;
 
-        return index < 0 || index >= allStreams.size() ? -1 : index;
+        return index < 0 || index > allStreams.size() ? -1 : index;
     }
 
     public boolean setSubtitleTrack(int index, @Nullable List<org.jellyfin.sdk.model.api.MediaStream> allStreams) {


### PR DESCRIPTION
Found this while testing #2690. In my test file I had the following streams:

| Index | ExoPlayer index | Description |
| --- | --- | --- |
| 0 | 1 | Video |
| 1 | 2 | Audio |
| 2 | 3 | Subtitle (PGS) |

As you can see, the subtitle track had id 3 but the check in the return didn't like that.

**Changes**
- Fix offsetStreamIndex when selecting last track

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
