### PR TITLE
Add volume state to playback rewrite

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AndroidModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AndroidModule.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.di
 
 import android.accounts.AccountManager
 import android.app.UiModeManager
+import android.media.AudioManager
 import androidx.core.content.getSystemService
 import androidx.work.WorkManager
 import org.koin.android.ext.koin.androidApplication
@@ -13,5 +14,6 @@ import org.koin.dsl.module
 val androidModule = module {
 	factory { androidApplication().getSystemService<AccountManager>()!! }
 	factory { androidApplication().getSystemService<UiModeManager>()!! }
+	factory { androidApplication().getSystemService<AudioManager>()!! }
 	factory { WorkManager.getInstance(get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -73,7 +73,7 @@ val appModule = module {
 
 	single { get<ApiClient>().ws() }
 
-	single { SocketHandler(get(), get(), get(), get(), get(), get(), get()) }
+	single { SocketHandler(get(), get(), get(), get(), get(), get(), get(), get()) }
 
 	// Old apiclient
 	single {

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -20,6 +20,7 @@ import org.jellyfin.playback.core.mediasession.mediaSessionPlugin
 import org.jellyfin.playback.core.playbackManager
 import org.jellyfin.playback.exoplayer.exoPlayerPlugin
 import org.jellyfin.playback.jellyfin.jellyfinPlugin
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.scope.Scope
 import org.koin.dsl.module
 import org.jellyfin.androidtv.ui.playback.PlaybackManager as LegacyPlaybackManager
@@ -49,7 +50,7 @@ val playbackModule = module {
 	single { createPlaybackManager() }
 }
 
-fun Scope.createPlaybackManager() = playbackManager {
+fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 	install(exoPlayerPlugin(get()))
 	install(jellyfinPlugin(get(), get()))
 

--- a/playback/core/src/main/kotlin/PlaybackManagerBuilder.kt
+++ b/playback/core/src/main/kotlin/PlaybackManagerBuilder.kt
@@ -1,13 +1,19 @@
 package org.jellyfin.playback.core
 
+import android.content.Context
+import android.os.Build
+import androidx.core.content.getSystemService
 import org.jellyfin.playback.core.backend.PlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStreamResolver
 import org.jellyfin.playback.core.plugin.PlaybackPlugin
 import org.jellyfin.playback.core.plugin.PlayerService
 
-class PlaybackManagerBuilder {
+class PlaybackManagerBuilder(context: Context) {
 	private val factories = mutableListOf<PlaybackPlugin>()
-	val options = PlaybackManagerOptions()
+	private val volumeState = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) NoOpPlayerVolumeState()
+	else AndroidPlayerVolumeState(audioManager = requireNotNull(context.getSystemService()))
+
+	val options = PlaybackManagerOptions(volumeState)
 
 	fun install(pluginFactory: PlaybackPlugin) {
 		factories.add(pluginFactory)
@@ -40,5 +46,5 @@ class PlaybackManagerBuilder {
 	}
 }
 
-fun playbackManager(init: PlaybackManagerBuilder.() -> Unit): PlaybackManager =
-	PlaybackManagerBuilder().apply { init() }.build()
+fun playbackManager(context: Context, init: PlaybackManagerBuilder.() -> Unit): PlaybackManager =
+	PlaybackManagerBuilder(context).apply { init() }.build()

--- a/playback/core/src/main/kotlin/PlaybackManagerOptions.kt
+++ b/playback/core/src/main/kotlin/PlaybackManagerOptions.kt
@@ -3,7 +3,10 @@ package org.jellyfin.playback.core
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.time.Duration.Companion.seconds
 
-class PlaybackManagerOptions {
+class PlaybackManagerOptions(
+	val playerVolumeState: PlayerVolumeState,
+) {
 	var defaultRewindAmount = MutableStateFlow(10.seconds)
 	var defaultFastForwardAmount = MutableStateFlow(10.seconds)
+
 }

--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -20,6 +20,7 @@ import kotlin.time.Duration
 
 interface PlayerState {
 	val queue: PlayerQueueState
+	val volume: PlayerVolumeState
 	val playState: StateFlow<PlayState>
 	val speed: StateFlow<Float>
 	val videoSize: StateFlow<VideoSize>
@@ -63,6 +64,7 @@ class MutablePlayerState(
 	private val backendService: BackendService,
 ) : PlayerState {
 	override val queue: PlayerQueueState
+	override val volume: PlayerVolumeState
 
 	private val _playState = MutableStateFlow(PlayState.STOPPED)
 	override val playState: StateFlow<PlayState> get() = _playState.asStateFlow()
@@ -96,6 +98,7 @@ class MutablePlayerState(
 		})
 
 		queue = DefaultPlayerQueueState(this, scope, backendService)
+		volume = options.playerVolumeState
 	}
 
 	override fun play(playQueue: Queue) {

--- a/playback/core/src/main/kotlin/PlayerVolumeState.kt
+++ b/playback/core/src/main/kotlin/PlayerVolumeState.kt
@@ -1,0 +1,131 @@
+package org.jellyfin.playback.core
+
+import android.media.AudioManager
+import android.os.Build
+import androidx.annotation.FloatRange
+import androidx.annotation.RequiresApi
+import timber.log.Timber
+import kotlin.math.roundToInt
+
+/**
+ * The state of the device volume. No flows are used due to platform limitations.
+ */
+interface PlayerVolumeState {
+	/**
+	 * Whether the volume of the device is muted or not.
+	 */
+	val muted: Boolean
+
+	/**
+	 * The current volume level of the device between 0f and 1f.
+	 */
+	val volume: Float
+
+	/**
+	 * Whether the volume and mute state can be changed or not.
+	 * Changing the volume/mute state will do nothing when false.
+	 */
+	val modifyable: Boolean
+
+	/**
+	 * Mute the device.
+	 */
+	fun mute()
+
+	/**
+	 * Unmute the device.
+	 */
+	fun unmute()
+
+	/**
+	 * Increase the device volume by the device prefered amount.
+	 */
+	fun increaseVolume()
+
+	/**
+	 * Decrease the device volume by the device prefered amount.
+	 */
+	fun decreaseVolume()
+
+	/**
+	 * Set the device volume to a level between 0f and 1f.
+	 */
+	fun setVolume(volume: Float)
+}
+
+/**
+ * Implementation of [PlayerVolumeState] that does nothing. Useful for platforms that do not
+ * support changing the volume properties.
+ */
+class NoOpPlayerVolumeState : PlayerVolumeState {
+	override val muted = false
+	override val volume = 1f
+	override val modifyable = false
+
+	override fun mute() = Unit
+	override fun unmute() = Unit
+
+	override fun increaseVolume() = Unit
+	override fun decreaseVolume() = Unit
+	override fun setVolume(volume: Float) = Unit
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+class AndroidPlayerVolumeState(
+	private val audioManager: AudioManager,
+) : PlayerVolumeState {
+	private val stream = AudioManager.STREAM_MUSIC
+
+	override val muted: Boolean
+		get() = audioManager.isStreamMute(stream)
+	override val volume: Float
+		get() = audioManager.getStreamVolume(stream).toFloat() / audioManager.getStreamMaxVolume(stream)
+
+	override val modifyable: Boolean
+		get() = !audioManager.isVolumeFixed
+
+	override fun mute() {
+		if (!modifyable) return
+		audioManager.adjustStreamVolume(
+			stream,
+			AudioManager.ADJUST_MUTE,
+			AudioManager.FLAG_SHOW_UI
+		)
+	}
+
+	override fun unmute() {
+		if (!modifyable) return
+		audioManager.adjustStreamVolume(
+			stream,
+			AudioManager.ADJUST_UNMUTE,
+			AudioManager.FLAG_SHOW_UI
+		)
+	}
+
+	override fun increaseVolume() {
+		if (!modifyable) return
+		audioManager.adjustStreamVolume(
+			stream,
+			AudioManager.ADJUST_RAISE,
+			AudioManager.FLAG_SHOW_UI
+		)
+	}
+
+	override fun decreaseVolume() {
+		if (!modifyable) return
+		audioManager.adjustStreamVolume(
+			stream,
+			AudioManager.ADJUST_LOWER,
+			AudioManager.FLAG_SHOW_UI
+		)
+	}
+
+	override fun setVolume(@FloatRange(0.0, 1.0) volume: Float) {
+		require(volume in 0f..1f)
+		if (!modifyable) return
+		val maxVolume = audioManager.getStreamMaxVolume(stream)
+		val index = (volume * maxVolume).roundToInt()
+		Timber.d("volume=$volume, maxVolume=$maxVolume, index=$index")
+		audioManager.setStreamVolume(stream, index, AudioManager.FLAG_SHOW_UI)
+	}
+}

--- a/playback/core/src/main/kotlin/mediasession/MediaSessionPlayer.kt
+++ b/playback/core/src/main/kotlin/mediasession/MediaSessionPlayer.kt
@@ -74,10 +74,10 @@ internal class MediaSessionPlayer(
 			// add(COMMAND_CHANGE_MEDIA_ITEMS)
 			// add(COMMAND_GET_AUDIO_ATTRIBUTES)
 			// add(COMMAND_GET_VOLUME)
-			// add(COMMAND_GET_DEVICE_VOLUME)
+			add(COMMAND_GET_DEVICE_VOLUME)
 			// add(COMMAND_SET_VOLUME)
-			// add(COMMAND_SET_DEVICE_VOLUME)
-			// add(COMMAND_ADJUST_DEVICE_VOLUME)
+			add(COMMAND_SET_DEVICE_VOLUME)
+			add(COMMAND_ADJUST_DEVICE_VOLUME)
 			// add(COMMAND_SET_VIDEO_SURFACE)
 			// add(COMMAND_GET_TEXT)
 			// add(COMMAND_SET_TRACK_SELECTION_PARAMETERS)
@@ -120,6 +120,9 @@ internal class MediaSessionPlayer(
 		setShuffleModeEnabled(state.playbackOrder.value != PlaybackOrder.DEFAULT)
 		setRepeatMode(if (state.repeatMode.value == RepeatMode.NONE) REPEAT_MODE_OFF else REPEAT_MODE_ALL)
 		setVideoSize(state.videoSize.value.let { VideoSize(it.width, it.height) })
+		@Suppress("MagicNumber")
+		setDeviceVolume((state.volume.volume * 100).toInt())
+		setIsDeviceMuted(state.volume.muted)
 	}.build()
 
 	override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
@@ -190,6 +193,22 @@ internal class MediaSessionPlayer(
 			else -> RepeatMode.NONE
 		}
 		state.setRepeatMode(mode)
+		return Futures.immediateVoidFuture()
+	}
+
+	override fun handleIncreaseDeviceVolume(): ListenableFuture<*> {
+		state.volume.increaseVolume()
+		return Futures.immediateVoidFuture()
+	}
+
+	override fun handleDecreaseDeviceVolume(): ListenableFuture<*> {
+		state.volume.decreaseVolume()
+		return Futures.immediateVoidFuture()
+	}
+
+	override fun handleSetDeviceVolume(deviceVolume: Int): ListenableFuture<*> {
+		@Suppress("MagicNumber")
+		state.volume.setVolume(deviceVolume / 100f)
 		return Futures.immediateVoidFuture()
 	}
 

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -13,6 +13,7 @@ fun jellyfinPlugin(
 ) = playbackPlugin {
 	provide(UniversalAudioMediaStreamResolver(api))
 
-	provide(PlaySessionService(api))
-	provide(PlaySessionSocketService(socketInstance))
+	val playSessionService = PlaySessionService(api)
+	provide(playSessionService)
+	provide(PlaySessionSocketService(socketInstance, playSessionService))
 }

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionSocketService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionSocketService.kt
@@ -6,18 +6,23 @@ import kotlinx.coroutines.launch
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.sdk.api.sockets.SocketInstance
+import org.jellyfin.sdk.api.sockets.addGeneralCommandsListener
 import org.jellyfin.sdk.api.sockets.addPlayStateCommandsListener
 import org.jellyfin.sdk.api.sockets.listener.SocketListener
+import org.jellyfin.sdk.model.api.GeneralCommandType
 import org.jellyfin.sdk.model.api.PlaystateCommand
+import org.jellyfin.sdk.model.extensions.get
 import org.jellyfin.sdk.model.extensions.ticks
 import kotlin.time.Duration
 
 class PlaySessionSocketService(
 	private val socketInstance: SocketInstance,
+	private val playSessionService: PlaySessionService,
 ) : PlayerService() {
 	private var listeners = mutableListOf<SocketListener>()
 
 	override suspend fun onInitialize() {
+		// Player control
 		listeners += socketInstance.addPlayStateCommandsListener { message ->
 			coroutineScope.launch(Dispatchers.Main) {
 				when (message.request.command) {
@@ -30,6 +35,7 @@ class PlaySessionSocketService(
 						val to = message.request.seekPositionTicks?.ticks ?: Duration.ZERO
 						state.seek(to)
 					}
+
 					PlaystateCommand.REWIND -> state.rewind()
 					PlaystateCommand.FAST_FORWARD -> state.fastForward()
 					PlaystateCommand.PLAY_PAUSE -> when (state.playState.value) {
@@ -37,7 +43,44 @@ class PlaySessionSocketService(
 						else -> state.unpause()
 					}
 				}
+				coroutineScope.launch { playSessionService.sendUpdateIfActive() }
 			}
+		}
+
+		// Volume control
+		listeners += socketInstance.addGeneralCommandsListener(setOf(GeneralCommandType.VOLUME_UP)) {
+			state.volume.increaseVolume()
+			coroutineScope.launch { playSessionService.sendUpdateIfActive() }
+		}
+
+		listeners += socketInstance.addGeneralCommandsListener(setOf(GeneralCommandType.VOLUME_DOWN)) {
+			state.volume.decreaseVolume()
+			coroutineScope.launch { playSessionService.sendUpdateIfActive() }
+		}
+
+		listeners += socketInstance.addGeneralCommandsListener(setOf(GeneralCommandType.SET_VOLUME)) { message ->
+			@Suppress("MagicNumber")
+			val volume = message["volume"]?.toFloatOrNull()?.div(100f)
+			if (volume != null && volume in 0f..1f) state.volume.setVolume(volume)
+			coroutineScope.launch { playSessionService.sendUpdateIfActive() }
+		}
+
+		listeners += socketInstance.addGeneralCommandsListener(setOf(GeneralCommandType.MUTE)) {
+			state.volume.mute()
+			coroutineScope.launch { playSessionService.sendUpdateIfActive() }
+		}
+
+		listeners += socketInstance.addGeneralCommandsListener(setOf(GeneralCommandType.UNMUTE)) {
+			state.volume.unmute()
+			coroutineScope.launch { playSessionService.sendUpdateIfActive() }
+		}
+
+		listeners += socketInstance.addGeneralCommandsListener(setOf(GeneralCommandType.TOGGLE_MUTE)) {
+			when (state.volume.muted) {
+				true -> state.volume.unmute()
+				false -> state.volume.mute()
+			}
+			coroutineScope.launch { playSessionService.sendUpdateIfActive() }
 		}
 
 		coroutineScope.launch {


### PR DESCRIPTION
**Changes**

Add volume state and manipulation to the playback code. It is also exposed to media sessions, play sessions and remote control. This means you can change the volume of your TV from jellyfin-web or the mobile app. Useful when playing music!

**Issues**

yes #1057 