### PR TITLE
Use navigation.goBack instead of activity finish in FullDetailsFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -85,10 +85,6 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 		adapter = MutableObjectAdapter<Row>(PositionableListRowPresenter())
 
 		val currentUser = userRepository.currentUser.value
-		if (currentUser == null) {
-			activity?.finish()
-			return
-		}
 
 		lifecycleScope.launch(Dispatchers.IO) {
 			// Start out with default sections
@@ -96,7 +92,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 			var includeLiveTvRows = false
 
 			// Check for live TV support
-			if (homesections.contains(HomeSectionType.LIVE_TV) && currentUser.policy?.enableLiveTvAccess == true) {
+			if (homesections.contains(HomeSectionType.LIVE_TV) && currentUser?.policy?.enableLiveTvAccess == true) {
 				// This is kind of ugly, but it mirrors how web handles the live TV rows on the home screen
 				// If we can retrieve one live TV recommendation, then we should display the rows
 				val recommendedPrograms by api.liveTvApi.getRecommendedPrograms(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1359,7 +1359,11 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                                             Utils.showToast(requireContext(), mSeriesTimerInfo.getName() + " Canceled");
                                             dataRefreshService.getValue().setLastDeletedItemId(UUIDSerializerKt.toUUID(mSeriesTimerInfo.getId()));
-                                            requireActivity().finish();
+                                            if (navigationRepository.getValue().getCanGoBack()) {
+                                                navigationRepository.getValue().goBack();
+                                            } else {
+                                                navigationRepository.getValue().reset(Destinations.INSTANCE.getHome());
+                                            }
                                         }
 
                                         @Override


### PR DESCRIPTION

**Changes**
- Use navigation.goBack instead of activity finish in FullDetailsFragment when deleting a series timer (I believe that's a scheduled recording for live tv?)
- Remove an obsolete check in HomeRowsFragment (the MainActivity already checks auth)
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
