### PR TITLE
Fix RewriteMediaManager never used in production builds

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -35,7 +35,7 @@ val playbackModule = module {
 
 	factory {
 		val preferences = get<UserPreferences>()
-		val useRewrite = preferences[UserPreferences.playbackRewriteAudioEnabled] && BuildConfig.DEVELOPMENT
+		val useRewrite = preferences[UserPreferences.playbackRewriteAudioEnabled]
 
 		if (useRewrite) get<RewriteMediaManager>()
 		else get<LegacyMediaManager>()


### PR DESCRIPTION
Just found this by accident... whoops

**Changes**
- Fix RewriteMediaManager never used in production builds

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
