### PR TITLE
Add fallback image to LeanbackChannelWorker

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -25,6 +25,7 @@ import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.startup.StartupActivity
+import org.jellyfin.androidtv.util.ImageUtils
 import org.jellyfin.androidtv.util.dp
 import org.jellyfin.androidtv.util.sdk.isUsable
 import org.jellyfin.sdk.api.client.ApiClient
@@ -246,7 +247,7 @@ class LeanbackChannelWorker(
 			tag = imageTags?.get(ImageType.THUMB),
 		)
 
-		else -> api.imageApi.getItemImageUrl(
+		imageTags?.containsKey(ImageType.PRIMARY) == true -> api.imageApi.getItemImageUrl(
 			itemId = id,
 			imageType = ImageType.PRIMARY,
 			format = ImageFormat.WEBP,
@@ -254,6 +255,8 @@ class LeanbackChannelWorker(
 			height = 153.dp(context),
 			tag = imageTags?.get(ImageType.PRIMARY),
 		)
+
+		else -> ImageUtils.getResourceUrl(context, R.drawable.tile_land_tv)
 	}.let(ImageProvider::getImageUri)
 
 	/**


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Make sure that channel items always have an image by using our "tile_land_tv" image as fallback
  - This was the previous behavior for the "my media" channel but was removed with #2515
  - This change also adds this image for other channel items

**Issues**

Fixes a regression from #2515