### PR TITLE
Only show PG-13 content in screensaver

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
@@ -76,6 +76,9 @@ private suspend fun getRandomLibraryShowcase(
 			sortBy = listOf(ItemSortBy.Random),
 			limit = 5,
 			imageTypes = listOf(ImageType.BACKDROP),
+			// TODO: Add preferences for these two settings
+			maxOfficialRating = "PG-13",
+			// hasParentalRating = true,
 		)
 
 		val item = response.items?.firstOrNull { item ->


### PR DESCRIPTION
This is the first of two pull requests to add filtering based on age rating to the screensaver. This one is backportable (no string changes). The second one will add preferences and is for 0.17.

**Changes**
- Add maxOfficialRating=PG-13 to library showcase in screensaver
- ~~Add hasParentalRating=true to library showcase in screensaver~~ <-- this one will come with the preference in 0.17

**Issues**

Partially resolves #3320