### PR TITLE
Add repeat mode to playback rewrite

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -22,6 +22,7 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PlaybackOrder
+import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.queue.Queue
 import org.jellyfin.playback.core.queue.item.QueueEntry
 import org.jellyfin.playback.jellyfin.queue.item.BaseItemDtoUserQueueEntry
@@ -59,14 +60,16 @@ class RewriteMediaManager(
 		get() = (playbackManager.state.queue.entry.value as? BaseItemDtoUserQueueEntry)?.baseItem
 
 	override fun toggleRepeat(): Boolean {
-		isRepeatMode = !isRepeatMode
-		// TODO
-		Toast.makeText(context, "Not yet implemented", Toast.LENGTH_LONG).show()
+		val newMode = when (playbackManager.state.repeatMode.value) {
+			RepeatMode.NONE -> RepeatMode.REPEAT_ENTRY_INFINITE
+			else -> RepeatMode.NONE
+		}
+		playbackManager.state.setRepeatMode(newMode)
+
 		return isRepeatMode
 	}
 
-	override var isRepeatMode: Boolean = false
-		private set
+	override val isRepeatMode get() = playbackManager.state.repeatMode.value != RepeatMode.NONE
 
 	override val isAudioPlayerInitialized: Boolean = true
 	override val isShuffleMode: Boolean

--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -10,6 +10,7 @@ import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PlaybackOrder
 import org.jellyfin.playback.core.model.PositionInfo
+import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.model.VideoSize
 import org.jellyfin.playback.core.queue.DefaultPlayerQueueState
 import org.jellyfin.playback.core.queue.EmptyQueue
@@ -23,6 +24,7 @@ interface PlayerState {
 	val speed: StateFlow<Float>
 	val videoSize: StateFlow<VideoSize>
 	val playbackOrder: StateFlow<PlaybackOrder>
+	val repeatMode: StateFlow<RepeatMode>
 
 	/**
 	 * The position information for the currently playing item or [PositionInfo.EMPTY]. This
@@ -51,6 +53,8 @@ interface PlayerState {
 	fun setSpeed(speed: Float)
 
 	fun setPlaybackOrder(order: PlaybackOrder)
+
+	fun setRepeatMode(mode: RepeatMode)
 }
 
 class MutablePlayerState(
@@ -71,6 +75,9 @@ class MutablePlayerState(
 
 	private val _playbackOrder = MutableStateFlow(PlaybackOrder.DEFAULT)
 	override val playbackOrder: StateFlow<PlaybackOrder> get() = _playbackOrder.asStateFlow()
+
+	private val _repeatMode = MutableStateFlow(RepeatMode.NONE)
+	override val repeatMode: StateFlow<RepeatMode> get() = _repeatMode.asStateFlow()
 
 	override val positionInfo: PositionInfo
 		get() = backendService.backend?.getPositionInfo() ?: PositionInfo.EMPTY
@@ -134,5 +141,9 @@ class MutablePlayerState(
 
 	override fun setPlaybackOrder(order: PlaybackOrder) {
 		_playbackOrder.value = order
+	}
+
+	override fun setRepeatMode(mode: RepeatMode) {
+		_repeatMode.value = mode
 	}
 }

--- a/playback/core/src/main/kotlin/model/RepeatMode.kt
+++ b/playback/core/src/main/kotlin/model/RepeatMode.kt
@@ -1,0 +1,7 @@
+package org.jellyfin.playback.core.model
+
+enum class RepeatMode {
+	NONE,
+	REPEAT_ENTRY_ONCE,
+	REPEAT_ENTRY_INFINITE,
+}

--- a/playback/core/src/main/kotlin/queue/order/DefaultOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/DefaultOrderIndexProvider.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.playback.core.queue.order
+
+import org.jellyfin.playback.core.queue.Queue
+import kotlin.math.min
+
+internal class DefaultOrderIndexProvider : OrderIndexProvider {
+	override fun provideIndices(
+		amount: Int,
+		queue: Queue,
+		playedIndices: Collection<Int>,
+		currentIndex: Int,
+	): Collection<Int> {
+		// No need to use currentQueueNextIndices because we can efficiently calculate the next items
+		val remainingItemsSize = queue.size - currentIndex - 1
+
+		return if (remainingItemsSize <= 0) emptyList()
+		else Array(min(amount, remainingItemsSize)) { i -> currentIndex + i + 1 }.toList()
+	}
+}

--- a/playback/core/src/main/kotlin/queue/order/OrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/OrderIndexProvider.kt
@@ -1,0 +1,34 @@
+package org.jellyfin.playback.core.queue.order
+
+import org.jellyfin.playback.core.queue.PlayerQueueState
+import org.jellyfin.playback.core.queue.Queue
+
+internal interface OrderIndexProvider {
+	/**
+	 * Called when the queue changes. Used to reset internal state of the provider.
+	 */
+	fun reset() = Unit
+
+	/**
+	 * Collect the next [amount] of indices to play.
+	 *
+	 * @param amount The maximum amount of indices to retrieve. May be less if there are none left.
+	 * @param queue The queue to generate indices for.
+	 * @param playedIndices The previously played indices, this may include the [currentIndex].
+	 * @param currentIndex The currently playing index or [PlayerQueueState.INDEX_NONE].
+	 *
+	 * @return A collection no more than [amount] items of indices to play next.
+	 */
+	fun provideIndices(
+		amount: Int,
+		queue: Queue,
+		playedIndices: Collection<Int>,
+		currentIndex: Int,
+	): Collection<Int>
+
+	/**
+	 * Called when the next index returned by [provideIndices] is starting to play. Used to
+	 * modify internal state for the provider.
+	 */
+	fun useNextIndex() = Unit
+}

--- a/playback/core/src/main/kotlin/queue/order/RandomOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/RandomOrderIndexProvider.kt
@@ -1,0 +1,29 @@
+package org.jellyfin.playback.core.queue.order
+
+import org.jellyfin.playback.core.queue.Queue
+import kotlin.random.Random
+
+internal class RandomOrderIndexProvider : OrderIndexProvider {
+	private val nextIndices = mutableListOf<Int>()
+
+	override fun reset() = nextIndices.clear()
+
+	override fun provideIndices(
+		amount: Int,
+		queue: Queue,
+		playedIndices: Collection<Int>,
+		currentIndex: Int,
+	) = List(amount) { i ->
+		if (i <= nextIndices.lastIndex) {
+			nextIndices[i]
+		} else {
+			val index = Random.nextInt(queue.size)
+			nextIndices.add(index)
+			index
+		}
+	}
+
+	override fun useNextIndex() {
+		nextIndices.removeFirst()
+	}
+}

--- a/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
@@ -1,0 +1,40 @@
+package org.jellyfin.playback.core.queue.order
+
+import org.jellyfin.playback.core.queue.Queue
+import kotlin.math.min
+
+internal class ShuffleOrderIndexProvider : OrderIndexProvider {
+	private val nextIndices = mutableListOf<Int>()
+
+	override fun reset() = nextIndices.clear()
+
+	override fun provideIndices(
+		amount: Int,
+		queue: Queue,
+		playedIndices: Collection<Int>,
+		currentIndex: Int,
+	): Collection<Int> {
+		val remainingItemsSize = queue.size - playedIndices.size
+		return if (remainingItemsSize <= 0) {
+			emptyList()
+		} else {
+			val remainingIndices = (0..queue.size).filterNot {
+				it in playedIndices || it in nextIndices
+			}.shuffled()
+
+			List(min(amount, remainingItemsSize)) { i ->
+				if (i <= nextIndices.lastIndex) {
+					nextIndices[i]
+				} else {
+					val index = remainingIndices[i - nextIndices.size]
+					nextIndices.add(index)
+					index
+				}
+			}
+		}
+	}
+
+	override fun useNextIndex() {
+		nextIndices.removeFirst()
+	}
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Add repeatMode
  - Can be turned off, set to repeat the entry once or repeat the entry infinitely
    - Will likely add REPEAT_QUEUE_INFINITE at some point
  - Media sessions can change this (off/entry-infinite)
  - AudioFragment thingy can change this (off/entry-infinite)
- Move index providers for playback order to separate files to clean up the PlayerQueueState class

**Issues**

Part of #1057