### PR TITLE
Fix user image being too cropped in

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -222,7 +222,7 @@ class ServerFragment : Fragment() {
 			holder.cardView.title = user.name
 			holder.cardView.setImage(
 				url = startupViewModel.getUserImage(server, user),
-				placeholder = ContextCompat.getDrawable(context, R.drawable.tile_square_user)
+				placeholder = ContextCompat.getDrawable(context, R.drawable.tile_user)
 			)
 			holder.cardView.setPopupMenu {
 				// Logout button

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -222,7 +222,7 @@ class ServerFragment : Fragment() {
 			holder.cardView.title = user.name
 			holder.cardView.setImage(
 				url = startupViewModel.getUserImage(server, user),
-				placeholder = ContextCompat.getDrawable(context, R.drawable.tile_port_user)
+				placeholder = ContextCompat.getDrawable(context, R.drawable.tile_square_user)
 			)
 			holder.cardView.setPopupMenu {
 				// Logout button

--- a/app/src/main/res/drawable/tile_square_user.xml
+++ b/app/src/main/res/drawable/tile_square_user.xml
@@ -3,16 +3,16 @@
     <item>
         <shape android:shape="rectangle">
             <size
-                android:width="256dp"
+                android:width="384dp"
                 android:height="384dp" />
             <solid android:color="?attr/tile_port_user_bg" />
         </shape>
     </item>
 
     <item
-        android:bottom="124dp"
         android:drawable="@drawable/ic_user"
-        android:left="60dp"
-        android:right="60dp"
-        android:top="124dp" />
+        android:left="124dp"
+        android:right="124dp"
+        android:top="124dp"
+        android:bottom="124dp"/>
 </layer-list>

--- a/app/src/main/res/drawable/tile_user.xml
+++ b/app/src/main/res/drawable/tile_user.xml
@@ -3,16 +3,16 @@
     <item>
         <shape android:shape="rectangle">
             <size
-                android:width="384dp"
-                android:height="384dp" />
-            <solid android:color="?attr/tile_port_user_bg" />
+                android:width="256dp"
+                android:height="256dp" />
+            <solid android:color="?attr/tile_user_bg" />
         </shape>
     </item>
 
     <item
         android:drawable="@drawable/ic_user"
-        android:left="124dp"
-        android:right="124dp"
-        android:top="124dp"
-        android:bottom="124dp"/>
+        android:bottom="60dp"
+        android:left="60dp"
+        android:right="60dp"
+        android:top="60dp" />
 </layer-list>

--- a/app/src/main/res/layout/fragment_server.xml
+++ b/app/src/main/res/layout/fragment_server.xml
@@ -40,7 +40,7 @@
     <androidx.leanback.widget.HorizontalGridView
         android:id="@+id/users"
         android:layout_width="match_parent"
-        android:layout_height="153dp"
+        android:layout_height="wrap_content"
         android:clipChildren="false"
         android:clipToPadding="false"
         android:scrollbars="none"
@@ -49,7 +49,6 @@
         app:layout_constraintTop_toBottomOf="@+id/title"
         app:rowHeight="153dp"
         tools:itemCount="4"
-        tools:layout_height="120dp"
         tools:listitem="@layout/view_card_default" />
 
     <TextView

--- a/app/src/main/res/layout/fragment_server.xml
+++ b/app/src/main/res/layout/fragment_server.xml
@@ -40,7 +40,7 @@
     <androidx.leanback.widget.HorizontalGridView
         android:id="@+id/users"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="153dp"
         android:clipChildren="false"
         android:clipToPadding="false"
         android:scrollbars="none"

--- a/app/src/main/res/values/attrs_tiles.xml
+++ b/app/src/main/res/values/attrs_tiles.xml
@@ -20,5 +20,5 @@
     <attr name="tile_port_folder_bg" format="color" />
     <attr name="tile_port_grid_bg" format="color" />
     <attr name="tile_port_guide_bg" format="color" />
-    <attr name="tile_port_user_bg" format="color" />
+    <attr name="tile_user_bg" format="color" />
 </resources>

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -64,7 +64,7 @@
 
         <!-- Tile colors -->
         <item name="tile_port_person_bg">@color/indigo_dye</item>
-        <item name="tile_port_user_bg">@color/indigo_dye</item>
+        <item name="tile_user_bg">@color/indigo_dye</item>
         <item name="tile_port_video_bg">@color/indigo_dye</item>
         <item name="tile_land_folder_bg">@color/indigo_dye</item>
         <item name="tile_chapter_bg">@color/indigo_dye</item>

--- a/app/src/main/res/values/theme_mutedpurple.xml
+++ b/app/src/main/res/values/theme_mutedpurple.xml
@@ -31,6 +31,6 @@
 
         <!-- Tile colors -->
         <item name="tile_port_person_bg">#212121</item>
-        <item name="tile_port_user_bg">#384873</item>
+        <item name="tile_user_bg">#384873</item>
     </style>
 </resources>


### PR DESCRIPTION
**Changes**
On first open of the user select menu the transition between the placeholder and the user image forced the image to use the dimensions of the placeholder. This resulted in the image being far too cropped in.

**Before**
![Screenshot 2023-08-28 133137](https://github.com/jellyfin/jellyfin-androidtv/assets/28051112/fb774a08-249c-4481-a8a0-5a1dfcccd105)

**After**
![Screenshot 2023-08-28 133100](https://github.com/jellyfin/jellyfin-androidtv/assets/28051112/06550803-85e1-4fb2-962c-e6ea529fac7b)


This is _kinda_ a hack as I simply converted the placeholder image into a square, but it works and I'm not sure what else could be done.
