### PR TITLE
util: Don't use TZ offset for media Premiere Date

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -24,6 +24,8 @@ import org.jellyfin.sdk.model.api.SeriesStatus;
 import org.koin.java.KoinJavaComponent;
 
 import java.text.NumberFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -315,7 +317,7 @@ public class InfoLayoutHelper {
                 break;
             default:
                 if (item.getPremiereDate() != null) {
-                    date.setText(DateFormat.getMediumDateFormat(context).format(TimeUtils.getDate(item.getPremiereDate())));
+                    date.setText(item.getPremiereDate().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)));
                     layout.addView(date);
                     addSpacer(context, layout, "  ");
                 } else if (item.getProductionYear() != null && item.getProductionYear() > 0) {


### PR DESCRIPTION
I'm fairly new to Java/Kotlin/Android, so I'm not sure if this approach is the best, or if it should be used in other instances (such as in `TimeUtils`). It at least appears to fix the linked issue.

Is it reasonable to cut out usage of `Date` and stick with `LocalDateTime`, here and perhaps in `TimeUtils`?

Also: the "Premiere" date for TV seasons inside `InfoLayoutHelper::addDate` is in UTC, but the "Premiere"/"Born" date for actors is... odd. For example, in UTC-6: `1950-01-01T06:00`, and UTC+3: `1950-01-01T15:00`. Is this coming from the server, or was it changed in the client? Perhaps it acts oddly when the client is set to a different TZ than the server?

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
`TimeUtils.getDate` internally calls `Date.format`, which translates the UTC timestamp into local TZ timestamp. If a user is in a TZ with negative offset, then the Premiere Date will be presented as a day earlier.

Example with TZ of UTC-6:

item.getPremiereDate()                    => 2023-12-09T00:00
TimeUtils.getDate(item.getPremiereDate()) => Sat Dec 08 18:00:00 CST 2023

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #3190.