### PR TITLE
Add more item types to search

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchViewModel.kt
@@ -21,15 +21,20 @@ class SearchViewModel(
 		private val debounceDuration = 600.milliseconds
 
 		private val groups = mapOf(
-			R.string.lbl_movies to setOf(BaseItemKind.MOVIE, BaseItemKind.BOX_SET),
+			R.string.lbl_movies to setOf(BaseItemKind.MOVIE),
 			R.string.lbl_series to setOf(BaseItemKind.SERIES),
 			R.string.lbl_episodes to setOf(BaseItemKind.EPISODE),
-			R.string.lbl_people to setOf(BaseItemKind.PERSON),
 			R.string.lbl_videos to setOf(BaseItemKind.VIDEO),
 			R.string.lbl_programs to setOf(BaseItemKind.LIVE_TV_PROGRAM),
+			R.string.channels to setOf(BaseItemKind.LIVE_TV_CHANNEL),
+			R.string.lbl_playlists to setOf(BaseItemKind.PLAYLIST),
 			R.string.lbl_artists to setOf(BaseItemKind.MUSIC_ARTIST),
 			R.string.lbl_albums to setOf(BaseItemKind.MUSIC_ALBUM),
 			R.string.lbl_songs to setOf(BaseItemKind.AUDIO),
+			R.string.photo_albums to setOf(BaseItemKind.PHOTO_ALBUM),
+			R.string.photos to setOf(BaseItemKind.PHOTO),
+			R.string.lbl_collections to setOf(BaseItemKind.BOX_SET),
+			R.string.lbl_people to setOf(BaseItemKind.PERSON),
 		)
 	}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -494,6 +494,9 @@
     <string name="pref_music_rewrite_disable">Disable new music backend</string>
     <string name="pref_music_rewrite_enable_description">Only disable this if you\'re experiencing issues with music playback</string>
     <string name="disable_ui_mode_warning">Disable device type warning</string>
+    <string name="channels">Channels</string>
+    <string name="photo_albums">Photo albums</string>
+    <string name="photos">Photos</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
**Changes**
- Add new item types: Live TV channel, Playlist, Photo Album, Photo
- Split Movies and Collections to separate rows
- Add special case for "Videos" row to be inline with jellyfin-web (Search using media type instead of item type)
- Re-order to be consistent with jellyfin-web (https://github.com/jellyfin/jellyfin-web/blob/3164e80276190b5624446827ab0b3811b75fbb20/src/components/search/SearchResults.tsx#L249-L335)

Only missing rows are books & audio books but those are currently unsupported in the app. Some rows might not render amazingly, for example: live tv channels show as posters instead of squares.

**Issues**

Fixes #3260
