### PR TITLE
Support tunneling and audio offloading

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -34,6 +34,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.extractor.DefaultExtractorsFactory;
 import androidx.media3.extractor.ts.TsExtractor;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -204,6 +205,17 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
         defaultRendererFactory.setEnableDecoderFallback(true);
         defaultRendererFactory.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON);
         exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
+
+        DefaultTrackSelector trackSelector = new DefaultTrackSelector(context);
+        trackSelector.setParameters(trackSelector.buildUponParameters()
+                .setTunnelingEnabled(true)
+                .setAudioOffloadPreferences(new TrackSelectionParameters.AudioOffloadPreferences.Builder()
+                        .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
+                        .build()
+                )
+                .build()
+        );
+        exoPlayerBuilder.setTrackSelector(trackSelector);
 
         DefaultExtractorsFactory defaultExtractorsFactory = new DefaultExtractorsFactory().setTsExtractorTimestampSearchBytes(TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES * 3);
         exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(context, defaultExtractorsFactory));

--- a/playback/exoplayer/build.gradle.kts
+++ b/playback/exoplayer/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
 	implementation(libs.kotlinx.coroutines)
 	implementation(libs.kotlinx.coroutines.guava)
 
+	// AndroidX
+	implementation(libs.androidx.core)
+
 	// ExoPlayer
 	implementation(libs.androidx.media3.exoplayer)
 	implementation(libs.jellyfin.androidx.media3.ffmpeg.decoder)

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -1,7 +1,9 @@
 package org.jellyfin.playback.exoplayer
 
+import android.app.ActivityManager
 import android.content.Context
 import androidx.annotation.OptIn
+import androidx.core.content.getSystemService
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
@@ -11,7 +13,10 @@ import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.ts.TsExtractor
 import org.jellyfin.playback.core.backend.BasePlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
@@ -29,6 +34,11 @@ import kotlin.time.Duration.Companion.milliseconds
 class ExoPlayerBackend(
 	private val context: Context,
 ) : BasePlayerBackend() {
+	companion object {
+		const val TS_SEARCH_BYTES_LM = TsExtractor.TS_PACKET_SIZE * 1800
+		const val TS_SEARCH_BYTES_HM = TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES
+	}
+
 	private var currentStream: PlayableMediaStream? = null
 
 	private val exoPlayer by lazy {
@@ -45,6 +55,16 @@ class ExoPlayerBackend(
 					}.build())
 				})
 			})
+			.setMediaSourceFactory(DefaultMediaSourceFactory(
+				context,
+				DefaultExtractorsFactory().apply {
+					val isLowRamDevice = context.getSystemService<ActivityManager>()?.isLowRamDevice == true
+					setTsExtractorTimestampSearchBytes(when (isLowRamDevice) {
+						true -> TS_SEARCH_BYTES_LM
+						false -> TS_SEARCH_BYTES_HM
+					})
+				}
+			))
 			.setPauseAtEndOfMediaItems(true)
 			.build()
 			.also { player -> player.addListener(PlayerListener()) }

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -6,10 +6,12 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import org.jellyfin.playback.core.backend.BasePlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
@@ -34,6 +36,14 @@ class ExoPlayerBackend(
 			.setRenderersFactory(DefaultRenderersFactory(context).apply {
 				setEnableDecoderFallback(true)
 				setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+			})
+			.setTrackSelector(DefaultTrackSelector(context).apply {
+				setParameters(buildUponParameters().apply {
+					setTunnelingEnabled(true)
+					setAudioOffloadPreferences(TrackSelectionParameters.AudioOffloadPreferences.DEFAULT.buildUpon().apply {
+						setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
+					}.build())
+				})
 			})
 			.setPauseAtEndOfMediaItems(true)
 			.build()


### PR DESCRIPTION
Backports tunneling & audio offloading support from playback rewrite branch to master. Also added the support to the old VideoManager implementation in case we still have that with 0.17.

See [media3 glossary](https://developer.android.com/guide/topics/media/exoplayer/glossary) for more information about these features.

**Changes**
- Add tunneling
- Add audio offloading
- Add TS file extractor configuration (partially based on VideoManager and partially on the mobile app implementation with the memory detection)

**Issues**

Fixes #3261
