### PR TITLE
Fix ExoPlayerProfile not always listing SubRip and SRT as external

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -208,8 +208,7 @@ class ExoPlayerProfile(
 
 		subtitleProfiles = arrayOf(
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
-			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
-			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Embed),


### PR DESCRIPTION
This should fix a regression in #2693 where SRT and SubRip would (often, but not always) use the ExoPlayer text rendering instead of our custom implementation.

**Changes**
- Fix ExoPlayerProfile not always listing SubRip and SRT as external

**Issues**

Fixes #2699