### PR TITLE
Fix screensaver support in video player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -163,6 +163,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
 
+    private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -245,7 +247,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         super.onViewCreated(view, savedInstanceState);
 
         if (playbackControllerContainer.getValue().getPlaybackController() != null) {
-            playbackControllerContainer.getValue().getPlaybackController().init(new VideoManager((requireActivity()), view), this);
+            playbackControllerContainer.getValue().getPlaybackController().init(new VideoManager((requireActivity()), view, helper), this);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayFragmentHelper.kt
@@ -1,0 +1,20 @@
+package org.jellyfin.androidtv.ui.playback
+
+import org.jellyfin.androidtv.ui.ScreensaverViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
+
+class PlaybackOverlayFragmentHelper(
+	private val fragment: CustomPlaybackOverlayFragment
+) {
+	private val screensaverViewModel by fragment.activityViewModel<ScreensaverViewModel>()
+	private var screensaverLock: (() -> Unit)? = null
+
+	fun setScreensaverLock(enabled: Boolean) {
+		if (enabled && screensaverLock == null) {
+			screensaverLock = screensaverViewModel.addLifecycleLock(fragment.lifecycle)
+		} else if (!enabled) {
+			screensaverLock?.invoke()
+			screensaverLock = null
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -71,6 +71,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private PlaybackControllerNotifiable mPlaybackControllerNotifiable;
     private SurfaceHolder mSurfaceHolder;
     private SurfaceView mSurfaceView;
+    private PlaybackOverlayFragmentHelper _helper;
     private SurfaceView mSubtitlesSurface;
     private FrameLayout mSurfaceFrame;
     private ExoPlayer mExoPlayer;
@@ -98,9 +99,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private boolean mSurfaceReady = false;
     public boolean isContracted = false;
 
-    public VideoManager(@NonNull Activity activity, @NonNull View view) {
+    public VideoManager(@NonNull Activity activity, @NonNull View view, @NonNull PlaybackOverlayFragmentHelper helper) {
         mActivity = activity;
         mSurfaceView = view.findViewById(R.id.player_surface);
+        _helper = helper;
         mSurfaceHolder = mSurfaceView.getHolder();
         mSurfaceHolder.addCallback(mSurfaceCallback);
         mSurfaceFrame = view.findViewById(R.id.player_surface_frame);
@@ -134,8 +136,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
                 if (isPlaying) {
                     if (mPlaybackControllerNotifiable != null) mPlaybackControllerNotifiable.onPrepared();
                     startProgressLoop();
+                    _helper.setScreensaverLock(true);
                 } else {
                     stopProgressLoop();
+                    _helper.setScreensaverLock(false);
                 }
             }
 
@@ -214,8 +218,10 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     public void setNativeMode(boolean value) {
         nativeMode = value;
         if (nativeMode) {
+            _helper.setScreensaverLock(false);
             mExoPlayerView.setVisibility(View.VISIBLE);
         } else {
+            _helper.setScreensaverLock(true);
             mExoPlayerView.setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
**Changes**
- Only allow screensaver to show when the player is paused
- Always disable screensaver when using LibVLC (we don't use the events we'd need to hook into)

The implementation adds yet another "helper" file written in Kotlin. This time because the `activityViewModel` extension function from Koin can only be used in Kotlin code.

**Issues**

Fixes #2225