### PR TITLE
Fix opening collections via search results showing empty screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
@@ -1,52 +1,36 @@
 package org.jellyfin.androidtv.ui.browsing;
 
-import android.os.Bundle;
-
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
-import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.querying.ItemFields;
+import org.jellyfin.sdk.model.api.BaseItemKind;
 
 public class CollectionFragment extends EnhancedBrowseFragment {
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-    }
-
     @Override
     protected void setupQueries(RowLoader rowLoader) {
-        if (Utils.getSafeValue(mFolder.getChildCount(), 0) > 0) {
-            StdItemQuery movies = new StdItemQuery(new ItemFields[]{
-                    ItemFields.PrimaryImageAspectRatio,
-                    ItemFields.Overview,
-                    ItemFields.ItemCounts,
-                    ItemFields.DisplayPreferencesId,
-                    ItemFields.ChildCount,
-                    ItemFields.MediaStreams,
-                    ItemFields.MediaSources
-            });
-            movies.setParentId(mFolder.getId().toString());
-            movies.setIncludeItemTypes(new String[]{"Movie"});
-            mRows.add(new BrowseRowDef(getString(R.string.lbl_movies), movies, 100));
+        StdItemQuery movies = new StdItemQuery(new ItemFields[]{
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.Overview,
+                ItemFields.ItemCounts,
+                ItemFields.DisplayPreferencesId,
+                ItemFields.ChildCount,
+                ItemFields.MediaStreams,
+                ItemFields.MediaSources
+        });
+        movies.setParentId(mFolder.getId().toString());
+        movies.setIncludeItemTypes(new String[]{BaseItemKind.MOVIE.getSerialName()});
+        mRows.add(new BrowseRowDef(getString(R.string.lbl_movies), movies, 100));
 
-            StdItemQuery series = new StdItemQuery();
-            series.setParentId(mFolder.getId().toString());
-            series.setIncludeItemTypes(new String[]{"Series"});
-            mRows.add(new BrowseRowDef(getString(R.string.lbl_tv_series), series, 100));
+        StdItemQuery series = new StdItemQuery();
+        series.setParentId(mFolder.getId().toString());
+        series.setIncludeItemTypes(new String[]{BaseItemKind.SERIES.getSerialName()});
+        mRows.add(new BrowseRowDef(getString(R.string.lbl_tv_series), series, 100));
 
-            StdItemQuery others = new StdItemQuery();
-            others.setParentId(mFolder.getId().toString());
-            others.setExcludeItemTypes(new String[]{"Movie", "Series"});
-            mRows.add(new BrowseRowDef(getString(R.string.lbl_other), others, 100));
+        StdItemQuery others = new StdItemQuery();
+        others.setParentId(mFolder.getId().toString());
+        others.setExcludeItemTypes(new String[]{BaseItemKind.MOVIE.getSerialName(), BaseItemKind.SERIES.getSerialName()});
+        mRows.add(new BrowseRowDef(getString(R.string.lbl_other), others, 100));
 
-
-            rowLoader.loadRows(mRows);
-        }
-
-
+        rowLoader.loadRows(mRows);
     }
-
-
 }


### PR DESCRIPTION
**Changes**
- Fix opening collections via search results showing empty screen
  - The childCount property is not set for search results so when the collection screen opened it would never load data. Removed a (unnecessary?) check.
  - Reformat file / remove useless onActivityCreated function that just calls super
  - Use BaseItemKind enum instead of strings for queries

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
