### PR TITLE
Fix rare race condition crash in HomeFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -74,7 +74,7 @@ class HomeFragment : Fragment() {
 	}
 
 	private fun setUserImage(image: String?) {
-		Glide.with(requireContext())
+		Glide.with(this)
 			.load(image)
 			.placeholder(R.drawable.ic_switch_users)
 			.centerInside()


### PR DESCRIPTION
When the user image was loaded after the fragment view was destroyed the app could crash. To fix this we send the fragment to Glide instead of the context so it can check if the fragment view is still visible.

**Changes**
- Fix rare race condition crash in HomeFragment


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
