### PR TITLE
Fix ExpandableTextView cutting content

### DIFF
--- a/app/src/main/res/layout/popup_expandable_text_view.xml
+++ b/app/src/main/res/layout/popup_expandable_text_view.xml
@@ -26,7 +26,6 @@
             android:id="@+id/content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
             android:duplicateParentState="true"
             android:textSize="16sp"
             tools:text="This is the expanded text!" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix ExpandableTextView cutting content
  The layout_gravity was redundant and actually caused the layout measurement to be incorrect, this then made the behavior of the scrollview weird.

**Issues**

Fixes #2708
