### PR TITLE
Add preferences for screensaver age rating

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.data.repository
 
-import android.app.UiModeManager
 import android.content.Context
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,7 +18,6 @@ interface NotificationsRepository {
 
 class NotificationsRepositoryImpl(
 	private val context: Context,
-	private val uiModeManager: UiModeManager,
 	private val systemPreferences: SystemPreferences,
 ) : NotificationsRepository {
 	override val notifications = MutableStateFlow(emptyList<AppNotification>())

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -112,7 +112,7 @@ val appModule = module {
 
 	single<UserRepository> { UserRepositoryImpl() }
 	single<UserViewsRepository> { UserViewsRepositoryImpl(get()) }
-	single<NotificationsRepository> { NotificationsRepositoryImpl(get(), get(), get()) }
+	single<NotificationsRepository> { NotificationsRepositoryImpl(get(), get()) }
 	single<ItemMutationRepository> { ItemMutationRepositoryImpl(get(), get()) }
 	single<CustomMessageRepository> { CustomMessageRepositoryImpl() }
 	single<NavigationRepository> { NavigationRepositoryImpl(Destinations.home) }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
@@ -46,7 +46,9 @@ fun DreamHost() {
 		delay(2.seconds)
 
 		while (true) {
-			libraryShowcase = getRandomLibraryShowcase(api, imageLoader, context)
+			val requireParentalRating = userPreferences[UserPreferences.screensaverAgeRatingRequired]
+			val maxOfficialRating = userPreferences[UserPreferences.screensaverAgeRatingMax]
+			libraryShowcase = getRandomLibraryShowcase(context, api, maxOfficialRating, requireParentalRating, imageLoader)
 			delay(30.seconds)
 		}
 	}
@@ -65,9 +67,11 @@ fun DreamHost() {
 }
 
 private suspend fun getRandomLibraryShowcase(
+	context: Context,
 	api: ApiClient,
+	maxParentalRating: Int,
+	requireParentalRating: Boolean,
 	imageLoader: ImageLoader,
-	context: Context
 ): DreamContent.LibraryShowcase? {
 	try {
 		val response by api.itemsApi.getItemsByUserId(
@@ -76,9 +80,8 @@ private suspend fun getRandomLibraryShowcase(
 			sortBy = listOf(ItemSortBy.Random),
 			limit = 5,
 			imageTypes = listOf(ImageType.BACKDROP),
-			// TODO: Add preferences for these two settings
-			maxOfficialRating = "PG-13",
-			// hasParentalRating = true,
+			maxOfficialRating = if (maxParentalRating == -1) null else maxParentalRating.toString(),
+			hasParentalRating = if (requireParentalRating) true else null,
 		)
 
 		val item = response.items?.firstOrNull { item ->

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -207,6 +207,16 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var screensaverInAppTimeout = longPreference("screensaver_inapp_timeout", 5.minutes.inWholeMilliseconds)
 
 		/**
+		 * Age rating used to filter items in the screensaver. Use -1 to disable (omits parameter from requests).
+		 */
+		var screensaverAgeRatingMax = intPreference("screensaver_agerating_max", 13)
+
+		/**
+		 * Whether items shown in the screensaver are required to have an age rating set.
+		 */
+		var screensaverAgeRatingRequired = booleanPreference("screensaver_agerating_required", true)
+
+		/**
 		 * Enable reactive homepage
 		 */
 		var homeReactive = booleanPreference("home_reactive", false)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -121,6 +121,37 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 
 				depends { userPreferences[UserPreferences.screensaverInAppEnabled] }
 			}
+
+			checkbox {
+				setTitle(R.string.pref_screensaver_ageratingrequired_title)
+				setContent(
+					R.string.pref_screensaver_ageratingrequired_enabled,
+					R.string.pref_screensaver_ageratingrequired_disabled,
+				)
+
+				bind(userPreferences, UserPreferences.screensaverAgeRatingRequired)
+			}
+
+			list {
+				setTitle(R.string.pref_screensaver_ageratingmax)
+
+				// Note: Must include 13 (default value)
+				// We may want to fetch this mapping from the server in the future
+				@Suppress("MagicNumber")
+				val ages = setOf(5, 10, 13, 14, 16, 18, 21)
+
+				entries = buildMap {
+					put("0", getString(R.string.pref_screensaver_ageratingmax_zero))
+					ages.forEach { age -> put(age.toString(), getString(R.string.pref_screensaver_ageratingmax_entry, age)) }
+					put("-1", getString(R.string.pref_screensaver_ageratingmax_unlimited))
+				}
+
+				bind {
+					get { userPreferences[UserPreferences.screensaverAgeRatingMax].toString() }
+					set { value -> userPreferences[UserPreferences.screensaverAgeRatingMax] = value.toInt() }
+					default { UserPreferences.screensaverAgeRatingMax.defaultValue.toString() }
+				}
+			}
 		}
 
 		category {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,6 +508,13 @@
     <string name="random">Random</string>
     <string name="unreleased">Not yet released</string>
     <string name="pref_playback_advanced">Advanced playback preferences</string>
+    <string name="pref_screensaver_ageratingmax">Maximum age rating</string>
+    <string name="pref_screensaver_ageratingmax_zero">All ages</string>
+    <string name="pref_screensaver_ageratingmax_entry">Up to age %1$d</string>
+    <string name="pref_screensaver_ageratingmax_unlimited">Disable maximum</string>
+    <string name="pref_screensaver_ageratingrequired_title">Require age rating</string>
+    <string name="pref_screensaver_ageratingrequired_enabled">Only showing items with an age rating set</string>
+    <string name="pref_screensaver_ageratingrequired_disabled">Showing all items</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
This change adds age rating preferences for the screensaver. It depends on jellyfin/jellyfin#11367.

This is not the exact implementation that I wanted, ideally the maximum age rating preference would show the parental ratings from the server. There are two problems with it though:
- There is a breaking API change in 10.9 and the SDK we're currently using breaks because of it
  - Not a huge problem as 0.17 is most likely going to require 10.9, still annoying now that we're using the older SDK version
- The responses are not localized, some names are hardcoded (unrated/approved/banned)
  - And even if they used the server language, the client might want a different language. We'd need to add `Accept-Language` support to both the API and SDK for this to work properly. Which might be something to look at for 10.10, but definitely not 10.9

Adding the mapping via the server is something we can always add later though.

**Changes**

- Add preference for screensaver "require age rating"
  - Defaults to on (changed behavior since 0.16)
  - When turned on, only items with an age rating set will show
  - When turned off, all items will show

- Add preference for screensaver "maximum age rating"
  - Defaults to 13 (same behavior as 0.16)
  - Can also be set to a few different values, notable are 0 and -1.
  - -1 means "no maximum", parameter will be omitted in requests

**Screenshots**

![9460000320](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/b43dbf0e-80f0-4e75-8b6a-7f2e0d531992)

![9080000321](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/99b52990-22a5-45d8-8f80-922c4868f1f3)

**Issues**

Fixes #3320