### PR TITLE
Use fully transparent background during video playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/background/AppBackground.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/background/AppBackground.kt
@@ -33,7 +33,7 @@ import org.koin.compose.koinInject
 private fun AppThemeBackground() {
 	val context = LocalContext.current
 	val themeBackground = remember(context.theme) {
-		val attributes = context.theme.obtainStyledAttributes(intArrayOf(android.R.attr.windowBackground))
+		val attributes = context.theme.obtainStyledAttributes(intArrayOf(R.attr.defaultBackground))
 		val drawable = attributes.getDrawable(0)
 		attributes.recycle()
 
@@ -62,26 +62,29 @@ private fun AppThemeBackground() {
 fun AppBackground() {
 	val backgroundService = koinInject<BackgroundService>()
 	val currentBackground by backgroundService.currentBackground.collectAsState()
+	val enabled by backgroundService.enabled.collectAsState()
 
-	AnimatedContent(
-		targetState = currentBackground,
-		transitionSpec = {
-			val duration = (BackgroundService.TRANSITION_DURATION.inWholeMilliseconds / 2).toInt()
-			fadeIn(tween(durationMillis = duration)) togetherWith fadeOut(snap(delayMillis = duration))
-		},
-		label = "BackgroundTransition",
-	) { background ->
-		if (background != null) {
-			Image(
-				bitmap = background,
-				contentDescription = null,
-				alignment = Alignment.Center,
-				contentScale = ContentScale.Crop,
-				colorFilter = ColorFilter.tint(colorResource(R.color.background_filter), BlendMode.SrcAtop),
-				modifier = Modifier.fillMaxSize()
-			)
-		} else {
-			AppThemeBackground()
+	if (enabled) {
+		AnimatedContent(
+			targetState = currentBackground,
+			transitionSpec = {
+				val duration = (BackgroundService.TRANSITION_DURATION.inWholeMilliseconds / 2).toInt()
+				fadeIn(tween(durationMillis = duration)) togetherWith fadeOut(snap(delayMillis = duration))
+			},
+			label = "BackgroundTransition",
+		) { background ->
+			if (background != null) {
+				Image(
+					bitmap = background,
+					contentDescription = null,
+					alignment = Alignment.Center,
+					contentScale = ContentScale.Crop,
+					colorFilter = ColorFilter.tint(colorResource(R.color.background_filter), BlendMode.SrcAtop),
+					modifier = Modifier.fillMaxSize()
+				)
+			} else {
+				AppThemeBackground()
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -201,7 +201,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             }
         };
 
-        backgroundService.getValue().clearBackgrounds();
+        backgroundService.getValue().disable();
     }
 
     @Nullable

--- a/app/src/main/res/layout/preference_button_remap.xml
+++ b/app/src/main/res/layout/preference_button_remap.xml
@@ -4,7 +4,6 @@
     android:id="@+id/main_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:attr/windowBackground"
     android:elevation="@dimen/lb_preference_decor_elevation"
     android:orientation="vertical"
     android:transitionGroup="false">

--- a/app/src/main/res/layout/preference_color_list.xml
+++ b/app/src/main/res/layout/preference_color_list.xml
@@ -4,7 +4,6 @@
     android:id="@+id/main_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:attr/windowBackground"
     android:elevation="@dimen/lb_preference_decor_elevation"
     android:orientation="vertical"
     android:transitionGroup="false">

--- a/app/src/main/res/layout/preference_rich_list.xml
+++ b/app/src/main/res/layout/preference_rich_list.xml
@@ -4,7 +4,6 @@
     android:id="@+id/main_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:attr/windowBackground"
     android:elevation="@dimen/lb_preference_decor_elevation"
     android:orientation="vertical"
     android:transitionGroup="false">

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/black">
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -26,6 +26,7 @@
         <attr name="controlIconBackground" format="reference|color" />
         <attr name="controlIconForegroundActive" format="reference|color" />
         <attr name="controlIconForegroundInactive" format="reference|color" />
+        <attr name="defaultBackground" format="reference|color" />
         <!-- QR drawables -->
         <attr name="qrBackground" format="color" />
         <attr name="qrForeground" format="color" />

--- a/app/src/main/res/values/theme_emerald.xml
+++ b/app/src/main/res/values/theme_emerald.xml
@@ -9,7 +9,7 @@
         <item name="android:colorPrimary">@color/theme_emerald_dark</item>
         <item name="android:colorPrimaryDark">@color/theme_emerald_dark</item>
         <item name="android:colorAccent">@color/theme_emerald_light</item>
-        <item name="android:windowBackground">@drawable/moviebg</item>
+        <item name="defaultBackground">@drawable/moviebg</item>
         <item name="defaultSearchColor">@color/theme_emerald_light</item>
         <item name="progressPrimary">@color/theme_emerald_light</item>
         <item name="progressSecondary">@color/theme_emerald_dark</item>

--- a/app/src/main/res/values/theme_jellyfin.xml
+++ b/app/src/main/res/values/theme_jellyfin.xml
@@ -7,7 +7,8 @@
         <item name="android:colorPrimaryDark">@color/grey</item>
         <item name="android:colorAccent">@color/jellyfin_blue</item>
         <!-- Background resource or color -->
-        <item name="android:windowBackground">@color/not_quite_black</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="defaultBackground">@color/not_quite_black</item>
         <!-- Background color for CardViews -->
         <item name="cardImageBackground">@color/grey</item>
         <item name="cardViewBackground">@android:color/transparent</item>
@@ -87,7 +88,6 @@
     </style>
 
     <style name="Theme.Jellyfin.Preferences" parent="Theme.Jellyfin">
-        <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:backgroundDimEnabled">true</item>
         <item name="android:windowAnimationStyle">@style/WindowAnimation.SlideRight</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Always use transparent windowBackground
- Move themed background to new attribute (defaultBackground)
- Add option to disable the BackgroundService entirely
  - Used in video player
  - Using any function to set a background will re-enable it automatically
- Remove background override in some preference layouts (why was it there??)
- 
**Issues**

Supersedes to #3384
Fixes #2967
