### PR TITLE
Use vignette effect in screensaver to darken background image

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
@@ -37,6 +36,9 @@ fun DreamContentLibraryShowcase(
 			contentScale = ContentScale.Crop,
 			modifier = Modifier.fillMaxSize()
 		)
+
+		// Image vignette
+		DreamContentVignette()
 	}
 
 	// Overlay
@@ -49,11 +51,7 @@ fun DreamContentLibraryShowcase(
 			text = content.item.name.orEmpty(),
 			style = TextStyle(
 				color = Color.White,
-				fontSize = 32.sp,
-				shadow = Shadow(
-					color = Color.Black,
-					blurRadius = 2f,
-				)
+				fontSize = 32.sp
 			),
 		)
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -24,9 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
@@ -73,8 +71,9 @@ fun DreamContentNowPlaying(
 			alignment = Alignment.Center,
 			contentScale = ContentScale.Crop,
 			modifier = Modifier.fillMaxSize(),
-			colorFilter = ColorFilter.tint(Color(0f, 0f, 0f, 0.4f), BlendMode.SrcAtop)
 		)
+
+		DreamContentVignette()
 	}
 
 	// Overlay

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentVignette.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentVignette.kt
@@ -1,0 +1,34 @@
+package org.jellyfin.androidtv.integration.dream.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RadialGradientShader
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.ShaderBrush
+
+private val vignetteBrush = object : ShaderBrush() {
+	override fun createShader(size: Size): Shader = RadialGradientShader(
+		colors = listOf(
+			Color.Black.copy(alpha = 0.2f),
+			Color.Black.copy(alpha = 0.7f),
+		),
+		center = size.center,
+		radius = maxOf(size.width, size.height) / 2f,
+		colorStops = listOf(0f, 0.95f)
+	)
+}
+
+@Composable
+fun DreamContentVignette(
+	modifier: Modifier = Modifier
+) = Box(
+	modifier = modifier
+		.background(vignetteBrush)
+		.fillMaxSize()
+)

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -65,11 +64,7 @@ fun DreamHeader(
 				text = DateUtils.formatDateTime(LocalContext.current, time, DateUtils.FORMAT_SHOW_TIME),
 				style = TextStyle(
 					color = Color.White,
-					fontSize = 20.sp,
-					shadow = Shadow(
-						color = Color.Black,
-						blurRadius = 2f,
-					)
+					fontSize = 20.sp
 				),
 			)
 		}


### PR DESCRIPTION
**Changes**
- Remove text shadows
- Add vignette on top of backgrounds for now playing & library showcase

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

**Screenshots**
<details>

![image](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/5597278e-d786-45bb-b811-c6faf0fb28fd)

</details>