### PR TITLE
Fix ExoPlayer extensions not used for music playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -9,6 +9,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.widget.Toast;
 
+import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackException;
@@ -254,12 +255,17 @@ public class LegacyMediaManager implements MediaManager {
 
     private boolean createPlayer(Context context, int buffer) {
         try {
-
             // Create a new media player based on platform
             if (DeviceUtils.is60()) {
                 Timber.i("creating audio player using: exoplayer");
                 nativeMode = true;
-                mExoPlayer = new ExoPlayer.Builder(context).build();
+
+                ExoPlayer.Builder exoPlayerBuilder = new ExoPlayer.Builder(context);
+                DefaultRenderersFactory defaultRendererFactory = new DefaultRenderersFactory(context);
+                defaultRendererFactory.setEnableDecoderFallback(true);
+                defaultRendererFactory.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON);
+                exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
+                mExoPlayer = exoPlayerBuilder.build();
                 mExoPlayer.addListener(new Player.Listener() {
                     @Override
                     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -28,7 +28,12 @@ class ExoPlayerBackend(
 			setEnableDecoderFallback(true)
 			setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
 		}
+
 		ExoPlayer.Builder(context, renderersFactory)
+			.setRenderersFactory(DefaultRenderersFactory(context).apply {
+				setEnableDecoderFallback(true)
+				setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+			})
 			.build()
 			.also { player -> player.addListener(PlayerListener()) }
 	}


### PR DESCRIPTION
Both the LegacyMediaManager (used for music) and the playback rewrite did not enable the ffmpeg extension for ExoPlayer. This caused some codecs, like flac, to not work when devices lacked support. Will open a separate PR with a fix for the 0.15 branch.

**Changes**
- Fix ExoPlayer extensions not used for music playback

**Issues**

Fixes #2048
