### PR TITLE
Grab background images no larger than the screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.data.service
 
 import android.content.Context
+import android.content.res.Resources
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.drawable.toBitmap
@@ -60,6 +61,7 @@ class BackgroundService(
 				imageType = ImageType.BACKDROP,
 				tag = tag,
 				imageIndex = index,
+				maxWidth = Resources.getSystem().getDisplayMetrics().widthPixels,
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -61,6 +61,7 @@ class BackgroundService(
 				tag = tag,
 				imageIndex = index,
 				fillWidth = context.resources.displayMetrics.widthPixels,
+				fillHeight = context.resources.displayMetrics.heightPixels,
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.data.service
 
 import android.content.Context
-import android.content.res.Resources
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.drawable.toBitmap
@@ -61,7 +60,7 @@ class BackgroundService(
 				imageType = ImageType.BACKDROP,
 				tag = tag,
 				imageIndex = index,
-				maxWidth = Resources.getSystem().getDisplayMetrics().widthPixels,
+				fillWidth = context.resources.displayMetrics.widthPixels,
 			)
 		}
 	}


### PR DESCRIPTION
**Changes**
Fix the app grabbing 4k background images even when the screen is just 1080p.

As a side-effect that also saves a lot of cache space :)
