### PR TITLE
Add a preference option to bypass AVC High10 checks

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -53,6 +53,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 
 		/* Playback - General*/
 		/**
+		 * Preferred behavior for audio streaming.
+		 */
+		var avcHigh10Bypass = enumPreference("avc_high10_bypass", false)
+
+		/**
 		 * Maximum bitrate in megabit for playback.
 		 */
 		var maxBitrate = stringPreference("pref_max_bitrate", "100")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -569,7 +569,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
+                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),userPreferences.getValue().get(UserPreferences.Companion.getAvcHigh10Bypass())
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -107,6 +107,13 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.refreshRateSwitchingBehavior)
 				depends { DeviceUtils.is60() && userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL }
 			}
+
+			checkbox {
+				setTitle(R.string.pref_avc_high10_bypass)
+				setContent(R.string.desc_bitstream_ac3)
+				bind(userPreferences, UserPreferences.avcHigh10Bypass)
+				depends { userPreferences[UserPreferences.videoPlayer] != PreferredVideoPlayer.EXTERNAL }
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -10,6 +10,7 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
+import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileConditionBypass
 import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditions
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
@@ -30,6 +31,7 @@ class ExoPlayerProfile(
 	context: Context,
 	disableVideoDirectPlay: Boolean = false,
 	isAC3Enabled: Boolean = false,
+	isAVCHigh10BypassEnabled: Boolean = false,
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		Codec.Audio.AAC,
@@ -151,7 +153,8 @@ class ExoPlayerProfile(
 				type = CodecType.Video
 				codec = Codec.Video.H264
 				conditions = buildList {
-					add(h264VideoProfileCondition)
+					if (!isAVCHigh10BypassEnabled) add(h264VideoProfileCondition)
+					else add(h264VideoProfileConditionBypass)
 					add(h264VideoLevelProfileCondition)
 					if (!DeviceUtils.has4kVideoSupport()) addAll(max1080pProfileConditions)
 				}.toTypedArray()

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -183,6 +183,19 @@ object ProfileHelper {
 			).joinToString("|")
 		)
 	}
+	val h264VideoProfileConditionBypass by lazy {
+		ProfileCondition(
+			ProfileConditionType.EqualsAny,
+			ProfileConditionValue.VideoProfile,
+			listOfNotNull(
+				"high",
+				"main",
+				"baseline",
+				"constrained baseline",
+				"high 10"
+			).joinToString("|")
+		)
+	}
 
 	val max1080pProfileConditions by lazy {
 		arrayOf(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,7 @@
     <string name="dca">DTS</string>
     <string name="ac3">DD</string>
     <string name="eac3">DD+</string>
+    <string name="pref_avc_high10_bypass">AVC High10 compatibility mode</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
Allow users to bypass AVC High10 checks by adding a preference option. Enabling this option will automatically add AVC High10 as a supported profile, as long as the device supports AVC Main. The same AVC Main levels will be used for AVC High10.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Add user preference to bypass AVC High10 check
- Add a new profile condition in ProfileHelper to be used if bypass is enabled
- Update ExoPlayerProfile  based on the new preference

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->Workaround for #3401
