### PR TITLE
Disable MPEG transport stream container in ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -600,7 +600,7 @@ public class LegacyMediaManager implements MediaManager {
         options.setMediaSources(item.getMediaSources());
         DeviceProfile profile;
         if (DeviceUtils.is60()) {
-            profile = new ExoPlayerProfile(context, false, false, false);
+            profile = new ExoPlayerProfile(context, false, false);
         } else {
             profile = new LibVlcProfile(context, false);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -568,8 +568,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         internalOptions.setMediaSourceId(forcedSubtitleIndex != null ? getCurrentMediaSource().getId() : null);
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),
-                isLiveTv,
-                userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
+                isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
                 userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
         );
         internalOptions.setProfile(internalProfile);

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -27,8 +27,7 @@ import org.jellyfin.apiclient.model.dlna.TranscodingProfile
 
 class ExoPlayerProfile(
 	context: Context,
-	isLiveTV: Boolean = false,
-	isLiveTVDirectPlayEnabled: Boolean = false,
+	disableVideoDirectPlay: Boolean = false,
 	isAC3Enabled: Boolean = false,
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
@@ -93,13 +92,11 @@ class ExoPlayerProfile(
 
 		directPlayProfiles = buildList {
 			// Video direct play
-			if (!isLiveTV || isLiveTVDirectPlayEnabled) {
+			if (!disableVideoDirectPlay) {
 				add(DirectPlayProfile().apply {
 					type = DlnaProfileType.Video
 
 					container = listOfNotNull(
-						if (isLiveTV) Codec.Container.TS else null,
-						if (isLiveTV) Codec.Container.MPEGTS else null,
 						Codec.Container.M4V,
 						Codec.Container.MOV,
 						Codec.Container.XVID,


### PR DESCRIPTION
The track switching code (for audio/subtitle) implementation for ExoPlayer doesn't support the track ids in a mpeg-ts container. Our implementation only allows integers and does some weird offset matching but the tracks in a ts file have id's like `1/161`.

Ideally we'd fix the selector logic but I can't think of an easy way to do that right now.

**Changes**
- Disable MPEG transport stream container in ExoPlayer

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
