### PR TITLE
Add <queries> element to Manifest for remote trailers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,15 @@
         android:name="android.hardware.microphone"
         android:required="false" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data
+                android:host="youtube.com"
+                android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:name=".JellyfinApplication"
         android:allowBackup="true"


### PR DESCRIPTION
Starting with Android 11 we cannot query the package manager without specifying what we're going to query in the manifest first. For some reason this behavior is not enforced in the Android TV emulator and my Nvidia Shield with Android 11 also works without it 🤷 

I was able to test with a mobile emulator though.

**Changes**

- Add <queries> element to Manifest for remote trailers
  This is for the code in `TrailerUtils.kt`.

**Issues**

Might fix #3131
