### PR TITLE
Fix crash and inconsistent ordering when using ShuffleOrderIndexProvider

### DIFF
--- a/playback/core/src/main/kotlin/mediasession/MediaSessionPlayer.kt
+++ b/playback/core/src/main/kotlin/mediasession/MediaSessionPlayer.kt
@@ -93,14 +93,15 @@ internal class MediaSessionPlayer(
 				val previous = state.queue.peekPrevious()
 				val next = state.queue.peekNext()
 
-				listOfNotNull(previous, current, next)
+				val playlist = listOfNotNull(previous, current, next)
 					.distinctBy { it.metadata.mediaId }
 					.map {
 						MediaItemData.Builder(requireNotNull(it.metadata.mediaId)).apply {
 							setMediaItem(it.metadata.toMediaItem())
 							setDurationUs(it.metadata.duration?.inWholeMicroseconds ?: C.TIME_UNSET)
 						}.build()
-					}.let(::setPlaylist)
+					}
+				setPlaylist(playlist)
 
 				setPlaybackState(when (state.playState.value) {
 					PlayState.STOPPED -> STATE_IDLE
@@ -109,7 +110,7 @@ internal class MediaSessionPlayer(
 					PlayState.ERROR -> STATE_ENDED
 				})
 
-				setCurrentMediaItemIndex(if (previous == null) 0 else 1)
+				setCurrentMediaItemIndex(if (previous == null || playlist.size <= 1) 0 else 1)
 			} else {
 				setPlaybackState(STATE_IDLE)
 				setCurrentMediaItemIndex(C.INDEX_UNSET)

--- a/playback/core/src/main/kotlin/queue/PlayerQueueState.kt
+++ b/playback/core/src/main/kotlin/queue/PlayerQueueState.kt
@@ -91,18 +91,14 @@ class DefaultPlayerQueueState(
 	override fun replaceQueue(queue: Queue) {
 		Timber.d("Queue changed, setting index to 0")
 
-		_current.value = queue
-		orderIndexProvider.reset()
-		if (orderIndexProvider != defaultOrderIndexProvider) defaultOrderIndexProvider.reset()
-
-		currentQueueIndicesPlayed.clear()
-
 		coroutineScope.launch {
-			when (state.playbackOrder.value) {
-				PlaybackOrder.DEFAULT -> setIndex(0)
-				PlaybackOrder.RANDOM,
-				PlaybackOrder.SHUFFLE -> setIndex((0 until queue.size).random())
-			}
+			_current.value = queue
+			orderIndexProvider.reset()
+			if (orderIndexProvider != defaultOrderIndexProvider) defaultOrderIndexProvider.reset()
+
+			currentQueueIndicesPlayed.clear()
+
+			setIndex(0)
 		}
 	}
 

--- a/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
@@ -20,13 +20,13 @@ internal class ShuffleOrderIndexProvider : OrderIndexProvider {
 		} else {
 			val remainingIndices = (0..queue.size).filterNot {
 				it in playedIndices || it in nextIndices
-			}.shuffled()
+			}
 
 			List(min(amount, remainingItemsSize)) { i ->
-				if (i <= nextIndices.lastIndex) {
+				if (i < nextIndices.lastIndex) {
 					nextIndices[i]
 				} else {
-					val index = remainingIndices[i - nextIndices.size]
+					val index = remainingIndices.random()
 					nextIndices.add(index)
 					index
 				}


### PR DESCRIPTION
Some issues that probably happened because I was developing the playback rewrite on multiple branches and at some point merging some incompatible stuff came together to create this issue.

**Changes**
- Make sure we never set `currentMediaItemIndex` to 1 when there is no next item in the generated media3 playlist
- Always use index 0 in replaceQueue as the index mapping (via sortOrder) will give a randomized value already. Setting a random index in `replaceQueue` will just skip a bunch of queue items
- Do all value setting in replaceQueue with the coroutineScope to prevent race conditions when the coroutine is delayed
- Fix ShuffleOrderIndexProvider not really shuffling. The first two items were shuffled but everything after that was just repeating the second item... oops

**Issues**

Supersedes #3249 
Fixes #3248