### PR TITLE
Add support for retrieving resume items in BaseRowAdapter using the SDK

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/QueryType.kt
@@ -26,4 +26,5 @@ enum class QueryType {
 	LatestItems,
 	SeriesTimer,
 	Premieres,
+	Resume,
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
@@ -16,6 +16,7 @@ import org.jellyfin.apiclient.model.querying.PersonsQuery;
 import org.jellyfin.apiclient.model.querying.SeasonQuery;
 import org.jellyfin.apiclient.model.querying.SimilarItemsQuery;
 import org.jellyfin.apiclient.model.querying.UpcomingEpisodesQuery;
+import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest;
 
 public class BrowseRowDef {
     private String headerText;
@@ -35,6 +36,7 @@ public class BrowseRowDef {
     private ArtistsQuery artistsQuery;
     private AlbumArtistsQuery albumArtistsQuery;
     private SeasonQuery seasonQuery;
+    private GetResumeItemsRequest resumeQuery;
     private QueryType queryType;
 
     private int chunkSize = 0;
@@ -183,6 +185,16 @@ public class BrowseRowDef {
         this.queryType = QueryType.Views;
     }
 
+    public BrowseRowDef(String header, GetResumeItemsRequest query, int chunkSize, boolean preferParentThumb, boolean staticHeight, ChangeTriggerType[] changeTriggers) {
+        headerText = header;
+        this.resumeQuery = query;
+        this.chunkSize = chunkSize;
+        this.queryType = QueryType.Resume;
+        this.staticHeight = staticHeight;
+        this.preferParentThumb = preferParentThumb;
+        this.changeTriggers = changeTriggers;
+    }
+
     public int getChunkSize() {
         return chunkSize;
     }
@@ -239,6 +251,8 @@ public class BrowseRowDef {
     public AlbumArtistsQuery getAlbumArtistsQuery() { return albumArtistsQuery; }
 
     public SeriesTimerQuery getSeriesTimerQuery() { return seriesTimerQuery; }
+
+    public GetResumeItemsRequest getResumeQuery() { return resumeQuery; }
 
     public ChangeTriggerType[] getChangeTriggers() {
         return changeTriggers;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentBrowseRowDefRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentBrowseRowDefRow.kt
@@ -36,6 +36,7 @@ class HomeFragmentBrowseRowDefRow(
 			QueryType.LiveTvChannel -> ItemRowAdapter(context, browseRowDef.tvChannelQuery, 40, cardPresenter, rowsAdapter)
 			QueryType.LiveTvProgram -> ItemRowAdapter(context, browseRowDef.programQuery, cardPresenter, rowsAdapter)
 			QueryType.LiveTvRecording -> ItemRowAdapter(context, browseRowDef.recordingQuery, browseRowDef.chunkSize, cardPresenter, rowsAdapter)
+			QueryType.Resume -> ItemRowAdapter(context, browseRowDef.resumeQuery, browseRowDef.chunkSize, browseRowDef.preferParentThumb, browseRowDef.isStaticHeight, cardPresenter, rowsAdapter)
 			else -> ItemRowAdapter(context, browseRowDef.query, browseRowDef.chunkSize, browseRowDef.preferParentThumb, browseRowDef.isStaticHeight, cardPresenter, rowsAdapter, browseRowDef.queryType)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -72,7 +72,16 @@ open class BaseRowItem protected constructor(
 		baseItem = item.asSdk(),
 	)
 
-	constructor(item: org.jellyfin.sdk.model.api.BaseItemDto) : this(
+	@JvmOverloads
+	constructor(
+		item: org.jellyfin.sdk.model.api.BaseItemDto,
+		index: Int = 0,
+		preferParentThumb: Boolean = false,
+		staticHeight: Boolean = false,
+	) : this(
+		index = index,
+		preferParentThumb = preferParentThumb,
+		staticHeight = staticHeight,
 		baseRowType = when (item.type) {
 			BaseItemKind.PROGRAM -> BaseRowType.LiveTvProgram
 			BaseItemKind.RECORDING -> BaseRowType.LiveTvRecording

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -63,6 +63,7 @@ import org.jellyfin.apiclient.model.search.SearchQuery;
 import org.jellyfin.sdk.model.api.BaseItemPerson;
 import org.jellyfin.sdk.model.api.SortOrder;
 import org.jellyfin.sdk.model.api.UserDto;
+import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest;
 import org.jellyfin.sdk.model.constant.ItemSortBy;
 import org.koin.java.KoinJavaComponent;
 
@@ -92,6 +93,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     private AlbumArtistsQuery mAlbumArtistsQuery;
     private LatestItemsQuery mLatestQuery;
     private SeriesTimerQuery mSeriesTimerQuery;
+    private GetResumeItemsRequest resumeQuery;
     private QueryType queryType;
 
     private String mSortBy;
@@ -122,6 +124,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     private boolean staticHeight = false;
 
     private final Lazy<ApiClient> apiClient = inject(ApiClient.class);
+    private final Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private final Lazy<UserViewsRepository> userViewsRepository = inject(UserViewsRepository.class);
     private Context context;
 
@@ -402,6 +405,17 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
         mParent = parent;
         queryType = QueryType.Views;
         staticHeight = true;
+    }
+
+    public ItemRowAdapter(Context context, GetResumeItemsRequest query, int chunkSize, boolean preferParentThumb, boolean staticHeight, Presenter presenter, MutableObjectAdapter<Row> parent) {
+        super(presenter);
+        this.context = context;
+        mParent = parent;
+        resumeQuery = query;
+        this.chunkSize = chunkSize;
+        this.preferParentThumb = preferParentThumb;
+        this.staticHeight = staticHeight;
+        this.queryType = QueryType.Resume;
     }
 
     public void setItemsLoaded(int itemsLoaded) {
@@ -753,6 +767,9 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
             case SeriesTimer:
                 retrieve(mSeriesTimerQuery);
                 break;
+            case Resume:
+                ItemRowAdapterHelperKt.retrieveResumeItems(this, api.getValue(), resumeQuery);
+            break;
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -1,5 +1,11 @@
 package org.jellyfin.androidtv.ui.itemhandling
 
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
 import timber.log.Timber
 
 fun <T : Any> ItemRowAdapter.setItems(
@@ -28,4 +34,14 @@ fun <T : Any> ItemRowAdapter.setItems(
 
 	replaceAll(allItems)
 	itemsLoaded = allItems.size
+}
+
+fun ItemRowAdapter.retrieveResumeItems(api: ApiClient, query: GetResumeItemsRequest) {
+	ProcessLifecycleOwner.get().lifecycleScope.launch {
+		val response by api.itemsApi.getResumeItems(query)
+
+		setItems(
+			items = response.items.orEmpty().toTypedArray(),
+			transform = { item, i -> BaseRowItem(item, i, preferParentThumb, isStaticHeight) })
+	}
 }


### PR DESCRIPTION
Feeding the dragon

**Changes**
- Add new `Resume` type to our fancy query system
- Implemented with the Kotlin SDK using the GetResumeItemsRequest model
- Uses the process lifecycle which will definitely not help preventing crashes but the item row adapter doesn't have a lifecycle :(

**Issues**

Fixes #2677
Fixes #600
Fixes #2077
