### PR TITLE
Implement queue management in RewriteMediaManager

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/LegacyMediaManager.java
@@ -407,7 +407,7 @@ public class LegacyMediaManager implements MediaManager {
     }
 
     @Override
-    public int queueAudioItem(org.jellyfin.sdk.model.api.BaseItemDto item) {
+    public void queueAudioItem(org.jellyfin.sdk.model.api.BaseItemDto item) {
         if (mCurrentAudioQueue == null) {
             createAudioQueue(new ArrayList<org.jellyfin.sdk.model.api.BaseItemDto>());
             clearUnShuffledQueue();
@@ -415,7 +415,6 @@ public class LegacyMediaManager implements MediaManager {
         pushToUnShuffledQueue();
         mCurrentAudioQueue.add(new AudioQueueItem(mCurrentAudioQueue.size(), item));
         fireQueueStatusChange();
-        return mCurrentAudioQueue.size()-1;
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -20,7 +20,7 @@ interface MediaManager {
 	val managedAudioQueue: ItemRowAdapter?
 	fun addAudioEventListener(listener: AudioEventListener)
 	fun removeAudioEventListener(listener: AudioEventListener)
-	fun queueAudioItem(item: BaseItemDto?): Int
+	fun queueAudioItem(item: BaseItemDto)
 	fun clearAudioQueue()
 	fun clearAudioQueue(releasePlayer: Boolean)
 	fun addToAudioQueue(items: List<BaseItemDto>)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MutableObjectAdapter.kt
@@ -41,13 +41,20 @@ open class MutableObjectAdapter<T : Any> : ObjectAdapter, Iterable<T> {
 		notifyItemRangeChanged(index, 1)
 	}
 
-	fun replaceAll(items: List<T>) {
+	fun replaceAll(
+		items: List<T>,
+		areItemsTheSame: (old: T, new: T) -> Boolean = { old, new -> old == new },
+		areContentsTheSame: (old: T, new: T) -> Boolean = { old, new -> old == new },
+	) {
 		val diff = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
 			override fun getOldListSize(): Int = data.size
 			override fun getNewListSize(): Int = items.size
 
-			override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = areContentsTheSame(oldItemPosition, newItemPosition)
-			override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = data[oldItemPosition] == items[newItemPosition]
+			override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+				areItemsTheSame(data[oldItemPosition], items[newItemPosition])
+
+			override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+				areContentsTheSame(data[oldItemPosition], items[newItemPosition])
 		})
 
 		data.clear()


### PR DESCRIPTION
So I found out that I didn't implement this yet a week ago... oops. Also found (and fixed) some bugs while working on it.

**Changes**
- Support custom `areItemsTheSame` and `areContentsTheSame` functions in MutableObjectAdapter
- Implement queue management in RewriteMediaManager
  - Adding to an existing queue will always add after the current playing item (or current if no item is playing)
  - Adding to an empty/stopped queue will play immediately
  - I deliberately did not look at the old implementation for this behavior and used what made the most sense to me
- Optimize queue->currentAudioQueue sync
  - Use AudioQueueItem instead of BaseRowItem so the KeyProcessor shows the correct menu items for queue management
  - Simplify the mapping
  - Use custom `areContentsTheSame` function that always returns false to fix issue where the UI shows invalid data because the equals function in AudioQueueItem/BaseRowItem only checks the item id

**Issues**

!! #1057 !!