### PR TITLE
Fix crash when starting player where playback controller may be null

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -11,10 +11,9 @@ import org.jellyfin.androidtv.ui.playback.PlaybackController;
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer;
 
 import kotlin.Lazy;
+import timber.log.Timber;
 
 public class LeanbackOverlayFragment extends PlaybackSupportFragment {
-
-    private PlaybackController playbackController;
     private CustomPlaybackTransportControlGlue playerGlue;
     private VideoPlayerAdapter playerAdapter;
     private boolean shouldShowOverlay = true;
@@ -27,14 +26,17 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
         setBackgroundType(BG_LIGHT);
 
         PlaybackController playbackController = playbackControllerContainer.getValue().getPlaybackController();
+        if (playbackController == null) {
+            Timber.w("PlaybackController is null, skipping initialization.");
+            return;
+        }
 
         playerAdapter = new VideoPlayerAdapter(playbackController, this);
         playerGlue = new CustomPlaybackTransportControlGlue(getContext(), playerAdapter, playbackController);
         playerGlue.setHost(new CustomPlaybackFragmentGlueHost(this));
     }
 
-    public void initFromView(PlaybackController playbackController, CustomPlaybackOverlayFragment customPlaybackOverlayFragment) {
-        this.playbackController = playbackController;
+    public void initFromView(CustomPlaybackOverlayFragment customPlaybackOverlayFragment) {
         playerGlue.setInitialPlaybackDrawable();
         playerAdapter.setMasterOverlayFragment(customPlaybackOverlayFragment);
     }
@@ -69,7 +71,7 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
     }
 
     public void mediaInfoChanged() {
-        org.jellyfin.sdk.model.api.BaseItemDto currentlyPlayingItem = playbackController.getCurrentlyPlayingItem();
+        org.jellyfin.sdk.model.api.BaseItemDto currentlyPlayingItem = playbackControllerContainer.getValue().getPlaybackController().getCurrentlyPlayingItem();
         if (currentlyPlayingItem == null) return;
 
         playerGlue.invalidatePlaybackControls();


### PR DESCRIPTION

**Changes**
This code is messy but basically we do a lot of magic to send the "PlaybackController" instance from the CustomPlaybackOverlayFragment to LeanbackOverlayFragment. This happened in two ways: via the PlaybackControllerContainer and the initFromView function. Then both classes contained a (m)playbackController variable to store the value.

In this PR I did a few things:
- Removed the local (m)playbackController variables
- Changed the initFromView function to not take a playback controller instance
- Check if the playback controller is null in LeanbackOverlayFragment.onCreate - which can happen when the video player in rare instances (empty queue / no audio manager in the android system)
- Always get the controller from the container

While I cannot reproduce the issue and thus have no idea if this fixes it, this PR does give the 🍝 a bit more 🌶️.

**Issues**

Hopefully fixes #3231
