### PR TITLE
Enable playback rewrite by default for music

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -128,6 +128,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var libVLCAudioDelay = intPreference("libvlc_audio_delay", 0)
 
+		/**
+		 * Use playback rewrite module for audio
+		 */
+		var playbackRewriteAudioEnabled = booleanPreference("playback_new_audio", true)
+
 		/* Live TV */
 		/**
 		 * Use direct play
@@ -159,11 +164,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Use playback rewrite module for video
 		 */
 		var playbackRewriteVideoEnabled = booleanPreference("playback_new", false)
-
-		/**
-		 * Use playback rewrite module for audio
-		 */
-		var playbackRewriteAudioEnabled = booleanPreference("playback_new_audio", false)
 
 		/**
 		 * When to show the clock.
@@ -265,6 +265,12 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 						it.getBoolean("pref_refresh_switching", false) -> RefreshRateSwitchingBehavior.SCALE_ON_TV
 						else -> RefreshRateSwitchingBehavior.DISABLED
 					})
+			}
+
+			// v0.15.z to v0.16.0
+			migration(toVersion = 7) {
+				// Enable playback rewrite for music
+				putBoolean("playback_new_audio", true)
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -38,13 +38,6 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 
 					bind(userPreferences, UserPreferences.playbackRewriteVideoEnabled)
 				}
-
-				checkbox {
-					title = "Enable new playback module for audio"
-					setContent(R.string.enable_playback_module_description)
-
-					bind(userPreferences, UserPreferences.playbackRewriteAudioEnabled)
-				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -205,6 +205,20 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 		}
 
 		category {
+			setTitle(R.string.pref_music_cat)
+
+			checkbox {
+				setTitle(R.string.pref_music_rewrite_disable)
+				bind {
+					get { !userPreferences[UserPreferences.playbackRewriteAudioEnabled] }
+					set { value -> userPreferences[UserPreferences.playbackRewriteAudioEnabled] = !value }
+					default { !UserPreferences.playbackRewriteAudioEnabled.defaultValue }
+				}
+				setContent(R.string.pref_music_rewrite_enable_description)
+			}
+		}
+
+		category {
 			setTitle(R.string.pref_live_tv_cat)
 
 			enum<PreferredVideoPlayer> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,9 @@
     <string name="enable_reactive_homepage">Enable reactive homepage</string>
     <string name="not_set">Not set</string>
     <string name="lbl_album_artists">Album artists</string>
+    <string name="pref_music_cat">Music</string>
+    <string name="pref_music_rewrite_disable">Disable new music backend</string>
+    <string name="pref_music_rewrite_enable_description">Only disable this if you\'re experiencing issues with music playback</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
This PR will be in draft until full feature parity is reached, which should be soon.

**Changes**
- Enable playback rewrite for all music playback by default
  - Also enable this for existing installs via a migration
- Add new option to disable playback rewrite for music (will use the old media manager)

**Issues**

edit: of course a part of #1057!
