### PR TITLE
Remove "automatically choose" option from video player preference

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -129,7 +129,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Preferred video player for live TV
 		 */
-		var liveTvVideoPlayer = enumPreference("live_tv_video_player", PreferredVideoPlayer.AUTO)
+		var liveTvVideoPlayer = enumPreference("live_tv_video_player", PreferredVideoPlayer.EXOPLAYER)
 
 		/**
 		 * Shortcut used for changing the audio track

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/PreferredVideoPlayer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/PreferredVideoPlayer.kt
@@ -7,11 +7,6 @@ enum class PreferredVideoPlayer(
 	override val nameRes: Int,
 ) : PreferenceEnum {
 	/**
-	 *  Automatically selects between exoplayer and vlc
-	 */
-	AUTO(R.string.pref_video_player_auto),
-
-	/**
 	 *  Force ExoPlayer
 	 */
 	EXOPLAYER(R.string.pref_video_player_exoplayer),

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -671,24 +671,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                             } else if (preferredVideoPlayer == PreferredVideoPlayer.EXOPLAYER) {
                                 // Make sure to not use VLC
                                 useVlc = false;
-                            } else if (preferredVideoPlayer == PreferredVideoPlayer.AUTO) {
-                                // TODO: Clean up this logic
-                                // Now look at both responses and choose the one that direct plays or bitstreams - favor VLC
-                                useVlc = !vlcErrorEncountered &&
-                                        !vlcResponse.getPlayMethod().equals(PlayMethod.Transcode) &&
-                                        (DeviceUtils.is60() ||
-                                                !userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()) ||
-                                                vlcResponse.getMediaSource() == null ||
-                                                JavaCompat.getDefaultAudioStream(vlcResponse.getMediaSource()) == null ||
-                                                (!"ac3".equals(JavaCompat.getDefaultAudioStream(vlcResponse.getMediaSource()).getCodec()) &&
-                                                        !"truehd".equals(JavaCompat.getDefaultAudioStream(vlcResponse.getMediaSource()).getCodec()))) &&
-                                        (Utils.downMixAudio(mFragment.getContext()) ||
-                                                !DeviceUtils.is60() ||
-                                                internalResponse.getPlayMethod().equals(PlayMethod.Transcode) ||
-                                                !userPreferences.getValue().get(UserPreferences.Companion.getDtsEnabled()) ||
-                                                internalResponse.getMediaSource() == null ||
-                                                JavaCompat.getDefaultAudioStream(internalResponse.getMediaSource()) == null ||
-                                                (JavaCompat.getVideoStream(vlcResponse.getMediaSource()) != null && JavaCompat.getVideoStream(vlcResponse.getMediaSource()).getWidth() < 1000));
                             } else if (preferredVideoPlayer == PreferredVideoPlayer.CHOOSE) {
                                 PreferredVideoPlayer preferredVideoPlayerByPlayWith = systemPreferences.getValue().get(SystemPreferences.Companion.getChosenPlayer());
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,7 +250,6 @@
     <string name="lbl_my_media">My media</string>
     <string name="pref_theme_dark">Dark (Default)</string>
     <string name="pref_theme_emerald">Classic emerald</string>
-    <string name="pref_video_player_auto">Automatically choose</string>
     <string name="pref_video_player_exoplayer">ExoPlayer</string>
     <string name="pref_video_player_vlc">LibVLC (experimental)</string>
     <string name="pref_video_player_external">External app</string>


### PR DESCRIPTION
This preference was unreliable at best.

**Changes**
- Remove "automatically choose" option from video player preference
- Set default for Live TV player to ExoPlayer (which auto was basically an alias for with live tv)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
