### PR TITLE
Fix crash when updating clock in FullDetailsFragment while item information is unavailable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -334,9 +334,13 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             @Override
             public void run() {
                 if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+                // View holder may be null when the base item is still loading - this is a rare case
+                // which generally happens when the server is unresponsive
+                MyDetailsOverviewRowPresenter.ViewHolder viewholder = mDorPresenter.getViewHolder();
+                if (viewholder == null) return;
 
                 if (mBaseItem != null && ((mBaseItem.getRunTimeTicks() != null && mBaseItem.getRunTimeTicks() > 0) || mBaseItem.getOriginalRunTimeTicks() != null)) {
-                    mDorPresenter.getViewHolder().setInfoValue3(getEndTime());
+                    viewholder.setInfoValue3(getEndTime());
                     mLoopHandler.postDelayed(this, 15000);
                 }
             }
@@ -411,6 +415,14 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     if (!getActive()) return;
 
                     setBaseItem(response);
+                }
+
+                @Override
+                public void onError(@Nullable Exception exception) {
+                    Timber.w(exception, "Failed to load item, trying to navigate back.");
+                    super.onError(exception);
+
+                    navigationRepository.getValue().goBack();
                 }
             });
         }


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Check if view holder is set (it won't be when the base item is not set) before trying to update the "ends at" of an item
- Add `onError` implementation for item refresh that logs the issue and navigates back

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
