### PR TITLE
Fix rare case where splash screen could get stuck

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/SessionInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/SessionInitializer.kt
@@ -18,7 +18,7 @@ class SessionInitializer : Initializer<Unit> {
 
 		// Restore system session
 		ProcessLifecycleOwner.get().lifecycleScope.launch {
-			koin.get<SessionRepository>().restoreSession()
+			koin.get<SessionRepository>().restoreSession(destroyOnly = false)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -117,7 +117,7 @@ class MainActivity : FragmentActivity() {
 
 		lifecycleScope.launch {
 			Timber.d("MainActivity stopped")
-			sessionRepository.restoreSession()
+			sessionRepository.restoreSession(destroyOnly = true)
 		}
 	}
 


### PR DESCRIPTION
When you use the switch user feature, then go to the "add user" screen, then go back twice (to close the app) and then re-open it the app would get stuck on the splash screen.

The underlying issue was caused by the `restoreSession` function being cancelled half-way (before it could set its state to READY again). Fixing that caused a new problem where using the "switch user" button would restore your session properly closing the user selection again, I've added a "destroyOnly" option to fix that.

**Changes**
- Fix rare case where splash screen could get stuck

**Issues**

