### PR TITLE
Fix progress bar appearing on fallback poster

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -449,8 +449,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             String primaryImageUrl = ImageUtils.getLogoImageUrl(ModelCompat.asSdk(mBaseItem), 600, true);
             if (primaryImageUrl == null) {
                 primaryImageUrl = ImageUtils.getPrimaryImageUrl(ModelCompat.asSdk(mBaseItem), false, null, posterHeight);
-                if (item.getRunTimeTicks() != null && item.getRunTimeTicks() > 0 && item.getUserData() != null && item.getUserData().getPlaybackPositionTicks() > 0)
-                    mDetailsOverviewRow.setProgress(((int) (item.getUserData().getPlaybackPositionTicks() * 100.0 / item.getRunTimeTicks())));
             }
 
             mDetailsOverviewRow.setSummary(item.getOverview());


### PR DESCRIPTION
**Changes**
Fix this:
![Screenshot 2023-09-19 201711](https://github.com/jellyfin/jellyfin-androidtv/assets/28051112/6348e699-2d01-449c-aa50-cb5375b46229)
