### PR TITLE
Fix pcm multichannel audio for Tvs

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -570,7 +570,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()), (hasSurroundAudio)
+                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()), hasSurroundAudio
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -561,6 +561,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         internalOptions.setItemId(item.getId().toString());
         internalOptions.setMediaSources(item.getMediaSources());
         internalOptions.setMaxBitrate(maxBitrate);
+        boolean hasSurroundAudio = getNumberOfChannels() > 2;
         if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
             internalOptions.setEnableDirectStream(false);
         internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
@@ -569,7 +570,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
+                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()), (hasSurroundAudio)
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;
@@ -860,6 +861,16 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                                             mVideoManager.getVLCAudioTrack(getCurrentlyPlayingItem().getMediaStreams());
         }
         return currIndex;
+    }
+
+    public Integer getNumberOfChannels() {
+        Integer numberOfChannels = 0;
+        if (getCurrentMediaSource() != null &&
+                JavaCompat.getDefaultAudioStream(getCurrentMediaSource()) != null &&
+                JavaCompat.getDefaultAudioStream(getCurrentMediaSource()).getChannels() != null) {
+            numberOfChannels = JavaCompat.getDefaultAudioStream(getCurrentMediaSource()).getChannels();
+        }
+        return numberOfChannels;
     }
 
     private Integer bestGuessAudioTrack(MediaSourceInfo info) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -570,7 +570,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()), hasSurroundAudio
+                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
+                userPreferences.getValue().get(UserPreferences.Companion.getDtsEnabled()),hasSurroundAudio
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/util/ContextExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ContextExtensions.kt
@@ -32,3 +32,17 @@ fun Context.isTvDevice(): Boolean {
 		packageManager.hasSystemFeature("android.hardware.hdmi.cec") or
 		!packageManager.hasSystemFeature("android.hardware.touchscreen")
 }
+
+fun Context.isActualTv(): Boolean {
+	val uiModeManager = getSystemService<UiModeManager>()
+	val supportedUiModes = setOf(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_TYPE_UNDEFINED)
+
+	return supportedUiModes.contains(uiModeManager?.currentModeType) and
+			packageManager.hasSystemFeature("android.hardware.hdmi.cec") and
+			!packageManager.hasSystemFeature("android.hardware.touchscreen") and
+			!packageManager.hasSystemFeature("android.hardware.faketouch") and
+			!packageManager.hasSystemFeature("android.hardware.telephony") and
+			!packageManager.hasSystemFeature("android.hardware.camera") and
+			!packageManager.hasSystemFeature("android.hardware.location.gps") and
+			!packageManager.hasSystemFeature("android.hardware.screen.portrait")
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -33,8 +33,19 @@ object DeviceUtils {
 	private const val SHIELD_TV_MODEL = "SHIELD Android TV"
 	private const val UNKNOWN = "Unknown"
 
+	//Television Manufacturers
+	private const val HISENSE = "Hisense"
+	private const val PANASONIC = "Panasonic"
+	private const val PHILIPS = "Philips"
+	private const val SHARP = "Sharp"
+	private const val SONY = "Sony"
+	private const val TCL = "TCL"
+	private const val TOSHIBA = "Toshiba"
+
 	// Stub to allow for mock injection
 	fun getBuildModel(): String = Build.MODEL ?: UNKNOWN
+
+	fun getManufacturer(): String = Build.MANUFACTURER ?: UNKNOWN
 
 	@JvmStatic val isChromecastWithGoogleTV: Boolean get() = getBuildModel() == CHROMECAST_GOOGLE_TV
 	@JvmStatic val isFireTv: Boolean get() = getBuildModel().startsWith(FIRE_TV_PREFIX)
@@ -54,6 +65,17 @@ object DeviceUtils {
 		FIRE_STICK_LITE_MODEL,
 		FIRE_TV_MODEL_GEN_1,
 		FIRE_TV_MODEL_GEN_2
+	)
+
+	@JvmStatic
+	fun isTV(): Boolean = getManufacturer() in listOf(
+		HISENSE,
+		PANASONIC,
+		PHILIPS,
+		SHARP,
+		SONY,
+		TCL,
+		TOSHIBA
 	)
 
 	@JvmStatic

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -33,19 +33,8 @@ object DeviceUtils {
 	private const val SHIELD_TV_MODEL = "SHIELD Android TV"
 	private const val UNKNOWN = "Unknown"
 
-	//Television Manufacturers
-	private const val HISENSE = "Hisense"
-	private const val PANASONIC = "Panasonic"
-	private const val PHILIPS = "Philips"
-	private const val SHARP = "Sharp"
-	private const val SONY = "Sony"
-	private const val TCL = "TCL"
-	private const val TOSHIBA = "Toshiba"
-
 	// Stub to allow for mock injection
 	fun getBuildModel(): String = Build.MODEL ?: UNKNOWN
-
-	fun getManufacturer(): String = Build.MANUFACTURER ?: UNKNOWN
 
 	@JvmStatic val isChromecastWithGoogleTV: Boolean get() = getBuildModel() == CHROMECAST_GOOGLE_TV
 	@JvmStatic val isFireTv: Boolean get() = getBuildModel().startsWith(FIRE_TV_PREFIX)
@@ -65,17 +54,6 @@ object DeviceUtils {
 		FIRE_STICK_LITE_MODEL,
 		FIRE_TV_MODEL_GEN_1,
 		FIRE_TV_MODEL_GEN_2
-	)
-
-	@JvmStatic
-	fun isTV(): Boolean = getManufacturer() in listOf(
-		HISENSE,
-		PANASONIC,
-		PHILIPS,
-		SHARP,
-		SONY,
-		TCL,
-		TOSHIBA
 	)
 
 	@JvmStatic

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -30,12 +30,14 @@ class ExoPlayerProfile(
 	context: Context,
 	disableVideoDirectPlay: Boolean = false,
 	isAC3Enabled: Boolean = false,
+	isSurroundSound: Boolean = false,
 ) : DeviceProfile() {
-	private val downmixSupportedAudioCodecs = arrayOf(
-		Codec.Audio.AAC,
-		Codec.Audio.MP3,
-		Codec.Audio.MP2
-	)
+	private val downmixSupportedAudioCodecs = buildList {
+		if (isAC3Enabled) add(Codec.Audio.AC3)
+		if (!DeviceUtils.isTV() || (!isSurroundSound)) add(Codec.Audio.AAC)
+		add(Codec.Audio.MP3)
+		add(Codec.Audio.MP2)
+	}.toTypedArray()
 
 	/**
 	 * Returns all audio codecs used commonly in video containers.
@@ -43,18 +45,19 @@ class ExoPlayerProfile(
 	 */
 	private val allSupportedAudioCodecs = buildList {
 		addAll(downmixSupportedAudioCodecs)
-		add(Codec.Audio.AAC_LATM)
-		add(Codec.Audio.ALAC)
-		if (isAC3Enabled) add(Codec.Audio.AC3)
 		if (isAC3Enabled) add(Codec.Audio.EAC3)
 		add(Codec.Audio.DCA)
 		add(Codec.Audio.DTS)
-		add(Codec.Audio.MLP)
-		add(Codec.Audio.TRUEHD)
-		add(Codec.Audio.PCM_ALAW)
-		add(Codec.Audio.PCM_MULAW)
-		add(Codec.Audio.OPUS)
-		add(Codec.Audio.FLAC)
+		if (!DeviceUtils.isTV() || (!isSurroundSound)) {
+			add(Codec.Audio.AAC_LATM)
+			add(Codec.Audio.ALAC)
+			add(Codec.Audio.MLP)
+			add(Codec.Audio.TRUEHD)
+			add(Codec.Audio.PCM_ALAW)
+			add(Codec.Audio.PCM_MULAW)
+			add(Codec.Audio.OPUS)
+			add(Codec.Audio.FLAC)
+		}
 	}.toTypedArray()
 
 	private val allSupportedAudioCodecsWithoutFFmpegExperimental = allSupportedAudioCodecs

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils
+import org.jellyfin.androidtv.util.isActualTv
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAV1CodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
@@ -26,6 +27,7 @@ import org.jellyfin.apiclient.model.dlna.ProfileConditionValue
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod
 import org.jellyfin.apiclient.model.dlna.TranscodingProfile
 
+
 class ExoPlayerProfile(
 	context: Context,
 	disableVideoDirectPlay: Boolean = false,
@@ -34,7 +36,7 @@ class ExoPlayerProfile(
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = buildList {
 		if (isAC3Enabled) add(Codec.Audio.AC3)
-		if (!DeviceUtils.isTV() || (!isSurroundSound)) add(Codec.Audio.AAC)
+		if (!context.isActualTv() || !isSurroundSound) add(Codec.Audio.AAC)
 		add(Codec.Audio.MP3)
 		add(Codec.Audio.MP2)
 	}.toTypedArray()
@@ -45,10 +47,10 @@ class ExoPlayerProfile(
 	 */
 	private val allSupportedAudioCodecs = buildList {
 		addAll(downmixSupportedAudioCodecs)
-		if (isAC3Enabled) add(Codec.Audio.EAC3)
+		if (isAC3Enabled)add(Codec.Audio.EAC3)
 		add(Codec.Audio.DCA)
 		add(Codec.Audio.DTS)
-		if (!DeviceUtils.isTV() || (!isSurroundSound)) {
+		if (!context.isActualTv()|| !isSurroundSound) {
 			add(Codec.Audio.AAC_LATM)
 			add(Codec.Audio.ALAC)
 			add(Codec.Audio.MLP)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -32,6 +32,7 @@ class ExoPlayerProfile(
 	context: Context,
 	disableVideoDirectPlay: Boolean = false,
 	isAC3Enabled: Boolean = false,
+	isDTSEnabled: Boolean = false,
 	isSurroundSound: Boolean = false,
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = buildList {
@@ -47,10 +48,12 @@ class ExoPlayerProfile(
 	 */
 	private val allSupportedAudioCodecs = buildList {
 		addAll(downmixSupportedAudioCodecs)
-		if (isAC3Enabled)add(Codec.Audio.EAC3)
-		add(Codec.Audio.DCA)
-		add(Codec.Audio.DTS)
-		if (!context.isActualTv()|| !isSurroundSound) {
+		if (isAC3Enabled) add(Codec.Audio.EAC3)
+		if (isDTSEnabled) {
+			add(Codec.Audio.DCA)
+			add(Codec.Audio.DTS)
+		}
+		if (!context.isActualTv() || !isSurroundSound) {
 			add(Codec.Audio.AAC_LATM)
 			add(Codec.Audio.ALAC)
 			add(Codec.Audio.MLP)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Android apps running on Smart TVs are limited to PCM 2.0 Audio, while DD(+) and DTS have full support. This causes multichannel formats such as AAC and Opus to output stereo audio when playing directly from a TV to a receiver. This change identifies what is a TV based on feature testing and will transcode non-DD (+)/DTS multichannel audio if the app is running on a TV.

Also, add a condition for enabling/disabling DTS. The bitstreaming option in the preference menu isn't tied to any action. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes  #2991  #3294  #3152  #520   

