### PR TITLE
Hide SSA tags from SRT subtitles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1525,11 +1525,13 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             return;
         }
         requireActivity().runOnUiThread(() -> {
-            // Encode whitespace as html entities
             final String htmlText = text
+                    // Encode whitespace as html entities
                     .replaceAll("\\r\\n", "<br>")
                     .replaceAll("\\n", "<br>")
-                    .replaceAll("\\\\h", "&ensp;");
+                    .replaceAll("\\\\h", "&ensp;")
+                    // Remove SSA tags
+                    .replaceAll("\\{\\\\.*?\\}", "");
 
             final SpannableString span = new SpannableString(TextUtilsKt.toHtmlSpanned(htmlText));
             if (subtitlesBackgroundEnabled) {


### PR DESCRIPTION
**Changes**
- Remove SSA tags when rendering text subtitles.

**Issues**
Partially fixes #1804, it doesn't implement the tags but hides them instead.