### PR TITLE
Migrate ExoPlayer to StyledPlayerView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -36,7 +36,7 @@ import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.trackselection.TrackSelectionOverride;
 import com.google.android.exoplayer2.trackselection.TrackSelectionParameters;
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
-import com.google.android.exoplayer2.ui.PlayerView;
+import com.google.android.exoplayer2.ui.StyledPlayerView;
 import com.google.common.collect.ImmutableSet;
 
 import org.jellyfin.androidtv.R;
@@ -75,7 +75,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private SurfaceView mSubtitlesSurface;
     private FrameLayout mSurfaceFrame;
     private ExoPlayer mExoPlayer;
-    private PlayerView mExoPlayerView;
+    private StyledPlayerView mExoPlayerView;
     private LibVLC mLibVLC;
     private MediaPlayer mVlcPlayer;
     private Media mCurrentMedia;

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -30,7 +30,7 @@
 
         </FrameLayout>
 
-        <com.google.android.exoplayer2.ui.PlayerView
+        <com.google.android.exoplayer2.ui.StyledPlayerView
             android:id="@+id/exoPlayerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION

Doesn't really change much except making the migration to androidx.media3 easier.

**Changes**
- Migrate ExoPlayer to StyledPlayerView

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
