### PR TITLE
Fix loading issues with embedded SUBRIP subtitles while using Exoplayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -207,7 +207,9 @@ class ExoPlayerProfile(
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(
+			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
+			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Encode),


### PR DESCRIPTION
Currently, embedded SRT/SUBRIP subtitles can take a long time to load because it requires the server to use ffmpeg to extract the embedded subtitles out of the video stream in order to return a JSON file of the subtitles so they can be used by the custom overlay. A longer explanation is [here](https://github.com/jellyfin/jellyfin-androidtv/issues/145#issuecomment-1121735121).  For large videos (such as 4K), this can take minutes to load a single subtitle. After these fixes, they load near instantaneously by Exoplayer.
<!--

Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
* Enables the SRT/SUBRIP embedded subtitle profiles, which means they will be displayed directly by Exoplayer instead of being shown through the custom overlay fragment
* In order to keep parity with the custom overlay's ability to change the formatting of the subtitles based on user preferences, this PR also implements subtitle formatting within Exoplayer, since otherwise those settings would be lost when using Exoplayer directly for embedded subtitles
* Some of these code changes have been influenced by this previous attempt to remedy the issue: https://github.com/jellyfin/jellyfin-androidtv/pull/1949

**Issues**
Fixes #145
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

(Note: I'm not a Java developer and haven't contributed to this project before, so any and all suggestions for how to implement this better are welcomed!)
