### PR TITLE
Support remux/transcode fallback in new music player

### DIFF
--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.jellyfin.playback.core.backend.BackendService
 import org.jellyfin.playback.core.backend.PlayerBackendEventListener
 import org.jellyfin.playback.core.mediastream.DefaultMediaStreamState
-import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.MediaStreamResolver
 import org.jellyfin.playback.core.mediastream.MediaStreamState
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PlaybackOrder
 import org.jellyfin.playback.core.model.PositionInfo
@@ -100,7 +100,7 @@ class MutablePlayerState(
 				_videoSize.value = VideoSize(width, height)
 			}
 
-			override fun onMediaStreamEnd(mediaStream: MediaStream) = Unit
+			override fun onMediaStreamEnd(mediaStream: PlayableMediaStream) = Unit
 		})
 
 		queue = DefaultPlayerQueueState(this, scope, backendService)

--- a/playback/core/src/main/kotlin/backend/BackendService.kt
+++ b/playback/core/src/main/kotlin/backend/BackendService.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.playback.core.backend
 
-import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 
 /**
@@ -42,7 +42,7 @@ class BackendService {
 			callListeners { onVideoSizeChange(width, height) }
 		}
 
-		override fun onMediaStreamEnd(mediaStream: MediaStream) {
+		override fun onMediaStreamEnd(mediaStream: PlayableMediaStream) {
 			callListeners { onMediaStreamEnd(mediaStream) }
 		}
 	}

--- a/playback/core/src/main/kotlin/backend/PlayerBackend.kt
+++ b/playback/core/src/main/kotlin/backend/PlayerBackend.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.playback.core.backend
 
 import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PositionInfo
 import org.jellyfin.playback.core.support.PlaySupportReport
 import kotlin.time.Duration
@@ -20,8 +21,8 @@ interface PlayerBackend {
 
 	// Mutation
 
-	fun prepareStream(stream: MediaStream)
-	fun playStream(stream: MediaStream)
+	fun prepareStream(stream: PlayableMediaStream)
+	fun playStream(stream: PlayableMediaStream)
 
 	fun play()
 	fun pause()

--- a/playback/core/src/main/kotlin/backend/PlayerBackendEventListener.kt
+++ b/playback/core/src/main/kotlin/backend/PlayerBackendEventListener.kt
@@ -1,10 +1,10 @@
 package org.jellyfin.playback.core.backend
 
-import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 
 interface PlayerBackendEventListener {
 	fun onPlayStateChange(state: PlayState)
 	fun onVideoSizeChange(width: Int, height: Int)
-	fun onMediaStreamEnd(mediaStream: MediaStream)
+	fun onMediaStreamEnd(mediaStream: PlayableMediaStream)
 }

--- a/playback/core/src/main/kotlin/mediastream/MediaStream.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStream.kt
@@ -2,14 +2,40 @@ package org.jellyfin.playback.core.mediastream
 
 import org.jellyfin.playback.core.queue.item.QueueEntry
 
-data class MediaStream(
-	val identifier: String,
+interface MediaStream {
+	val identifier: String
+	val conversionMethod: MediaConversionMethod
+	val container: MediaStreamContainer
+	val tracks: Collection<MediaStreamTrack>
+}
+
+data class BasicMediaStream(
+	override val identifier: String,
+	override val conversionMethod: MediaConversionMethod,
+	override val container: MediaStreamContainer,
+	override val tracks: Collection<MediaStreamTrack>,
+) : MediaStream {
+	fun toPlayableMediaStream(
+		queueEntry: QueueEntry,
+		url: String,
+	) = PlayableMediaStream(
+		identifier = identifier,
+		conversionMethod = conversionMethod,
+		container = container,
+		tracks = tracks,
+		queueEntry = queueEntry,
+		url = url,
+	)
+}
+
+data class PlayableMediaStream(
+	override val identifier: String,
+	override val conversionMethod: MediaConversionMethod,
+	override val container: MediaStreamContainer,
+	override val tracks: Collection<MediaStreamTrack>,
 	val queueEntry: QueueEntry,
-	val conversionMethod: MediaConversionMethod,
 	val url: String,
-	val container: MediaStreamContainer,
-	val tracks: Collection<MediaStreamTrack>,
-)
+) : MediaStream
 
 data class MediaStreamContainer(
 	val format: String,

--- a/playback/core/src/main/kotlin/mediastream/MediaStreamResolver.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStreamResolver.kt
@@ -1,13 +1,17 @@
 package org.jellyfin.playback.core.mediastream
 
 import org.jellyfin.playback.core.queue.item.QueueEntry
+import org.jellyfin.playback.core.support.PlaySupportReport
 
 /**
  * Determine the media stream for a given queue item.
  */
 interface MediaStreamResolver {
 	/**
-	 * @return [MediaStream] or null if no stream can be determined by this resolver
+	 * @return [PlayableMediaStream] or null if no stream can be determined by this resolver
 	 */
-	suspend fun getStream(queueEntry: QueueEntry): MediaStream?
+	suspend fun getStream(
+		queueEntry: QueueEntry,
+		testStream: (stream: MediaStream) -> PlaySupportReport,
+	): PlayableMediaStream?
 }

--- a/playback/core/src/main/kotlin/queue/PlayerQueueState.kt
+++ b/playback/core/src/main/kotlin/queue/PlayerQueueState.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import org.jellyfin.playback.core.PlayerState
 import org.jellyfin.playback.core.backend.BackendService
 import org.jellyfin.playback.core.backend.PlayerBackendEventListener
-import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PlaybackOrder
 import org.jellyfin.playback.core.model.RepeatMode
@@ -80,7 +80,7 @@ class DefaultPlayerQueueState(
 			override fun onPlayStateChange(state: PlayState) = Unit
 			override fun onVideoSizeChange(width: Int, height: Int) = Unit
 
-			override fun onMediaStreamEnd(mediaStream: MediaStream) {
+			override fun onMediaStreamEnd(mediaStream: PlayableMediaStream) {
 				// TODO: Find position based on $mediaStream instead
 				// TODO: This doesn't work as expected
 				coroutineScope.launch { next(usePlaybackOrder = true, useRepeatMode = true) }

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.video.VideoSize
 import org.jellyfin.playback.core.backend.BasePlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PositionInfo
 import org.jellyfin.playback.core.support.PlaySupportReport
@@ -23,7 +24,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class ExoPlayerBackend(
 	private val context: Context,
 ) : BasePlayerBackend() {
-	private var currentStream: MediaStream? = null
+	private var currentStream: PlayableMediaStream? = null
 
 	private val exoPlayer by lazy {
 		val renderersFactory = DefaultRenderersFactory(context).apply {
@@ -74,7 +75,7 @@ class ExoPlayerBackend(
 		stream: MediaStream
 	): PlaySupportReport = exoPlayer.getPlaySupportReport(stream.toFormat())
 
-	override fun prepareStream(stream: MediaStream) {
+	override fun prepareStream(stream: PlayableMediaStream) {
 		val mediaItem = MediaItem.Builder().apply {
 			setTag(stream)
 			setMediaId(stream.hashCode().toString())
@@ -89,7 +90,7 @@ class ExoPlayerBackend(
 		exoPlayer.prepare()
 	}
 
-	override fun playStream(stream: MediaStream) {
+	override fun playStream(stream: PlayableMediaStream) {
 		if (currentStream == stream) return
 
 		currentStream = stream

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -7,6 +7,9 @@ import org.jellyfin.playback.jellyfin.playsession.PlaySessionSocketService
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.api.DeviceProfile
+import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.jellyfin.sdk.model.api.EncodingContext
+import org.jellyfin.sdk.model.api.TranscodingProfile
 
 fun jellyfinPlugin(
 	api: ApiClient,
@@ -20,13 +23,23 @@ fun jellyfinPlugin(
 		responseProfiles = emptyList(),
 		subtitleProfiles = emptyList(),
 		supportedMediaTypes = "",
-		transcodingProfiles = emptyList(),
+		// Add at least one transcoding profile so the server returns a value
+		// for "SupportsTranscoding" based on the user policy
+		// We don't actually use this profile in the client
+		transcodingProfiles = listOf(
+			TranscodingProfile(
+				type = DlnaProfileType.AUDIO,
+				context = EncodingContext.STREAMING,
+				protocol = "hls",
+				container = "mp3",
+				audioCodec = "mp3",
+				videoCodec = "",
+				conditions = emptyList()
+			)
+		),
 		xmlRootAttributes = emptyList(),
 	)
-	provide(AudioMediaStreamResolver(api, profile).apply {
-		// TODO: Remove once we have a proper device profile
-		forceDirectPlay = true
-	})
+	provide(AudioMediaStreamResolver(api, profile))
 
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)

--- a/playback/jellyfin/src/main/kotlin/mediastream/AudioMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/AudioMediaStreamResolver.kt
@@ -1,13 +1,16 @@
 package org.jellyfin.playback.jellyfin.mediastream
 
+import org.jellyfin.playback.core.mediastream.BasicMediaStream
 import org.jellyfin.playback.core.mediastream.MediaConversionMethod
 import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.MediaStreamContainer
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.queue.item.QueueEntry
+import org.jellyfin.playback.core.support.PlaySupportReport
 import org.jellyfin.playback.jellyfin.queue.item.BaseItemDtoUserQueueEntry
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.exception.MissingBaseUrlException
 import org.jellyfin.sdk.api.client.extensions.audioApi
-import org.jellyfin.sdk.api.client.util.UrlBuilder
+import org.jellyfin.sdk.api.client.extensions.dynamicHlsApi
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.DeviceProfile
 
@@ -15,72 +18,94 @@ class AudioMediaStreamResolver(
 	val api: ApiClient,
 	val profile: DeviceProfile,
 ) : JellyfinStreamResolver(api, profile) {
-	/**
-	 * Force direct play when enabled, even when we know it will fail.
-	 */
-	var forceDirectPlay = false
+	companion object {
+		private val REMUX_CONTAINERS = arrayOf("mp3", "ogg", "mkv")
+		private const val REMUX_SEGMENT_CONTAINER = "mp3"
+	}
 
-	override suspend fun getStream(queueEntry: QueueEntry): MediaStream? {
+	private fun MediaInfo.getDirectPlayStream() = BasicMediaStream(
+		identifier = playSessionId,
+		conversionMethod = MediaConversionMethod.None,
+		container = getMediaStreamContainer(),
+		tracks = getTracks()
+	)
+
+	private fun MediaInfo.getRemuxStream(container: String) = BasicMediaStream(
+		identifier = playSessionId,
+		conversionMethod = MediaConversionMethod.Remux,
+		container = MediaStreamContainer(
+			format = container
+		),
+		tracks = getTracks()
+	)
+
+	private fun MediaInfo.getTranscodeStream() = BasicMediaStream(
+		identifier = playSessionId,
+		conversionMethod = MediaConversionMethod.Transcode,
+		// The server doesn't provide us with the transcode information os we return mock data
+		container = MediaStreamContainer(format = "unknown"),
+		tracks = emptyList()
+	)
+
+	override suspend fun getStream(
+		queueEntry: QueueEntry,
+		testStream: (stream: MediaStream) -> PlaySupportReport,
+	): PlayableMediaStream? {
 		if (queueEntry !is BaseItemDtoUserQueueEntry) return null
 		if (queueEntry.baseItem.type != BaseItemKind.AUDIO) return null
 
 		val mediaInfo = getPlaybackInfo(queueEntry.baseItem)
 
-		val conversionMethod = when {
-			// Direct play
-			mediaInfo.mediaSource.supportsDirectPlay || forceDirectPlay -> MediaConversionMethod.None
-			// Remux (Direct stream)
-			mediaInfo.mediaSource.supportsDirectStream -> MediaConversionMethod.Remux
-			// Transcode
-			mediaInfo.mediaSource.supportsTranscoding -> MediaConversionMethod.Transcode
-			else -> error("Unable to find a suitable playback method for media")
-		}
-
-		val url = when (conversionMethod) {
-			// Direct play
-			is MediaConversionMethod.None -> {
-				api.audioApi.getAudioStreamUrl(
+		// Test for direct play support
+		val directPlayStream = mediaInfo.getDirectPlayStream()
+		if (testStream(directPlayStream).canPlay) {
+			return directPlayStream.toPlayableMediaStream(
+				queueEntry = queueEntry,
+				url = api.audioApi.getAudioStreamUrl(
 					itemId = queueEntry.baseItem.id,
 					mediaSourceId = mediaInfo.mediaSource.id,
 					playSessionId = mediaInfo.playSessionId,
 					static = true,
 				)
-			}
-			// Remux (Direct stream)
-			is MediaConversionMethod.Remux -> {
-				val container = requireNotNull(mediaInfo.mediaSource.container) {
-					"MediaSource supports direct stream but container is null"
-				}
+			)
+		}
 
-				api.audioApi.getAudioStreamByContainerUrl(
-					itemId = queueEntry.baseItem.id,
-					mediaSourceId = mediaInfo.mediaSource.id,
-					playSessionId = mediaInfo.playSessionId,
-					container = container,
-				)
-			}
-			// Transcode
-			is MediaConversionMethod.Transcode -> {
-				val url = requireNotNull(mediaInfo.mediaSource.transcodingUrl) {
-					"MediaSource supports transcoding but transcodingUrl is null"
+		// Try remuxing
+		if (mediaInfo.mediaSource.supportsDirectStream) {
+			for (container in REMUX_CONTAINERS) {
+				val remuxStream = mediaInfo.getRemuxStream(container)
+				if (testStream(remuxStream).canPlay) {
+					return remuxStream.toPlayableMediaStream(
+						queueEntry = queueEntry,
+						url = api.audioApi.getAudioStreamByContainerUrl(
+							itemId = queueEntry.baseItem.id,
+							mediaSourceId = mediaInfo.mediaSource.id,
+							playSessionId = mediaInfo.playSessionId,
+							container = container,
+						)
+					)
 				}
-
-				// TODO Use api.createUrl() with SDK 1.5
-				UrlBuilder.buildUrl(
-					api.baseUrl ?: throw MissingBaseUrlException(),
-					url,
-					ignorePathParameters = true,
-				)
 			}
 		}
 
-		return MediaStream(
-			identifier = mediaInfo.playSessionId,
-			queueEntry = queueEntry,
-			conversionMethod = conversionMethod,
-			url = url,
-			container = mediaInfo.getMediaStreamContainer(),
-			tracks = mediaInfo.getTracks()
-		)
+		// Fallback to provided transcode
+		if (mediaInfo.mediaSource.supportsTranscoding) {
+			val transcodeStream = mediaInfo.getTranscodeStream()
+
+			// Skip testing transcode stream because we lack the information to do so
+			return transcodeStream.toPlayableMediaStream(
+				queueEntry = queueEntry,
+				url = api.dynamicHlsApi.getMasterHlsAudioPlaylistUrl(
+					itemId = queueEntry.baseItem.id,
+					mediaSourceId = requireNotNull(mediaInfo.mediaSource.id),
+					playSessionId = mediaInfo.playSessionId,
+					tag = mediaInfo.mediaSource.eTag,
+					segmentContainer = REMUX_SEGMENT_CONTAINER,
+				)
+			)
+		}
+
+		// Unable to find a suitable stream, return
+		return null
 	}
 }

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.playback.core.mediastream.MediaConversionMethod
-import org.jellyfin.playback.core.mediastream.MediaStream
+import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.plugin.PlayerService
@@ -25,7 +25,7 @@ import org.jellyfin.sdk.model.api.RepeatMode as SdkRepeatMode
 class PlaySessionService(
 	private val api: ApiClient,
 ) : PlayerService() {
-	private var reportedStream: MediaStream? = null
+	private var reportedStream: PlayableMediaStream? = null
 
 	override suspend fun onInitialize() {
 		state.streams.current.onEach { stream -> onMediaStreamChange(stream) }.launchIn(coroutineScope)
@@ -40,7 +40,7 @@ class PlaySessionService(
 		}.launchIn(coroutineScope)
 	}
 
-	private val MediaStream.baseItem
+	private val PlayableMediaStream.baseItem
 		get() = when (val entry = queueEntry) {
 			is BaseItemDtoUserQueueEntry -> entry.baseItem
 			else -> null
@@ -66,7 +66,7 @@ class PlaySessionService(
 		}
 	}
 
-	private fun onMediaStreamChange(stream: MediaStream?) {
+	private fun onMediaStreamChange(stream: PlayableMediaStream?) {
 		reportedStream = stream
 		onStart()
 	}
@@ -98,7 +98,7 @@ class PlaySessionService(
 			.map { QueueItem(id = it.baseItem.id, playlistItemId = it.baseItem.playlistItemId) }
 	}
 
-	private suspend fun sendStreamStart(stream: MediaStream) {
+	private suspend fun sendStreamStart(stream: PlayableMediaStream) {
 		val item = stream.baseItem ?: return
 		api.playStateApi.reportPlaybackStart(PlaybackStartInfo(
 			itemId = item.id,
@@ -116,7 +116,7 @@ class PlaySessionService(
 		))
 	}
 
-	private suspend fun sendStreamUpdate(stream: MediaStream) {
+	private suspend fun sendStreamUpdate(stream: PlayableMediaStream) {
 		val item = stream.baseItem ?: return
 		api.playStateApi.reportPlaybackProgress(PlaybackProgressInfo(
 			itemId = item.id,
@@ -134,7 +134,7 @@ class PlaySessionService(
 		))
 	}
 
-	private suspend fun sendStreamStop(stream: MediaStream) {
+	private suspend fun sendStreamStop(stream: PlayableMediaStream) {
 		val item = stream.baseItem ?: return
 		api.playStateApi.reportPlaybackStopped(PlaybackStopInfo(
 			itemId = item.id,


### PR DESCRIPTION
Add automatic transcoding support to new playback code based on the capability testing from #3062. This is the final release blocker, unless something else comes up.
I'm not entirely happy with how it works but unfortunately the server doesn't give us much to work with. Direct play & remux can be tested client side because we know what the media information will look like but a proposed transcode from the server does not give us any information except for the container & protocol which is too little to properly do capability testing with.

**Changes**
- Add IMediaStream interface for the base definition of a media stream
  - Implemented by MediaStream and PlayableMediaStream
  - What we previously called MediaStream is now PlayableMediaStream - it adds the queueEntry & url propertyes on top of the interface
  - Use IMediaStream for play report testing magic
- Refactor MediaStreamState
  - Move responsibility of generating a compatible stream to the resolvers
  - Skip to next entry if no stream is found
- Rewrite the Jellyfin AudioMediaStreamResolver
  - Now does some magic to find a direct play -> remux -> transcoding stream (in order)

**Issues**

:) #1057