### PR TITLE
Fix disabling subtitles not always working

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -74,7 +74,7 @@ public class PlaybackManager {
             request.setAudioStreamIndex(audioIdx);
         }
         Integer subIdx = options.getSubtitleStreamIndex();
-        if (subIdx != null && subIdx >= 0) {
+        if (subIdx != null) {
             request.setSubtitleStreamIndex(subIdx);
         }
 


### PR DESCRIPTION
Tested the specific case where the subtitles are on by default and require transcoding. Disabling those will set the index to `-1` which was ignored in the PlaybackManager `getVideoStreamInfo` function so the server would happily reply the video info with default subtitles enabled.

**Changes**
- Fix disabling subtitles not always working

**Issues**

Fixes #2045
Fixes #2631
