### PR TITLE
Add transcoding and remuxing

### DIFF
--- a/playback/core/src/main/kotlin/mediastream/MediaConversionMethod.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaConversionMethod.kt
@@ -1,0 +1,7 @@
+package org.jellyfin.playback.core.mediastream
+
+sealed interface MediaConversionMethod {
+	data object None : MediaConversionMethod
+	data object Remux : MediaConversionMethod
+	data object Transcode : MediaConversionMethod
+}

--- a/playback/core/src/main/kotlin/mediastream/MediaStream.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStream.kt
@@ -5,5 +5,6 @@ import org.jellyfin.playback.core.queue.item.QueueEntry
 data class MediaStream(
 	val identifier: String,
 	val queueEntry: QueueEntry,
+	val conversionMethod: MediaConversionMethod,
 	val url: String,
 )

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -23,7 +23,10 @@ fun jellyfinPlugin(
 		transcodingProfiles = emptyList(),
 		xmlRootAttributes = emptyList(),
 	)
-	provide(AudioMediaStreamResolver(api, profile))
+	provide(AudioMediaStreamResolver(api, profile).apply {
+		// TODO: Remove once we have a proper device profile
+		forceDirectPlay = true
+	})
 
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)

--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinStreamResolver.kt
@@ -19,7 +19,7 @@ abstract class JellyfinStreamResolver(
 
 	protected suspend fun getPlaybackInfo(
 		item: BaseItemDto,
-		mediaSource: MediaSourceInfo?=null,
+		mediaSource: MediaSourceInfo? = null,
 	): MediaInfo {
 		val response by api.mediaInfoApi.getPostedPlaybackInfo(
 			itemId = item.id,
@@ -42,7 +42,7 @@ abstract class JellyfinStreamResolver(
 			error("Failed to get media info for item ${item.id} source ${mediaSource?.id}: ${response.errorCode}")
 		}
 
-		val responseMediaSource = when(mediaSource){
+		val responseMediaSource = when (mediaSource) {
 			null -> response.mediaSources.firstOrNull()
 			else -> response.mediaSources.firstOrNull { it.id === mediaSource.id }
 		}

--- a/playback/jellyfin/src/main/kotlin/mediastream/UniversalAudioMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/UniversalAudioMediaStreamResolver.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.playback.jellyfin.mediastream
 
+import org.jellyfin.playback.core.mediastream.MediaConversionMethod
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.queue.item.QueueEntry
 import org.jellyfin.playback.jellyfin.queue.item.BaseItemDtoUserQueueEntry
@@ -37,6 +38,7 @@ class UniversalAudioMediaStreamResolver(
 		return MediaStream(
 			identifier = mediaInfo.playSessionId,
 			queueEntry = queueEntry,
+			conversionMethod = MediaConversionMethod.None,
 			url = url,
 		)
 	}

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
@@ -5,27 +5,27 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jellyfin.playback.core.mediastream.MediaConversionMethod
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.jellyfin.queue.item.BaseItemDtoUserQueueEntry
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
-import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.PlaybackProgressInfo
 import org.jellyfin.sdk.model.api.PlaybackStartInfo
 import org.jellyfin.sdk.model.api.PlaybackStopInfo
 import org.jellyfin.sdk.model.api.QueueItem
-import org.jellyfin.sdk.model.api.RepeatMode
 import org.jellyfin.sdk.model.extensions.inWholeTicks
 import kotlin.math.roundToInt
+import org.jellyfin.sdk.model.api.RepeatMode as SdkRepeatMode
 
 class PlaySessionService(
 	private val api: ApiClient,
 ) : PlayerService() {
-	private var playSessionId: String? = null
-	private var reportedItem: BaseItemDto? = null
+	private var reportedStream: MediaStream? = null
 
 	override suspend fun onInitialize() {
 		state.streams.current.onEach { stream -> onMediaStreamChange(stream) }.launchIn(coroutineScope)
@@ -40,39 +40,52 @@ class PlaySessionService(
 		}.launchIn(coroutineScope)
 	}
 
-	suspend fun sendUpdateIfActive() {
-		reportedItem?.let {
-			updateBaseItem(it)
-		}
-	}
-
-	private fun onMediaStreamChange(stream: MediaStream?) {
-		playSessionId = stream?.identifier
-		reportedItem = when (val entry = stream?.queueEntry) {
+	private val MediaStream.baseItem
+		get() = when (val entry = queueEntry) {
 			is BaseItemDtoUserQueueEntry -> entry.baseItem
 			else -> null
 		}
 
+	private val MediaConversionMethod.playMethod
+		get() = when (this) {
+			MediaConversionMethod.None -> PlayMethod.DIRECT_PLAY
+			MediaConversionMethod.Remux -> PlayMethod.DIRECT_STREAM
+			MediaConversionMethod.Transcode -> PlayMethod.TRANSCODE
+		}
+
+	private val RepeatMode.remoteRepeatMode
+		get() = when (this) {
+			RepeatMode.NONE -> SdkRepeatMode.REPEAT_NONE
+			RepeatMode.REPEAT_ENTRY_ONCE -> SdkRepeatMode.REPEAT_ONE
+			RepeatMode.REPEAT_ENTRY_INFINITE -> SdkRepeatMode.REPEAT_ALL
+		}
+
+	suspend fun sendUpdateIfActive() {
+		reportedStream?.let {
+			coroutineScope.launch { sendStreamUpdate(it) }
+		}
+	}
+
+	private fun onMediaStreamChange(stream: MediaStream?) {
+		reportedStream = stream
 		onStart()
 	}
 
 	private fun onStart() {
-		coroutineScope.launch {
-			if (reportedItem != null) startBaseItem(reportedItem!!)
+		reportedStream?.let {
+			coroutineScope.launch { sendStreamStart(it) }
 		}
 	}
 
 	private fun onStop() {
-		coroutineScope.launch {
-			if (reportedItem != null) {
-				stopBaseItem(reportedItem!!)
-			}
+		reportedStream?.let {
+			coroutineScope.launch { sendStreamStop(it) }
 		}
 	}
 
 	private fun onPause() {
-		coroutineScope.launch {
-			if (reportedItem != null) updateBaseItem(reportedItem!!)
+		reportedStream?.let {
+			coroutineScope.launch { sendStreamUpdate(it) }
 		}
 	}
 
@@ -85,10 +98,11 @@ class PlaySessionService(
 			.map { QueueItem(id = it.baseItem.id, playlistItemId = it.baseItem.playlistItemId) }
 	}
 
-	private suspend fun startBaseItem(item: BaseItemDto) {
+	private suspend fun sendStreamStart(stream: MediaStream) {
+		val item = stream.baseItem ?: return
 		api.playStateApi.reportPlaybackStart(PlaybackStartInfo(
 			itemId = item.id,
-			playSessionId = playSessionId,
+			playSessionId = stream.identifier,
 			playlistItemId = item.playlistItemId,
 			canSeek = true,
 			isMuted = state.volume.muted,
@@ -96,16 +110,17 @@ class PlaySessionService(
 			isPaused = state.playState.value != PlayState.PLAYING,
 			aspectRatio = state.videoSize.value.aspectRatio.toString(),
 			positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },
-			playMethod = PlayMethod.DIRECT_PLAY,
-			repeatMode = RepeatMode.REPEAT_NONE,
+			playMethod = stream.conversionMethod.playMethod,
+			repeatMode = state.repeatMode.value.remoteRepeatMode,
 			nowPlayingQueue = getQueue(),
 		))
 	}
 
-	private suspend fun updateBaseItem(item: BaseItemDto) {
+	private suspend fun sendStreamUpdate(stream: MediaStream) {
+		val item = stream.baseItem ?: return
 		api.playStateApi.reportPlaybackProgress(PlaybackProgressInfo(
 			itemId = item.id,
-			playSessionId = playSessionId,
+			playSessionId = stream.identifier,
 			playlistItemId = item.playlistItemId,
 			canSeek = true,
 			isMuted = state.volume.muted,
@@ -113,16 +128,17 @@ class PlaySessionService(
 			isPaused = state.playState.value != PlayState.PLAYING,
 			aspectRatio = state.videoSize.value.aspectRatio.toString(),
 			positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },
-			playMethod = PlayMethod.DIRECT_PLAY,
-			repeatMode = RepeatMode.REPEAT_NONE,
+			playMethod = stream.conversionMethod.playMethod,
+			repeatMode = state.repeatMode.value.remoteRepeatMode,
 			nowPlayingQueue = getQueue(),
 		))
 	}
 
-	private suspend fun stopBaseItem(item: BaseItemDto) {
+	private suspend fun sendStreamStop(stream: MediaStream) {
+		val item = stream.baseItem ?: return
 		api.playStateApi.reportPlaybackStopped(PlaybackStopInfo(
 			itemId = item.id,
-			playSessionId = playSessionId,
+			playSessionId = stream.identifier,
 			playlistItemId = item.playlistItemId,
 			positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },
 			failed = false,


### PR DESCRIPTION
**Changes**

- Add MediaConversionMethod to MediaStream
  Right now there are 3 modes that correspond to the existing play methods but the idea is to extend them in the future to more detailed variants, e.g. `MediaConversionMethod.Transcode.BakeSubs`. This information can then be used for easy troubleshooting

- Support remuxing and transcoding in AudioMediaStreamResolver
  We request media info from the server and previously used it to construct a direct play URL. Now we actually use the provided information to choose a suitable media conversion method, including remux and transcode.
- Report playMethod and repeatMode in PlaySessionService
  Server is dumb and if we don't set the playMethod it will tell everyone "HEY THIS DUDE IS DIRECT PLAYING!" while it is transcoding 🤷


**Remux & Transcoding is disabled**
We don't have a DeviceProfile in the new playback code yet so all of these fancy changes are disabled for now using an override (forceDirectPlay). Use this patch to force transcoding instead:

```patch
diff --git a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt	(revision f4d3770925f8a33662507248eac90212c91e6724)
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt	(date 1693145130151)
@@ -7,6 +7,8 @@
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.api.DeviceProfile
+import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.jellyfin.sdk.model.api.TranscodingProfile
 
 fun jellyfinPlugin(
 	api: ApiClient,
@@ -20,13 +22,19 @@
 		responseProfiles = emptyList(),
 		subtitleProfiles = emptyList(),
 		supportedMediaTypes = "",
-		transcodingProfiles = emptyList(),
+		transcodingProfiles = listOf(
+			TranscodingProfile(
+				type = DlnaProfileType.AUDIO,
+				container = "mp3",
+				audioCodec = "mp3",
+				videoCodec = "",
+				protocol = "http",
+				conditions = emptyList()
+			)
+		),
 		xmlRootAttributes = emptyList(),
 	)
-	provide(AudioMediaStreamResolver(api, profile).apply {
-		// TODO: Remove once we have a proper device profile
-		forceDirectPlay = true
-	})
+	provide(AudioMediaStreamResolver(api, profile))
 
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)
```

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
