### PR TITLE
Fix system screensaver starting during video playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -56,6 +56,12 @@ class MainActivity : FragmentActivity() {
 
 		if (!validateAuthentication()) return
 
+		screensaverViewModel.keepScreenOn.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+			.onEach { keepScreenOn ->
+				if (keepScreenOn) window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+				else window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+			}.launchIn(lifecycleScope)
+
 		onBackPressedDispatcher.addCallback(this, backPressedCallback)
 
 		supportFragmentManager.addOnBackStackChangedListener {
@@ -87,9 +93,6 @@ class MainActivity : FragmentActivity() {
 		applyTheme()
 
 		screensaverViewModel.activityPaused = false
-
-		if (screensaverViewModel.enabled) window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-		else window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 	}
 
 	private fun validateAuthentication(): Boolean {


### PR DESCRIPTION
`FLAG_KEEP_SCREEN_ON` was never set if not using the new in-app screensaver. This caused the system screensaver to start during video playback... whoops.

From my initial testing this does however crash the video player once the (system-)screensaver is closed and the app needs to resume. ~~Will need to do some more testing and potentially fix that (separate PR)~~ see #3207.

**Changes**
- Dynammically set FLAG_KEEP_SCREEN_ON based on both the lock count and whether the in-app screensaver is enabled or not

**Issues**

Fixes #3193
