### PR TITLE
Fix blurry banners and thumbnails 

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -152,27 +152,27 @@ open class BaseRowItem protected constructor(
 		BaseItemKind.MUSIC_ARTIST
 	).contains(baseItem?.type)
 
-	fun getImageUrl(context: Context, imageType: ImageType, requiredWidth: Int) = when (baseRowType) {
+	fun getImageUrl(context: Context, imageType: ImageType, preferedWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
 		BaseRowType.LiveTvRecording -> {
 			val apiClient = get<LegacyApiClient>()
 			when (imageType) {
-				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, requiredWidth)
-				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, requiredWidth)
-				else -> getPrimaryImageUrl(context, requiredWidth)
+				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, preferedWidth)
+				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, preferedWidth)
+				else -> getPrimaryImageUrl(context, preferedWidth)
 			}
 		}
 
-		else -> getPrimaryImageUrl(context, requiredWidth)
+		else -> getPrimaryImageUrl(context, preferedWidth)
 	}
 
-	fun getPrimaryImageUrl(context: Context, requiredWidth: Int) = when (baseRowType) {
+	fun getPrimaryImageUrl(context: Context, preferedWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
-		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, requiredWidth)
+		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, preferedWidth)
 
-		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, requiredWidth)
+		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, preferedWidth)
 		BaseRowType.Chapter -> chapterInfo?.imagePath
 		BaseRowType.LiveTvChannel -> ImageUtils.getPrimaryImageUrl(baseItem!!)
 		BaseRowType.GridButton -> gridButton?.imageRes?.let { ImageUtils.getResourceUrl(context, it) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -152,27 +152,27 @@ open class BaseRowItem protected constructor(
 		BaseItemKind.MUSIC_ARTIST
 	).contains(baseItem?.type)
 
-	fun getImageUrl(context: Context, imageType: ImageType, maxHeight: Int) = when (baseRowType) {
+	fun getImageUrl(context: Context, imageType: ImageType, requiredWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
 		BaseRowType.LiveTvRecording -> {
 			val apiClient = get<LegacyApiClient>()
 			when (imageType) {
-				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, maxHeight)
-				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, maxHeight)
-				else -> getPrimaryImageUrl(context, maxHeight)
+				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, requiredWidth)
+				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, requiredWidth)
+				else -> getPrimaryImageUrl(context, requiredWidth)
 			}
 		}
 
-		else -> getPrimaryImageUrl(context, maxHeight)
+		else -> getPrimaryImageUrl(context, requiredWidth)
 	}
 
-	fun getPrimaryImageUrl(context: Context, maxHeight: Int) = when (baseRowType) {
+	fun getPrimaryImageUrl(context: Context, requiredWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
-		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, maxHeight)
+		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, requiredWidth)
 
-		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, maxHeight)
+		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, requiredWidth)
 		BaseRowType.Chapter -> chapterInfo?.imagePath
 		BaseRowType.LiveTvChannel -> ImageUtils.getPrimaryImageUrl(baseItem!!)
 		BaseRowType.GridButton -> gridButton?.imageRes?.let { ImageUtils.getResourceUrl(context, it) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -152,27 +152,27 @@ open class BaseRowItem protected constructor(
 		BaseItemKind.MUSIC_ARTIST
 	).contains(baseItem?.type)
 
-	fun getImageUrl(context: Context, imageType: ImageType, preferedWidth: Int) = when (baseRowType) {
+	fun getImageUrl(context: Context, imageType: ImageType, preferredWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
 		BaseRowType.LiveTvRecording -> {
 			val apiClient = get<LegacyApiClient>()
 			when (imageType) {
-				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, preferedWidth)
-				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, preferedWidth)
-				else -> getPrimaryImageUrl(context, preferedWidth)
+				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, preferredWidth)
+				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, preferredWidth)
+				else -> getPrimaryImageUrl(context, preferredWidth)
 			}
 		}
 
-		else -> getPrimaryImageUrl(context, preferedWidth)
+		else -> getPrimaryImageUrl(context, preferredWidth)
 	}
 
-	fun getPrimaryImageUrl(context: Context, preferedWidth: Int) = when (baseRowType) {
+	fun getPrimaryImageUrl(context: Context, preferredWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
-		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, preferedWidth)
+		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, preferredWidth)
 
-		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, preferedWidth)
+		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, preferredWidth)
 		BaseRowType.Chapter -> chapterInfo?.imagePath
 		BaseRowType.LiveTvChannel -> ImageUtils.getPrimaryImageUrl(baseItem!!)
 		BaseRowType.GridButton -> gridButton?.imageRes?.let { ImageUtils.getResourceUrl(context, it) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -152,27 +152,27 @@ open class BaseRowItem protected constructor(
 		BaseItemKind.MUSIC_ARTIST
 	).contains(baseItem?.type)
 
-	fun getImageUrl(context: Context, imageType: ImageType, preferredWidth: Int) = when (baseRowType) {
+	fun getImageUrl(context: Context, imageType: ImageType, maxHeight: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
 		BaseRowType.LiveTvRecording -> {
 			val apiClient = get<LegacyApiClient>()
 			when (imageType) {
-				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, preferredWidth)
-				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, preferredWidth)
-				else -> getPrimaryImageUrl(context, preferredWidth)
+				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, maxHeight)
+				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, maxHeight)
+				else -> getPrimaryImageUrl(context, maxHeight)
 			}
 		}
 
-		else -> getPrimaryImageUrl(context, preferredWidth)
+		else -> getPrimaryImageUrl(context, maxHeight)
 	}
 
-	fun getPrimaryImageUrl(context: Context, preferredWidth: Int) = when (baseRowType) {
+	fun getPrimaryImageUrl(context: Context, maxHeight: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
-		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, preferredWidth)
+		BaseRowType.LiveTvRecording -> ImageUtils.getPrimaryImageUrl(baseItem!!, preferParentThumb, maxHeight)
 
-		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, preferredWidth)
+		BaseRowType.Person -> ImageUtils.getPrimaryImageUrl(basePerson!!, maxHeight)
 		BaseRowType.Chapter -> chapterInfo?.imagePath
 		BaseRowType.LiveTvChannel -> ImageUtils.getPrimaryImageUrl(baseItem!!)
 		BaseRowType.GridButton -> gridButton?.imageRes?.let { ImageUtils.getResourceUrl(context, it) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseRowItem.kt
@@ -152,14 +152,14 @@ open class BaseRowItem protected constructor(
 		BaseItemKind.MUSIC_ARTIST
 	).contains(baseItem?.type)
 
-	fun getImageUrl(context: Context, imageType: ImageType, maxHeight: Int) = when (baseRowType) {
+	fun getImageUrl(context: Context, imageType: ImageType, maxHeight: Int, preferredWidth: Int) = when (baseRowType) {
 		BaseRowType.BaseItem,
 		BaseRowType.LiveTvProgram,
 		BaseRowType.LiveTvRecording -> {
 			val apiClient = get<LegacyApiClient>()
 			when (imageType) {
-				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, maxHeight)
-				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, maxHeight)
+				ImageType.BANNER -> ImageUtils.getBannerImageUrl(baseItem, apiClient, preferredWidth)
+				ImageType.THUMB -> ImageUtils.getThumbImageUrl(baseItem, apiClient, preferredWidth)
 				else -> getPrimaryImageUrl(context, maxHeight)
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -83,8 +83,8 @@ public class CardPresenter extends Presenter {
             this.lifecycleOwner = lifecycleOwner;
         }
 
-        public int getCardHeight() {
-            return cardHeight;
+        public int getCardWidth() {
+            return cardWidth;
         }
 
         public void setItem(BaseRowItem m) {
@@ -405,9 +405,9 @@ public class CardPresenter extends Presenter {
             }
         }
 
-        float maxHeight = holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density;
+        float requiredWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(requiredWidth)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -83,8 +83,8 @@ public class CardPresenter extends Presenter {
             this.lifecycleOwner = lifecycleOwner;
         }
 
-        public int getCardWidth() {
-            return cardWidth;
+        public int getCardHeight() {
+            return cardHeight;
         }
 
         public void setItem(BaseRowItem m) {
@@ -405,9 +405,9 @@ public class CardPresenter extends Presenter {
             }
         }
 
-        float preferredWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
+        float maxHeight = holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(preferredWidth)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -385,7 +385,6 @@ public class CardPresenter extends Presenter {
             }
         }
 
-        float requiredImageHeight = 100;
         String blurHash = null;
         if (rowItem.getBaseItem() != null && rowItem.getBaseItem().getImageBlurHashes() != null) {
             Map<String, String> blurHashMap;
@@ -393,26 +392,22 @@ public class CardPresenter extends Presenter {
             if (aspect == ASPECT_RATIO_BANNER) {
                 blurHashMap = rowItem.getBaseItem().getImageBlurHashes().get(org.jellyfin.sdk.model.api.ImageType.BANNER);
                 imageTag = rowItem.getBaseItem().getImageTags().get(org.jellyfin.sdk.model.api.ImageType.BANNER);
-                //Calculate the height of the image required to fill the banner
-                requiredImageHeight = (float) (holder.getCardHeight() * ASPECT_RATIO_BANNER / (1 / ImageUtils.ASPECT_RATIO_16_9));
             } else if (aspect == ImageUtils.ASPECT_RATIO_16_9 && !isUserView && (rowItem.getBaseItemType() != BaseItemKind.EPISODE || !rowItem.getBaseItem().getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.PRIMARY) || (rowItem.getPreferParentThumb() && rowItem.getBaseItem().getParentThumbImageTag() != null))) {
                 blurHashMap = rowItem.getBaseItem().getImageBlurHashes().get(org.jellyfin.sdk.model.api.ImageType.THUMB);
                 imageTag = (rowItem.getPreferParentThumb() || !rowItem.getBaseItem().getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.PRIMARY)) ? rowItem.getBaseItem().getParentThumbImageTag() : rowItem.getBaseItem().getImageTags().get(org.jellyfin.sdk.model.api.ImageType.THUMB);
-                //Calculate the height of the image required to fill the banner
-                requiredImageHeight = (float) (holder.getCardHeight() * ImageUtils.ASPECT_RATIO_16_9 * ImageUtils.ASPECT_RATIO_16_9);
             } else {
                 blurHashMap = rowItem.getBaseItem().getImageBlurHashes().get(org.jellyfin.sdk.model.api.ImageType.PRIMARY);
                 imageTag = rowItem.getBaseItem().getImageTags().get(org.jellyfin.sdk.model.api.ImageType.PRIMARY);
-                requiredImageHeight = holder.getCardHeight();
             }
 
             if (blurHashMap != null && !blurHashMap.isEmpty() && imageTag != null && blurHashMap.get(imageTag) != null) {
                 blurHash = blurHashMap.get(imageTag);
             }
         }
-        requiredImageHeight *= holder.mCardView.getResources().getDisplayMetrics().density;
+
+        float maxHeight = holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(requiredImageHeight)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -87,6 +87,10 @@ public class CardPresenter extends Presenter {
             return cardHeight;
         }
 
+        public int getCardWidth() {
+            return cardWidth;
+        }
+
         public void setItem(BaseRowItem m) {
             setItem(m, ImageType.POSTER, 130, 150, 150);
         }
@@ -404,10 +408,10 @@ public class CardPresenter extends Presenter {
                 blurHash = blurHashMap.get(imageTag);
             }
         }
-
+        float preferredWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
         float maxHeight = holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight), Math.round(preferredWidth)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -405,9 +405,9 @@ public class CardPresenter extends Presenter {
             }
         }
 
-        float preferedWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
+        float preferredWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(preferedWidth)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(preferredWidth)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -405,9 +405,9 @@ public class CardPresenter extends Presenter {
             }
         }
 
-        float requiredWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
+        float preferedWidth = holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(requiredWidth)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(preferedWidth)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -385,6 +385,7 @@ public class CardPresenter extends Presenter {
             }
         }
 
+        float requiredImageHeight = 100;
         String blurHash = null;
         if (rowItem.getBaseItem() != null && rowItem.getBaseItem().getImageBlurHashes() != null) {
             Map<String, String> blurHashMap;
@@ -392,22 +393,26 @@ public class CardPresenter extends Presenter {
             if (aspect == ASPECT_RATIO_BANNER) {
                 blurHashMap = rowItem.getBaseItem().getImageBlurHashes().get(org.jellyfin.sdk.model.api.ImageType.BANNER);
                 imageTag = rowItem.getBaseItem().getImageTags().get(org.jellyfin.sdk.model.api.ImageType.BANNER);
+                //Calculate the height of the image required to fill the banner
+                requiredImageHeight = (float) (holder.getCardHeight() * ASPECT_RATIO_BANNER / (1 / ImageUtils.ASPECT_RATIO_16_9));
             } else if (aspect == ImageUtils.ASPECT_RATIO_16_9 && !isUserView && (rowItem.getBaseItemType() != BaseItemKind.EPISODE || !rowItem.getBaseItem().getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.PRIMARY) || (rowItem.getPreferParentThumb() && rowItem.getBaseItem().getParentThumbImageTag() != null))) {
                 blurHashMap = rowItem.getBaseItem().getImageBlurHashes().get(org.jellyfin.sdk.model.api.ImageType.THUMB);
                 imageTag = (rowItem.getPreferParentThumb() || !rowItem.getBaseItem().getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.PRIMARY)) ? rowItem.getBaseItem().getParentThumbImageTag() : rowItem.getBaseItem().getImageTags().get(org.jellyfin.sdk.model.api.ImageType.THUMB);
+                //Calculate the height of the image required to fill the banner
+                requiredImageHeight = (float) (holder.getCardHeight() * ImageUtils.ASPECT_RATIO_16_9 * ImageUtils.ASPECT_RATIO_16_9);
             } else {
                 blurHashMap = rowItem.getBaseItem().getImageBlurHashes().get(org.jellyfin.sdk.model.api.ImageType.PRIMARY);
                 imageTag = rowItem.getBaseItem().getImageTags().get(org.jellyfin.sdk.model.api.ImageType.PRIMARY);
+                requiredImageHeight = holder.getCardHeight();
             }
 
             if (blurHashMap != null && !blurHashMap.isEmpty() && imageTag != null && blurHashMap.get(imageTag) != null) {
                 blurHash = blurHashMap.get(imageTag);
             }
         }
-
-        float maxHeight = holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density;
+        requiredImageHeight *= holder.mCardView.getResources().getDisplayMetrics().density;
         holder.updateCardViewImage(
-                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(maxHeight)),
+                rowItem.getImageUrl(holder.mCardView.getContext(), mImageType, Math.round(requiredImageHeight)),
                 blurHash
         );
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -12,7 +12,7 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 class ImageHelper(
 	private val api: ApiClient,
 ) {
-	fun getPrimaryImageUrl(item: BaseItemPerson, maxHeight: Int? = null): String? {
+	fun getPrimaryImageUrl(item: BaseItemPerson, requiredWidth: Int? = null): String? {
 		if (item.primaryImageTag == null) return null
 
 		return item.id.let { itemId ->
@@ -20,7 +20,7 @@ class ImageHelper(
 				itemId = itemId,
 				imageType = ImageType.PRIMARY,
 				tag = item.primaryImageTag,
-				maxHeight = maxHeight,
+				maxWidth = requiredWidth,
 			)
 		}
 	}
@@ -57,7 +57,7 @@ class ImageHelper(
 		)
 	}
 
-	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, maxHeight: Int): String {
+	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, requiredWidth: Int): String {
 		var itemId = item.id
 		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
 		var imageType = ImageType.PRIMARY
@@ -94,7 +94,7 @@ class ImageHelper(
 			itemId = itemId,
 			imageType = imageType,
 			tag = imageTag,
-			maxHeight = maxHeight,
+			maxWidth = requiredWidth,
 		)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -98,6 +98,19 @@ class ImageHelper(
 		)
 	}
 
+	fun getPrimaryImageUrlByWidth(item: BaseItemDto, preferredWidth: Int): String {
+		var itemId = item.id
+		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
+		var imageType = ImageType.PRIMARY
+
+		return api.imageApi.getItemImageUrl(
+				itemId = itemId,
+				imageType = imageType,
+				tag = imageTag,
+				maxWidth = preferredWidth,
+		)
+	}
+
 	fun getLogoImageUrl(item: BaseItemDto?, maxWidth: Int? = null, useSeriesFallback: Boolean = true): String? {
 		val logoTag = item?.imageTags?.get(ImageType.LOGO)
 		return when {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -12,7 +12,7 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 class ImageHelper(
 	private val api: ApiClient,
 ) {
-	fun getPrimaryImageUrl(item: BaseItemPerson, preferredWidth: Int? = null): String? {
+	fun getPrimaryImageUrl(item: BaseItemPerson, maxHeight: Int? = null): String? {
 		if (item.primaryImageTag == null) return null
 
 		return item.id.let { itemId ->
@@ -20,7 +20,7 @@ class ImageHelper(
 				itemId = itemId,
 				imageType = ImageType.PRIMARY,
 				tag = item.primaryImageTag,
-				maxWidth = preferredWidth,
+				maxHeight = maxHeight,
 			)
 		}
 	}
@@ -57,7 +57,7 @@ class ImageHelper(
 		)
 	}
 
-	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, preferredWidth: Int): String {
+	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, maxHeight: Int): String {
 		var itemId = item.id
 		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
 		var imageType = ImageType.PRIMARY
@@ -94,7 +94,7 @@ class ImageHelper(
 			itemId = itemId,
 			imageType = imageType,
 			tag = imageTag,
-			maxWidth = preferredWidth,
+			maxHeight = maxHeight,
 		)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -12,7 +12,7 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 class ImageHelper(
 	private val api: ApiClient,
 ) {
-	fun getPrimaryImageUrl(item: BaseItemPerson, requiredWidth: Int? = null): String? {
+	fun getPrimaryImageUrl(item: BaseItemPerson, preferedWidth: Int? = null): String? {
 		if (item.primaryImageTag == null) return null
 
 		return item.id.let { itemId ->
@@ -20,7 +20,7 @@ class ImageHelper(
 				itemId = itemId,
 				imageType = ImageType.PRIMARY,
 				tag = item.primaryImageTag,
-				maxWidth = requiredWidth,
+				maxWidth = preferedWidth,
 			)
 		}
 	}
@@ -57,7 +57,7 @@ class ImageHelper(
 		)
 	}
 
-	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, requiredWidth: Int): String {
+	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, preferedWidth: Int): String {
 		var itemId = item.id
 		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
 		var imageType = ImageType.PRIMARY
@@ -94,7 +94,7 @@ class ImageHelper(
 			itemId = itemId,
 			imageType = imageType,
 			tag = imageTag,
-			maxWidth = requiredWidth,
+			maxWidth = preferedWidth,
 		)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -12,7 +12,7 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 class ImageHelper(
 	private val api: ApiClient,
 ) {
-	fun getPrimaryImageUrl(item: BaseItemPerson, preferedWidth: Int? = null): String? {
+	fun getPrimaryImageUrl(item: BaseItemPerson, preferredWidth: Int? = null): String? {
 		if (item.primaryImageTag == null) return null
 
 		return item.id.let { itemId ->
@@ -20,7 +20,7 @@ class ImageHelper(
 				itemId = itemId,
 				imageType = ImageType.PRIMARY,
 				tag = item.primaryImageTag,
-				maxWidth = preferedWidth,
+				maxWidth = preferredWidth,
 			)
 		}
 	}
@@ -57,7 +57,7 @@ class ImageHelper(
 		)
 	}
 
-	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, preferedWidth: Int): String {
+	fun getPrimaryImageUrl(item: BaseItemDto, preferParentThumb: Boolean, preferredWidth: Int): String {
 		var itemId = item.id
 		var imageTag = item.imageTags?.get(ImageType.PRIMARY)
 		var imageType = ImageType.PRIMARY
@@ -94,7 +94,7 @@ class ImageHelper(
 			itemId = itemId,
 			imageType = imageType,
 			tag = imageTag,
-			maxWidth = preferedWidth,
+			maxWidth = preferredWidth,
 		)
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -55,8 +55,8 @@ public class ImageUtils {
         return item.getPrimaryImageAspectRatio() != null ? item.getPrimaryImageAspectRatio() : ASPECT_RATIO_7_9;
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int preferredWidth) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferredWidth);
+    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int maxHeight) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, maxHeight);
     }
 
     public static String getPrimaryImageUrl(@NonNull UserDto item) {
@@ -82,9 +82,9 @@ public class ImageUtils {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getImageUrl(itemId, ModelCompat.asSdk(imageType), imageTag);
     }
 
-    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int preferredWidth) {
+    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int maxHeight) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.BANNER)) {
-            return getPrimaryImageUrl(item, false, preferredWidth);
+            return getPrimaryImageUrl(item, false, maxHeight);
         }
 
         ImageOptions options = new ImageOptions();
@@ -105,9 +105,9 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int preferredWidth) {
+    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int maxHeight) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.THUMB)) {
-            return getPrimaryImageUrl(item, true, preferredWidth);
+            return getPrimaryImageUrl(item, true, maxHeight);
         }
 
         ImageOptions options = new ImageOptions();
@@ -116,8 +116,8 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int preferredWidth) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, preferredWidth);
+    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int maxHeight) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, maxHeight);
     }
 
     public static String getLogoImageUrl(@Nullable org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -55,8 +55,8 @@ public class ImageUtils {
         return item.getPrimaryImageAspectRatio() != null ? item.getPrimaryImageAspectRatio() : ASPECT_RATIO_7_9;
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int preferedWidth) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferedWidth);
+    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int preferredWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferredWidth);
     }
 
     public static String getPrimaryImageUrl(@NonNull UserDto item) {
@@ -82,9 +82,9 @@ public class ImageUtils {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getImageUrl(itemId, ModelCompat.asSdk(imageType), imageTag);
     }
 
-    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int preferedWidth) {
+    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int preferredWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.BANNER)) {
-            return getPrimaryImageUrl(item, false, preferedWidth);
+            return getPrimaryImageUrl(item, false, preferredWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -105,9 +105,9 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int preferedWidth) {
+    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int preferredWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.THUMB)) {
-            return getPrimaryImageUrl(item, true, preferedWidth);
+            return getPrimaryImageUrl(item, true, preferredWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -116,8 +116,8 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int preferedWidth) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, preferedWidth);
+    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int preferredWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, preferredWidth);
     }
 
     public static String getLogoImageUrl(@Nullable org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -8,7 +8,6 @@ import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
@@ -56,8 +55,8 @@ public class ImageUtils {
         return item.getPrimaryImageAspectRatio() != null ? item.getPrimaryImageAspectRatio() : ASPECT_RATIO_7_9;
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int maxHeight) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, maxHeight);
+    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int requiredWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, requiredWidth);
     }
 
     public static String getPrimaryImageUrl(@NonNull UserDto item) {
@@ -83,11 +82,9 @@ public class ImageUtils {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getImageUrl(itemId, ModelCompat.asSdk(imageType), imageTag);
     }
 
-    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int maxHeight) {
+    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int requiredWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.BANNER)) {
-            //Calculate the height of the image required to fill the banner
-            maxHeight *= CardPresenter.ASPECT_RATIO_BANNER * ASPECT_RATIO_16_9;
-            return getPrimaryImageUrl(item, false, maxHeight);
+            return getPrimaryImageUrl(item, false, requiredWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -108,11 +105,9 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int maxHeight) {
+    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int requiredWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.THUMB)) {
-            //Calculate the height of the image required to fill the thumbnail
-            maxHeight *= ASPECT_RATIO_16_9 * ASPECT_RATIO_16_9;
-            return getPrimaryImageUrl(item, true, maxHeight);
+            return getPrimaryImageUrl(item, true, requiredWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -121,8 +116,8 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int maxHeight) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, maxHeight);
+    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int requiredWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, requiredWidth);
     }
 
     public static String getLogoImageUrl(@Nullable org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -55,8 +55,8 @@ public class ImageUtils {
         return item.getPrimaryImageAspectRatio() != null ? item.getPrimaryImageAspectRatio() : ASPECT_RATIO_7_9;
     }
 
-    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int requiredWidth) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, requiredWidth);
+    public static String getPrimaryImageUrl(@NonNull BaseItemPerson item, @Nullable int preferedWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferedWidth);
     }
 
     public static String getPrimaryImageUrl(@NonNull UserDto item) {
@@ -82,9 +82,9 @@ public class ImageUtils {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getImageUrl(itemId, ModelCompat.asSdk(imageType), imageTag);
     }
 
-    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int requiredWidth) {
+    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int preferedWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.BANNER)) {
-            return getPrimaryImageUrl(item, false, requiredWidth);
+            return getPrimaryImageUrl(item, false, preferedWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -105,9 +105,9 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int requiredWidth) {
+    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int preferedWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.THUMB)) {
-            return getPrimaryImageUrl(item, true, requiredWidth);
+            return getPrimaryImageUrl(item, true, preferedWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -116,8 +116,8 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int requiredWidth) {
-        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, requiredWidth);
+    public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int preferedWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, preferedWidth);
     }
 
     public static String getLogoImageUrl(@Nullable org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -8,6 +8,7 @@ import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.ImageOptions;
@@ -84,6 +85,8 @@ public class ImageUtils {
 
     public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int maxHeight) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.BANNER)) {
+            //Calculate the height of the image required to fill the banner
+            maxHeight *= CardPresenter.ASPECT_RATIO_BANNER * ASPECT_RATIO_16_9;
             return getPrimaryImageUrl(item, false, maxHeight);
         }
 
@@ -107,6 +110,8 @@ public class ImageUtils {
 
     public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int maxHeight) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.THUMB)) {
+            //Calculate the height of the image required to fill the thumbnail
+            maxHeight *= ASPECT_RATIO_16_9 * ASPECT_RATIO_16_9;
             return getPrimaryImageUrl(item, true, maxHeight);
         }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageUtils.java
@@ -82,9 +82,9 @@ public class ImageUtils {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getImageUrl(itemId, ModelCompat.asSdk(imageType), imageTag);
     }
 
-    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int maxHeight) {
+    public static String getBannerImageUrl(org.jellyfin.sdk.model.api.BaseItemDto item, ApiClient apiClient, int preferredWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.BANNER)) {
-            return getPrimaryImageUrl(item, false, maxHeight);
+            return getPrimaryImageUrlByWidth(item, preferredWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -105,9 +105,9 @@ public class ImageUtils {
         return apiClient.GetImageUrl(item.getId().toString(), options);
     }
 
-    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int maxHeight) {
+    public static String getThumbImageUrl(BaseItemDto item, ApiClient apiClient, int preferredWidth) {
         if (!item.getImageTags().containsKey(org.jellyfin.sdk.model.api.ImageType.THUMB)) {
-            return getPrimaryImageUrl(item, true, maxHeight);
+            return getPrimaryImageUrlByWidth(item, preferredWidth);
         }
 
         ImageOptions options = new ImageOptions();
@@ -118,6 +118,10 @@ public class ImageUtils {
 
     public static String getPrimaryImageUrl(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull boolean preferParentThumb, @NonNull int maxHeight) {
         return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrl(item, preferParentThumb, maxHeight);
+    }
+
+    public static String getPrimaryImageUrlByWidth(@NonNull org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull int preferredWidth) {
+        return KoinJavaComponent.<ImageHelper>get(ImageHelper.class).getPrimaryImageUrlByWidth(item, preferredWidth);
     }
 
     public static String getLogoImageUrl(@Nullable org.jellyfin.sdk.model.api.BaseItemDto item, @NonNull int maxWidth, @NonNull boolean useSeriesFallback) {


### PR DESCRIPTION
**Changes**

Now when a banner/thumbnail is not found the image height used in retrieving an appropriate image from the server will be changed to account for the increased width.

Sadly this results in some performance issues as an image required to fill a banned can become quite large but I'm not sure how to fix that.

**Issues**
Fixes #2974 
