### PR TITLE
Widen support for HEVC Main 10

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -7,6 +7,7 @@ import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAV1CodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditions
@@ -191,8 +192,9 @@ class ExoPlayerProfile(
 					)
 				)
 			})
-			// HEVC profile
+			// HEVC profiles
 			add(deviceHevcCodecProfile)
+			addAll(deviceHevcLevelCodecProfiles)
 			// AV1 profile
 			add(deviceAV1CodecProfile)
 			// Limit video resolution support for older devices

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -5,6 +5,7 @@ import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
@@ -116,21 +117,22 @@ class LibVlcProfile(
 			photoDirectPlayProfile
 		)
 
-		codecProfiles = arrayOf(
+		codecProfiles = buildList {
 			// HEVC profile
-			deviceHevcCodecProfile,
+			add(deviceHevcCodecProfile)
+			addAll(deviceHevcLevelCodecProfiles)
 			// H264 profile
-			CodecProfile().apply {
+			add(CodecProfile().apply {
 				type = CodecType.Video
 				codec = Codec.Video.H264
 				conditions = arrayOf(
 					h264VideoProfileCondition,
 					h264VideoLevelProfileCondition
 				)
-			},
+			})
 			// Audio channel profile
-			maxAudioChannelsCodecProfile(channels = 8)
-		)
+			add(maxAudioChannelsCodecProfile(channels = 8))
+		}.toTypedArray()
 
 		containerProfiles = arrayOf(
 			ContainerProfile().apply {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -24,7 +24,15 @@ class MediaCodecCapabilitiesTest {
 	fun supportsHevcMain10(): Boolean = hasDecoder(
 		MediaFormat.MIMETYPE_VIDEO_HEVC,
 		CodecProfileLevel.HEVCProfileMain10,
-		CodecProfileLevel.HEVCMainTierLevel5
+		CodecProfileLevel.HEVCMainTierLevel4
+	)
+
+	fun getHevcMainLevel(): String = getHevcLevelString(
+		CodecProfileLevel.HEVCProfileMain
+	)
+
+	fun getHevcMain10Level(): String = getHevcLevelString(
+		CodecProfileLevel.HEVCProfileMain10
 	)
 
 	fun supportsAVCHigh10(): Boolean = hasDecoder(
@@ -32,6 +40,48 @@ class MediaCodecCapabilitiesTest {
 		CodecProfileLevel.AVCProfileHigh10,
 		CodecProfileLevel.AVCLevel4
 	)
+
+	private fun getHevcLevelString(profile: Int) : String {
+		val level = getDecoderLevel(MediaFormat.MIMETYPE_VIDEO_HEVC, profile)
+
+		when {
+			level < CodecProfileLevel.HEVCMainTierLevel1 -> return "0"
+			level < CodecProfileLevel.HEVCMainTierLevel2 -> return "30"
+			level < CodecProfileLevel.HEVCMainTierLevel21 -> return "60"
+			level < CodecProfileLevel.HEVCMainTierLevel3 -> return "63"
+			level < CodecProfileLevel.HEVCMainTierLevel31 -> return "90"
+			level < CodecProfileLevel.HEVCMainTierLevel4 -> return "93"
+			level < CodecProfileLevel.HEVCMainTierLevel41 -> return "120"
+			level < CodecProfileLevel.HEVCMainTierLevel5 -> return "123"
+			level < CodecProfileLevel.HEVCMainTierLevel51 -> return "150"
+			level < CodecProfileLevel.HEVCMainTierLevel52 -> return "153"
+			level < CodecProfileLevel.HEVCMainTierLevel6 -> return "156"
+			level < CodecProfileLevel.HEVCMainTierLevel61 -> return "180"
+			level < CodecProfileLevel.HEVCMainTierLevel62 -> return "183"
+			else -> return "186"
+		}
+	}
+
+	private fun getDecoderLevel(mime: String, profile: Int) : Int {
+		var maxLevel = 0
+
+		for (info in mediaCodecList.codecInfos) {
+			if (info.isEncoder) continue
+
+			try {
+				val capabilities = info.getCapabilitiesForType(mime)
+				for (profileLevel in capabilities.profileLevels) {
+					if (profileLevel.profile == profile) {
+						maxLevel = maxOf(maxLevel, profileLevel.level)
+					}
+				}
+			} catch (e: IllegalArgumentException) {
+				Timber.w(e)
+			}
+		}
+
+		return maxLevel
+	}
 
 	private fun hasDecoder(mime: String, profile: Int, level: Int): Boolean {
 		for (info in mediaCodecList.codecInfos) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -9,6 +9,23 @@ import timber.log.Timber
 class MediaCodecCapabilitiesTest {
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
 
+	// HEVC levels as reported by ffprobe are multiplied by 30, e.g. level 4.1 is 123
+	private val hevcLevelStrings = listOf(
+		CodecProfileLevel.HEVCMainTierLevel1 to "30",
+		CodecProfileLevel.HEVCMainTierLevel2 to "60",
+		CodecProfileLevel.HEVCMainTierLevel21 to "63",
+		CodecProfileLevel.HEVCMainTierLevel3 to "90",
+		CodecProfileLevel.HEVCMainTierLevel31 to "93",
+		CodecProfileLevel.HEVCMainTierLevel4 to "120",
+		CodecProfileLevel.HEVCMainTierLevel41 to "123",
+		CodecProfileLevel.HEVCMainTierLevel5 to "150",
+		CodecProfileLevel.HEVCMainTierLevel51 to "153",
+		CodecProfileLevel.HEVCMainTierLevel52 to "156",
+		CodecProfileLevel.HEVCMainTierLevel6 to "180",
+		CodecProfileLevel.HEVCMainTierLevel61 to "183",
+		CodecProfileLevel.HEVCMainTierLevel62 to "186",
+	)
+
 	fun supportsAV1(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
 		hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AV1)
 
@@ -41,25 +58,12 @@ class MediaCodecCapabilitiesTest {
 		CodecProfileLevel.AVCLevel4
 	)
 
-	private fun getHevcLevelString(profile: Int) : String {
+	private fun getHevcLevelString(profile: Int): String {
 		val level = getDecoderLevel(MediaFormat.MIMETYPE_VIDEO_HEVC, profile)
 
-		when {
-			level < CodecProfileLevel.HEVCMainTierLevel1 -> return "0"
-			level < CodecProfileLevel.HEVCMainTierLevel2 -> return "30"
-			level < CodecProfileLevel.HEVCMainTierLevel21 -> return "60"
-			level < CodecProfileLevel.HEVCMainTierLevel3 -> return "63"
-			level < CodecProfileLevel.HEVCMainTierLevel31 -> return "90"
-			level < CodecProfileLevel.HEVCMainTierLevel4 -> return "93"
-			level < CodecProfileLevel.HEVCMainTierLevel41 -> return "120"
-			level < CodecProfileLevel.HEVCMainTierLevel5 -> return "123"
-			level < CodecProfileLevel.HEVCMainTierLevel51 -> return "150"
-			level < CodecProfileLevel.HEVCMainTierLevel52 -> return "153"
-			level < CodecProfileLevel.HEVCMainTierLevel6 -> return "156"
-			level < CodecProfileLevel.HEVCMainTierLevel61 -> return "180"
-			level < CodecProfileLevel.HEVCMainTierLevel62 -> return "183"
-			else -> return "186"
-		}
+		return hevcLevelStrings.asReversed().find { item: Pair<Int, String> ->
+			level >= item.first
+		}?.second ?: "0"
 	}
 
 	private fun getDecoderLevel(mime: String, profile: Int) : Int {
@@ -76,7 +80,7 @@ class MediaCodecCapabilitiesTest {
 					}
 				}
 			} catch (e: IllegalArgumentException) {
-				Timber.w(e)
+				Timber.d(e, "Decoder %s does not support %s", info.name, mime)
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -66,7 +66,7 @@ class MediaCodecCapabilitiesTest {
 		}?.second ?: "0"
 	}
 
-	private fun getDecoderLevel(mime: String, profile: Int) : Int {
+	private fun getDecoderLevel(mime: String, profile: Int): Int {
 		var maxLevel = 0
 
 		for (info in mediaCodecList.codecInfos) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -105,6 +105,56 @@ object ProfileHelper {
 		}
 	}
 
+	val deviceHevcLevelCodecProfiles by lazy {
+		buildList {
+			if (MediaTest.supportsHevc()) {
+				add(CodecProfile().apply {
+					type = CodecType.Video
+					codec = Codec.Video.HEVC
+
+					applyConditions = arrayOf(
+						ProfileCondition(
+							ProfileConditionType.Equals,
+							ProfileConditionValue.VideoProfile,
+							"Main"
+						)
+					)
+
+					conditions = arrayOf(
+						ProfileCondition(
+							ProfileConditionType.LessThanEqual,
+							ProfileConditionValue.VideoLevel,
+							MediaTest.getHevcMainLevel()
+						)
+					)
+				})
+
+				if (MediaTest.supportsHevcMain10()) {
+					add(CodecProfile().apply {
+						type = CodecType.Video
+						codec = Codec.Video.HEVC
+
+						applyConditions = arrayOf(
+							ProfileCondition(
+								ProfileConditionType.Equals,
+								ProfileConditionValue.VideoProfile,
+								"Main 10"
+							)
+						)
+
+						conditions = arrayOf(
+							ProfileCondition(
+								ProfileConditionType.LessThanEqual,
+								ProfileConditionValue.VideoLevel,
+								MediaTest.getHevcMain10Level()
+							)
+						)
+					})
+				}
+			}
+		}
+	}
+
 	val h264VideoLevelProfileCondition by lazy {
 		ProfileCondition(
 			ProfileConditionType.LessThanEqual,


### PR DESCRIPTION
Previously the HEVC codec profile only flagged support for HEVC Main 10 when MediaCodec advertised its support for level 5 (main tier) or above. This meant devices that support only levels 4 or 4.1 (such as the Chromecast with Google TV HD) would transcode HEVC Main 10 content even when supported.

This change lowers the requirement from level 5 to level 4 and also adds additional profiles specifically for HEVC Main and Main 10 with conditions on the level so that levels beyond what is supported by MediaCodec get transcoded.

The result is that HEVC Main 10 level 5 videos get transcoded on devices supporting only 4.1, but HEVC Main 10 level 4.1 content plays back directly.
