### PR TITLE
Keep codec info displayed for HDR streams

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -375,15 +375,16 @@ public class InfoLayoutHelper {
 
     private static void addVideoCodecDetails(Context context, LinearLayout layout, MediaStream stream) {
         if (stream != null) {
+            if (stream.getCodec() != null && stream.getCodec().trim().length() > 0) {
+                String codec = stream.getCodec().toUpperCase();
+                addBlockText(context, layout, codec);
+                addSpacer(context, layout, "  ");
+            }
             if (stream.getVideoDoViTitle() != null && stream.getVideoDoViTitle().trim().length() > 0) {
                 addBlockText(context, layout, "VISION");
                 addSpacer(context, layout, "  ");
             } else if (stream.getVideoRangeType() != null && !stream.getVideoRangeType().equals("SDR")) {
                 addBlockText(context, layout, stream.getVideoRangeType().toUpperCase());
-                addSpacer(context, layout, "  ");
-            } else if (stream.getCodec() != null && stream.getCodec().trim().length() > 0) {
-                String codec = stream.getCodec().toUpperCase();
-                addBlockText(context, layout, codec);
                 addSpacer(context, layout, "  ");
             }
         }


### PR DESCRIPTION
Several codecs support HDR, so the codec info is useful to display even for HDR streams.

**Changes**
- Keep codec info displayed for HDR streams
- Display codec info before any HDR info
