### PR TITLE
Fix crash in SocketHandler.onPlayMessage when user id is not set

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
@@ -145,12 +145,14 @@ class SocketHandler(
 	private fun onPlayMessage(message: PlayMessage) {
 		val itemId = message.request.itemIds?.firstOrNull() ?: return
 
-		PlaybackHelper.retrieveAndPlay(
-			itemId.toString(),
-			false,
-			message.request.startPositionTicks,
-			context
-		)
+		runCatching {
+			PlaybackHelper.retrieveAndPlay(
+				itemId.toString(),
+				false,
+				message.request.startPositionTicks,
+				context
+			)
+		}.onFailure { Timber.w(it, "Failed to start playback") }
 	}
 
 	@Suppress("ComplexMethod")


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix crash in SocketHandler.onPlayMessage when user id is not set


**Issues**
Related #3387 