### PR TITLE
Replace ExoPlayer with androidx.media3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,8 +139,10 @@ dependencies {
 	implementation(libs.bundles.koin)
 
 	// Media players
-	implementation(libs.exoplayer)
-	implementation(libs.jellyfin.exoplayer.ffmpegextension)
+	implementation(libs.androidx.media3.exoplayer)
+	implementation(libs.androidx.media3.exoplayer.hls)
+	implementation(libs.androidx.media3.ui)
+	implementation(libs.jellyfin.androidx.media3.ffmpeg.decoder)
 	implementation(libs.libvlc)
 
 	// Markdown

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -9,14 +9,16 @@ import android.os.Handler;
 import android.os.Looper;
 import android.widget.Toast;
 
-import com.google.android.exoplayer2.DefaultRenderersFactory;
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.PlaybackException;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.source.ProgressiveMediaSource;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import androidx.annotation.OptIn;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.Player;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DefaultDataSourceFactory;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.source.ProgressiveMediaSource;
 
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.constant.QueryType;
@@ -53,6 +55,7 @@ import java.util.Random;
 import kotlin.Lazy;
 import timber.log.Timber;
 
+@OptIn(markerClass = UnstableApi.class)
 public class LegacyMediaManager implements MediaManager {
     private Context context;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -18,25 +18,27 @@ import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.OptIn;
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.PlaybackParameters;
+import androidx.media3.common.Player;
+import androidx.media3.common.Timeline;
+import androidx.media3.common.TrackGroup;
+import androidx.media3.common.TrackSelectionOverride;
+import androidx.media3.common.TrackSelectionParameters;
+import androidx.media3.common.Tracks;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.extractor.DefaultExtractorsFactory;
+import androidx.media3.extractor.ts.TsExtractor;
+import androidx.media3.ui.AspectRatioFrameLayout;
+import androidx.media3.ui.PlayerView;
 
-import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.Format;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.PlaybackException;
-import com.google.android.exoplayer2.PlaybackParameters;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.Timeline;
-import com.google.android.exoplayer2.Tracks;
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.extractor.ts.TsExtractor;
-import com.google.android.exoplayer2.source.DefaultMediaSourceFactory;
-import com.google.android.exoplayer2.source.TrackGroup;
-import com.google.android.exoplayer2.trackselection.TrackSelectionOverride;
-import com.google.android.exoplayer2.trackselection.TrackSelectionParameters;
-import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
-import com.google.android.exoplayer2.ui.StyledPlayerView;
 import com.google.common.collect.ImmutableSet;
 
 import org.jellyfin.androidtv.R;
@@ -58,6 +60,7 @@ import java.util.Optional;
 
 import timber.log.Timber;
 
+@OptIn(markerClass = UnstableApi.class)
 public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     public final static int ZOOM_FIT = 0;
     public final static int ZOOM_AUTO_CROP = 1;
@@ -76,7 +79,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private SurfaceView mSubtitlesSurface;
     private FrameLayout mSurfaceFrame;
     private ExoPlayer mExoPlayer;
-    private StyledPlayerView mExoPlayerView;
+    private PlayerView mExoPlayerView;
     private LibVLC mLibVLC;
     private MediaPlayer mVlcPlayer;
     private Media mCurrentMedia;
@@ -94,7 +97,7 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
     private long mMetaDuration = -1;
     private long mMetaVLCStreamStartPosition = -1;
     private long lastExoPlayerPosition = -1;
-    private boolean nightModeEnabled = false;
+    private boolean nightModeEnabled;
 
     private boolean nativeMode = false;
     private boolean mSurfaceReady = false;

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -31,7 +31,7 @@
 
         </FrameLayout>
 
-        <com.google.android.exoplayer2.ui.StyledPlayerView
+        <androidx.media3.ui.PlayerView
             android:id="@+id/exoPlayerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,10 +25,9 @@ androidx-work = "2.9.0"
 blurhash = "0.2.0"
 coil = "2.5.0"
 detekt = "1.23.4"
-exoplayer = "2.19.1"
 gson = "2.8.9"
+jellyfin-androidx-media = "1.2.0+1"
 jellyfin-apiclient = "v0.7.10"
-jellyfin-exoplayer-ffmpegextension = "2.19.1+1"
 jellyfin-sdk = "1.4.6"
 junit = "4.13.2"
 koin = "3.5.3"
@@ -79,6 +78,7 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "androidx-media3" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
@@ -93,8 +93,9 @@ koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", versi
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin" }
 
 # Media players
-exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
-jellyfin-exoplayer-ffmpegextension = { group = "org.jellyfin.exoplayer", name = "exoplayer-ffmpeg-extension", version.ref = "jellyfin-exoplayer-ffmpegextension" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
+androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "androidx-media3" }
+jellyfin-androidx-media3-ffmpeg-decoder = { group = "org.jellyfin.media3", name = "media3-ffmpeg-decoder", version.ref = "jellyfin-androidx-media" }
 libvlc = { module = "org.videolan.android:libvlc-all", version.ref = "libvlc" }
 
 # Markwon

--- a/playback/exoplayer/build.gradle.kts
+++ b/playback/exoplayer/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
 	implementation(libs.kotlinx.coroutines.guava)
 
 	// ExoPlayer
-	implementation(libs.exoplayer)
-	implementation(libs.jellyfin.exoplayer.ffmpegextension)
+	implementation(libs.androidx.media3.exoplayer)
+	implementation(libs.jellyfin.androidx.media3.ffmpeg.decoder)
 
 	// Logging
 	implementation(libs.timber)

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -1,13 +1,15 @@
 package org.jellyfin.playback.exoplayer
 
 import android.content.Context
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.DefaultRenderersFactory
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.PlaybackException
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.video.VideoSize
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
 import org.jellyfin.playback.core.backend.BasePlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
@@ -21,18 +23,14 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
 
+@OptIn(UnstableApi::class)
 class ExoPlayerBackend(
 	private val context: Context,
 ) : BasePlayerBackend() {
 	private var currentStream: PlayableMediaStream? = null
 
 	private val exoPlayer by lazy {
-		val renderersFactory = DefaultRenderersFactory(context).apply {
-			setEnableDecoderFallback(true)
-			setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
-		}
-
-		ExoPlayer.Builder(context, renderersFactory)
+		ExoPlayer.Builder(context)
 			.setRenderersFactory(DefaultRenderersFactory(context).apply {
 				setEnableDecoderFallback(true)
 				setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)

--- a/playback/exoplayer/src/main/kotlin/mapping/audio.kt
+++ b/playback/exoplayer/src/main/kotlin/mapping/audio.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.playback.exoplayer.mapping
 
-import com.google.android.exoplayer2.util.MimeTypes
+import androidx.media3.common.MimeTypes
 
 fun getFfmpegAudioMimeType(codec: String): String {
 	return ffmpegAudioMimeTypes.getOrDefault(codec, codec)

--- a/playback/exoplayer/src/main/kotlin/mapping/container.kt
+++ b/playback/exoplayer/src/main/kotlin/mapping/container.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.playback.exoplayer.mapping
 
-import com.google.android.exoplayer2.util.MimeTypes
+import androidx.annotation.OptIn
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
 
 fun getFfmpegContainerMimeType(codec: String): String {
 	// Find in container mime type list
@@ -13,6 +15,7 @@ fun getFfmpegContainerMimeType(codec: String): String {
 	}
 }
 
+@OptIn(UnstableApi::class)
 val ffmpegContainerMimeTypes = mapOf(
 	"aac" to MimeTypes.AUDIO_AAC,
 	"alaw" to MimeTypes.AUDIO_ALAW,

--- a/playback/exoplayer/src/main/kotlin/support/AdaptiveSupport.kt
+++ b/playback/exoplayer/src/main/kotlin/support/AdaptiveSupport.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.playback.exoplayer.support
 
-import com.google.android.exoplayer2.RendererCapabilities
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.RendererCapabilities
 
 enum class AdaptiveSupport {
 	SEAMLESS,
@@ -8,6 +10,7 @@ enum class AdaptiveSupport {
 	NOT_SUPPORTED;
 
 	companion object {
+		@OptIn(UnstableApi::class)
 		fun fromFlags(flags: Int) = when (RendererCapabilities.getAdaptiveSupport(flags)) {
 			RendererCapabilities.ADAPTIVE_SEAMLESS -> SEAMLESS
 			RendererCapabilities.ADAPTIVE_NOT_SEAMLESS -> NOT_SEAMLESS

--- a/playback/exoplayer/src/main/kotlin/support/DecoderSupport.kt
+++ b/playback/exoplayer/src/main/kotlin/support/DecoderSupport.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.playback.exoplayer.support
 
-import com.google.android.exoplayer2.RendererCapabilities
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.RendererCapabilities
 
 enum class DecoderSupport {
 	PRIMARY,
@@ -8,6 +10,7 @@ enum class DecoderSupport {
 	FALLBACK;
 
 	companion object {
+		@OptIn(UnstableApi::class)
 		fun fromFlags(flags: Int) = when (RendererCapabilities.getDecoderSupport(flags)) {
 			RendererCapabilities.DECODER_SUPPORT_PRIMARY -> PRIMARY
 			RendererCapabilities.DECODER_SUPPORT_FALLBACK_MIMETYPE -> FALLBACK_MIMETYPE

--- a/playback/exoplayer/src/main/kotlin/support/ExoPlayerPlaySupportReport.kt
+++ b/playback/exoplayer/src/main/kotlin/support/ExoPlayerPlaySupportReport.kt
@@ -1,9 +1,11 @@
 package org.jellyfin.playback.exoplayer.support
 
-import com.google.android.exoplayer2.BaseRenderer
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.Format
-import com.google.android.exoplayer2.RendererCapabilities
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.BaseRenderer
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.RendererCapabilities
 import org.jellyfin.playback.core.support.PlaySupportReport
 
 data class ExoPlayerPlaySupportReport(
@@ -16,6 +18,7 @@ data class ExoPlayerPlaySupportReport(
 	override val canPlay = format == FormatSupport.HANDLED || tunneling == true || hardwareAcceleration == true
 
 	companion object {
+		@OptIn(UnstableApi::class)
 		fun fromFlags(flags: Int): ExoPlayerPlaySupportReport = ExoPlayerPlaySupportReport(
 			format = FormatSupport.fromFlags(RendererCapabilities.getFormatSupport(flags)),
 			adaptive = AdaptiveSupport.fromFlags(RendererCapabilities.getAdaptiveSupport(flags)),
@@ -24,12 +27,14 @@ data class ExoPlayerPlaySupportReport(
 			decoder = DecoderSupport.fromFlags(RendererCapabilities.getDecoderSupport(flags)),
 		)
 
+		@OptIn(UnstableApi::class)
 		private fun tunnelingFromFlags(flags: Int) = when (RendererCapabilities.getTunnelingSupport(flags)) {
 			RendererCapabilities.TUNNELING_SUPPORTED -> true
 			RendererCapabilities.TUNNELING_NOT_SUPPORTED -> false
 			else -> null
 		}
 
+		@OptIn(UnstableApi::class)
 		private fun hardwareAccelerationFromFlags(flags: Int) = when (RendererCapabilities.getHardwareAccelerationSupport(flags)) {
 			RendererCapabilities.HARDWARE_ACCELERATION_SUPPORTED -> true
 			RendererCapabilities.HARDWARE_ACCELERATION_NOT_SUPPORTED -> false
@@ -41,6 +46,7 @@ data class ExoPlayerPlaySupportReport(
 fun ExoPlayer.getPlaySupportReport(format: Format): ExoPlayerPlaySupportReport =
 	ExoPlayerPlaySupportReport.fromFlags(supportsFormat(format))
 
+@OptIn(UnstableApi::class)
 fun ExoPlayer.supportsFormat(format: Format): Int {
 	var capabilities = 0
 

--- a/playback/exoplayer/src/main/kotlin/support/FormatSupport.kt
+++ b/playback/exoplayer/src/main/kotlin/support/FormatSupport.kt
@@ -1,6 +1,9 @@
 package org.jellyfin.playback.exoplayer.support
 
-import com.google.android.exoplayer2.RendererCapabilities
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.RendererCapabilities
 
 enum class FormatSupport {
 	HANDLED,
@@ -10,12 +13,13 @@ enum class FormatSupport {
 	UNSUPPORTED_TYPE;
 
 	companion object {
+		@OptIn(UnstableApi::class)
 		fun fromFlags(flags: Int) = when (RendererCapabilities.getFormatSupport(flags)) {
-			RendererCapabilities.FORMAT_HANDLED -> HANDLED
-			RendererCapabilities.FORMAT_EXCEEDS_CAPABILITIES -> EXCEEDS_CAPABILITIES
-			RendererCapabilities.FORMAT_UNSUPPORTED_DRM -> UNSUPPORTED_DRM
-			RendererCapabilities.FORMAT_UNSUPPORTED_SUBTYPE -> UNSUPPORTED_SUBTYPE
-			RendererCapabilities.FORMAT_UNSUPPORTED_TYPE -> UNSUPPORTED_TYPE
+			C.FORMAT_HANDLED -> HANDLED
+			C.FORMAT_EXCEEDS_CAPABILITIES -> EXCEEDS_CAPABILITIES
+			C.FORMAT_UNSUPPORTED_DRM -> UNSUPPORTED_DRM
+			C.FORMAT_UNSUPPORTED_SUBTYPE -> UNSUPPORTED_SUBTYPE
+			C.FORMAT_UNSUPPORTED_TYPE -> UNSUPPORTED_TYPE
 			else -> null
 		}
 	}

--- a/playback/exoplayer/src/main/kotlin/support/mediaStreamToFormat.kt
+++ b/playback/exoplayer/src/main/kotlin/support/mediaStreamToFormat.kt
@@ -1,11 +1,14 @@
 package org.jellyfin.playback.exoplayer.support
 
-import com.google.android.exoplayer2.Format
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.MediaStreamAudioTrack
 import org.jellyfin.playback.exoplayer.mapping.getFfmpegAudioMimeType
 import org.jellyfin.playback.exoplayer.mapping.getFfmpegContainerMimeType
 
+@OptIn(UnstableApi::class)
 fun MediaStream.toFormat() = Format.Builder().also { f ->
 	f.setId(identifier)
 	f.setContainerMimeType(getFfmpegContainerMimeType(container.format))


### PR DESCRIPTION
**Changes**

Replace our usages of ExoPlayer with androidx.media3. This affects the old playback code and the rewritten code. It's pretty much only package name changes because I fixed the breaking changes in earlier PR's.

**To do**

- ~~Migrate `exoplayer-ffmpeg-extension` to media3~~

**Issues**

Also a part of #1057 I guess
