### PR TITLE
Fix InfoLayoutHelper not using first video stream, update details when selecting version

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -158,8 +158,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     BaseItemDto mBaseItem;
 
     private ArrayList<MediaSourceInfo> versions;
-    private int selectedVersionPopupIndex = 0;
-
     private Lazy<ApiClient> apiClient = inject(ApiClient.class);
     private Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
@@ -1383,16 +1381,15 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
         for (int i = 0; i< versions.size(); i++) {
             MenuItem item = menu.getMenu().add(Menu.NONE, i, Menu.NONE, versions.get(i).getName());
-            item.setChecked(i == selectedVersionPopupIndex);
+            item.setChecked(i == mDetailsOverviewRow.getSelectedMediaSourceIndex());
         }
 
         menu.getMenu().setGroupCheckable(0,true,false);
         menu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem menuItem) {
-                selectedVersionPopupIndex = menuItem.getItemId();
-                mDetailsOverviewRow.setSelectedMediaSourceIndex(selectedVersionPopupIndex);
-                apiClient.getValue().GetItemAsync(versions.get(selectedVersionPopupIndex).getId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new LifecycleAwareResponse<BaseItemDto>(getLifecycle()) {
+                mDetailsOverviewRow.setSelectedMediaSourceIndex(menuItem.getItemId());
+                apiClient.getValue().GetItemAsync(versions.get(mDetailsOverviewRow.getSelectedMediaSourceIndex()).getId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new LifecycleAwareResponse<BaseItemDto>(getLifecycle()) {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         if (!getActive()) return;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1391,12 +1391,14 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             @Override
             public boolean onMenuItemClick(MenuItem menuItem) {
                 selectedVersionPopupIndex = menuItem.getItemId();
+                mDetailsOverviewRow.setSelectedMediaSourceIndex(selectedVersionPopupIndex);
                 apiClient.getValue().GetItemAsync(versions.get(selectedVersionPopupIndex).getId(), KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString(), new LifecycleAwareResponse<BaseItemDto>(getLifecycle()) {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         if (!getActive()) return;
 
                         mBaseItem = response;
+                        mDorPresenter.getViewHolder().setItem(mDetailsOverviewRow);
                     }
                 });
                 return true;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
@@ -14,7 +14,7 @@ class MyDetailsOverviewRow @JvmOverloads constructor(
 	var infoItem1: InfoItem? = null,
 	var infoItem2: InfoItem? = null,
 	var infoItem3: InfoItem? = null,
-	var selectedMediaSourceIndex: Int = 0
+	var selectedMediaSourceIndex: Int = 0,
 ) : Row() {
 	private val _actions = mutableListOf<TextUnderButton>()
 	val actions get() = _actions.toList()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
@@ -14,6 +14,7 @@ class MyDetailsOverviewRow @JvmOverloads constructor(
 	var infoItem1: InfoItem? = null,
 	var infoItem2: InfoItem? = null,
 	var infoItem3: InfoItem? = null,
+	var selectedMediaSourceIndex: Int = 0
 ) : Row() {
 	private val _actions = mutableListOf<TextUnderButton>()
 	val actions get() = _actions.toList()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
@@ -24,7 +24,7 @@ class MyDetailsOverviewRowPresenter(
 		fun setItem(row: MyDetailsOverviewRow) {
 			setTitle(row.item.name)
 
-			InfoLayoutHelper.addInfoRow(view.context, row.item, binding.fdMainInfoRow, false, false)
+			InfoLayoutHelper.addInfoRow(view.context, row.item, row.selectedMediaSourceIndex, binding.fdMainInfoRow, false, false)
 			binding.fdGenreRow.text = row.item.genres?.joinToString(" / ")
 
 			binding.infoTitle1.text = row.infoItem1?.label

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -45,6 +45,7 @@ public class InfoLayoutHelper {
                 break;
         }
     }
+
     public static void addInfoRow(Context context, BaseItemDto item, int mediaSourceIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
         layout.removeAllViews();
         if (item.getId() != null) {
@@ -336,7 +337,7 @@ public class InfoLayoutHelper {
 
         MediaStream videoStream = StreamHelper.getFirstVideoStream(item, mediaSourceIndex);
 
-        if(videoStream != null && videoStream.getWidth() != null && videoStream.getHeight() != null) {
+        if (videoStream != null && videoStream.getWidth() != null && videoStream.getHeight() != null) {
             int width = videoStream.getWidth();
             int height = videoStream.getHeight();
             if (width <= 960 && height <= 576) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -336,26 +336,24 @@ public class InfoLayoutHelper {
 
         MediaStream videoStream = StreamHelper.getFirstVideoStream(item, selectedVersionPopupIndex);
 
-        if (videoStream != null) {
-            if(videoStream.getWidth() != null && videoStream.getHeight() != null) {
-                int width = videoStream.getWidth();
-                int height = videoStream.getHeight();
-                if (width <= 960 && height <= 576) {
-                    addBlockText(context, layout, context.getString(R.string.lbl_sd));
-                } else if (width <= 1280 && height <= 962) {
-                    addBlockText(context, layout, "720");
-                } else if (width <= 1920 && height <= 1440) {
-                    addBlockText(context, layout, "1080");
-                } else if (width <= 4096 && height <= 3072) {
-                    addBlockText(context, layout, "4K");
-                } else {
-                    addBlockText(context, layout, "8K");
-                }
-
-                addSpacer(context, layout, " ");
-
-                addVideoCodecDetails(context, layout, videoStream);
+        if(videoStream != null && videoStream.getWidth() != null && videoStream.getHeight() != null) {
+            int width = videoStream.getWidth();
+            int height = videoStream.getHeight();
+            if (width <= 960 && height <= 576) {
+                addBlockText(context, layout, context.getString(R.string.lbl_sd));
+            } else if (width <= 1280 && height <= 962) {
+                addBlockText(context, layout, "720");
+            } else if (width <= 1920 && height <= 1440) {
+                addBlockText(context, layout, "1080");
+            } else if (width <= 4096 && height <= 3072) {
+                addBlockText(context, layout, "4K");
+            } else {
+                addBlockText(context, layout, "8K");
             }
+
+            addSpacer(context, layout, " ");
+
+            addVideoCodecDetails(context, layout, videoStream);
         }
         if (Utils.isTrue(item.getHasSubtitles())) {
             addBlockText(context, layout, "CC");

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -58,7 +58,7 @@ public class InfoLayoutHelper {
         addInfoRow(context, item, 0, layout, includeRuntime, includeEndTime);
     }
 
-    public static void addInfoRow(Context context, BaseItemDto item, int selectedVersionPopupIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
+    public static void addInfoRow(Context context, BaseItemDto item, int mediaSourceIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
         RatingType ratingType = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getDefaultRatingType());
         if (ratingType != RatingType.RATING_HIDDEN) {
             addCriticInfo(context, item, layout);
@@ -103,7 +103,7 @@ public class InfoLayoutHelper {
         }
         if (includeRuntime) addRuntime(context, item, layout, includeEndTime);
         addSeriesStatus(context, item, layout);
-        addRatingAndRes(context, item, selectedVersionPopupIndex, layout);
+        addRatingAndRes(context, item, mediaSourceIndex, layout);
         addMediaDetails(context, audioStream, layout);
     }
 
@@ -328,13 +328,13 @@ public class InfoLayoutHelper {
 
     }
 
-    private static void addRatingAndRes(Context context, BaseItemDto item, int selectedVersionPopupIndex, LinearLayout layout) {
+    private static void addRatingAndRes(Context context, BaseItemDto item, int mediaSourceIndex, LinearLayout layout) {
         if (item.getOfficialRating() != null && !item.getOfficialRating().equals("0")) {
             addBlockText(context, layout, item.getOfficialRating());
             addSpacer(context, layout, "  ");
         }
 
-        MediaStream videoStream = StreamHelper.getFirstVideoStream(item, selectedVersionPopupIndex);
+        MediaStream videoStream = StreamHelper.getFirstVideoStream(item, mediaSourceIndex);
 
         if(videoStream != null && videoStream.getWidth() != null && videoStream.getHeight() != null) {
             int width = videoStream.getWidth();

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -45,10 +45,10 @@ public class InfoLayoutHelper {
                 break;
         }
     }
-    public static void addInfoRow(Context context, BaseItemDto item, int selectedVersionPopupIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
+    public static void addInfoRow(Context context, BaseItemDto item, int mediaSourceIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
         layout.removeAllViews();
         if (item.getId() != null) {
-            addInfoRow(context, item, selectedVersionPopupIndex, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
+            addInfoRow(context, item, mediaSourceIndex, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
         }else{
             addProgramChannel(context, item, layout);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -20,6 +20,7 @@ import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.jellyfin.sdk.model.api.MediaStream;
+import org.jellyfin.sdk.model.api.MediaStreamType;
 import org.jellyfin.sdk.model.api.SeriesStatus;
 import org.koin.java.KoinJavaComponent;
 
@@ -27,6 +28,7 @@ import java.text.NumberFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Optional;
 
 public class InfoLayoutHelper {
 
@@ -330,25 +332,33 @@ public class InfoLayoutHelper {
             addBlockText(context, layout, item.getOfficialRating());
             addSpacer(context, layout, "  ");
         }
-        if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0 && item.getMediaStreams().get(0).getWidth() != null && item.getMediaStreams().get(0).getHeight() != null) {
-            int width = item.getMediaStreams().get(0).getWidth();
-            int height = item.getMediaStreams().get(0).getHeight();
-            if (width <= 960 && height <= 576) {
-                addBlockText(context, layout, context.getString(R.string.lbl_sd));
-            } else if (width <= 1280 && height <= 962) {
-                addBlockText(context, layout, "720");
-            } else if (width <= 1920 && height <= 1440) {
-                addBlockText(context, layout, "1080");
-            } else if (width <= 4096 && height <= 3072) {
-                addBlockText(context, layout, "4K");
-            } else {
-                addBlockText(context, layout, "8K");
+        if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0) {
+            Optional<MediaStream> optionalVideoStream = item.getMediaStreams()
+                    .stream()
+                    .filter(x -> x.getType() == MediaStreamType.VIDEO)
+                    .findFirst();
+            if (optionalVideoStream.isPresent()) {
+                MediaStream videoStream = optionalVideoStream.get();
+                if(videoStream.getWidth() != null && videoStream.getHeight() != null) {
+                    int width = videoStream.getWidth();
+                    int height = videoStream.getHeight();
+                    if (width <= 960 && height <= 576) {
+                        addBlockText(context, layout, context.getString(R.string.lbl_sd));
+                    } else if (width <= 1280 && height <= 962) {
+                        addBlockText(context, layout, "720");
+                    } else if (width <= 1920 && height <= 1440) {
+                        addBlockText(context, layout, "1080");
+                    } else if (width <= 4096 && height <= 3072) {
+                        addBlockText(context, layout, "4K");
+                    } else {
+                        addBlockText(context, layout, "8K");
+                    }
+
+                    addSpacer(context, layout, " ");
+
+                    addVideoCodecDetails(context, layout, videoStream);
+                }
             }
-
-            addSpacer(context, layout, " ");
-
-            addVideoCodecDetails(context, layout, item.getMediaStreams().get(0));
-
         }
         if (Utils.isTrue(item.getHasSubtitles())) {
             addBlockText(context, layout, "CC");

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -47,17 +47,20 @@ public class InfoLayoutHelper {
                 break;
         }
     }
-
-    public static void addInfoRow(Context context, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
+    public static void addInfoRow(Context context, BaseItemDto item, int selectedVersionPopupIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
         layout.removeAllViews();
         if (item.getId() != null) {
-            addInfoRow(context, item, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
+            addInfoRow(context, item, selectedVersionPopupIndex, layout, includeRuntime, includeEndTime, StreamHelper.getFirstAudioStream(item));
         }else{
             addProgramChannel(context, item, layout);
         }
     }
 
-    public static void addInfoRow(Context context, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
+    public static void addInfoRow(Context context, BaseItemDto item, LinearLayout layout, boolean includeRuntime, boolean includeEndTime) {
+        addInfoRow(context, item, 0, layout, includeRuntime, includeEndTime);
+    }
+
+    public static void addInfoRow(Context context, BaseItemDto item, int selectedVersionPopupIndex, LinearLayout layout, boolean includeRuntime, boolean includeEndTime, MediaStream audioStream) {
         RatingType ratingType = KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getDefaultRatingType());
         if (ratingType != RatingType.RATING_HIDDEN) {
             addCriticInfo(context, item, layout);
@@ -102,7 +105,7 @@ public class InfoLayoutHelper {
         }
         if (includeRuntime) addRuntime(context, item, layout, includeEndTime);
         addSeriesStatus(context, item, layout);
-        addRatingAndRes(context, item, layout);
+        addRatingAndRes(context, item, selectedVersionPopupIndex, layout);
         addMediaDetails(context, audioStream, layout);
     }
 
@@ -327,37 +330,33 @@ public class InfoLayoutHelper {
 
     }
 
-    private static void addRatingAndRes(Context context, BaseItemDto item, LinearLayout layout) {
+    private static void addRatingAndRes(Context context, BaseItemDto item, int selectedVersionPopupIndex, LinearLayout layout) {
         if (item.getOfficialRating() != null && !item.getOfficialRating().equals("0")) {
             addBlockText(context, layout, item.getOfficialRating());
             addSpacer(context, layout, "  ");
         }
-        if (item.getMediaStreams() != null && item.getMediaStreams().size() > 0) {
-            Optional<MediaStream> optionalVideoStream = item.getMediaStreams()
-                    .stream()
-                    .filter(x -> x.getType() == MediaStreamType.VIDEO)
-                    .findFirst();
-            if (optionalVideoStream.isPresent()) {
-                MediaStream videoStream = optionalVideoStream.get();
-                if(videoStream.getWidth() != null && videoStream.getHeight() != null) {
-                    int width = videoStream.getWidth();
-                    int height = videoStream.getHeight();
-                    if (width <= 960 && height <= 576) {
-                        addBlockText(context, layout, context.getString(R.string.lbl_sd));
-                    } else if (width <= 1280 && height <= 962) {
-                        addBlockText(context, layout, "720");
-                    } else if (width <= 1920 && height <= 1440) {
-                        addBlockText(context, layout, "1080");
-                    } else if (width <= 4096 && height <= 3072) {
-                        addBlockText(context, layout, "4K");
-                    } else {
-                        addBlockText(context, layout, "8K");
-                    }
 
-                    addSpacer(context, layout, " ");
+        MediaStream videoStream = StreamHelper.getFirstVideoStream(item, selectedVersionPopupIndex);
 
-                    addVideoCodecDetails(context, layout, videoStream);
+        if (videoStream != null) {
+            if(videoStream.getWidth() != null && videoStream.getHeight() != null) {
+                int width = videoStream.getWidth();
+                int height = videoStream.getHeight();
+                if (width <= 960 && height <= 576) {
+                    addBlockText(context, layout, context.getString(R.string.lbl_sd));
+                } else if (width <= 1280 && height <= 962) {
+                    addBlockText(context, layout, "720");
+                } else if (width <= 1920 && height <= 1440) {
+                    addBlockText(context, layout, "1080");
+                } else if (width <= 4096 && height <= 3072) {
+                    addBlockText(context, layout, "4K");
+                } else {
+                    addBlockText(context, layout, "8K");
                 }
+
+                addSpacer(context, layout, " ");
+
+                addVideoCodecDetails(context, layout, videoStream);
             }
         }
         if (Utils.isTrue(item.getHasSubtitles())) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -20,7 +20,6 @@ import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.jellyfin.sdk.model.api.MediaStream;
-import org.jellyfin.sdk.model.api.MediaStreamType;
 import org.jellyfin.sdk.model.api.SeriesStatus;
 import org.koin.java.KoinJavaComponent;
 
@@ -28,7 +27,6 @@ import java.text.NumberFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Optional;
 
 public class InfoLayoutHelper {
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
@@ -35,10 +35,7 @@ public class StreamHelper {
     }
 
     public static MediaStream getFirstAudioStream(BaseItemDto item, int mediaSourceIndex) {
-        if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex - 1) return null;
-        List<MediaStream> streams = getAudioStreams(item.getMediaSources().get(mediaSourceIndex));
-        if (streams == null || streams.size() < 1) return null;
-        return streams.get(0);
+        return getFirstStreamOfType(item, MediaStreamType.AUDIO, mediaSourceIndex);
     }
 
     public static MediaStream getFirstVideoStream(BaseItemDto item) {
@@ -46,8 +43,16 @@ public class StreamHelper {
     }
 
     public static MediaStream getFirstVideoStream(BaseItemDto item, int mediaSourceIndex) {
+        return getFirstStreamOfType(item, MediaStreamType.VIDEO, mediaSourceIndex);
+    }
+
+    public static MediaStream getFirstStreamOfType(BaseItemDto item, MediaStreamType streamType) {
+        return getFirstStreamOfType(item, streamType, 0);
+    }
+
+    public static MediaStream getFirstStreamOfType(BaseItemDto item, MediaStreamType streamType, int mediaSourceIndex) {
         if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex - 1) return null;
-        List<MediaStream> streams = getVideoStreams(item.getMediaSources().get(mediaSourceIndex));
+        List<MediaStream> streams = getStreams(item.getMediaSources().get(mediaSourceIndex), streamType);
         if (streams == null || streams.size() < 1) return null;
         return streams.get(0);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
@@ -26,9 +26,28 @@ public class StreamHelper {
         return getStreams(mediaSource, MediaStreamType.AUDIO);
     }
 
+    public static List<MediaStream> getVideoStreams(MediaSourceInfo mediaSource) {
+        return getStreams(mediaSource, MediaStreamType.VIDEO);
+    }
+
     public static MediaStream getFirstAudioStream(BaseItemDto item) {
-        if (item.getMediaSources() == null || item.getMediaSources().size() < 1) return null;
-        List<MediaStream> streams = getAudioStreams(item.getMediaSources().get(0));
+        return getFirstAudioStream(item, 0);
+    }
+
+    public static MediaStream getFirstAudioStream(BaseItemDto item, int mediaSourceIndex) {
+        if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex - 1) return null;
+        List<MediaStream> streams = getAudioStreams(item.getMediaSources().get(mediaSourceIndex));
+        if (streams == null || streams.size() < 1) return null;
+        return streams.get(0);
+    }
+
+    public static MediaStream getFirstVideoStream(BaseItemDto item) {
+        return getFirstVideoStream(item, 0);
+    }
+
+    public static MediaStream getFirstVideoStream(BaseItemDto item, int mediaSourceIndex) {
+        if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex - 1) return null;
+        List<MediaStream> streams = getVideoStreams(item.getMediaSources().get(mediaSourceIndex));
         if (streams == null || streams.size() < 1) return null;
         return streams.get(0);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
@@ -51,7 +51,7 @@ public class StreamHelper {
     }
 
     public static MediaStream getFirstStreamOfType(BaseItemDto item, MediaStreamType streamType, int mediaSourceIndex) {
-        if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex + 1) return null;
+        if (item.getMediaSources() == null || mediaSourceIndex > item.getMediaSources().size() - 1) return null;
         List<MediaStream> streams = getStreams(item.getMediaSources().get(mediaSourceIndex), streamType);
         if (streams == null || streams.size() < 1) return null;
         return streams.get(0);

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
@@ -51,7 +51,7 @@ public class StreamHelper {
     }
 
     public static MediaStream getFirstStreamOfType(BaseItemDto item, MediaStreamType streamType, int mediaSourceIndex) {
-        if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex - 1) return null;
+        if (item.getMediaSources() == null || item.getMediaSources().size() < mediaSourceIndex + 1) return null;
         List<MediaStream> streams = getStreams(item.getMediaSources().get(mediaSourceIndex), streamType);
         if (streams == null || streams.size() < 1) return null;
         return streams.get(0);


### PR DESCRIPTION
On Android TV some tags are shown such as 'R', '4K' 'HEVC', etc.
Titles which have external subtitles, are missing the resolution and video codec tags (e.g. '1080' and 'H264').

The source of the issue is `org.jellyfin.androidtv.util.InfoLayoutHelper.addRatingAndRes` getting all media streams, and assuming that the video stream will be the first one, when in fact external subtitles are first (also verifiable by looking at the debug info at the bottom).

**Changes**
Instead of assuming the video is the first stream, take the first stream tagged as `MediaStreamType.VIDEO`.

**Issues**
#2811 
