### PR TITLE
Fix support for switching embedded subtitle tracks in ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1022,9 +1022,17 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                         mCurrentOptions.setSubtitleStreamIndex(index);
                         mDefaultSubIndex = index;
                     }
-                    break;
+                } else {
+                    if (!mVideoManager.setExoPlayerTrack(index, MediaStreamType.SUBTITLE, getCurrentlyPlayingItem().getMediaStreams())) {
+                        // error selecting internal subs
+                        if (mFragment != null)
+                            Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_unable_load_subs));
+                    } else {
+                        mCurrentOptions.setSubtitleStreamIndex(index);
+                        mDefaultSubIndex = index;
+                    }
                 }
-                // not using vlc - fall through to external handling
+                break;
             case External:
                 if (mFragment != null) mFragment.showSubLoadingMsg(true);
 


### PR DESCRIPTION
We didn't support switching to an embedded subtitle track in ExoPlayer. This is needed for the PGS support in #2690.

**Changes**
- Fix switching ExoPlayer subtitle track

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
