### PR TITLE
Enable DVB subtitles in ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
@@ -67,6 +67,7 @@ object Codec {
 
 	object Subtitle {
 		const val ASS = "ass"
+		const val DVBSUB = "dvbsub"
 		const val DVDSUB = "dvdsub"
 		const val IDX = "idx"
 		const val PGS = "pgs"

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -217,6 +217,7 @@ class ExoPlayerProfile(
 			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.PGSSUB, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.DVBSUB, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.DVDSUB, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.VTT, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SUB, SubtitleDeliveryMethod.Embed),


### PR DESCRIPTION
Similar to #2690. Could only find ts files for testing which is not a supported container format but I could see in the JF dashboard that the file went from transcoding (subs baking+container change) to just remuxing (container change) with this change.

**Changes**
- Enable DVB subtitles in ExoPlayer

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
