### PR TITLE
Cache computed PlayableMediaStream in QueueEntry element

### DIFF
--- a/playback/core/src/main/kotlin/mediastream/QueueEntryMediaStream.kt
+++ b/playback/core/src/main/kotlin/mediastream/QueueEntryMediaStream.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.playback.core.mediastream
+
+import org.jellyfin.playback.core.element.ElementKey
+import org.jellyfin.playback.core.element.element
+import org.jellyfin.playback.core.queue.QueueEntry
+
+private val mediaStreamKey = ElementKey<PlayableMediaStream>("MediaStream")
+
+/**
+ * Get or set the [MediaStream] for this [QueueEntry].
+ */
+var QueueEntry.mediaStream by element(mediaStreamKey)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Cache computed PlayableMediaStream in QueueEntry element

Right now this improves performance when the same queue entry is played a second time, either via the previous/next buttons or when using repeat mode. We'll eventually use this to preload media stream information and reintroduce gappless playback.

**Issues**

Part of #1057 