### PR TITLE
Fix crash when reusing actions in MyDetailsOverviewRowPresenter

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
@@ -59,7 +59,12 @@ class MyDetailsOverviewRowPresenter(
 			}
 
 			binding.fdButtonRow.removeAllViews()
-			for (button in row.actions) binding.fdButtonRow.addView(button)
+			for (button in row.actions) {
+				val parent = button.parent
+				if (parent is ViewGroup) parent.removeView(button)
+
+				binding.fdButtonRow.addView(button)
+			}
 		}
 
 		fun setTitle(title: String?) {


### PR DESCRIPTION
This is a bit of a hack but the FullDetailsFragment is too messy to fix it properly right now...

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Remove current parent first if set to avoid a crash (parent already set)
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
