### PR TITLE
Fix search action ignoring received query

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -44,7 +44,7 @@ class HomeFragment : Fragment() {
 		}
 
 		binding.search.setOnClickListener {
-			navigationRepository.navigate(Destinations.search)
+			navigationRepository.navigate(Destinations.search())
 		}
 
 		return binding.root

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -46,7 +46,9 @@ object Destinations {
 
 	// General
 	val home = fragmentDestination<HomeFragment>()
-	val search = fragmentDestination<SearchFragment>()
+	fun search(query: String? = null) = fragmentDestination<SearchFragment>(
+		SearchFragment.EXTRA_QUERY to query,
+	)
 	val userPreferences = preferenceDestination<UserPreferencesScreen>()
 
 	// Browsing

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/LeanbackSearchFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/LeanbackSearchFragment.kt
@@ -31,6 +31,9 @@ class LeanbackSearchFragment : SearchSupportFragment(), SearchSupportFragment.Se
 		viewModel.searchResultsFlow
 			.onEach { searchFragmentDelegate.showResults(it) }
 			.launchIn(lifecycleScope)
+
+		val query = arguments?.getString(SearchFragment.EXTRA_QUERY)
+		if (!query.isNullOrBlank()) setSearchQuery(query, true)
 	}
 
 	override fun getResultsAdapter() = searchFragmentDelegate.rowsAdapter

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
@@ -6,9 +6,14 @@ import android.os.Bundle
 import android.speech.SpeechRecognizer
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
 import org.jellyfin.androidtv.R
 
 class SearchFragment : Fragment(R.layout.fragment_content_view) {
+	companion object {
+		const val EXTRA_QUERY = "query"
+	}
+
 	private val isSpeechEnabled by lazy {
 		SpeechRecognizer.isRecognitionAvailable(requireContext())
 			&& ContextCompat.checkSelfPermission(
@@ -22,14 +27,13 @@ class SearchFragment : Fragment(R.layout.fragment_content_view) {
 
 		// Determine fragment to use
 		val searchFragment = when {
-			isSpeechEnabled -> LeanbackSearchFragment()
-			else -> TextSearchFragment()
+			isSpeechEnabled -> LeanbackSearchFragment::class.java
+			else -> TextSearchFragment::class.java
 		}
 
 		// Add fragment
-		childFragmentManager
-			.beginTransaction()
-			.replace(R.id.content_view, searchFragment)
-			.commit()
+		childFragmentManager.commit {
+			replace(R.id.content_view, searchFragment, arguments)
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.ui.startup
 
 import android.Manifest
+import android.app.SearchManager
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
@@ -137,7 +138,9 @@ class StartupActivity : FragmentActivity() {
 		// Create destination
 		val destination = when {
 			// Search is requested
-			intent.action === Intent.ACTION_SEARCH -> Destinations.search
+			intent.action === Intent.ACTION_SEARCH -> Destinations.search(
+				query = intent.getStringExtra(SearchManager.QUERY)
+			)
 			// User view item is requested
 			itemId != null && itemIsUserView -> {
 				val item by api.userLibraryApi.getItem(itemId = itemId)

--- a/app/src/main/res/layout/fragment_search_text.xml
+++ b/app/src/main/res/layout/fragment_search_text.xml
@@ -48,9 +48,8 @@
         app:layout_constraintTop_toTopOf="@id/logo" />
 
     <!-- Fragment showing search results -->
-    <androidx.fragment.app.FragmentContainerView
+    <FrameLayout
         android:id="@+id/results_frame"
-        android:name="androidx.leanback.app.RowsSupportFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="27dp"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Update search destination to take an optional search query
- Update StartupActivity to send query to search destination
- Update leanback/text search implementations to use a given non-empty query automatically
- Use -ktx extensions to set fragments
- Refactor view creation slightly for text search fragment to try and fix auto-focus (spoiler: it does not)

**Issues**

Fixes #3444 
