### PR TITLE
Add fallthrough to media3 MimeTypes in codec->mime type mapping

### DIFF
--- a/playback/exoplayer/src/main/kotlin/mapping/audio.kt
+++ b/playback/exoplayer/src/main/kotlin/mapping/audio.kt
@@ -1,9 +1,14 @@
 package org.jellyfin.playback.exoplayer.mapping
 
+import androidx.annotation.OptIn
 import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
 
+@OptIn(UnstableApi::class)
 fun getFfmpegAudioMimeType(codec: String): String {
-	return ffmpegAudioMimeTypes.getOrDefault(codec, codec)
+	return ffmpegAudioMimeTypes[codec]
+		?: MimeTypes.getAudioMediaMimeType(codec)
+		?: codec
 }
 
 val ffmpegAudioMimeTypes = mapOf(

--- a/playback/exoplayer/src/main/kotlin/mapping/container.kt
+++ b/playback/exoplayer/src/main/kotlin/mapping/container.kt
@@ -4,15 +4,13 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
+@OptIn(UnstableApi::class)
 fun getFfmpegContainerMimeType(codec: String): String {
-	// Find in container mime type list
-	return ffmpegContainerMimeTypes.getOrElse(codec) {
-		// Find in audio mime type list
-		ffmpegAudioMimeTypes.getOrElse(codec) {
-			// Return input
-			codec
-		}
-	}
+	return ffmpegContainerMimeTypes[codec]
+		?: ffmpegVideoMimeTypes[codec]
+		?: ffmpegAudioMimeTypes[codec]
+		?: MimeTypes.getMediaMimeType(codec)
+		?: codec
 }
 
 @OptIn(UnstableApi::class)

--- a/playback/exoplayer/src/main/kotlin/mapping/video.kt
+++ b/playback/exoplayer/src/main/kotlin/mapping/video.kt
@@ -1,0 +1,16 @@
+package org.jellyfin.playback.exoplayer.mapping
+
+import androidx.annotation.OptIn
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+
+@OptIn(UnstableApi::class)
+fun getFfmpegVideoMimeType(codec: String): String {
+	return ffmpegVideoMimeTypes[codec]
+		?: MimeTypes.getVideoMediaMimeType(codec)
+		?: codec
+}
+
+val ffmpegVideoMimeTypes = mapOf<String, String>(
+	// TODO: Add map
+)


### PR DESCRIPTION
**Changes**

Add fall through to media3's MimeType getters when our own mapping does not have a specific codec. This also adds an (empty) implementation for video codecs.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

part of #1057 