### PR TITLE
Close video player on resume with invalid state

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -728,6 +728,17 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     public void onResume() {
         super.onResume();
 
+        // Close player when resuming without a valid playback contoller
+        if (!mPlaybackController.hasFragment()) {
+            if (navigationRepository.getValue().getCanGoBack()) {
+                navigationRepository.getValue().goBack();
+            } else {
+                navigationRepository.getValue().reset(Destinations.INSTANCE.getHome());
+            }
+
+            return;
+        }
+
         // Hide system bars
         WindowCompat.setDecorFitsSystemWindows(requireActivity().getWindow(), false);
         WindowCompat.getInsetsController(requireActivity().getWindow(), requireActivity().getWindow().getDecorView()).hide(WindowInsetsCompat.Type.systemBars());


### PR DESCRIPTION
In some cases the video player may be stopped when the activity is paused. This ends up crashing the app on resume. Check for this kind of invalid state and close the video player to prevent crashing.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Close video player on resume with invalid state
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
