### PR TITLE
Enable support for Opus and FLAC in ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -52,6 +52,8 @@ class ExoPlayerProfile(
 		add(Codec.Audio.TRUEHD)
 		add(Codec.Audio.PCM_ALAW)
 		add(Codec.Audio.PCM_MULAW)
+		add(Codec.Audio.OPUS)
+		add(Codec.Audio.FLAC)
 	}.toTypedArray()
 
 	private val allSupportedAudioCodecsWithoutFFmpegExperimental = allSupportedAudioCodecs
@@ -129,14 +131,12 @@ class ExoPlayerProfile(
 			// Audio direct play
 			add(audioDirectPlayProfile(allSupportedAudioCodecs + arrayOf(
 				Codec.Audio.MPA,
-				Codec.Audio.FLAC,
 				Codec.Audio.WAV,
 				Codec.Audio.WMA,
 				Codec.Audio.OGG,
 				Codec.Audio.OGA,
 				Codec.Audio.WEBMA,
 				Codec.Audio.APE,
-				Codec.Audio.OPUS,
 			)))
 			// Photo direct play
 			add(photoDirectPlayProfile)


### PR DESCRIPTION
**Changes**
Add Opus and FLAC to ExoPlayer's list of codecs so they can direct-play.

Remake of https://github.com/jellyfin/jellyfin-androidtv/pull/2376 since the original author seems to be absent.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/2359 https://github.com/jellyfin/jellyfin-androidtv/issues/2366
