### PR TITLE
Use rounded corner for item details image

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/DetailRowView.kt
@@ -48,5 +48,6 @@ class DetailRowView @JvmOverloads constructor(
 
 	init {
 		binding.fdButtonRow.setOnHierarchyChangeListener(buttonsHierarchyChangeListener)
+		binding.mainImage.clipToOutline = true
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -93,6 +93,7 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
         FragmentAudioNowPlayingBinding binding = FragmentAudioNowPlayingBinding.inflate(getLayoutInflater(), container, false);
 
         mPoster = binding.poster;
+        mPoster.setClipToOutline(true);
         mArtistName = binding.artistTitle;
         mGenreRow = binding.genreRow;
         mSongTitle = binding.song;

--- a/app/src/main/res/drawable/shape_card.xml
+++ b/app/src/main/res/drawable/shape_card.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="?attr/cardRounding" />
+</shape>

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -203,7 +203,8 @@
                 android:layout_width="250dp"
                 android:layout_height="250dp"
                 android:layout_alignParentEnd="true"
-                android:layout_marginEnd="60dp" />
+                android:layout_marginEnd="60dp"
+                android:background="@drawable/shape_card" />
 
             <FrameLayout
                 android:id="@+id/rowsFragment"

--- a/app/src/main/res/layout/view_row_details.xml
+++ b/app/src/main/res/layout/view_row_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -154,13 +155,13 @@
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
             android:layout_centerVertical="true"
-            android:layout_marginTop="60dp"
+            android:layout_marginStart="50dp"
+            android:layout_marginTop="140dp"
+            android:layout_marginEnd="50dp"
+            android:layout_marginBottom="30dp"
+            android:background="@drawable/shape_card"
             android:contentDescription="@null"
             android:foregroundGravity="fill_horizontal"
-            android:paddingStart="50dp"
-            android:paddingTop="80dp"
-            android:paddingEnd="50dp"
-            android:paddingBottom="30dp"
             android:scaleType="centerInside"
             app:srcCompat="@drawable/blank30x30" />
 


### PR DESCRIPTION
**Changes**
- Use rounded corner for item details image
 ~~Only works on Android 12 and up for now~~

**Screenshots**

| Before | After |
| --- | --- |
| ![image](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/ad7034ae-4b93-4272-b874-f6cba7ff4534) | ![image](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/12e891fd-c355-4beb-ba90-709064bded7d) |
