### PR TITLE
Specify BUILD_TOOLS_VERSION for r0adkll/sign-android-release step in publish workflow

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Sign APK
         id: signApk
         uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # tag=v1
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
         with:
           releaseDirectory: app/build/outputs/apk/release
           signingKeyBase64: ${{ secrets.KEYSTORE }}
@@ -36,6 +38,8 @@ jobs:
       - name: Sign app bundle
         id: signAab
         uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # tag=v1
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
         with:
           releaseDirectory: app/build/outputs/bundle/release
           signingKeyBase64: ${{ secrets.KEYSTORE }}


### PR DESCRIPTION
**Changes**

Fixes publishing

**Issues**

https://github.com/r0adkll/sign-android-release/issues/84