### PR TITLE
Watched indicator settings string clarity improvements

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/WatchedIndicatorBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/WatchedIndicatorBehavior.kt
@@ -19,7 +19,7 @@ enum class WatchedIndicatorBehavior(
 	/**
 	 * Hide unwatched count indicator, show watched check mark on individual episodes only.
 	 */
-	EPISODES_ONLY(R.string.lbl_episode_marks),
+	EPISODES_ONLY(R.string.lbl_hide_watched_checkmark),
 
 	/**
 	 * Never show watched indicators.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,7 +344,7 @@
     <string name="login_help_title">Need help?</string>
     <string name="login_help_description">Jellyfin requires a server to connect with. Visit our documentation at docs.jellyfin.org or scan the QR code to get started with Jellyfin.</string>
     <string name="pref_watched_indicator">Show watched indicators</string>
-    <string name="lbl_hide_unwatched_count">When the show has been watched</string>
+    <string name="lbl_hide_unwatched_count">When the item is watched</string>
     <string name="lbl_hide_watched_checkmark">When there are episodes remaining</string>
     <string name="lbl_use_series_thumbnails">Prefer series thumbnails</string>
     <string name="lbl_use_series_thumbnails_description">Use series thumbnails when displaying episodes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,8 +344,8 @@
     <string name="login_help_title">Need help?</string>
     <string name="login_help_description">Jellyfin requires a server to connect with. Visit our documentation at docs.jellyfin.org or scan the QR code to get started with Jellyfin.</string>
     <string name="pref_watched_indicator">Show watched indicators</string>
-    <string name="lbl_hide_unwatched_count">Hide unwatched count</string>
-    <string name="lbl_episode_marks">On episodes only</string>
+    <string name="lbl_hide_unwatched_count">When the show has been watched</string>
+    <string name="lbl_hide_watched_checkmark">When there are episodes remaining</string>
     <string name="lbl_use_series_thumbnails">Prefer series thumbnails</string>
     <string name="lbl_use_series_thumbnails_description">Use series thumbnails when displaying episodes</string>
     <string name="auto_sign_in">Automatic sign in</string>


### PR DESCRIPTION
**Changes**
The settings strings are now clearer in what they mean.

For reference, the setting is titled `Show watched indicators`

`Hide unwatched count` -> `When the show has been watched`;
The new string follows up the setting to create sentence `Show watched indicator when the show has been watched`. The previous string was very hard to understand as the word "Hide" opposes the word "Show" and "Watched indicators" and "Unwatched count" are referring to the same thing.

`On episodes only` -> `When there are episodes remaining`
In this case the original is not clear in whether it only changes the behavior when there are episodes you haven't seen yet or whether it shows on all forms of media that have episodes.

