### PR TITLE
Add missing view action to StartupActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,6 +118,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.SEARCH" />
+                <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />


### PR DESCRIPTION
This fixes an issue on Android 13 and newer where the channels on the home screen could not be launched because the view action was not added to the manifest.

**Changes**
- Add missing view action to StartupActivity

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
