### PR TITLE
Fix sync issue in ItemRowAdapterHelper

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -168,7 +168,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 				if (userPreferences[UserPreferences.homeReactive]) {
 					val listener = socketInstance.addGlobalListener {
 						if (it is UserDataChangedMessage || it is LibraryChangedMessage) {
-							refreshRows(force = true)
+							refreshRows(force = true, delayed = false)
 						}
 					}
 
@@ -220,9 +220,10 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 		nowPlaying.update(requireContext(), adapter as MutableObjectAdapter<Row>)
 	}
 
-	private fun refreshRows(force: Boolean = false) {
+	private fun refreshRows(force: Boolean = false, delayed: Boolean = true) {
 		lifecycleScope.launch(Dispatchers.IO) {
-			delay(1.5.seconds)
+			if (delayed) delay(1.5.seconds)
+
 			repeat(adapter.size()) { i ->
 				val rowAdapter = (adapter[i] as? ListRow)?.adapter as? ItemRowAdapter
 				if (force) rowAdapter?.Retrieve()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -7,6 +7,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
 import timber.log.Timber
+import kotlin.math.min
 
 fun <T : Any> ItemRowAdapter.setItems(
 	items: Array<T>,
@@ -27,7 +28,7 @@ fun <T : Any> ItemRowAdapter.setItems(
 		mappedItems.forEach { add(it) }
 
 		// Add current items after loaded items
-		repeat(size() - itemsLoaded - mappedItems.size) {
+		repeat(min(totalItems, size()) - itemsLoaded - mappedItems.size) {
 			add(this@setItems.get(it + itemsLoaded + mappedItems.size))
 		}
 	}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix sync issue in ItemRowAdapterHelper
  Basically the item row adapter is garbage and my helper failed with an edge case because the code is garbage
- Add some changes to experimental reactive home to have it reload faster
  Previous fix introduced a new (or actually it now happened more often..) race condition where having two retrievals running for the same row would duplicate items because once again the item row adapter is garbage

**Issues**

Fixes #3021
