### PR TITLE
Fix ExoPlayer extensions not used for music playback (backport)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -13,6 +13,7 @@ import android.text.InputType;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackException;
@@ -288,7 +289,13 @@ public class MediaManager {
             if (DeviceUtils.is60()) {
                 Timber.i("creating audio player using: exoplayer");
                 nativeMode = true;
-                mExoPlayer = new ExoPlayer.Builder(context).build();
+
+                ExoPlayer.Builder exoPlayerBuilder = new ExoPlayer.Builder(context);
+                DefaultRenderersFactory defaultRendererFactory = new DefaultRenderersFactory(context);
+                defaultRendererFactory.setEnableDecoderFallback(true);
+                defaultRendererFactory.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON);
+                exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
+                mExoPlayer = exoPlayerBuilder.build();
                 mExoPlayer.addListener(new Player.Listener() {
                     @Override
                     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {


### PR DESCRIPTION
Same as #2711 but for the 0.15.z branch.

**Changes**
- Fix ExoPlayer extensions not used for music playback

**Issues**
Fixes #2048
