### PR TITLE
Fix race condition in HomeFragment causing a crash

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -81,18 +81,24 @@ class HomeFragment : Fragment() {
 			.circleCrop()
 			.into(object : CustomViewTarget<ImageButton, Drawable>(binding.switchUsers) {
 				override fun onLoadFailed(errorDrawable: Drawable?) {
-					binding.switchUsers.imageTintMode = PorterDuff.Mode.SRC_IN
-					binding.switchUsers.setImageDrawable(errorDrawable)
+					if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+						binding.switchUsers.imageTintMode = PorterDuff.Mode.SRC_IN
+						binding.switchUsers.setImageDrawable(errorDrawable)
+					}
 				}
 
 				override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
-					binding.switchUsers.imageTintMode = null
-					binding.switchUsers.setImageDrawable(resource)
+					if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+						binding.switchUsers.imageTintMode = null
+						binding.switchUsers.setImageDrawable(resource)
+					}
 				}
 
 				override fun onResourceCleared(placeholder: Drawable?) {
-					binding.switchUsers.imageTintMode = PorterDuff.Mode.SRC_IN
-					binding.switchUsers.setImageDrawable(placeholder)
+					if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+						binding.switchUsers.imageTintMode = PorterDuff.Mode.SRC_IN
+						binding.switchUsers.setImageDrawable(placeholder)
+					}
 				}
 			})
 	}


### PR DESCRIPTION
Crash occurred when the profile picture loads when the view is already destroyed.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix race condition in HomeFragment 
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

I guess #2780 wasn't enough
