### PR TITLE
Update unsupported server messages

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import org.jellyfin.androidtv.auth.model.AuthenticationStoreServer
@@ -47,6 +46,7 @@ interface ServerRepository {
 
 	companion object {
 		val minimumServerVersion = Jellyfin.minimumVersion.copy(build = null)
+		val recommendedServerVersion = Jellyfin.apiVersion.copy(build = null)
 	}
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -87,7 +87,11 @@ class ServerFragment : Fragment() {
 
 						is ServerVersionNotSupported -> Toast.makeText(
 							context,
-							getString(R.string.server_unsupported, state.server.version, ServerRepository.minimumServerVersion.toString()),
+							getString(
+								R.string.server_issue_outdated_version,
+								state.server.version,
+								ServerRepository.recommendedServerVersion.toString()
+							),
 							Toast.LENGTH_LONG
 						).show()
 					}
@@ -156,7 +160,7 @@ class ServerFragment : Fragment() {
 			binding.notification.text = getString(
 				R.string.server_unsupported_notification,
 				server.version,
-				ServerRepository.minimumServerVersion.toString(),
+				ServerRepository.recommendedServerVersion.toString(),
 			)
 		} else if (!server.setupCompleted) {
 			binding.notification.isVisible = true

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
@@ -69,9 +69,9 @@ class UserLoginCredentialsFragment : Fragment() {
 			userLoginViewModel.loginState.collect { state ->
 				when (state) {
 					is ServerVersionNotSupported -> binding.error.setText(getString(
-						R.string.server_unsupported,
+						R.string.server_issue_outdated_version,
 						state.server.version,
-						ServerRepository.minimumServerVersion.toString()
+						ServerRepository.recommendedServerVersion.toString()
 					))
 
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
@@ -62,9 +62,9 @@ class UserLoginQuickConnectFragment : Fragment() {
 			userLoginViewModel.loginState.collect { state ->
 				when (state) {
 					is ServerVersionNotSupported -> binding.error.setText(getString(
-						R.string.server_unsupported,
+						R.string.server_issue_outdated_version,
 						state.server.version,
-						ServerRepository.minimumServerVersion.toString()
+						ServerRepository.recommendedServerVersion.toString()
 					))
 
 					AuthenticatingState -> binding.error.setText(R.string.login_authenticating)

--- a/app/src/main/java/org/jellyfin/androidtv/util/RecommendedServerIssueExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/RecommendedServerIssueExtensions.kt
@@ -35,7 +35,7 @@ fun RecommendedServerIssue.getFriendlyMessage(context: Context): String = when (
 	is RecommendedServerIssue.OutdatedServerVersion -> context.getString(
 		R.string.server_issue_outdated_version,
 		version.toString(),
-		ServerRepository.minimumServerVersion.toString()
+		ServerRepository.recommendedServerVersion.toString()
 	)
 
 	is RecommendedServerIssue.SlowResponse -> context.getString(R.string.server_issue_timeout)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,7 +360,6 @@
     <string name="saved_servers">Saved servers</string>
     <string name="welcome_title">Welcome to Jellyfin!</string>
     <string name="welcome_content">Connect to your server to get started.</string>
-    <string name="server_unsupported">Server needs to be updated. Current version is %1$s but app requires %2$s or newer</string>
     <string name="no_user_warning">We couldn\'t find any accounts!\nAdd a new account by pressing the \"Add account\" button.</string>
     <string name="who_is_watching">Who\'s watching?</string>
     <string name="add_user">Add account</string>
@@ -427,7 +426,7 @@
     <string name="server_issue_invalid_product">Server software is incompatible</string>
     <string name="server_issue_missing_version">Could not determine server version</string>
     <string name="server_issue_unsupported_version">Server uses version %1$s which is not supported</string>
-    <string name="server_issue_outdated_version">Server uses version %1$s but needs to be %2$s or newer</string>
+    <string name="server_issue_outdated_version">Server uses unsupported version %1$s. Please update to %2$s or newer</string>
     <string name="server_issue_timeout">Connection timed out</string>
     <string name="server_issue_ssl_handshake">SSL handshake failed</string>
     <string name="pref_customization">Customization</string>
@@ -465,7 +464,7 @@
     <string name="action_connect">Connect</string>
     <string name="live_tv_preferences">Live TV options</string>
     <string name="app_notification_uimode_invalid">This app is optimized for televisions. We recommend using our mobile app on other devices.</string>
-    <string name="server_unsupported_notification">This server uses Jellyfin version %1$s which is unsupported. Please update to Jellyfin %2$s to continue using the app.</string>
+    <string name="server_unsupported_notification">This server uses Jellyfin version %1$s which is unsupported. Please update to Jellyfin %2$s or newer to continue using the app.</string>
     <string name="pref_telemetry_category">Crash reporting</string>
     <string name="pref_telemetry_description">Send crash reports, include logs</string>
     <string name="pref_crash_reports">Send crash reports to server</string>


### PR DESCRIPTION
**Changes**
- Remove server_unsupported
- Reword server_issue_outdated_version and server_unsupported_notification
  - Both now use the recommended server version instead of the minimum version. The recommended version is the version used to generate the API. We generally update the SDK for each server release and update the app in about 2 weeks, so the recommended version is the latest server version most of the time.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
