### PR TITLE
Fix ItemLauncher retrieving base item via from media manager when launching a photo

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -133,7 +133,7 @@ public class ItemLauncher {
                         KoinJavaComponent.<MediaManager>get(MediaManager.class).setCurrentMediaPosition(pos);
 
                         navigationRepository.navigate(Destinations.INSTANCE.pictureViewer(
-                                mediaManager.getCurrentMediaItem().getBaseItem().getId(),
+                                baseItem.getId(),
                                 false,
                                 mediaManager.getCurrentMediaAdapter().getSortBy(),
                                 mediaManager.getCurrentMediaAdapter().getSortOrder()


### PR DESCRIPTION
**Backports** a single line from #2461 that should fix some issues.

**Changes**
- Fix ItemLauncher retrieving base item via from media manager when launching a photo

**Issues**
Should fix #2764