### PR TITLE
Enable Vorbis audio in video direct play

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
@@ -50,6 +50,7 @@ object Codec {
 		const val PCM_S16LE = "pcm_s16le"
 		const val PCM_S24LE = "pcm_s24le"
 		const val TRUEHD = "truehd"
+		const val VORBIS = "vorbis"
 		const val WAV = "wav"
 		const val WEBMA = "webma"
 		const val WMA = "wma"

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -55,6 +55,7 @@ class ExoPlayerProfile(
 		add(Codec.Audio.PCM_MULAW)
 		add(Codec.Audio.OPUS)
 		add(Codec.Audio.FLAC)
+		add(Codec.Audio.VORBIS)
 	}.toTypedArray()
 
 	private val allSupportedAudioCodecsWithoutFFmpegExperimental = allSupportedAudioCodecs


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Adds support for the Vorbis audio codec in direct video playback in the exoplayer profile.

The decoder seems to be supported according to the [Android documentation](https://developer.android.com/guide/topics/media/media-formats#core). Also, it's been supported on Amazon devices since the [first ](https://www.developer.amazon.com/docs/fire-tv/device-specifications-fire-tv-streaming-media-player.html?v=ftvgen1) gen.

**Issues**