### PR TITLE
Disable crossfading for CardLegacyImageView to fix scaling issue

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -82,7 +82,10 @@ class AsyncImageView @JvmOverloads constructor(
 				}.build())
 			} else {
 				imageLoader.enqueue(ImageRequest.Builder(context).apply {
-					crossfade(crossFadeDuration.inWholeMilliseconds.toInt())
+					val crossFadeDurationMs = crossFadeDuration.inWholeMilliseconds.toInt()
+					if (crossFadeDurationMs > 0) crossfade(crossFadeDurationMs)
+					else crossfade(false)
+
 					target(this@AsyncImageView)
 					data(url)
 					placeholder(placeholderOrBlurHash)

--- a/app/src/main/res/layout/view_card_legacy_image.xml
+++ b/app/src/main/res/layout/view_card_legacy_image.xml
@@ -12,6 +12,7 @@
      MODIFIED to add Jellyfin specifics
 -->
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:lb="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="androidx.leanback.widget.BaseCardView">
@@ -26,6 +27,7 @@
         tools:ignore="UnusedAttribute"
         tools:visibility="visible">
 
+        <!-- Crossfading is broken with this specific layout, especially when using thumbnails -->
         <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/main_image"
             android:layout_width="wrap_content"
@@ -33,6 +35,7 @@
             android:background="@drawable/shape_card_image_background"
             android:contentDescription="@null"
             android:scaleType="centerCrop"
+            app:crossfadeDuration="0"
             lb:layout_viewType="main"
             tools:src="@drawable/app_logo" />
 


### PR DESCRIPTION
**Changes**
- Support a value of `0` to disable crossfade in AsyncImageView
- Disable crossfade in the legacy image card view because it scales thumbnails incorrectly (aspect ratio differs between the placeholder and actual image)

**Issues**

Fixes #3251