### PR TITLE
Restore session on MainActivity stop

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
@@ -106,6 +107,15 @@ class MainActivity : FragmentActivity() {
 		super.onPause()
 
 		screensaverViewModel.activityPaused = true
+	}
+
+	override fun onStop() {
+		super.onStop()
+
+		lifecycleScope.launch {
+			Timber.d("MainActivity stopped")
+			sessionRepository.restoreSession()
+		}
 	}
 
 	private fun handleNavigationAction(action: NavigationAction) = when (action) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Restore session on MainActivity stop, this fixes an issue where resuming the app from a paused state won't show the login screen when automatic sign in is disabled.

**Issues**

Fixes #3038