### PR TITLE
Disable tunneling

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -208,7 +208,6 @@ public class VideoManager implements IVLCVout.OnNewVideoLayoutListener {
 
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(context);
         trackSelector.setParameters(trackSelector.buildUponParameters()
-                .setTunnelingEnabled(true)
                 .setAudioOffloadPreferences(new TrackSelectionParameters.AudioOffloadPreferences.Builder()
                         .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
                         .build()

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -49,7 +49,6 @@ class ExoPlayerBackend(
 			})
 			.setTrackSelector(DefaultTrackSelector(context).apply {
 				setParameters(buildUponParameters().apply {
-					setTunnelingEnabled(true)
 					setAudioOffloadPreferences(TrackSelectionParameters.AudioOffloadPreferences.DEFAULT.buildUpon().apply {
 						setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
 					}.build())


### PR DESCRIPTION
**Release branch only**

Although I tested this on my own devices, it turns out that enabling tunneling does in fact have some big issues on various devices. After more testing I was able to also get playback issues with some media on my Fire TV with tunneling enabled. For now, disable tunneling in 0.16.

**Changes**
- Disable tunneling

**Issues**

Fixes #3295 
