### PR TITLE
Only check length of mediaAdapter if videoqueue is not null

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.java
@@ -1022,7 +1022,7 @@ public class MediaManager {
     public void setCurrentMediaPosition(int currentMediaPosition) {
         if (currentMediaPosition < 0) return;
         if (mCurrentMediaAdapter == null && mCurrentVideoQueue == null) return;
-        if (mCurrentMediaAdapter != null && currentMediaPosition > mCurrentMediaAdapter.size()) return;
+        if (mCurrentMediaAdapter != null && mCurrentVideoQueue == null && currentMediaPosition > mCurrentMediaAdapter.size()) return;
         if (mCurrentVideoQueue != null && currentMediaPosition > mCurrentVideoQueue.size()) return;
 
         mCurrentMediaPosition = currentMediaPosition;


### PR DESCRIPTION
Fixes issue where shuffle eventually stop progressing to next video in queue

**Changes**
Only check media adapter queue length if not viewing videos.

**Issues**
https://github.com/jellyfin/jellyfin-androidtv/issues/2378