### PR TITLE
Add "clear image cache" button to developer preferences

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -1,10 +1,14 @@
 package org.jellyfin.androidtv.ui.preference.screen
 
+import android.text.format.Formatter
+import coil.ImageLoader
+import coil.annotation.ExperimentalCoilApi
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.SystemPreferences
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.action
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.util.isTvDevice
@@ -13,6 +17,7 @@ import org.koin.android.ext.android.inject
 class DeveloperPreferencesScreen : OptionsFragment() {
 	private val userPreferences: UserPreferences by inject()
 	private val systemPreferences: SystemPreferences by inject()
+	private val imageLoader: ImageLoader by inject()
 
 	override val screen by optionsScreen {
 		setTitle(R.string.pref_developer_link)
@@ -48,6 +53,17 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 					setContent(R.string.enable_playback_module_description)
 
 					bind(userPreferences, UserPreferences.playbackRewriteVideoEnabled)
+				}
+			}
+
+			@OptIn(ExperimentalCoilApi::class)
+			action {
+				setTitle(R.string.clear_image_cache)
+				content = getString(R.string.clear_image_cache_content, Formatter.formatFileSize(context, imageLoader.diskCache?.size ?: 0))
+				onActivate = {
+					imageLoader.memoryCache?.clear()
+					imageLoader.diskCache?.clear()
+					rebuild()
 				}
 			}
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,8 @@
     <string name="dca">DTS</string>
     <string name="ac3">DD</string>
     <string name="eac3">DD+</string>
+    <string name="clear_image_cache">Clear image cache</string>
+    <string name="clear_image_cache_content">Used: %1$s</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
Useful during development but also in general to clear app cache without going to system preferences. It clears both disk and memory cache of Coil (our image library).

**Changes**
- Add "clear image cache" button to developer preferences

![95100002ce](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/a71a2c25-87bf-4942-b4a2-54ef8f940e57)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
