### PR TITLE
android tv hls playback direct play fix

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
@@ -7,6 +7,7 @@ object Codec {
 		const val ASF = "asf"
 		const val AVI = "avi"
 		const val DVR_MS = "dvr-ms"
+		const val HLS = "hls"
 		const val M2V = "m2v"
 		const val M4V = "m4v"
 		const val MKV = "mkv"

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -24,6 +24,11 @@ object DeviceUtils {
 	private const val FIRE_TV_MODEL_GEN_2 = "AFTS"
 	private const val FIRE_TV_MODEL_GEN_3 = "AFTN"
 
+	// Fire TV 4k Models
+	private const val Toshiba_4K_2022 = "AFTHA004"	//Toshiba 4K UHD - Fire TV (2022)
+	private const val Hisense_4K_2022 = "AFTHA001"	//Hisense U6 4K UHD - Fire TV (2022), Toshiba 4K UHD - Fire TV (2021)
+	private const val Toshiba_4K_2021 = "AFTHA003"	//Toshiba 4K Far-field UHD - Fire TV (2021)
+
 	// Nvidia Shield TV Model
 	private const val SHIELD_TV_MODEL = "SHIELD Android TV"
 	private const val UNKNOWN = "Unknown"
@@ -33,6 +38,9 @@ object DeviceUtils {
 
 	@JvmStatic val isChromecastWithGoogleTV: Boolean get() = getBuildModel() == CHROMECAST_GOOGLE_TV
 	@JvmStatic val isFireTv: Boolean get() = getBuildModel().startsWith(FIRE_TV_PREFIX)
+	@JvmStatic val isFireTv4k: Boolean get() = getBuildModel() in listOf(Toshiba_4K_2022, 
+												Hisense_4K_2022, 
+												Toshiba_4K_2021)
 	@JvmStatic val isFireTvStickGen1: Boolean get() = getBuildModel() == FIRE_STICK_MODEL_GEN_1
 	@JvmStatic val isFireTvStick4k: Boolean get() = getBuildModel() in listOf(FIRE_STICK_4K_MODEL, FIRE_STICK_4K_MAX_MODEL)
 	@JvmStatic val isShieldTv: Boolean get() = getBuildModel() == SHIELD_TV_MODEL

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -110,7 +110,9 @@ class ExoPlayerProfile(
 						Codec.Container.OGM,
 						Codec.Container.OGV,
 						Codec.Container.MP4,
-						Codec.Container.WEBM
+						Codec.Container.WEBM,
+						Codec.Container.TS,
+						Codec.Container.HLS
 					).joinToString(",")
 
 					videoCodec = arrayOf(

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -162,6 +162,7 @@ object ProfileHelper {
 			when {
 				// https://developer.amazon.com/docs/fire-tv/device-specifications.html
 				DeviceUtils.isFireTvStick4k -> H264_LEVEL_5_2
+				DeviceUtils.isFireTv4k -> H264_LEVEL_5_2
 				DeviceUtils.isFireTv -> H264_LEVEL_4_1
 				DeviceUtils.isShieldTv -> H264_LEVEL_5_2
 				else -> H264_LEVEL_5_1

--- a/app/src/test/kotlin/util/DeviceUtilsTests.kt
+++ b/app/src/test/kotlin/util/DeviceUtilsTests.kt
@@ -65,6 +65,14 @@ class DeviceUtilsTests : FunSpec({
 		}
 	}
 
+	test("DeviceUtils.isFireTv4k() works correctly") {
+		arrayOf("AFTHA001", "AFTHA004").forEach { input ->
+			withBuildModel(input) {
+				DeviceUtils.isFireTv4k shouldBe true
+			}
+		}
+	}
+
 	test("DeviceUtils.has4kVideoSupport() works correctly") {
 		arrayOf("AFTM", "AFTT", "AFTSSS", "AFTSS", "AFTB", "AFTS").forEach { input ->
 			withBuildModel(input) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Allow m3u8 links embedded in the .strm files to be direct played

**Issues**
Two fixes mainly, one was that the devices are not fully recognized as appropriate for h264 levels which is forcing the transcoding. Second is to allow the m3u8 links to be direct play instead of rencode. 
