### PR TITLE
Fix downmixing AAC to stereo audio in exoplayer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -207,7 +207,8 @@ class ExoPlayerProfile(
 				})
 			}
 			// Audio channel profile
-			add(maxAudioChannelsCodecProfile(channels = 8))
+			if (!Utils.downMixAudio(context)) add(maxAudioChannelsCodecProfile(channels = 8))
+			else add(maxAudioChannelsCodecProfile(channels = 2))
 		}.toTypedArray()
 
 		subtitleProfiles = arrayOf(


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Add a condition to set max audio channels to 2 when downmixing support is enabled.

**Issues**
Fixes #3227