### PR TITLE
Add playback order support to playback rewrite

### DIFF
--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -7,6 +7,7 @@ import org.jellyfin.playback.core.backend.BackendService
 import org.jellyfin.playback.core.backend.PlayerBackendEventListener
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.PlaybackOrder
 import org.jellyfin.playback.core.model.PositionInfo
 import org.jellyfin.playback.core.model.VideoSize
 import org.jellyfin.playback.core.queue.EmptyQueue
@@ -20,6 +21,7 @@ interface PlayerState {
 	val playState: StateFlow<PlayState>
 	val speed: StateFlow<Float>
 	val videoSize: StateFlow<VideoSize>
+	val playbackOrder: StateFlow<PlaybackOrder>
 
 	/**
 	 * The position information for the currently playing item or [PositionInfo.EMPTY]. This
@@ -44,9 +46,11 @@ interface PlayerState {
 	fun fastForward(amount: Duration? = null)
 	fun rewind(amount: Duration? = null)
 
-	// Playback properties (repeat & shuffle are managed by queue)
+	// Playback properties
 
 	fun setSpeed(speed: Float)
+
+	fun setPlaybackOrder(order: PlaybackOrder)
 }
 
 class MutablePlayerState(
@@ -67,6 +71,9 @@ class MutablePlayerState(
 
 	private val _videoSize = MutableStateFlow(VideoSize.EMPTY)
 	override val videoSize: StateFlow<VideoSize> get() = _videoSize.asStateFlow()
+
+	private val _playbackOrder = MutableStateFlow(PlaybackOrder.DEFAULT)
+	override val playbackOrder: StateFlow<PlaybackOrder> get() = _playbackOrder.asStateFlow()
 
 	override val positionInfo: PositionInfo
 		get() = backendService.backend?.getPositionInfo() ?: PositionInfo.EMPTY
@@ -127,5 +134,9 @@ class MutablePlayerState(
 	override fun setSpeed(speed: Float) {
 		_speed.value = speed
 		backendService.backend?.setSpeed(speed)
+	}
+
+	override fun setPlaybackOrder(order: PlaybackOrder) {
+		_playbackOrder.value = order
 	}
 }

--- a/playback/core/src/main/kotlin/model/PlaybackOrder.kt
+++ b/playback/core/src/main/kotlin/model/PlaybackOrder.kt
@@ -1,0 +1,7 @@
+package org.jellyfin.playback.core.model
+
+enum class PlaybackOrder {
+	DEFAULT,
+	RANDOM,
+	SHUFFLE,
+}

--- a/playback/core/src/main/kotlin/queue/EmptyQueue.kt
+++ b/playback/core/src/main/kotlin/queue/EmptyQueue.kt
@@ -3,5 +3,6 @@ package org.jellyfin.playback.core.queue
 import org.jellyfin.playback.core.queue.item.QueueEntry
 
 object EmptyQueue : Queue {
+	override val size: Int = 0
 	override suspend fun getItem(index: Int): QueueEntry? = null
 }

--- a/playback/core/src/main/kotlin/queue/Queue.kt
+++ b/playback/core/src/main/kotlin/queue/Queue.kt
@@ -7,5 +7,10 @@ import org.jellyfin.playback.core.queue.item.QueueEntry
  * the currently playing item and future items.
  */
 interface Queue {
+	/**
+	 * The total size of the queue.
+	 */
+	val size: Int
+
 	suspend fun getItem(index: Int): QueueEntry?
 }

--- a/playback/core/src/main/kotlin/queue/QueueService.kt
+++ b/playback/core/src/main/kotlin/queue/QueueService.kt
@@ -1,13 +1,18 @@
 package org.jellyfin.playback.core.queue
 
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.backend.PlayerBackendEventListener
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.PlaybackOrder
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.queue.item.QueueEntry
 import timber.log.Timber
+import kotlin.math.min
+import kotlin.random.Random
 
 class QueueService(
 	private val setCurrentEntry: (QueueEntry?) -> Unit,
@@ -16,14 +21,28 @@ class QueueService(
 		private const val POSITION_NONE = -1
 	}
 
+	private var currentQueueIndicesPlayed = mutableListOf<Int>()
+	private var currentQueueNextIndices = mutableListOf<Int>()
+
 	override suspend fun onInitialize() {
-		coroutineScope.launch {
-			// Update current queue entry when queue changes
-			state.queue.collect {
-				Timber.d("Queue changed, setting index to 0")
-				setIndex(0)
+		// Reset calculated next-up indices when playback order changes
+		state.playbackOrder.onEach {
+			currentQueueNextIndices.clear()
+		}.launchIn(coroutineScope)
+
+		// Update current queue entry when queue changes
+		state.queue.onEach { queue ->
+			Timber.d("Queue changed, setting index to 0")
+
+			currentQueueIndicesPlayed.clear()
+			currentQueueNextIndices.clear()
+
+			when (state.playbackOrder.value) {
+				PlaybackOrder.DEFAULT -> setIndex(0)
+				PlaybackOrder.RANDOM,
+				PlaybackOrder.SHUFFLE -> setIndex((0 until queue.size).random())
 			}
-		}
+		}.launchIn(coroutineScope)
 
 		manager.backendService.addListener(object : PlayerBackendEventListener {
 			override fun onPlayStateChange(state: PlayState) = Unit
@@ -40,14 +59,73 @@ class QueueService(
 	var currentItemPosition = POSITION_NONE
 		private set
 
+	private fun getNextIndices(amount: Int, usePlaybackOrder: Boolean = true): List<Int> {
+		val order = if (usePlaybackOrder) state.playbackOrder.value else PlaybackOrder.DEFAULT
+		val queue = state.queue.value
+
+		return when (order) {
+			PlaybackOrder.DEFAULT -> {
+				// No need to use currentQueueNextIndices because we can efficiently calculate the next items
+				val remainingItemsSize = queue.size - currentItemPosition - 1
+				if (remainingItemsSize <= 0) emptyList()
+				else Array(min(amount, remainingItemsSize)) { i -> currentItemPosition + i + 1 }.toList()
+			}
+
+			PlaybackOrder.RANDOM -> Array(amount) { i ->
+				if (i <= currentQueueNextIndices.lastIndex) {
+					currentQueueNextIndices[i]
+				} else {
+					val index = Random.nextInt(queue.size)
+					currentQueueNextIndices.add(index)
+					index
+				}
+			}.toList()
+
+			PlaybackOrder.SHUFFLE -> {
+				val remainingItemsSize = queue.size - currentQueueIndicesPlayed.size
+				if (remainingItemsSize <= 0) {
+					emptyList()
+				} else {
+					val remainingIndices = (0..queue.size).filterNot {
+						it in currentQueueIndicesPlayed || it in currentQueueNextIndices
+					}.shuffled()
+
+					Array(min(amount, remainingItemsSize)) { i ->
+						if (i <= currentQueueNextIndices.lastIndex) {
+							currentQueueNextIndices[i]
+						} else {
+							val index = remainingIndices[i - currentQueueNextIndices.size]
+							currentQueueNextIndices.add(index)
+							index
+						}
+					}.toList()
+				}
+			}
+		}
+	}
+
 	// Jumping
 
-	suspend fun previous(): QueueEntry? = setIndex(currentItemPosition - 1)
-	suspend fun next(): QueueEntry? = setIndex(currentItemPosition + 1)
+	suspend fun previous(): QueueEntry? = currentQueueIndicesPlayed.removeLastOrNull()?.let {
+		setIndex(it)
+	}
 
-	suspend fun setIndex(index: Int): QueueEntry? {
+	suspend fun next(usePlaybackOrder: Boolean = true): QueueEntry? {
+		val index = getNextIndices(1, usePlaybackOrder).firstOrNull() ?: return null
+		if (usePlaybackOrder) currentQueueNextIndices.removeFirstOrNull()
+
+		return setIndex(index, true)
+	}
+
+	suspend fun setIndex(index: Int, saveHistory: Boolean = false): QueueEntry? {
 		if (index < 0) return null
 
+		// Save previous index
+		if (saveHistory && currentItemPosition != POSITION_NONE) {
+			currentQueueIndicesPlayed.add(currentItemPosition)
+		}
+
+		// Set new index
 		val currentEntry = state.queue.value.getItem(index)
 		currentItemPosition = if (currentEntry == null) POSITION_NONE else index
 		setCurrentEntry(currentEntry)
@@ -57,12 +135,18 @@ class QueueService(
 
 	// Peeking
 
-	suspend fun peekPrevious(): QueueEntry? = state.queue.value.getItem(currentItemPosition + 1)
-	suspend fun peekNext(): QueueEntry? = state.queue.value.getItem(currentItemPosition + 1)
+	suspend fun peekPrevious(): QueueEntry? = currentQueueIndicesPlayed.lastOrNull()?.let {
+		state.queue.value.getItem(it)
+	}
 
-	suspend fun peekNext(amount: Int): Collection<QueueEntry> = Array(amount) { i ->
-		state.queue.value.getItem(currentItemPosition + i + 1)
-	}.filterNotNull()
+	suspend fun peekNext(
+		usePlaybackOrder: Boolean = true,
+	): QueueEntry? = peekNext(1, usePlaybackOrder).firstOrNull()
+
+	suspend fun peekNext(amount: Int, usePlaybackOrder: Boolean = true): Collection<QueueEntry> {
+		val queue = state.queue.value
+		return getNextIndices(amount, usePlaybackOrder).mapNotNull { index -> queue.getItem(index) }
+	}
 }
 
 inline val PlaybackManager.queue get() = getService<QueueService>()

--- a/playback/jellyfin/src/main/kotlin/queue/AudioAlbumQueue.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioAlbumQueue.kt
@@ -18,6 +18,9 @@ class AudioAlbumQueue(
 		require(album.type == BaseItemKind.MUSIC_ALBUM)
 	}
 
+	override var size: Int = 0
+		private set
+
 	override suspend fun loadPage(offset: Int, size: Int): Collection<QueueEntry> {
 		val result by api.itemsApi.getItemsByUserId(
 			parentId = album.id,
@@ -29,7 +32,9 @@ class AudioAlbumQueue(
 			// Pagination
 			startIndex = offset,
 			limit = size,
+			enableTotalRecordCount = true,
 		)
+		this.size = result.totalRecordCount
 		return result.items.orEmpty().map { BaseItemDtoUserQueueEntry.build(api, it) }
 	}
 }

--- a/playback/jellyfin/src/main/kotlin/queue/AudioInstantMixQueue.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioInstantMixQueue.kt
@@ -28,6 +28,9 @@ class AudioInstantMixQueue(
 		require(item.type in instantMixableItems)
 	}
 
+	override var size: Int = 0
+		private set
+
 	override suspend fun loadPage(offset: Int, size: Int): Collection<QueueEntry> {
 		// API doesn't support paging for instant mix
 		if (offset > 0) return emptyList()
@@ -39,6 +42,7 @@ class AudioInstantMixQueue(
 			// Pagination
 			limit = size,
 		)
+		this.size = result.totalRecordCount
 		return result.items.orEmpty().map { BaseItemDtoUserQueueEntry.build(api, it) }
 	}
 }

--- a/playback/jellyfin/src/main/kotlin/queue/AudioTrackQueue.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioTrackQueue.kt
@@ -16,6 +16,8 @@ class AudioTrackQueue(
 		require(item.type == BaseItemKind.AUDIO)
 	}
 
+	override var size: Int = 1
+
 	override suspend fun loadPage(offset: Int, size: Int): Collection<QueueEntry> {
 		// We only have a single item
 		if (offset > 0) return emptyList()

--- a/playback/jellyfin/src/main/kotlin/queue/EpisodeQueue.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/EpisodeQueue.kt
@@ -18,6 +18,9 @@ class EpisodeQueue(
 		require(episode.type == BaseItemKind.EPISODE)
 	}
 
+	override var size: Int = 0
+		private set
+
 	override suspend fun loadPage(offset: Int, size: Int): Collection<QueueEntry> {
 		val result by api.itemsApi.getItemsByUserId(
 			parentId = episode.parentId,
@@ -31,6 +34,7 @@ class EpisodeQueue(
 			startIndex = offset,
 			limit = size,
 		)
+		this.size = result.totalRecordCount
 		return result.items.orEmpty().map { BaseItemDtoUserQueueEntry.build(api, it) }
 	}
 }


### PR DESCRIPTION
**Changes**

This change adds a new "playbackOrder" property to the playback state. The currently supported values are:

- default - this plays back items in the default order of the queue
- random - this plays random items, infinitely
- shuffle - this plays items in a shuffled order, this is the same as random but every item in the queue can only be played once

Changing the order property only affects the upcoming items in a queue. This means you can play the first 3 items using default order and then switch to shuffling. The queue service keeps track of this and manages the ordering.

To implement this ordering we now need to know the size of a queue, for this a new "size" property is added to the queue interface. I've implemented this properly for the queue used by the RewriteMediaManager but the other queue implementations that aren't used yet have implementations that may not work (expose size=0 until the first getItem call which will never happen because size=0). This will be fixed later, when we start using those queues.

The current playback UI only allows switching between default & shuffle. The random option is not used.

**Issues**

Part of #1057 
