### PR TITLE
Disable custom key handling when using playback rewrite

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -37,6 +37,7 @@ import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
+import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.util.ImageUtils;
 import org.jellyfin.androidtv.util.KeyProcessor;
@@ -229,6 +230,9 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         if (event.getAction() != KeyEvent.ACTION_UP) return false;
+
+        // Rewrite uses media sessions which the system automatically manipulates on key presses
+        if (mediaManager.getValue() instanceof RewriteMediaManager) return false;
 
         switch (keyCode) {
             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowType;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
+import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
 import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
@@ -60,11 +61,15 @@ public class KeyProcessor {
 
     public static boolean HandleKey(int key, BaseRowItem rowItem, Activity activity) {
         if (rowItem == null) return false;
+        MediaManager mediaManager = KoinJavaComponent.<MediaManager>get(MediaManager.class);
         switch (key) {
             case KeyEvent.KEYCODE_MEDIA_PLAY:
             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                if (KoinJavaComponent.<MediaManager>get(MediaManager.class).isPlayingAudio() && (rowItem.getBaseRowType() != BaseRowType.BaseItem || rowItem.getBaseItemType() != BaseItemKind.PHOTO)) {
-                    KoinJavaComponent.<MediaManager>get(MediaManager.class).pauseAudio();
+                if (mediaManager.isPlayingAudio() && (rowItem.getBaseRowType() != BaseRowType.BaseItem || rowItem.getBaseItemType() != BaseItemKind.PHOTO)) {
+                    // Rewrite uses media sessions which the system automatically manipulates on key presses
+                    if (mediaManager instanceof RewriteMediaManager) return false;
+
+                    mediaManager.pauseAudio();
                     return true;
                 }
 
@@ -129,8 +134,11 @@ public class KeyProcessor {
                         break;
                 }
 
-                if (KoinJavaComponent.<MediaManager>get(MediaManager.class).hasAudioQueueItems()) {
-                    KoinJavaComponent.<MediaManager>get(MediaManager.class).resumeAudio();
+                if (mediaManager.hasAudioQueueItems()) {
+                    // Rewrite uses media sessions which the system automatically manipulates on key presses
+                    if (mediaManager instanceof RewriteMediaManager) return false;
+
+                    mediaManager.resumeAudio();
                     return true;
                 }
 


### PR DESCRIPTION
This fixes a case where both the system and the app would act on key presses at the same time. So when you pressed the "PAUSE_PLAY" button on a remote it would toggle the state twice, so you'd never pause/play the item.

**Changes**
- Disable custom key handling when using playback rewrite

**Issues**

Companion for #2803. Part of #797 