### PR TITLE
Make aspect ratio setting use radio buttons

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ZoomAction.kt
@@ -55,7 +55,7 @@ class ZoomAction(
 					isChecked = playbackController.zoomMode == VideoManager.ZOOM_STRETCH
 				}
 
-				setGroupCheckable(0, true, false)
+				setGroupCheckable(0, true, true)
 			}
 
 			setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }


### PR DESCRIPTION
**Changes**
Check marks are usually used for settings where the user is allowed to select multiple options.

In this case only one way of fitting the video onto the screen can be used at a time.

Thus radio buttons are a better fit.
