### PR TITLE
Fix GridButtonPresenter focus on old Android platforms

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
@@ -30,6 +30,9 @@ class GridButtonPresenter @JvmOverloads constructor(
 ) : Presenter() {
 	private class ComposeViewWrapper(composeView: ComposeView) : FrameLayout(composeView.context) {
 		init {
+			isFocusable = true
+			isFocusableInTouchMode = true
+			descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
 			addView(composeView)
 		}
 


### PR DESCRIPTION
Two issues:
1) Old Android versions need `isFocusableInTouchMode` for some stupid reason
2) The focus was actually sent to the ComposeView so we had to block it

**Changes**
- Fix GridButtons not working on Android ~7ish and below

**Issues**

Fixes #3118
