### PR TITLE
Fix app closing when media finishes playing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -184,7 +184,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         mItemsToPlay = videoQueueManager.getValue().getCurrentVideoQueue();
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
             Utils.showToast(requireContext(), getString(R.string.msg_no_playable_items));
-            finish();
+            closePlayer();
             return;
         }
 
@@ -434,7 +434,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             } else if (mGuideVisible) {
                 hideGuide();
             } else {
-                finish();
+                closePlayer();
             }
         }
     };
@@ -533,7 +533,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 }
 
                 if (keyCode == KeyEvent.KEYCODE_MEDIA_STOP) {
-                    finish();
+                    closePlayer();
                     return true;
                 }
 
@@ -697,7 +697,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     if (!getActive()) return;
 
                     Utils.showToast(requireContext(), R.string.msg_video_playback_error);
-                    finish();
+                    closePlayer();
                 }
             });
         }
@@ -1443,7 +1443,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         });
     }
 
-    public void finish() {
+    public void closePlayer() {
         if (navigationRepository.getValue().getCanGoBack()) {
             navigationRepository.getValue().goBack();
         } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -301,7 +301,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             mPlaybackState = PlaybackState.ERROR;
             if (mFragment != null) {
                 Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.too_many_errors));
-                mFragment.finish();
+                mFragment.closePlayer();
             }
         }
     }
@@ -479,7 +479,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     Timber.d("item is null - aborting play");
                     if (mFragment != null) {
                         Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_cannot_play));
-                        mFragment.requireActivity().finish();
+                        mFragment.closePlayer();
                     }
                     return;
                 }
@@ -499,7 +499,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                                 .setNegativeButton(R.string.lbl_no, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
-                                        mFragment.requireActivity().finish();
+                                        mFragment.closePlayer();
                                     }
                                 })
                                 .create()
@@ -511,7 +511,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                                 .setPositiveButton(R.string.lbl_ok, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
-                                        mFragment.requireActivity().finish();
+                                        mFragment.closePlayer();
                                     }
                                 })
                                 .create()
@@ -758,7 +758,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         } catch (InterruptedException e) {
             Timber.e(e);
         }
-        if (mFragment != null) mFragment.finish();
+        if (mFragment != null) mFragment.closePlayer();
     }
 
     private void startItem(org.jellyfin.sdk.model.api.BaseItemDto item, long position, StreamInfo response) {
@@ -1135,7 +1135,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     public void endPlayback(Boolean closeActivity) {
-        if (closeActivity && mFragment != null) mFragment.getActivity().finish();
+        if (closeActivity && mFragment != null) mFragment.closePlayer();
         stop();
         if (mVideoManager != null)
             mVideoManager.destroy();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackOverlayFragmentHelper.kt
@@ -4,7 +4,7 @@ import org.jellyfin.androidtv.ui.ScreensaverViewModel
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class PlaybackOverlayFragmentHelper(
-	private val fragment: CustomPlaybackOverlayFragment
+	val fragment: CustomPlaybackOverlayFragment
 ) {
 	private val screensaverViewModel by fragment.activityViewModel<ScreensaverViewModel>()
 	private var screensaverLock: (() -> Unit)? = null

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -329,7 +329,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         if (nativeMode) {
             if (mExoPlayer == null) {
                 Timber.e("mExoPlayer should not be null!!");
-                mActivity.finish();
+                _helper.getFragment().closePlayer();
                 return;
             }
             mExoPlayer.setPlayWhenReady(true);


### PR DESCRIPTION
Removing a hidden surprise feature from #2745.

**Changes**
- Rename "finish()" function in CustomPlaybackOverlayFragment to "closePlayer" so it won't be confused with Android's finish function
- Update some activity finish calls to use closePlayer in the PlaybackController & VideoManager

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
