### PR TITLE
Replace CoroutineUtils.runBlocking with new CoroutineUtils.runOnLifecycle

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.ui.browsing;
 
 import static org.koin.java.KoinJavaComponent.inject;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.DisplayMetrics;
@@ -19,6 +18,7 @@ import android.widget.PopupWindow;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.leanback.widget.BaseGridView;
 import androidx.leanback.widget.OnItemViewClickedListener;
 import androidx.leanback.widget.OnItemViewSelectedListener;
@@ -85,7 +85,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     private final static int CHUNK_SIZE_MINIMUM = 25;
 
     private String mainTitle;
-    private Activity mActivity;
+    private FragmentActivity mActivity;
     private BaseRowItem mCurrentItem;
     private CompositeClickedListener mClickedListener = new CompositeClickedListener();
     private CompositeSelectedListener mSelectedListener = new CompositeSelectedListener();
@@ -763,7 +763,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
         libraryPreferences.set(LibraryPreferences.Companion.getFilterUnwatchedOnly(), mAdapter.getFilters().isUnwatchedOnly());
         libraryPreferences.set(LibraryPreferences.Companion.getSortBy(), mAdapter.getSortBy());
         libraryPreferences.set(LibraryPreferences.Companion.getSortOrder(), getSortOption(mAdapter.getSortBy()).order);
-        CoroutineUtils.runBlocking((coroutineScope, continuation) -> libraryPreferences.commit(continuation));
+        CoroutineUtils.runOnLifecycle(getLifecycle(), (coroutineScope, continuation) -> libraryPreferences.commit(continuation));
     }
 
     private void addTools() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/CoroutineUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/CoroutineUtils.kt
@@ -8,12 +8,14 @@ import androidx.lifecycle.flowWithLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.constant.CustomMessage
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository
 
-fun <T : Any> runBlocking(block: suspend CoroutineScope.() -> T) = kotlinx.coroutines.runBlocking {
-	block()
-}
+fun <T : Any> runOnLifecycle(
+	lifecycle: Lifecycle,
+	block: suspend CoroutineScope.() -> T
+) = lifecycle.coroutineScope.launch { block() }
 
 fun readCustomMessagesOnLifecycle(
 	lifecycle: Lifecycle,


### PR DESCRIPTION
This will prevent the main thread from blocking, which in extreme cases can kill the app. It should also improve performance of the library view when changing the filters.

**Changes**
- Add CoroutineUtils.runOnLifecycle
- Remove CoroutineUtils.runBlocking
- Update KeyProcessor and BrowseGridFragment to run async operations on their lifecycle

**Issues**

Fixes #3252