### PR TITLE
Fix crash when switching users while playing music

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.databinding.FragmentHomeBinding
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.ImageUtils
 import org.koin.android.ext.android.inject
@@ -28,6 +29,7 @@ class HomeFragment : Fragment() {
 	private val sessionRepository by inject<SessionRepository>()
 	private val userRepository by inject<UserRepository>()
 	private val navigationRepository by inject<NavigationRepository>()
+	private val mediaManager by inject<MediaManager>()
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		_binding = FragmentHomeBinding.inflate(inflater, container, false)
@@ -71,6 +73,7 @@ class HomeFragment : Fragment() {
 	}
 
 	private fun switchUser() {
+		mediaManager.clearAudioQueue()
 		sessionRepository.destroyCurrentSession()
 
 		// Open login activity


### PR DESCRIPTION
Previously we only stopped playback after the user is changed, with this change we also stop media immediately after usiong the switch users button in the home toolbar<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

- Stop media playback when switching users
  Previously we only stopped playback after the user is changed, with this change we also stop media immediately after usiong the switch users button in the home toolbar

- Don't clear ApiClient credentials when destroying a session
  This fixes various crashes where API calls would fail after a session was destroyed. Most notable was the crash that occurred when stopping music playback when switching users
  

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
