### PR TITLE
Improve detection for AVC/H264 Main & High 10

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -6,10 +6,10 @@ import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAV1CodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCCodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
-import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
-import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditions
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
@@ -147,15 +147,16 @@ class ExoPlayerProfile(
 
 		codecProfiles = buildList {
 			// H264 profile
-			add(CodecProfile().apply {
-				type = CodecType.Video
-				codec = Codec.Video.H264
-				conditions = buildList {
-					add(h264VideoProfileCondition)
-					add(h264VideoLevelProfileCondition)
-					if (!DeviceUtils.has4kVideoSupport()) addAll(max1080pProfileConditions)
-				}.toTypedArray()
-			})
+			if (!DeviceUtils.has4kVideoSupport())   {
+				add(CodecProfile().apply {
+					type = CodecType.Video
+					codec = Codec.Video.H264
+					conditions = max1080pProfileConditions
+				})
+			}else {
+				add(deviceAVCCodecProfile)
+				addAll(deviceAVCLevelCodecProfiles)
+			}
 			// H264 ref frames profile
 			add(CodecProfile().apply {
 				type = CodecType.Video
@@ -195,16 +196,25 @@ class ExoPlayerProfile(
 				)
 			})
 			// HEVC profiles
-			add(deviceHevcCodecProfile)
-			addAll(deviceHevcLevelCodecProfiles)
+			if (!DeviceUtils.has4kVideoSupport())   {
+				add(CodecProfile().apply {
+					type = CodecType.Video
+					codec = Codec.Video.HEVC
+					conditions = max1080pProfileConditions
+				})
+			}else {
+				add(deviceHevcCodecProfile)
+				addAll(deviceHevcLevelCodecProfiles)
+			}
 			// AV1 profile
-			add(deviceAV1CodecProfile)
-			// Limit video resolution support for older devices
 			if (!DeviceUtils.has4kVideoSupport()) {
 				add(CodecProfile().apply {
 					type = CodecType.Video
+					codec = Codec.Video.AV1
 					conditions = max1080pProfileConditions
 				})
+			}else {
+				add(deviceAV1CodecProfile)
 			}
 			// Audio channel profile
 			if (!Utils.downMixAudio(context)) add(maxAudioChannelsCodecProfile(channels = 8))

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -147,15 +147,8 @@ class ExoPlayerProfile(
 
 		codecProfiles = buildList {
 			// H264 profile
-			add(CodecProfile().apply {
-				type = CodecType.Video
-				codec = Codec.Video.H264
-				conditions = buildList {
-					addAll(deviceAVCCodecProfile)
-					addAll(deviceAVCLevelCodecProfiles)
-					if (!DeviceUtils.has4kVideoSupport()) addAll(max1080pProfileConditions)
-				}.toTypedArray()
-			})
+			add(deviceAVCCodecProfile)
+			addAll(deviceAVCLevelCodecProfiles)
 			// H264 ref frames profile
 			add(CodecProfile().apply {
 				type = CodecType.Video

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -199,9 +199,6 @@ class ExoPlayerProfile(
 			addAll(deviceHevcLevelCodecProfiles)
 			// AV1 profile
 			add(deviceAV1CodecProfile)
-			// Audio channel profile
-			if (!Utils.downMixAudio(context)) add(maxAudioChannelsCodecProfile(channels = 8))
-			else add(maxAudioChannelsCodecProfile(channels = 2))
 			// Limit video resolution support for older devices
 			if (!DeviceUtils.has4kVideoSupport()) {
 				add(CodecProfile().apply {
@@ -209,6 +206,9 @@ class ExoPlayerProfile(
 					conditions = max1080pProfileConditions
 				})
 			}
+			// Audio channel profile
+			if (!Utils.downMixAudio(context)) add(maxAudioChannelsCodecProfile(channels = 8))
+			else add(maxAudioChannelsCodecProfile(channels = 2))
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -147,16 +147,15 @@ class ExoPlayerProfile(
 
 		codecProfiles = buildList {
 			// H264 profile
-			if (!DeviceUtils.has4kVideoSupport())   {
-				add(CodecProfile().apply {
-					type = CodecType.Video
-					codec = Codec.Video.H264
-					conditions = max1080pProfileConditions
-				})
-			}else {
-				add(deviceAVCCodecProfile)
-				addAll(deviceAVCLevelCodecProfiles)
-			}
+			add(CodecProfile().apply {
+				type = CodecType.Video
+				codec = Codec.Video.H264
+				conditions = buildList {
+					addAll(deviceAVCCodecProfile)
+					addAll(deviceAVCLevelCodecProfiles)
+					if (!DeviceUtils.has4kVideoSupport()) addAll(max1080pProfileConditions)
+				}.toTypedArray()
+			})
 			// H264 ref frames profile
 			add(CodecProfile().apply {
 				type = CodecType.Video
@@ -196,29 +195,20 @@ class ExoPlayerProfile(
 				)
 			})
 			// HEVC profiles
-			if (!DeviceUtils.has4kVideoSupport())   {
-				add(CodecProfile().apply {
-					type = CodecType.Video
-					codec = Codec.Video.HEVC
-					conditions = max1080pProfileConditions
-				})
-			}else {
-				add(deviceHevcCodecProfile)
-				addAll(deviceHevcLevelCodecProfiles)
-			}
+			add(deviceHevcCodecProfile)
+			addAll(deviceHevcLevelCodecProfiles)
 			// AV1 profile
-			if (!DeviceUtils.has4kVideoSupport()) {
-				add(CodecProfile().apply {
-					type = CodecType.Video
-					codec = Codec.Video.AV1
-					conditions = max1080pProfileConditions
-				})
-			}else {
-				add(deviceAV1CodecProfile)
-			}
+			add(deviceAV1CodecProfile)
 			// Audio channel profile
 			if (!Utils.downMixAudio(context)) add(maxAudioChannelsCodecProfile(channels = 8))
 			else add(maxAudioChannelsCodecProfile(channels = 2))
+			// Limit video resolution support for older devices
+			if (!DeviceUtils.has4kVideoSupport()) {
+				add(CodecProfile().apply {
+					type = CodecType.Video
+					conditions = max1080pProfileConditions
+				})
+			}
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -6,13 +6,9 @@ import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
-import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
-import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
-import org.jellyfin.apiclient.model.dlna.CodecProfile
-import org.jellyfin.apiclient.model.dlna.CodecType
 import org.jellyfin.apiclient.model.dlna.ContainerProfile
 import org.jellyfin.apiclient.model.dlna.DeviceProfile
 import org.jellyfin.apiclient.model.dlna.DirectPlayProfile
@@ -122,14 +118,8 @@ class LibVlcProfile(
 			add(deviceHevcCodecProfile)
 			addAll(deviceHevcLevelCodecProfiles)
 			// H264 profile
-			add(CodecProfile().apply {
-				type = CodecType.Video
-				codec = Codec.Video.H264
-				conditions = arrayOf(
-					h264VideoProfileCondition,
-					h264VideoLevelProfileCondition
-				)
-			})
+			add(ProfileHelper.deviceAVCCodecProfile)
+			addAll(ProfileHelper.deviceAVCLevelCodecProfiles)
 			// Audio channel profile
 			add(maxAudioChannelsCodecProfile(channels = 8))
 		}.toTypedArray()

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.util.profile
 
 import android.content.Context
 import org.jellyfin.androidtv.constant.Codec
-import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCCodecProfile
@@ -12,8 +11,6 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecPro
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
-import org.jellyfin.apiclient.model.dlna.CodecProfile
-import org.jellyfin.apiclient.model.dlna.CodecType
 import org.jellyfin.apiclient.model.dlna.ContainerProfile
 import org.jellyfin.apiclient.model.dlna.DeviceProfile
 import org.jellyfin.apiclient.model.dlna.DirectPlayProfile
@@ -123,14 +120,8 @@ class LibVlcProfile(
 			add(deviceHevcCodecProfile)
 			addAll(deviceHevcLevelCodecProfiles)
 			// H264 profile
-			add(CodecProfile().apply {
-				type = CodecType.Video
-				codec = Codec.Video.H264
-				conditions = buildList {
-					addAll(deviceAVCCodecProfile)
-					addAll(deviceAVCLevelCodecProfiles)
-				}.toTypedArray()
-			})
+			add(deviceAVCCodecProfile)
+			addAll(deviceAVCLevelCodecProfiles)
 			// Audio channel profile
 			add(maxAudioChannelsCodecProfile(channels = 8))
 		}.toTypedArray()

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/LibVlcProfile.kt
@@ -2,13 +2,18 @@ package org.jellyfin.androidtv.util.profile
 
 import android.content.Context
 import org.jellyfin.androidtv.constant.Codec
+import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCCodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
+import org.jellyfin.apiclient.model.dlna.CodecProfile
+import org.jellyfin.apiclient.model.dlna.CodecType
 import org.jellyfin.apiclient.model.dlna.ContainerProfile
 import org.jellyfin.apiclient.model.dlna.DeviceProfile
 import org.jellyfin.apiclient.model.dlna.DirectPlayProfile
@@ -118,8 +123,14 @@ class LibVlcProfile(
 			add(deviceHevcCodecProfile)
 			addAll(deviceHevcLevelCodecProfiles)
 			// H264 profile
-			add(ProfileHelper.deviceAVCCodecProfile)
-			addAll(ProfileHelper.deviceAVCLevelCodecProfiles)
+			add(CodecProfile().apply {
+				type = CodecType.Video
+				codec = Codec.Video.H264
+				conditions = buildList {
+					addAll(deviceAVCCodecProfile)
+					addAll(deviceAVCLevelCodecProfiles)
+				}.toTypedArray()
+			})
 			// Audio channel profile
 			add(maxAudioChannelsCodecProfile(channels = 8))
 		}.toTypedArray()

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -21,7 +21,7 @@ class MediaCodecCapabilitiesTest {
 		CodecProfileLevel.AVCLevel22 to "22",
 		CodecProfileLevel.AVCLevel3 to "30",
 		CodecProfileLevel.AVCLevel31 to "31",
-		CodecProfileLevel.AVCLevel32 to "33",
+		CodecProfileLevel.AVCLevel32 to "32",
 		CodecProfileLevel.AVCLevel4 to "40",
 		CodecProfileLevel.AVCLevel41 to "41",
 		CodecProfileLevel.AVCLevel42 to "42",

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -9,6 +9,27 @@ import timber.log.Timber
 class MediaCodecCapabilitiesTest {
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
 
+	// AVC levels as reported by ffprobe are multiplied by 10, e.g. level 4.1 is 41. Level 1b is set to 9
+	private val avcLevelStrings = listOf(
+		CodecProfileLevel.AVCLevel1b to "9",
+		CodecProfileLevel.AVCLevel1 to "10",
+		CodecProfileLevel.AVCLevel11 to "11",
+		CodecProfileLevel.AVCLevel12 to "12",
+		CodecProfileLevel.AVCLevel13 to "13",
+		CodecProfileLevel.AVCLevel2 to "20",
+		CodecProfileLevel.AVCLevel21 to "21",
+		CodecProfileLevel.AVCLevel22 to "22",
+		CodecProfileLevel.AVCLevel3 to "30",
+		CodecProfileLevel.AVCLevel31 to "31",
+		CodecProfileLevel.AVCLevel32 to "33",
+		CodecProfileLevel.AVCLevel4 to "40",
+		CodecProfileLevel.AVCLevel41 to "41",
+		CodecProfileLevel.AVCLevel42 to "42",
+		CodecProfileLevel.AVCLevel5 to "50",
+		CodecProfileLevel.AVCLevel51 to "51",
+		CodecProfileLevel.AVCLevel52 to "52",
+	)
+
 	// HEVC levels as reported by ffprobe are multiplied by 30, e.g. level 4.1 is 123
 	private val hevcLevelStrings = listOf(
 		CodecProfileLevel.HEVCMainTierLevel1 to "30",
@@ -52,11 +73,38 @@ class MediaCodecCapabilitiesTest {
 		CodecProfileLevel.HEVCProfileMain10
 	)
 
+	fun supportsAVC(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AVC)
+
+	fun supportsAVCHigh(): Boolean = hasDecoder(
+		MediaFormat.MIMETYPE_VIDEO_AVC,
+		CodecProfileLevel.AVCProfileHigh,
+		CodecProfileLevel.AVCLevel4
+	)
+
 	fun supportsAVCHigh10(): Boolean = hasDecoder(
 		MediaFormat.MIMETYPE_VIDEO_AVC,
 		CodecProfileLevel.AVCProfileHigh10,
 		CodecProfileLevel.AVCLevel4
 	)
+
+	fun getAVCMainLevel(): String = getAVCLevelString(
+		CodecProfileLevel.AVCProfileMain
+	)
+
+	fun getAVCHighLevel(): String = getAVCLevelString(
+		CodecProfileLevel.AVCProfileHigh
+	)
+	fun getAVCHigh10Level(): String = getAVCLevelString(
+		CodecProfileLevel.AVCProfileHigh10
+	)
+
+	private fun getAVCLevelString(profile: Int): String {
+		val level = getDecoderLevel(MediaFormat.MIMETYPE_VIDEO_AVC, profile)
+
+		return avcLevelStrings.asReversed().find { item: Pair<Int, String> ->
+			level >= item.first
+		}?.second ?: "0"
+	}
 
 	private fun getHevcLevelString(profile: Int): String {
 		val level = getDecoderLevel(MediaFormat.MIMETYPE_VIDEO_HEVC, profile)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -75,12 +75,6 @@ class MediaCodecCapabilitiesTest {
 
 	fun supportsAVC(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AVC)
 
-	fun supportsAVCHigh(): Boolean = hasDecoder(
-		MediaFormat.MIMETYPE_VIDEO_AVC,
-		CodecProfileLevel.AVCProfileHigh,
-		CodecProfileLevel.AVCLevel4
-	)
-
 	fun supportsAVCHigh10(): Boolean = hasDecoder(
 		MediaFormat.MIMETYPE_VIDEO_AVC,
 		CodecProfileLevel.AVCProfileHigh10,
@@ -91,9 +85,6 @@ class MediaCodecCapabilitiesTest {
 		CodecProfileLevel.AVCProfileMain
 	)
 
-	fun getAVCHighLevel(): String = getAVCLevelString(
-		CodecProfileLevel.AVCProfileHigh
-	)
 	fun getAVCHigh10Level(): String = getAVCLevelString(
 		CodecProfileLevel.AVCProfileHigh10
 	)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -58,14 +58,11 @@ object ProfileHelper {
 	}
 
 	val deviceAVCCodecProfile by lazy {
-		CodecProfile().apply {
-			type = CodecType.Video
-			codec = Codec.Video.H264
-			conditions = when {
+		buildList {
+			when {
 				!MediaTest.supportsAVC() -> {
-					// The following condition is a method to exclude all AVC
 					Timber.i("*** Does NOT support AVC")
-					arrayOf(
+					add(
 						ProfileCondition(
 							ProfileConditionType.Equals,
 							ProfileConditionValue.VideoProfile,
@@ -75,7 +72,7 @@ object ProfileHelper {
 				}
 				!MediaTest.supportsAVCHigh() -> {
 					Timber.i("*** Does NOT support AVC High")
-					arrayOf(
+					add(
 						ProfileCondition(
 							ProfileConditionType.NotEquals,
 							ProfileConditionValue.VideoProfile,
@@ -84,8 +81,8 @@ object ProfileHelper {
 					)
 				}
 				!MediaTest.supportsAVCHigh10() -> {
-					Timber.i("*** Does NOT support AVC High 10")
-					arrayOf(
+					Timber.i("*** Does NOT support AVC High 10 bit")
+					add(
 						ProfileCondition(
 							ProfileConditionType.NotEquals,
 							ProfileConditionValue.VideoProfile,
@@ -94,9 +91,8 @@ object ProfileHelper {
 					)
 				}
 				else -> {
-					// supports all AVC
 					Timber.i("*** Supports AVC High 10 bit")
-					arrayOf(
+					add(
 						ProfileCondition(
 							ProfileConditionType.NotEquals,
 							ProfileConditionValue.VideoProfile,
@@ -110,78 +106,34 @@ object ProfileHelper {
 
 	val deviceAVCLevelCodecProfiles by lazy {
 		buildList {
-			if (MediaTest.supportsAVC()) {
-				add(CodecProfile().apply {
-					type = CodecType.Video
-					codec = Codec.Video.H264
-
-					applyConditions = arrayOf(
+			when {
+				!MediaTest.supportsAVCHigh10() && MediaTest.supportsAVCHigh() -> {
+					add(
 						ProfileCondition(
-							ProfileConditionType.EqualsAny,
-							ProfileConditionValue.VideoProfile,
-							listOfNotNull(
-								"main",
-								"baseline",
-								"constrained baseline"
-							).joinToString("|")
+							ProfileConditionType.LessThanEqual,
+							ProfileConditionValue.VideoLevel,
+							MediaTest.getAVCHighLevel()
 						)
 					)
-
-					conditions = arrayOf(
+				}
+				MediaTest.supportsAVCHigh10() -> {
+					add(
+						ProfileCondition(
+							ProfileConditionType.LessThanEqual,
+							ProfileConditionValue.VideoLevel,
+							MediaTest.getAVCHigh10Level()
+						)
+					)
+				}
+				else -> {
+					add(
 						ProfileCondition(
 							ProfileConditionType.LessThanEqual,
 							ProfileConditionValue.VideoLevel,
 							MediaTest.getAVCMainLevel()
 						)
 					)
-				})
-
-				if (MediaTest.supportsAVCHigh()) {
-					add(CodecProfile().apply {
-						type = CodecType.Video
-						codec = Codec.Video.H264
-
-						applyConditions = arrayOf(
-							ProfileCondition(
-								ProfileConditionType.Equals,
-								ProfileConditionValue.VideoProfile,
-								"high"
-							)
-						)
-
-						conditions = arrayOf(
-							ProfileCondition(
-								ProfileConditionType.LessThanEqual,
-								ProfileConditionValue.VideoLevel,
-								MediaTest.getAVCHighLevel()
-							)
-						)
-					})
-
 				}
-					if (MediaTest.supportsAVCHigh10()) {
-						add(CodecProfile().apply {
-							type = CodecType.Video
-							codec = Codec.Video.H264
-
-							applyConditions = arrayOf(
-								ProfileCondition(
-									ProfileConditionType.Equals,
-									ProfileConditionValue.VideoProfile,
-									"high 10"
-								)
-							)
-
-							conditions = arrayOf(
-								ProfileCondition(
-									ProfileConditionType.LessThanEqual,
-									ProfileConditionValue.VideoLevel,
-									MediaTest.getAVCHigh10Level()
-								)
-							)
-						})
-
-					}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -70,16 +70,6 @@ object ProfileHelper {
 						)
 					)
 				}
-				!MediaTest.supportsAVCHigh() -> {
-					Timber.i("*** Does NOT support AVC High")
-					add(
-						ProfileCondition(
-							ProfileConditionType.NotEquals,
-							ProfileConditionValue.VideoProfile,
-							"High"
-						)
-					)
-				}
 				!MediaTest.supportsAVCHigh10() -> {
 					Timber.i("*** Does NOT support AVC High 10 bit")
 					add(
@@ -107,15 +97,6 @@ object ProfileHelper {
 	val deviceAVCLevelCodecProfiles by lazy {
 		buildList {
 			when {
-				!MediaTest.supportsAVCHigh10() && MediaTest.supportsAVCHigh() -> {
-					add(
-						ProfileCondition(
-							ProfileConditionType.LessThanEqual,
-							ProfileConditionValue.VideoLevel,
-							MediaTest.getAVCHighLevel()
-						)
-					)
-				}
 				MediaTest.supportsAVCHigh10() -> {
 					add(
 						ProfileCondition(


### PR DESCRIPTION
**Changes**

MediaCodecCapabilitiesTest:
Add additional H264 Main & High 10 profiles with level checks to ensure that only unsupported media gets transcoded.

Profile Helper:
Replace hardcoded H264 profile levels with video & level profile conditions based on the new Mediacodec tests.

ExoPlayerProfile & LibVlcProfile:
Update H264 video and level profiles with new profile conditions created in profile helper. 


**Issues**

Fixes:
Hardcoded H264 profile levels could lead to unnecessary transcoding due to unsupported video codec levels. 

