### PR TITLE
Improve info row colors

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -92,14 +92,14 @@ fun InfoRowSeriesStatus(
 		when (seriesStatus) {
 			SeriesStatus.CONTINUING -> InfoRowItem(
 				contentDescription = stringResource(R.string.lbl__continuing),
-				background = InfoRowColors.Green,
+				colors = InfoRowColors.Green,
 			) {
 				Text(stringResource(R.string.lbl__continuing))
 			}
 
 			SeriesStatus.ENDED -> InfoRowItem(
 				contentDescription = stringResource(R.string.lbl_ended),
-				background = InfoRowColors.Red,
+				colors = InfoRowColors.Red,
 			) {
 				Text(stringResource(R.string.lbl_ended))
 			}
@@ -150,7 +150,7 @@ fun InfoRowMediaDetails(item: BaseItemDto) {
 	if (item.hasSubtitles == true) {
 		InfoRowItem(
 			contentDescription = null,
-			background = InfoRowColors.Default,
+			colors = InfoRowColors.Default,
 		) {
 			Text(stringResource(R.string.indicator_subtitles))
 		}
@@ -166,7 +166,7 @@ fun InfoRowMediaDetails(item: BaseItemDto) {
 
 		InfoRowItem(
 			contentDescription = null,
-			background = InfoRowColors.Default,
+			colors = InfoRowColors.Default,
 		) {
 			Text(resolution)
 		}
@@ -183,7 +183,7 @@ fun InfoRowMediaDetails(item: BaseItemDto) {
 	if (!videoCodecName.isNullOrBlank()) {
 		InfoRowItem(
 			contentDescription = null,
-			background = InfoRowColors.Default,
+			colors = InfoRowColors.Default,
 		) {
 			Text(videoCodecName)
 		}
@@ -204,7 +204,7 @@ fun InfoRowMediaDetails(item: BaseItemDto) {
 	if (!audioCodecName.isNullOrBlank()) {
 		InfoRowItem(
 			contentDescription = null,
-			background = InfoRowColors.Default,
+			colors = InfoRowColors.Default,
 		) {
 			Text(audioCodecName)
 		}
@@ -215,7 +215,7 @@ fun InfoRowMediaDetails(item: BaseItemDto) {
 	if (!audioChannelLayout.isNullOrBlank()) {
 		InfoRowItem(
 			contentDescription = null,
-			background = InfoRowColors.Default,
+			colors = InfoRowColors.Default,
 		) {
 			Text(audioChannelLayout)
 		}
@@ -295,7 +295,7 @@ fun BaseItemInfoRow(
 				if (item.isNew()) {
 					InfoRowItem(
 						contentDescription = null,
-						background = InfoRowColors.Green,
+						colors = InfoRowColors.Green,
 					) {
 						Text(stringResource(R.string.lbl_new))
 					}
@@ -304,7 +304,7 @@ fun BaseItemInfoRow(
 				if (item.isSeries == true && item.isNews != true) {
 					InfoRowItem(
 						contentDescription = null,
-						background = InfoRowColors.Default,
+						colors = InfoRowColors.Default,
 					) {
 						Text(stringResource(R.string.lbl_repeat))
 					}
@@ -313,7 +313,7 @@ fun BaseItemInfoRow(
 				if (item.isLive == true) {
 					InfoRowItem(
 						contentDescription = null,
-						background = InfoRowColors.Default,
+						colors = InfoRowColors.Default,
 					) {
 						Text(stringResource(R.string.lbl_live))
 					}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowColors.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowColors.kt
@@ -6,7 +6,8 @@ import androidx.compose.ui.graphics.Color
  * Colors used in the [BaseItemInfoRow].
  */
 object InfoRowColors {
-	val Default = Color(0xFF333333)
-	val Green = Color(0xFF30843D)
-	val Red = Color(0xFFB20000)
+	val Transparent = Color.Transparent to Color.White
+	val Default = Color(0x80FFFFFF) to Color.Black
+	val Green = Color(0x8034D97C) to Color.Black
+	val Red = Color(0x80F2364D) to Color.Black
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
@@ -28,13 +28,15 @@ fun InfoRowItem(
 	icon: Painter? = null,
 	contentDescription: String?,
 	// Styling
-	background: Color = Color.Transparent,
+	colors: Pair<Color, Color> = InfoRowColors.Transparent,
 	// Content
 	content: @Composable RowScope.() -> Unit,
 ) {
+	val (backgroundColor, foregroundColor) = colors
+
 	val modifier = when {
-		background.alpha > 0f -> Modifier
-			.background(background, RoundedCornerShape(3.dp))
+		backgroundColor.alpha > 0f -> Modifier
+			.background(backgroundColor, RoundedCornerShape(3.dp))
 			.padding(horizontal = 5.dp)
 
 		else -> Modifier
@@ -42,8 +44,8 @@ fun InfoRowItem(
 
 	ProvideTextStyle(
 		value = TextStyle(
-			color = Color.LightGray,
-			fontSize = if (background.alpha > 0f) 12.sp else 16.sp,
+			color = foregroundColor,
+			fontSize = if (backgroundColor.alpha > 0f) 12.sp else 16.sp,
 		)
 	) {
 		Row(
@@ -55,7 +57,7 @@ fun InfoRowItem(
 				Image(
 					painter = icon,
 					contentDescription = contentDescription,
-					modifier = Modifier.size(if (background.alpha > 0f) 16.dp else 18.dp),
+					modifier = Modifier.size(if (backgroundColor.alpha > 0f) 16.dp else 18.dp),
 				)
 			}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.ui.browsing.composable.inforow
 
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
@@ -50,7 +49,7 @@ fun InfoRowCriticRating(criticRating: Float) {
 fun InfoRowParentalRating(parentalRating: String) {
 	InfoRowItem(
 		contentDescription = stringResource(R.string.lbl_rating),
-		background = Color(0xFF333333),
+		colors = InfoRowColors.Default,
 	) {
 		Text(parentalRating)
 	}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Update the colors used in the new InfoRow (#3379) to some better ones. I've shamefully stolen them from the Figma lab project. The background colors all have 50% transparency, creating some sort of "glassy" effect.

The biggest improvement is in the used red/green colors because I really hated those. They're missing in the screenshots though.

Before
![96900002f4](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/8201e2f4-f52b-43e9-bb4d-b9319f3166bf)

After
![97800002f3](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/4fbded1f-b856-438a-b61f-c83345a87387)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
