### PR TITLE
Dim static elements in screensaver

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
@@ -45,7 +46,8 @@ fun DreamContentLibraryShowcase(
 	Row(
 		modifier = Modifier
 			.align(Alignment.BottomStart)
-			.overscan(),
+			.overscan()
+			.alpha(SCREENSAVER_OVERLAY_ALPHA),
 	) {
 		Text(
 			text = content.item.name.orEmpty(),

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLogo.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLogo.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -26,5 +27,6 @@ fun DreamContentLogo() = Box(
 		modifier = Modifier
 			.align(Alignment.Center)
 			.width(400.dp)
+			.alpha(SCREENSAVER_OVERLAY_ALPHA)
 	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -24,6 +25,8 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.composable.overscan
 import org.jellyfin.androidtv.ui.composable.rememberCurrentTime
 
+const val SCREENSAVER_OVERLAY_ALPHA = 0.7f
+
 @Composable
 fun DreamHeader(
 	showLogo: Boolean,
@@ -33,7 +36,8 @@ fun DreamHeader(
 		horizontalArrangement = Arrangement.SpaceBetween,
 		modifier = Modifier
 			.fillMaxWidth()
-			.overscan(),
+			.overscan()
+			.alpha(SCREENSAVER_OVERLAY_ALPHA),
 	) {
 		// Logo
 		AnimatedVisibility(

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
@@ -23,7 +23,7 @@ fun DreamView(
 	AnimatedContent(
 		targetState = content,
 		transitionSpec = {
-			fadeIn(tween(durationMillis = 1_000)) togetherWith fadeOut(snap(delayMillis = 1_000))
+			fadeIn(tween(durationMillis = 1_000)) togetherWith fadeOut(tween(durationMillis = 500, delayMillis = 500))
 		},
 		label = "DreamContentTransition"
 	) { content ->


### PR DESCRIPTION
I'd like to "reopen" pull #2566 to dim the white static elements on the screensaver

**Changes**

Set alpha on logo, clock, and content title.

I also did a miniscule change to the fade since I think the snap-out was sometimes off and gave a janky feeling when the old image disappeared, not sure why, maybe a frame timing thing. Seems hard to record and report but I can try making it a seperate issue if you dont want it here

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
