### PR TITLE
Fix grid getting focus when empty

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -719,8 +719,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                     updateCounter(mAdapter.getTotalItems() > 0 ? 1 : 0);
                 }
                 mLetterButton.setVisibility(ItemSortBy.SortName.equals(mAdapter.getSortBy()) ? View.VISIBLE : View.GONE);
-                if (mAdapter.getTotalItems() == 0) {
-                    binding.toolBar.requestFocus();
+                if (mAdapter.getItemsLoaded() == 0) {
                     mHandler.postDelayed(() -> {
                         if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED))
                             return;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -720,14 +720,16 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                 }
                 mLetterButton.setVisibility(ItemSortBy.SortName.equals(mAdapter.getSortBy()) ? View.VISIBLE : View.GONE);
                 if (mAdapter.getItemsLoaded() == 0) {
+                    mGridView.setFocusable(false);
                     mHandler.postDelayed(() -> {
                         if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED))
                             return;
 
                         binding.title.setText(mFolder.getName());
                     }, 500);
-                } else {
-                    if (mGridView != null) mGridView.requestFocus();
+                } else if (mGridView != null) {
+                    mGridView.setFocusable(true);
+                    mGridView.requestFocus();
                 }
             }
         });


### PR DESCRIPTION
**Changes**
Right now the grid checks the total item amount, not the item amount after filtering. This results in the grid being focused on even if it is empty.

Side-note: I'm not sure how good of an idea it is to hijack the focus even when there are items in the grid.
