### PR TITLE
Fix embedded subtitles not loading when subtitle filter on library

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -54,6 +54,7 @@ import org.videolan.libvlc.interfaces.IVLCVout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import timber.log.Timber;
 
@@ -554,10 +555,11 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
         int chosenTrackType = streamType == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE ? C.TRACK_TYPE_TEXT : C.TRACK_TYPE_AUDIO;
 
-        // Make sure the index is not out of bounds
-        if (index >= allStreams.size()) return false;
+        // Make sure the index is present
+        Optional<MediaStream> candidateOptional = allStreams.stream().filter(stream -> stream.getIndex() == index).findFirst();
+        if (!candidateOptional.isPresent()) return false;
 
-        org.jellyfin.sdk.model.api.MediaStream candidate = allStreams.get(index);
+        org.jellyfin.sdk.model.api.MediaStream candidate = candidateOptional.get();
         if (candidate.isExternal() || candidate.getType() != streamType)
             return false;
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
In `setExoPlayerTrack`, filter for the correct index instead of addressing the index directly. This ensures the correct subtitle steam is selected, even when some tracks are filtered out.

**Issues**
#3089
