### PR TITLE
Fix view binding leak in fragments

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -207,6 +207,8 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+
+        binding = null;
         mGridView = null;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -26,14 +26,16 @@ import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.ImageUtils
 import org.koin.android.ext.android.inject
 
-class HomeFragment : Fragment(R.layout.fragment_home) {
-	private lateinit var binding: FragmentHomeBinding
+class HomeFragment : Fragment() {
+	private var _binding: FragmentHomeBinding? = null
+	private val binding get() = _binding!!
+
 	private val sessionRepository by inject<SessionRepository>()
 	private val userRepository by inject<UserRepository>()
 	private val navigationRepository by inject<NavigationRepository>()
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		binding = FragmentHomeBinding.inflate(inflater, container, false)
+		_binding = FragmentHomeBinding.inflate(inflater, container, false)
 
 		binding.settings.setOnClickListener {
 			navigationRepository.navigate(Destinations.userPreferences)
@@ -63,6 +65,12 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
 				}
 			}
 		}
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	private fun setUserImage(image: String?) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.FragmentPictureViewerBinding
@@ -46,7 +45,8 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 	private val screensaverViewModel by activityViewModel<ScreensaverViewModel>()
 	private val pictureViewerViewModel by activityViewModel<PictureViewerViewModel>()
 	private val api by inject<ApiClient>()
-	private lateinit var binding: FragmentPictureViewerBinding
+	private var _binding: FragmentPictureViewerBinding? = null
+	private val binding get() = _binding!!
 
 	private var actionHideTimer: Job? = null
 
@@ -79,7 +79,7 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentPictureViewerBinding.inflate(inflater, container, false)
+		_binding = FragmentPictureViewerBinding.inflate(inflater, container, false)
 		binding.actionPrevious.setOnClickListener {
 			pictureViewerViewModel.showPrevious()
 			resetHideActionsTimer()
@@ -117,6 +117,12 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 				binding.actionPlayPause.isActivated = active
 			}
 		}
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	private val keyHandler = createKeyHandler {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -252,6 +252,13 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        binding = null;
+    }
+
+    @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (mItemsToPlay == null || mItemsToPlay.size() == 0) return;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -25,8 +25,10 @@ class NextUpFragment : Fragment() {
 		const val ARGUMENT_ITEM_ID = "item_id"
 	}
 
+	private var _binding: FragmentNextUpBinding? = null
+	private val binding get() = _binding!!
+
 	private val viewModel: NextUpViewModel by viewModel()
-	private lateinit var binding: FragmentNextUpBinding
 	private val backgroundService: BackgroundService by inject()
 	private val userPreferences: UserPreferences by inject()
 	private val navigationRepository: NavigationRepository by inject()
@@ -55,7 +57,7 @@ class NextUpFragment : Fragment() {
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentNextUpBinding.inflate(inflater, container, false)
+		_binding = FragmentNextUpBinding.inflate(inflater, container, false)
 
 		viewLifecycleOwner.lifecycleScope.launch {
 			viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -111,5 +113,11 @@ class NextUpFragment : Fragment() {
 		super.onPause()
 
 		binding.fragmentNextUpButtons.stopTimer()
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ButtonRemapDialogFragment.kt
@@ -11,7 +11,8 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.PreferenceButtonRemapBinding
 
 class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
-	private lateinit var binding: PreferenceButtonRemapBinding
+	private var _binding: PreferenceButtonRemapBinding? = null
+	private val binding get() = _binding!!
 
 	private var dialogTitle: CharSequence? = null
 	private var dialogMessage: CharSequence? = null
@@ -70,7 +71,7 @@ class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
 		val styledContext = ContextThemeWrapper(activity, androidx.leanback.preference.R.style.PreferenceThemeOverlayLeanback)
 		val styledInflater = inflater.cloneInContext(styledContext)
-		binding = PreferenceButtonRemapBinding.inflate(styledInflater, container, false)
+		_binding = PreferenceButtonRemapBinding.inflate(styledInflater, container, false)
 
 		return binding.root
 	}
@@ -108,6 +109,12 @@ class ButtonRemapDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 		}
 
 		setKeyCodeText()
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	private fun setKeyCodeText() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ColorPickerDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/ColorPickerDialogFragment.kt
@@ -28,7 +28,8 @@ class ColorPickerDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 		}
 	}
 
-	private lateinit var binding: PreferenceColorListBinding
+	private var _binding: PreferenceColorListBinding? = null
+	private val binding get() = _binding!!
 	private lateinit var adapter: RecyclerView.Adapter<*>
 
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,7 +46,7 @@ class ColorPickerDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
 		val styledContext = ContextThemeWrapper(activity, androidx.leanback.preference.R.style.PreferenceThemeOverlayLeanback)
 		val styledInflater = inflater.cloneInContext(styledContext)
-		binding = PreferenceColorListBinding.inflate(styledInflater, container, false)
+		_binding = PreferenceColorListBinding.inflate(styledInflater, container, false)
 
 		// Dialog
 		binding.decorTitle.text = preference.dialogTitle
@@ -62,6 +63,12 @@ class ColorPickerDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 		verticalGridView.requestFocus()
 
 		return binding.root
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	/**
@@ -97,8 +104,10 @@ class ColorPickerDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 				holder.button.isChecked -> when (item.key) {
 					@Suppress("MagicNumber")
 					0xFFEEDC00 -> R.color.button_default_disabled_text
+
 					else -> R.color.button_default_normal_text
 				}
+
 				else -> R.color.transparent
 			}
 			holder.buttonbg.background = context?.let {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/custom/RichListDialogFragment.kt
@@ -24,7 +24,8 @@ class RichListDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 		}
 	}
 
-	private lateinit var binding: PreferenceRichListBinding
+	private var _binding: PreferenceRichListBinding? = null
+	private val binding get() = _binding!!
 	private lateinit var adapter: RecyclerView.Adapter<*>
 
 	private fun <K> RichListPreference<K>.createAdapter() = Adapter(
@@ -43,6 +44,7 @@ class RichListDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 				},
 				selectedValue = preference.value
 			)
+
 			is RichListPreference<*> -> preference.createAdapter()
 			else -> throw NotImplementedError()
 		}
@@ -51,7 +53,7 @@ class RichListDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 	public override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
 		val styledContext = ContextThemeWrapper(activity, androidx.leanback.preference.R.style.PreferenceThemeOverlayLeanback)
 		val styledInflater = inflater.cloneInContext(styledContext)
-		binding = PreferenceRichListBinding.inflate(styledInflater, container, false)
+		_binding = PreferenceRichListBinding.inflate(styledInflater, container, false)
 
 		// Dialog
 		binding.decorTitle.text = preference.dialogTitle
@@ -68,6 +70,12 @@ class RichListDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 		verticalGridView.requestFocus()
 
 		return binding.root
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	/**
@@ -116,6 +124,7 @@ class RichListDialogFragment : LeanbackPreferenceDialogFragmentCompat() {
 				holder.summary.text = item.summary
 				holder.summary.isVisible = item.summary?.isNotBlank() == true
 			}
+
 			is RichListItem.RichListSection -> {
 				holder as CategoryViewHolder
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
@@ -8,10 +8,11 @@ import androidx.fragment.app.Fragment
 import org.jellyfin.androidtv.databinding.FragmentAlertConnectHelpBinding
 
 class ConnectHelpAlertFragment : Fragment() {
-	private lateinit var binding: FragmentAlertConnectHelpBinding
+	private var _binding: FragmentAlertConnectHelpBinding? = null
+	private val binding get() = _binding!!
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentAlertConnectHelpBinding.inflate(inflater, container, false)
+		_binding = FragmentAlertConnectHelpBinding.inflate(inflater, container, false)
 		return binding.root
 	}
 
@@ -22,5 +23,11 @@ class ConnectHelpAlertFragment : Fragment() {
 			requestFocus()
 			setOnClickListener { parentFragmentManager.popBackStack() }
 		}
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -33,12 +33,13 @@ import org.jellyfin.androidtv.util.getSummary
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class SelectServerFragment : Fragment() {
-	private lateinit var binding: FragmentSelectServerBinding
+	private var _binding: FragmentSelectServerBinding? = null
+	private val binding get() = _binding!!
 	private val startupViewModel: StartupViewModel by activityViewModel()
 
 	@Suppress("LongMethod")
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		binding = FragmentSelectServerBinding.inflate(inflater, container, false)
+		_binding = FragmentSelectServerBinding.inflate(inflater, container, false)
 
 		// Create spacing for recycler view of 8dp
 		@Suppress("MagicNumber")
@@ -162,6 +163,12 @@ class SelectServerFragment : Fragment() {
 		binding.root.requestFocus()
 
 		return binding.root
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	override fun onResume() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerAddFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerAddFragment.kt
@@ -27,12 +27,13 @@ class ServerAddFragment : Fragment() {
 	}
 
 	private val startupViewModel: ServerAddViewModel by viewModel()
-	private lateinit var binding: FragmentServerAddBinding
+	private var _binding: FragmentServerAddBinding? = null
+	private val binding get() = _binding!!
 
 	private val serverAddressArgument get() = arguments?.getString(ARG_SERVER_ADDRESS)?.ifBlank { null }
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentServerAddBinding.inflate(inflater, container, false)
+		_binding = FragmentServerAddBinding.inflate(inflater, container, false)
 
 		with(binding.address) {
 			setOnEditorActionListener { _, actionId, _ ->
@@ -41,6 +42,7 @@ class ServerAddFragment : Fragment() {
 						submitAddress()
 						true
 					}
+
 					else -> false
 				}
 			}
@@ -74,6 +76,7 @@ class ServerAddFragment : Fragment() {
 						// Update state text
 						binding.error.text = getString(R.string.server_connecting, state.address)
 					}
+
 					is UnableToConnectState -> {
 						// Enable form
 						binding.address.isEnabled = true
@@ -86,6 +89,7 @@ class ServerAddFragment : Fragment() {
 								.joinToString(prefix = "\n", separator = "\n")
 						)
 					}
+
 					is ConnectedState -> parentFragmentManager.commit {
 						// Open server view
 						replace<StartupToolbarFragment>(R.id.content_view)
@@ -97,10 +101,17 @@ class ServerAddFragment : Fragment() {
 							)
 						)
 					}
+
 					null -> Unit
 				}
 			}
 		}
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	private fun submitAddress() = when {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -53,7 +53,8 @@ class ServerFragment : Fragment() {
 	private val authenticationRepository: AuthenticationRepository by inject()
 	private val serverUserRepository: ServerUserRepository by inject()
 	private val backgroundService: BackgroundService by inject()
-	private lateinit var binding: FragmentServerBinding
+	private var _binding: FragmentServerBinding? = null
+	private val binding get() = _binding!!
 
 	private val serverIdArgument get() = arguments?.getString(ARG_SERVER_ID)?.ifBlank { null }?.toUUIDOrNull()
 
@@ -65,7 +66,7 @@ class ServerFragment : Fragment() {
 			return null
 		}
 
-		binding = FragmentServerBinding.inflate(inflater, container, false)
+		_binding = FragmentServerBinding.inflate(inflater, container, false)
 
 		val userAdapter = UserAdapter(requireContext(), server, startupViewModel, authenticationRepository, serverUserRepository)
 		userAdapter.onItemPressed = { user ->
@@ -82,7 +83,8 @@ class ServerFragment : Fragment() {
 						))
 						// Errors
 						ServerUnavailableState,
-						is ApiClientErrorLoginState-> Toast.makeText(context, R.string.server_connection_failed, Toast.LENGTH_LONG).show()
+						is ApiClientErrorLoginState -> Toast.makeText(context, R.string.server_connection_failed, Toast.LENGTH_LONG).show()
+
 						is ServerVersionNotSupported -> Toast.makeText(
 							context,
 							getString(R.string.server_unsupported, state.server.version, ServerRepository.minimumServerVersion.toString()),
@@ -118,6 +120,12 @@ class ServerFragment : Fragment() {
 		}
 
 		return binding.root
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	private fun onServerChange(server: Server) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/StartupToolbarFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/StartupToolbarFragment.kt
@@ -15,10 +15,11 @@ import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.preference.screen.AuthPreferencesScreen
 
 class StartupToolbarFragment : Fragment() {
-	private lateinit var binding: FragmentToolbarStartupBinding
+	private var _binding: FragmentToolbarStartupBinding? = null
+	private val binding get() = _binding!!
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		binding = FragmentToolbarStartupBinding.inflate(inflater, container, false)
+		_binding = FragmentToolbarStartupBinding.inflate(inflater, container, false)
 
 		binding.help.setOnClickListener {
 			parentFragmentManager.commit {
@@ -37,5 +38,11 @@ class StartupToolbarFragment : Fragment() {
 		}
 
 		return binding.root
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
@@ -22,10 +22,11 @@ import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class UserLoginCredentialsFragment : Fragment() {
 	private val userLoginViewModel: UserLoginViewModel by activityViewModel()
-	private lateinit var binding: FragmentUserLoginCredentialsBinding
+	private var _binding: FragmentUserLoginCredentialsBinding? = null
+	private val binding get() = _binding!!
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentUserLoginCredentialsBinding.inflate(inflater, container, false)
+		_binding = FragmentUserLoginCredentialsBinding.inflate(inflater, container, false)
 
 		with(binding.username) {
 			// Prefill username
@@ -43,6 +44,7 @@ class UserLoginCredentialsFragment : Fragment() {
 						loginWithCredentials()
 						true
 					}
+
 					else -> false
 				}
 			}
@@ -71,6 +73,7 @@ class UserLoginCredentialsFragment : Fragment() {
 						state.server.version,
 						ServerRepository.minimumServerVersion.toString()
 					))
+
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)
 					RequireSignInState -> binding.error.setText(R.string.login_invalid_credentials)
 					ServerUnavailableState,
@@ -84,6 +87,12 @@ class UserLoginCredentialsFragment : Fragment() {
 		}
 	}
 
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
+	}
+
 	private fun loginWithCredentials() {
 		when {
 			binding.username.text.isNotBlank() -> lifecycleScope.launch {
@@ -92,6 +101,7 @@ class UserLoginCredentialsFragment : Fragment() {
 					binding.password.text.toString()
 				)
 			}
+
 			else -> binding.error.setText(R.string.login_username_field_empty)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginFragment.kt
@@ -30,7 +30,8 @@ class UserLoginFragment : Fragment() {
 
 	private val userLoginViewModel: UserLoginViewModel by activityViewModel()
 	private val backgroundService: BackgroundService by inject()
-	private lateinit var binding: FragmentUserLoginBinding
+	private var _binding: FragmentUserLoginBinding? = null
+	private val binding get() = _binding!!
 
 	private val usernameArgument get() = arguments?.getString(ARG_USERNAME)?.ifBlank { null }
 	private val serverIdArgument get() = arguments?.getString(ARG_SERVER_ID)?.ifBlank { null }
@@ -44,7 +45,7 @@ class UserLoginFragment : Fragment() {
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentUserLoginBinding.inflate(inflater, container, false)
+		_binding = FragmentUserLoginBinding.inflate(inflater, container, false)
 
 		binding.cancel.setOnClickListener { parentFragmentManager.popBackStack() }
 		binding.useCredentials.setOnClickListener { setLoginMethod<UserLoginCredentialsFragment>() }
@@ -80,6 +81,12 @@ class UserLoginFragment : Fragment() {
 				if (state == UnavailableQuickConnectState) setLoginMethod<UserLoginCredentialsFragment>()
 			}
 		}
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	private inline fun <reified T : Fragment> setLoginMethod() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
@@ -26,10 +26,11 @@ import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class UserLoginQuickConnectFragment : Fragment() {
 	private val userLoginViewModel: UserLoginViewModel by activityViewModel()
-	private lateinit var binding: FragmentUserLoginQuickConnectBinding
+	private var _binding: FragmentUserLoginQuickConnectBinding? = null
+	private val binding get() = _binding!!
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-		binding = FragmentUserLoginQuickConnectBinding.inflate(inflater, container, false)
+		_binding = FragmentUserLoginQuickConnectBinding.inflate(inflater, container, false)
 		return binding.root
 	}
 
@@ -65,6 +66,7 @@ class UserLoginQuickConnectFragment : Fragment() {
 						state.server.version,
 						ServerRepository.minimumServerVersion.toString()
 					))
+
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)
 					RequireSignInState -> binding.error.setText(R.string.login_invalid_credentials)
 					ServerUnavailableState,
@@ -76,6 +78,12 @@ class UserLoginQuickConnectFragment : Fragment() {
 				}
 			}
 		}
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+
+		_binding = null
 	}
 
 	/**


### PR DESCRIPTION
See https://developer.android.com/topic/libraries/view-binding#fragments

**Changes**
- Don't use `lateinit var` for view binding in fragments
- Clean up view binding instance when destroying fragment view

We still have some fragments written in Java that don't store the binding as class property that need migration. Out of the scope for this PR though.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
