### PR TITLE
Fix screensaver and media manager displaying video entries

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
@@ -27,6 +27,7 @@ import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.constant.ItemSortBy
+import org.jellyfin.sdk.model.constant.MediaType
 import org.koin.compose.koinInject
 import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
@@ -55,7 +56,7 @@ fun DreamHost() {
 
 	DreamView(
 		content = when {
-			mediaItem != null -> DreamContent.NowPlaying(mediaItem)
+			mediaItem?.mediaType == MediaType.Audio -> DreamContent.NowPlaying(mediaItem)
 			libraryShowcase != null -> libraryShowcase!!
 			else -> DreamContent.Logo
 		},

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -30,6 +30,7 @@ import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.createBaseItemQueueEntry
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.constant.MediaType
 import kotlin.math.max
 
 @Suppress("TooManyFunctions")
@@ -61,6 +62,7 @@ class RewriteMediaManager(
 
 	override val currentAudioItem: BaseItemDto?
 		get() = playbackManager.state.queue.entry.value?.baseItem
+			?.takeIf { it.mediaType == MediaType.Audio }
 
 	override fun toggleRepeat(): Boolean {
 		val newMode = when (playbackManager.state.repeatMode.value) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix the screensaver showing video entries, it should only show audio entries (music)
- Fix the "now playing" thingy while browsing showing video entries
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Part of #1057 