### PR TITLE
Fix navigation reset called during back stack pop call

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
@@ -65,11 +65,11 @@ class NavigationRepositoryImpl(
 		// Never add the initial destination to the history to prevent an empty screen when the user
 		// uses the "back" button to close the app
 		_currentAction.tryEmit(NavigationAction.NavigateFragment(initialDestination, false, false))
-		Timber.d("Navigating to $initialDestination")
+		Timber.d("Navigating to $initialDestination (via init)")
 	}
 
 	override fun navigate(destination: Destination, replace: Boolean) {
-		Timber.d("Navigating to $destination")
+		Timber.d("Navigating to $destination (via navigate function)")
 		val action = when (destination) {
 			is Destination.Fragment -> NavigationAction.NavigateFragment(destination, true, replace)
 			is Destination.Activity -> NavigationAction.NavigateActivity(destination) {
@@ -99,7 +99,7 @@ class NavigationRepositoryImpl(
 		fragmentHistory.clear()
 		val actualDestination = destination ?: initialDestination
 		_currentAction.tryEmit(NavigationAction.NavigateFragment(actualDestination, false, false))
-		Timber.d("Navigating to $actualDestination")
+		Timber.d("Navigating to $actualDestination (via reset)")
 	}
 }
 


### PR DESCRIPTION
When navigating between fragments we have various options to how the navigation should act. One specific navigation flow could cause some issues. When navigating as follows:

Home -> Player -> Next Up -> Player

You'll notice the home fragment flickering in the background. This was because of multiple issues:
1) The `addOnBackStackChangedListener` function could sometimes falsely trigger itself
2) the `popBackStackImmediate` call would run before the next transaction, causing the revert of that transaction to add the HomeFragment again before the transaction would run

To solve this I had to offer my soul to the developer gods and then make two changes:

1) Use `popBackStack` instead, this will then run just before the next transaction instead of immediately
2) Use the `replace` function instead of `remove` and `add` in the transaction. The Android docs both approaches to the same but they actually don't.

This issue also exists in 0.15 but it never triggers so I won't backport it.

**Changes**
- Improve navigation logging
- Fix a specific navigation issue when using the replace option
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
