### PR TITLE
Show UI mode notification on startup screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/model/AppNotification.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/model/AppNotification.kt
@@ -3,4 +3,5 @@ package org.jellyfin.androidtv.data.model
 data class AppNotification(
 	val message: String,
 	val dismiss: () -> Unit,
+	val public: Boolean,
 )

--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
@@ -34,8 +34,8 @@ class NotificationsRepositoryImpl(
 		addBetaNotification()
 	}
 
-	private fun addNotification(message: String, dismiss: () -> Unit = {}) {
-		notifications.value = notifications.value + AppNotification(message, dismiss)
+	private fun addNotification(message: String, public: Boolean = false, dismiss: () -> Unit = {}) {
+		notifications.value = notifications.value + AppNotification(message, dismiss, public)
 	}
 
 	private fun addUiModeNotification() {
@@ -45,7 +45,7 @@ class NotificationsRepositoryImpl(
 		val hasHdmiCec = context.packageManager.hasSystemFeature("android.hardware.hdmi.cec")
 
 		if (invalidUiMode && isTouch && !hasHdmiCec) {
-			addNotification(context.getString(R.string.app_notification_uimode_invalid))
+			addNotification(context.getString(R.string.app_notification_uimode_invalid), public = true)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -5,6 +5,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -23,6 +34,7 @@ import org.jellyfin.androidtv.auth.model.ConnectingState
 import org.jellyfin.androidtv.auth.model.Server
 import org.jellyfin.androidtv.auth.model.ServerAdditionState
 import org.jellyfin.androidtv.auth.model.UnableToConnectState
+import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.databinding.FragmentSelectServerBinding
 import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.SpacingItemDecoration
@@ -31,6 +43,7 @@ import org.jellyfin.androidtv.util.ListAdapter
 import org.jellyfin.androidtv.util.MenuBuilder
 import org.jellyfin.androidtv.util.getSummary
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
+import org.koin.compose.rememberKoinInject
 
 class SelectServerFragment : Fragment() {
 	private var _binding: FragmentSelectServerBinding? = null
@@ -144,6 +157,32 @@ class SelectServerFragment : Fragment() {
 				}
 
 				binding.discoveryProgressIndicator.isVisible = false
+			}
+		}
+
+		// Notifications
+		binding.notifications.setContent {
+			val notificationsRepository = rememberKoinInject<NotificationsRepository>()
+			val notifications by notificationsRepository.notifications.collectAsState()
+
+			Column(
+				verticalArrangement = Arrangement.spacedBy(5.dp)
+			) {
+				for (notification in notifications) {
+					if (!notification.public) continue
+
+					Card(
+						modifier = Modifier
+							.fillMaxWidth(),
+						backgroundColor = colorResource(id = R.color.lb_basic_card_info_bg_color),
+						contentColor = colorResource(id = R.color.white),
+					) {
+						Text(
+							text = notification.message,
+							modifier = Modifier.padding(10.dp)
+						)
+					}
+				}
 			}
 		}
 

--- a/app/src/main/res/layout/fragment_select_server.xml
+++ b/app/src/main/res/layout/fragment_select_server.xml
@@ -64,6 +64,11 @@
         android:layout_weight="1"
         android:orientation="vertical">
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/notifications"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/buildSrc/src/main/kotlin/Properties.kt
+++ b/buildSrc/src/main/kotlin/Properties.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
  */
 fun Project.getProperty(name: String): String? {
 	// sample.var --> SAMPLE_VAR
-	val environmentName = name.toUpperCase().replace(".", "_")
+	val environmentName = name.uppercase().replace(".", "_")
 
 	return findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
 }


### PR DESCRIPTION
This PR shows the UI mode warning on the startup screen. The login UI is not really usable on phones so we can't rely on the notification after sign in anymore.

**Changes**
- Add "public" option to AppNotification
  - Currently only used for the UI mode warning
- Show public notification on server selection screen
  - This is the initial screen that shows on a fresh install
- Sneak in a little build script warning fix

![image](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/a57c32df-058b-482e-982c-4196d12ce80c)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
