### PR TITLE
Remove PlayAccess checks

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -59,7 +59,6 @@ import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.dto.UserItemDataDto;
-import org.jellyfin.apiclient.model.library.PlayAccess;
 import org.jellyfin.apiclient.model.playlists.PlaylistItemQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
@@ -331,7 +330,6 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             item.setId(FakeBaseItem.INSTANCE.getFAV_SONGS_ID().toString());
             item.setName(getString(R.string.lbl_favorites));
             item.setOverview(getString(R.string.desc_automatic_fav_songs));
-            item.setPlayAccess(PlayAccess.Full);
             item.setMediaType(MediaType.Audio);
             item.setBaseItemType(BaseItemType.Playlist);
             item.setIsFolder(true);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -23,7 +23,6 @@ import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
-import org.jellyfin.sdk.model.api.PlayAccess;
 import org.jellyfin.sdk.model.constant.CollectionType;
 import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
 import org.koin.java.KoinJavaComponent;
@@ -158,20 +157,16 @@ public class ItemLauncher {
                             navigationRepository.navigate(Destinations.INSTANCE.itemDetails(baseItem.getId()));
                             break;
                         case Play:
-                            if (baseItem.getPlayAccess() == org.jellyfin.sdk.model.api.PlayAccess.FULL) {
-                                //Just play it directly
-                                final BaseItemKind itemType = baseItem.getType();
-                                PlaybackHelper.getItemsToPlay(baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
-                                    @Override
-                                    public void onResponse(List<BaseItemDto> response) {
-                                        KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
-                                        Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(itemType, 0);
-                                        navigationRepository.navigate(destination);
-                                    }
-                                });
-                            } else {
-                                Utils.showToast(context, "Item not playable at this time");
-                            }
+                            //Just play it directly
+                            final BaseItemKind itemType = baseItem.getType();
+                            PlaybackHelper.getItemsToPlay(baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
+                                @Override
+                                public void onResponse(List<BaseItemDto> response) {
+                                    KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
+                                    Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(itemType, 0);
+                                    navigationRepository.navigate(destination);
+                                }
+                            });
                             break;
                     }
                 }
@@ -205,22 +200,18 @@ public class ItemLauncher {
                         navigationRepository.navigate(Destinations.INSTANCE.channelDetails(program.getId(), program.getChannelId(), program));
                         break;
                     case Play:
-                        if (program.getPlayAccess() == org.jellyfin.sdk.model.api.PlayAccess.FULL) {
-                            //Just play it directly - need to retrieve program channel via items api to convert to BaseItem
-                            ItemLauncherHelper.getItem(program.getChannelId(), new Response<BaseItemDto>() {
-                                @Override
-                                public void onResponse(BaseItemDto response) {
-                                    List<BaseItemDto> items = new ArrayList<>();
-                                    items.add(response);
-                                    KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
-                                    Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(response.getType(), 0);
-                                    navigationRepository.navigate(destination);
+                        //Just play it directly - need to retrieve program channel via items api to convert to BaseItem
+                        ItemLauncherHelper.getItem(program.getChannelId(), new Response<BaseItemDto>() {
+                            @Override
+                            public void onResponse(BaseItemDto response) {
+                                List<BaseItemDto> items = new ArrayList<>();
+                                items.add(response);
+                                KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
+                                Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(response.getType(), 0);
+                                navigationRepository.navigate(destination);
 
-                                }
-                            });
-                        } else {
-                            Utils.showToast(context, "Item not playable at this time");
-                        }
+                            }
+                        });
                 }
                 break;
 
@@ -249,21 +240,17 @@ public class ItemLauncher {
                         navigationRepository.navigate(Destinations.INSTANCE.itemDetails(rowItem.getBaseItem().getId()));
                         break;
                     case Play:
-                        if (rowItem.getBaseItem().getPlayAccess() == PlayAccess.FULL) {
-                            //Just play it directly but need to retrieve as base item
-                            ItemLauncherHelper.getItem(rowItem.getBaseItem().getId(), new Response<BaseItemDto>() {
-                                @Override
-                                public void onResponse(BaseItemDto response) {
-                                    List<BaseItemDto> items = new ArrayList<>();
-                                    items.add(response);
-                                    KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
-                                    Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(rowItem.getBaseItemType(), 0);
-                                    navigationRepository.navigate(destination);
-                                }
-                            });
-                        } else {
-                            Utils.showToast(context, "Item not playable at this time");
-                        }
+                        //Just play it directly but need to retrieve as base item
+                        ItemLauncherHelper.getItem(rowItem.getBaseItem().getId(), new Response<BaseItemDto>() {
+                            @Override
+                            public void onResponse(BaseItemDto response) {
+                                List<BaseItemDto> items = new ArrayList<>();
+                                items.add(response);
+                                KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
+                                Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(rowItem.getBaseItemType(), 0);
+                                navigationRepository.navigate(destination);
+                            }
+                        });
                         break;
                 }
                 break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -47,7 +47,6 @@ import org.jellyfin.sdk.model.api.LocationType;
 import org.jellyfin.sdk.model.api.MediaSourceInfo;
 import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
-import org.jellyfin.sdk.model.api.PlayAccess;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.List;
@@ -516,13 +515,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                                 .create()
                                 .show();
                     }
-                    return;
-                }
-
-                // confirm we actually can play
-                if (item.getPlayAccess() != PlayAccess.FULL) {
-                    String msg = item.isPlaceHolder() ? mFragment.getString(R.string.msg_cannot_play) : mFragment.getString(R.string.msg_cannot_play_time);
-                    Utils.showToast(mFragment.getContext(), msg);
                     return;
                 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
@@ -12,7 +12,6 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.LocationType
-import org.jellyfin.sdk.model.api.PlayAccess
 import java.util.Calendar
 
 fun BaseItemDto.getSeasonEpisodeName(context: Context): String {
@@ -49,7 +48,6 @@ fun BaseItemDto.getDisplayName(context: Context): String {
 
 
 fun BaseItemDto?.canPlay() = this != null
-	&& playAccess == PlayAccess.FULL
 	&& isPlaceHolder != true
 	&& (type != BaseItemKind.EPISODE || locationType != LocationType.VIRTUAL)
 	&& type != BaseItemKind.PERSON


### PR DESCRIPTION
The "PlayAccess" field for BaseItemDto is not populated by default, it needs to be explicitly requested (for some stupid reason). We don't do that in a bunch of places which may cause playback to fail if started from a source that didn't have that field set. We don't really need the checks because client side security is stupid.

**Changes**
- Remove PlayAccess checks as playback works fine even when disallowed

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
