### PR TITLE
Fix video player background not black

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -44,6 +44,7 @@ import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.constant.CustomMessage;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
+import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.databinding.OverlayTvGuideBinding;
 import org.jellyfin.androidtv.databinding.VlcPlayerInterfaceBinding;
 import org.jellyfin.androidtv.preference.UserPreferences;
@@ -162,6 +163,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<PlaybackControllerContainer> playbackControllerContainer = inject(PlaybackControllerContainer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
+    private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
 
     private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
 
@@ -200,6 +202,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 leanbackOverlayFragment.hideOverlay();
             }
         };
+
+        backgroundService.getValue().clearBackgrounds();
     }
 
     @Nullable

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/black">
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -90,17 +91,17 @@
             android:id="@+id/item_logo"
             android:layout_width="wrap_content"
             android:layout_height="60dp"
-            android:layout_marginBottom="2dp"
             android:layout_centerInParent="true"
             android:layout_centerVertical="true"
+            android:layout_marginBottom="2dp"
             android:contentDescription="@null"
             android:foregroundGravity="fill_horizontal"
             android:scaleType="fitCenter"
-            app:layout_constraintWidth_max="450dp"
             app:layout_constraintEnd_toStartOf="@id/textClock"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintHorizontal_bias="0.0" />
+            app:layout_constraintWidth_max="450dp" />
 
         <TextView
             android:id="@+id/item_title"
@@ -110,9 +111,9 @@
             android:textColor="@color/white"
             android:textSize="32sp"
             app:layout_constraintEnd_toStartOf="@id/textClock"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/item_logo"
-            app:layout_constraintHorizontal_bias="0.0"
             tools:text="Title" />
 
         <TextView
@@ -122,9 +123,9 @@
             android:textColor="@color/white"
             android:textSize="20sp"
             app:layout_constraintEnd_toStartOf="@id/textClock"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/item_title"
-            app:layout_constraintHorizontal_bias="0.0"
             tools:text="Subtitle" />
 
         <org.jellyfin.androidtv.ui.ClockUserView


### PR DESCRIPTION
I just started a 21:9 video on my 16:9 TV and instead of black bars the backdrop showed behind the player.. oops

**Changes**
- Fix player background not black
- Reformat vlc_player_interface.xml

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
