### PR TITLE
Improve BaseRowItem refreshing (fix crash after item deletion)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -51,7 +51,7 @@ import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.MarkdownRenderer;
-import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
+import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse;
 import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.sdk.model.api.BaseItemDto;
@@ -349,13 +349,15 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                 mCurrentItem.getBaseItemType() != BaseItemKind.MUSIC_ALBUM &&
                 mCurrentItem.getBaseItemType() != BaseItemKind.PLAYLIST
         ) {
-            mCurrentItem.refresh(new EmptyLifecycleAwareResponse(getLifecycle()) {
+            BaseRowItem item = mCurrentItem;
+            item.refresh(new LifecycleAwareResponse<BaseItemDto>(getLifecycle()) {
                 @Override
-                public void onResponse() {
+                public void onResponse(BaseItemDto response) {
                     if (!getActive()) return;
 
                     ItemRowAdapter adapter = (ItemRowAdapter) mCurrentRow.getAdapter();
-                    adapter.notifyItemRangeChanged(adapter.indexOf(mCurrentItem), 1);
+                    if (response == null) adapter.removeAt(adapter.indexOf(item), 1);
+					else adapter.notifyItemRangeChanged(adapter.indexOf(item), 1);
                 }
             });
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -44,11 +44,12 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter
 import org.jellyfin.androidtv.util.KeyProcessor
-import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse
+import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.api.sockets.addGlobalListener
+import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.socket.LibraryChangedMessage
 import org.jellyfin.sdk.model.socket.UserDataChangedMessage
@@ -236,12 +237,13 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 
 			Timber.d("Refresh item ${item.getFullName(requireContext())}")
 
-			item.refresh(object : EmptyLifecycleAwareResponse(lifecycle) {
-				override fun onResponse() {
+			item.refresh(object : LifecycleAwareResponse<BaseItemDto?>(lifecycle) {
+				override fun onResponse(response: BaseItemDto?) {
 					if (!active) return
 
 					val adapter = currentRow?.adapter as? ItemRowAdapter
-					adapter?.notifyItemRangeChanged(adapter.indexOf(item), 1)
+					if (response == null) adapter?.removeAt(adapter.indexOf(item), 1)
+					else adapter?.notifyItemRangeChanged(adapter.indexOf(item), 1)
 				}
 			})
 		}


### PR DESCRIPTION
**Changes**

- Fix race conditions where selected item would change during refresh
- Catch API exceptions
- Remove item from adapter when refresh fails (~~should actually only happen with a 404 but the server returns a 500 🤷~~)
- Format some files

**Issues**

Fixes #2948
