### PR TITLE
Fix resume row not hiding when empty

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -42,6 +42,9 @@ fun ItemRowAdapter.retrieveResumeItems(api: ApiClient, query: GetResumeItemsRequ
 
 		setItems(
 			items = response.items.orEmpty().toTypedArray(),
-			transform = { item, i -> BaseRowItem(item, i, preferParentThumb, isStaticHeight) })
+			transform = { item, i -> BaseRowItem(item, i, preferParentThumb, isStaticHeight) }
+		)
+
+		if (response.items.isNullOrEmpty()) removeRow()
 	}
 }


### PR DESCRIPTION
**Changes**
- Fix resume row not hiding when empty

**Issues**

Fixes a regression in #2723 where the row would still show when there are no items. Reported in https://github.com/jellyfin/jellyfin-androidtv/issues/2706#issuecomment-1529238140