### PR TITLE
Use LTR for default subtitle direction

### DIFF
--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -55,6 +55,7 @@
             android:gravity="center"
             android:textColor="@color/white"
             android:textSize="28sp"
+            android:textDirection="ltr"
             app:strokeWidth="5.0"
             tools:text="Subtitles" />
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Similar to  [#4895](https://github.com/jellyfin/jellyfin-web/pull/4895) setting the text direction LTR will place the punctuations in the correct direction for RTL text. 


**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/3257
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
