### PR TITLE
Fix crash when checking whether a person is a folder or not

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.java
@@ -21,12 +21,28 @@ public class CollectionFragment extends EnhancedBrowseFragment {
         movies.setIncludeItemTypes(new String[]{BaseItemKind.MOVIE.getSerialName()});
         mRows.add(new BrowseRowDef(getString(R.string.lbl_movies), movies, 100));
 
-        StdItemQuery series = new StdItemQuery();
+        StdItemQuery series = new StdItemQuery(new ItemFields[]{
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.Overview,
+                ItemFields.ItemCounts,
+                ItemFields.DisplayPreferencesId,
+                ItemFields.ChildCount,
+                ItemFields.MediaStreams,
+                ItemFields.MediaSources
+        });
         series.setParentId(mFolder.getId().toString());
         series.setIncludeItemTypes(new String[]{BaseItemKind.SERIES.getSerialName()});
         mRows.add(new BrowseRowDef(getString(R.string.lbl_tv_series), series, 100));
 
-        StdItemQuery others = new StdItemQuery();
+        StdItemQuery others = new StdItemQuery(new ItemFields[]{
+                ItemFields.PrimaryImageAspectRatio,
+                ItemFields.Overview,
+                ItemFields.ItemCounts,
+                ItemFields.DisplayPreferencesId,
+                ItemFields.ChildCount,
+                ItemFields.MediaStreams,
+                ItemFields.MediaSources
+        });
         others.setParentId(mFolder.getId().toString());
         others.setExcludeItemTypes(new String[]{BaseItemKind.MOVIE.getSerialName(), BaseItemKind.SERIES.getSerialName()});
         mRows.add(new BrowseRowDef(getString(R.string.lbl_other), others, 100));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -142,7 +142,7 @@ public class ItemLauncher {
                 }
 
                 // or generic handling
-                if (baseItem.isFolder()) {
+                if (Utils.isTrue(baseItem.isFolder())) {
                     // Some items don't have a display preferences id, but it's required for StdGridFragment
                     // Use the id of the item as a workaround, it's a unique key for the specific item
                     // Which is exactly what we want


### PR DESCRIPTION
Spoiler: they are not (mostly).

**Changes**
- Fix a crash in ItemLauncher when isFolder() returns null
- Add item fields to all queries in CollectionFragment, didn't fix the crash but they are probably needed somewhere in this spaghetti.

**Issues**

Fixes #3397 
