### PR TITLE
Allow changing the (a)ac3 bitstreaming option on all devices

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -182,7 +182,7 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.lbl_bitstream_ac3)
 				setContent(R.string.desc_bitstream_ac3)
 				bind(userPreferences, UserPreferences.ac3Enabled)
-				depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL && !DeviceUtils.is60() }
+				depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL }
 			}
 
 			checkbox {


### PR DESCRIPTION
There is no reason to not allow users to disable the option (it's enabled by default).

**Changes**
- Allow changing the (a)ac3 bitstreaming option on all devices

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
