### PR TITLE
Fix Live TV progress reporting

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.java
@@ -11,6 +11,7 @@ import org.jellyfin.apiclient.interaction.EmptyResponse;
 import org.jellyfin.apiclient.model.session.PlaybackProgressInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStartInfo;
 import org.jellyfin.apiclient.model.session.PlaybackStopInfo;
+import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.koin.java.KoinJavaComponent;
 
 import timber.log.Timber;
@@ -39,7 +40,7 @@ public class ReportingHelper {
     public static void reportStart(org.jellyfin.sdk.model.api.BaseItemDto item, long pos) {
         PlaybackStartInfo startInfo = new PlaybackStartInfo();
         startInfo.setItemId(item.getId().toString());
-        startInfo.setPositionTicks(pos);
+        if (item.getType() != BaseItemKind.TV_CHANNEL) startInfo.setPositionTicks(pos);
         KoinJavaComponent.<PlaybackManager>get(PlaybackManager.class).reportPlaybackStart(startInfo, KoinJavaComponent.<ApiClient>get(ApiClient.class), new EmptyResponse());
         Timber.i("Playback of %s started.", item.getName());
     }
@@ -48,9 +49,11 @@ public class ReportingHelper {
         if (item != null && currentStreamInfo != null) {
             PlaybackProgressInfo info = new PlaybackProgressInfo();
             info.setItemId(item.getId().toString());
-            info.setPositionTicks(position);
+            if (item.getType() != BaseItemKind.TV_CHANNEL) {
+                info.setPositionTicks(position);
+                info.setCanSeek(currentStreamInfo.getRunTimeTicks() != null && currentStreamInfo.getRunTimeTicks() > 0);
+            }
             info.setIsPaused(isPaused);
-            info.setCanSeek(currentStreamInfo.getRunTimeTicks() != null && currentStreamInfo.getRunTimeTicks() > 0);
             info.setPlayMethod(currentStreamInfo.getPlayMethod());
             if (playbackController != null && playbackController.isPlaying()) {
                 info.setAudioStreamIndex(playbackController.getAudioStreamIndex());


### PR DESCRIPTION
When reporting the progress of a live tv stream the position was technically correct (time since the stream started) but that would end up causing issues like [this](https://www.reddit.com/r/jellyfin/comments/13ywrfl/i_wish_i_could_claim_credit_for_the_uptime/). This change always reports 0 as progress for live tv.

We might want to add additional changes to jellyfin-web eventually to now show progress if runtime is 0.

**Changes**
- Fix Live TV progress reporting

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
