### PR TITLE
Fix Live TV channels refreshing to infinity

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -39,6 +39,7 @@ import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.results.ChannelInfoDtoResult;
 import org.jellyfin.apiclient.model.results.TimerInfoDtoResult;
 import org.jellyfin.sdk.model.constant.ItemSortBy;
+import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
 import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
@@ -88,8 +89,9 @@ public class TvManager {
     public static boolean shouldForceReload() { return forceReload; }
 
     public static int getAllChannelsIndex(UUID id) {
+        if (allChannels == null) return -1;
         for (int i = 0; i < allChannels.size(); i++) {
-            if (allChannels.get(i).getId().equals(id.toString())) return i;
+            if (UUIDSerializerKt.toUUIDOrNull(allChannels.get(i).getId()).equals(id)) return i;
         }
         return -1;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1459,7 +1459,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 ArrayObjectAdapter channelAdapter = new ArrayObjectAdapter(new ChannelCardPresenter());
                 channelAdapter.addAll(0, TvManager.getAllChannels());
                 if (mChapterRow != null) mPopupRowAdapter.remove(mChapterRow);
-                mChapterRow = new ListRow(new HeaderItem("Channels"), channelAdapter);
+                mChapterRow = new ListRow(new HeaderItem(requireContext().getString(R.string.channels)), channelAdapter);
                 mPopupRowAdapter.add(mChapterRow);
             }
         });


### PR DESCRIPTION
**Changes**
- Fix `getAllChannelsIndex` function in TvManager causing an NPE if allChannels is null (now returns -1)
- Fix `getAllChannelsIndex` function in TvManager always returning -1 because the UUID format for the channels was different from the UUID.toString() format
- Fix channel row in player overlay not using the string resource for channels
- Fix check for program end failing because of timezone issues, causing the channel row to refresh infinitely in the player overlay

I believe the UUID issue is a regression from an earlier 0.17 pull request. The others will be backported.

**Issues**

Fixes #2375