### PR TITLE
Prevent usage of Jellyfin 10.9 to prevent crashes due to incompatibility

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
@@ -19,7 +19,10 @@ data class Server(
 	var dateLastAccessed: Date = Date(0),
 ) {
 	private val serverVersion = version?.let(ServerVersion::fromString)
-	val versionSupported = serverVersion != null && serverVersion >= ServerRepository.minimumServerVersion
+
+	val versionTooOld = serverVersion == null || serverVersion < ServerRepository.minimumServerVersion
+	val versionTooNew = serverVersion != null && ServerRepository.minimumUnsupportedServerVersion != null && serverVersion >= ServerRepository.minimumUnsupportedServerVersion
+	val versionSupported = !versionTooOld && !versionTooNew
 
 	operator fun compareTo(other: ServerVersion): Int = serverVersion?.compareTo(other) ?: -1
 

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -22,6 +22,7 @@ import org.jellyfin.sdk.api.client.extensions.brandingApi
 import org.jellyfin.sdk.api.client.extensions.systemApi
 import org.jellyfin.sdk.discovery.RecommendedServerInfo
 import org.jellyfin.sdk.discovery.RecommendedServerInfoScore
+import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.BrandingOptions
 import org.jellyfin.sdk.model.api.ServerDiscoveryInfo
 import org.jellyfin.sdk.model.serializer.toUUID
@@ -45,7 +46,24 @@ interface ServerRepository {
 	suspend fun deleteServer(server: UUID): Boolean
 
 	companion object {
+		/**
+		 * The minimum Jellyfin server version required to use the app. This is normally set to the
+		 * minimum version of the SDK (`Jellyfin.minimumVersion`).
+		 */
 		val minimumServerVersion = Jellyfin.minimumVersion.copy(build = null)
+
+		/**
+		 * The first unsupported version of the Jellyfin server. This is normally set to either
+		 * `null` or the upcoming minor release in case of breaking changes.
+		 */
+		@Suppress("RedundantNullableReturnType")
+		val minimumUnsupportedServerVersion: ServerVersion? = ServerVersion(10, 9, 0)
+
+		/**
+		 * The recommended version of the Jellyfin server. This is normally set to the current
+		 * version used to generate the SDK, which should be latest stable release
+		 * (`Jellyfin.apiVersion`).
+		 */
 		val recommendedServerVersion = Jellyfin.apiVersion.copy(build = null)
 	}
 }
@@ -99,6 +117,7 @@ class ServerRepositoryImpl(
 					goodRecommendations += recommendedServer
 					false
 				}
+
 				else -> {
 					badRecommendations += recommendedServer
 					false

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -90,7 +90,7 @@ class ServerFragment : Fragment() {
 					is ServerVersionNotSupported -> Toast.makeText(
 						context,
 						getString(
-							R.string.server_issue_outdated_version,
+							if (server.versionTooNew) R.string.server_issue_unsupported_version else R.string.server_issue_outdated_version,
 							state.server.version,
 							ServerRepository.recommendedServerVersion.toString()
 						),
@@ -156,8 +156,9 @@ class ServerFragment : Fragment() {
 
 		if (!server.versionSupported) {
 			binding.notification.isVisible = true
+
 			binding.notification.text = getString(
-				R.string.server_unsupported_notification,
+				if (server.versionTooNew) R.string.server_issue_unsupported_version else R.string.server_unsupported_notification,
 				server.version,
 				ServerRepository.recommendedServerVersion.toString(),
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginCredentialsFragment.kt
@@ -70,7 +70,7 @@ class UserLoginCredentialsFragment : Fragment() {
 		userLoginViewModel.loginState.onEach { state ->
 			when (state) {
 				is ServerVersionNotSupported -> binding.error.setText(getString(
-					R.string.server_issue_outdated_version,
+					if (state.server.versionTooNew) R.string.server_issue_unsupported_version else R.string.server_issue_outdated_version,
 					state.server.version,
 					ServerRepository.recommendedServerVersion.toString()
 				))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/UserLoginQuickConnectFragment.kt
@@ -63,7 +63,7 @@ class UserLoginQuickConnectFragment : Fragment() {
 		userLoginViewModel.loginState.onEach { state ->
 			when (state) {
 				is ServerVersionNotSupported -> binding.error.setText(getString(
-					R.string.server_issue_outdated_version,
+					if (state.server.versionTooNew) R.string.server_issue_unsupported_version else R.string.server_issue_outdated_version,
 					state.server.version,
 					ServerRepository.recommendedServerVersion.toString()
 				))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,6 +465,7 @@
     <string name="live_tv_preferences">Live TV options</string>
     <string name="app_notification_uimode_invalid">This app is optimized for televisions. We recommend using our mobile app on other devices.</string>
     <string name="server_unsupported_notification">This server uses Jellyfin version %1$s which is unsupported. Please update to Jellyfin %2$s or newer to continue using the app.</string>
+    <string name="server_unsupported_notification_downgrade">This server uses Jellyfin version %1$s which is unsupported. Please downgrade to Jellyfin %2$s to continue using the app.</string>
     <string name="pref_telemetry_category">Crash reporting</string>
     <string name="pref_telemetry_description">Send crash reports, include logs</string>
     <string name="pref_crash_reports">Send crash reports to server</string>


### PR DESCRIPTION
We already have a minimum supported server version, this PR adds a minimum unsupported version (the first version we know doesn't work). Right now the app and 10.9 are incompatible. Depending on how many issue reports are going to come in I'll decide if we really need this or not (in which case the PR will suddenly be gone)

**Changes**
- Block login when server is using a version too new and marked as unsupported (currently set to >=10.9)
- Added additional documentation to the versions specified

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
