### PR TITLE
Fix UI corruption when resuming the FullDetailsFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -182,7 +182,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
 
         mRowsFragment = new RowsSupportFragment();
-        getChildFragmentManager().beginTransaction().add(R.id.rowsFragment, mRowsFragment).commit();
+        getChildFragmentManager().beginTransaction().replace(R.id.rowsFragment, mRowsFragment).commit();
 
         mRowsFragment.setOnItemViewClickedListener(new ItemViewClickedListener());
         mRowsFragment.setOnItemViewSelectedListener(new ItemViewSelectedListener());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -184,7 +184,7 @@ public class AudioNowPlayingFragment extends Fragment implements View.OnKeyListe
         requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
 
         mRowsFragment = new RowsSupportFragment();
-        getChildFragmentManager().beginTransaction().add(R.id.rowsFragment, mRowsFragment).commit();
+        getChildFragmentManager().beginTransaction().replace(R.id.rowsFragment, mRowsFragment).commit();
 
         mRowsFragment.setOnItemViewClickedListener(new ItemViewClickedListener());
         mRowsFragment.setOnItemViewSelectedListener(new ItemViewSelectedListener());


### PR DESCRIPTION
Basically every time the fragment resumed (e.g. going back to it from another screen) it would add another rows fragment instead of replacing it.

**Changes**
- Fix UI corruption when resuming the FullDetailsFragment

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
