### PR TITLE
Add preference to disable device type detection notification

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
@@ -2,13 +2,13 @@ package org.jellyfin.androidtv.data.repository
 
 import android.app.UiModeManager
 import android.content.Context
-import android.content.res.Configuration
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.model.AppNotification
 import org.jellyfin.androidtv.preference.SystemPreferences
+import org.jellyfin.androidtv.util.isTvDevice
 
 interface NotificationsRepository {
 	val notifications: StateFlow<List<AppNotification>>
@@ -39,12 +39,9 @@ class NotificationsRepositoryImpl(
 	}
 
 	private fun addUiModeNotification() {
-		val supportedUiModes = setOf(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_TYPE_UNDEFINED)
-		val invalidUiMode = !supportedUiModes.contains(uiModeManager.currentModeType)
-		val isTouch = context.packageManager.hasSystemFeature("android.hardware.touchscreen")
-		val hasHdmiCec = context.packageManager.hasSystemFeature("android.hardware.hdmi.cec")
+		val disableUiModeWarning = systemPreferences[SystemPreferences.disableUiModeWarning]
 
-		if (invalidUiMode && isTouch && !hasHdmiCec) {
+		if (!context.isTvDevice() && !disableUiModeWarning) {
 			addNotification(context.getString(R.string.app_notification_uimode_invalid), public = true)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/SystemPreferences.kt
@@ -69,5 +69,10 @@ class SystemPreferences(context: Context) : SharedPreferenceStore(
 		 * The version name for the latest dismissed beta notification or empty if none.
 		 */
 		val dismissedBetaNotificationVersion = stringPreference("dismissed_beta_notification_version", "")
+
+		/**
+		 * Whether to disable the "UI mode" warning that shows when using the app on non TV devices.
+		 */
+		val disableUiModeWarning = booleanPreference("disable_ui_mode_warning", false)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -2,14 +2,17 @@ package org.jellyfin.androidtv.ui.preference.screen
 
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.SystemPreferences
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.androidtv.util.isTvDevice
 import org.koin.android.ext.android.inject
 
 class DeveloperPreferencesScreen : OptionsFragment() {
 	private val userPreferences: UserPreferences by inject()
+	private val systemPreferences: SystemPreferences by inject()
 
 	override val screen by optionsScreen {
 		setTitle(R.string.pref_developer_link)
@@ -21,6 +24,14 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.lbl_enable_debug)
 				setContent(R.string.desc_debug)
 				bind(userPreferences, UserPreferences.debuggingEnabled)
+			}
+
+			// UI Mode toggle
+			if (!context.isTvDevice()) {
+				checkbox {
+					setTitle(R.string.disable_ui_mode_warning)
+					bind(systemPreferences, SystemPreferences.disableUiModeWarning)
+				}
 			}
 
 			checkbox {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ContextExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ContextExtensions.kt
@@ -1,9 +1,12 @@
 package org.jellyfin.androidtv.util
 
 import android.app.Activity
+import android.app.UiModeManager
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.res.Configuration
 import androidx.annotation.PluralsRes
+import androidx.core.content.getSystemService
 
 /**
  * Get the activity hosting the current context
@@ -20,3 +23,12 @@ tailrec fun Context.getActivity(): Activity? = when (this) {
  */
 fun Context.getQuantityString(@PluralsRes id: Int, quantity: Number, vararg args: Any) =
 	resources.getQuantityString(id, quantity.toInt(), quantity, *args)
+
+fun Context.isTvDevice(): Boolean {
+	val uiModeManager = getSystemService<UiModeManager>()
+	val supportedUiModes = setOf(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_TYPE_UNDEFINED)
+
+	return supportedUiModes.contains(uiModeManager?.currentModeType) or
+		packageManager.hasSystemFeature("android.hardware.hdmi.cec") or
+		!packageManager.hasSystemFeature("android.hardware.touchscreen")
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,6 +493,7 @@
     <string name="pref_music_cat">Music</string>
     <string name="pref_music_rewrite_disable">Disable new music backend</string>
     <string name="pref_music_rewrite_enable_description">Only disable this if you\'re experiencing issues with music playback</string>
+    <string name="disable_ui_mode_warning">Disable device type warning</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION


**Changes**
- Add preference to disable device type detection notification
  - Shows under "developer options"
  - Only shows when the warning would normally show (on phones)
  - Requires app restart to take effect

**Issues**

Fixes #2881