### PR TITLE
Initial subtitle support in playback rewrite

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -36,7 +36,7 @@ val playbackModule = module {
 		val preferences = get<UserPreferences>()
 		val useRewrite = preferences[UserPreferences.playbackRewriteVideoEnabled] && BuildConfig.DEVELOPMENT
 
-		if (useRewrite) RewritePlaybackLauncher(get())
+		if (useRewrite) RewritePlaybackLauncher()
 		else GarbagePlaybackLauncher(get())
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1611,9 +1611,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             public void onResponse(List<org.jellyfin.sdk.model.api.BaseItemDto> response) {
                 if (!getActive()) return;
 
-                PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
-                if (playbackLauncher.interceptPlayRequest(requireContext(), ModelCompat.asSdk(item))) return;
-
                 if (ModelCompat.asSdk(item).getType() == BaseItemKind.MUSIC_ARTIST) {
                     mediaManager.getValue().playNow(requireContext(), response, 0, shuffle);
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -301,9 +301,6 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             queue.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
-                    PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
-                    if (playbackLauncher.interceptPlayRequest(requireContext(), row.getItem())) return true;
-
                     mediaManager.getValue().queueAudioItem(row.getItem());
                     return true;
                 }
@@ -460,9 +457,6 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
     }
 
     private void play(List<BaseItemDto> items, int ndx, boolean shuffle) {
-        PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
-        if (playbackLauncher.interceptPlayRequest(requireContext(), items.size() > 0 ? ModelCompat.asSdk(items.get(0)) : null)) return;
-
         Timber.d("play items: %d, ndx: %d, shuffle: %b", items.size(), ndx, shuffle);
 
         if (MediaType.Video.equals(mBaseItem.getMediaType())) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -97,10 +97,6 @@ public class ItemLauncher {
                         if (rowItem.getBaseItem() == null)
                             return;
 
-                        PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
-                        if (playbackLauncher.interceptPlayRequest(context, rowItem.getBaseItem()))
-                            return;
-
                         // if the song currently playing is selected (and is the exact item - this only happens in the nowPlayingRow), open AudioNowPlayingActivity
                         if (mediaManager.hasAudioQueueItems() && rowItem instanceof AudioQueueItem && rowItem.getBaseItem().getId().equals(mediaManager.getCurrentAudioItem().getId())) {
                             navigationRepository.navigate(Destinations.INSTANCE.getNowPlaying());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -25,6 +25,7 @@ import org.jellyfin.androidtv.ui.playback.AudioNowPlayingFragment
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpFragment
+import org.jellyfin.androidtv.ui.playback.rewrite.PlaybackRewriteFragment
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
@@ -158,6 +159,10 @@ object Destinations {
 
 	fun videoPlayer(position: Int?) = fragmentDestination<CustomPlaybackOverlayFragment>(
 		"Position" to (position ?: 0)
+	)
+
+	fun playbackRewritePlayer(position: Int?) = fragmentDestination<PlaybackRewriteFragment>(
+		PlaybackRewriteFragment.EXTRA_POSITION to position
 	)
 
 	fun nextUp(item: UUID) = fragmentDestination<NextUpFragment>(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -5,12 +5,8 @@ import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.ui.navigation.Destination
 import org.jellyfin.androidtv.ui.navigation.Destinations
-import org.jellyfin.androidtv.ui.navigation.NavigationRepository
-import org.jellyfin.androidtv.ui.navigation.fragmentDestination
-import org.jellyfin.androidtv.ui.playback.rewrite.PlaybackRewriteFragment
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.constant.MediaType
 
 interface PlaybackLauncher {
 	fun useExternalPlayer(itemType: BaseItemKind?): Boolean
@@ -29,9 +25,11 @@ class GarbagePlaybackLauncher(
 		BaseItemKind.SEASON,
 		BaseItemKind.RECORDING,
 		-> userPreferences[UserPreferences.videoPlayer] === PreferredVideoPlayer.EXTERNAL
+
 		BaseItemKind.TV_CHANNEL,
 		BaseItemKind.PROGRAM,
 		-> userPreferences[UserPreferences.liveTvVideoPlayer] === PreferredVideoPlayer.EXTERNAL
+
 		else -> false
 	}
 
@@ -43,21 +41,8 @@ class GarbagePlaybackLauncher(
 	override fun interceptPlayRequest(context: Context, item: BaseItemDto?): Boolean = false
 }
 
-class RewritePlaybackLauncher(
-	private val navigationRepository: NavigationRepository,
-) : PlaybackLauncher {
+class RewritePlaybackLauncher : PlaybackLauncher {
 	override fun useExternalPlayer(itemType: BaseItemKind?) = false
-	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) =
-		fragmentDestination<PlaybackRewriteFragment>()
-
-	override fun interceptPlayRequest(context: Context, item: BaseItemDto?): Boolean {
-		if (item == null) return false
-		if (item.mediaType == MediaType.Audio) return false
-
-		navigationRepository.navigate(fragmentDestination<PlaybackRewriteFragment>(
-			PlaybackRewriteFragment.EXTRA_ITEM_ID to item.id.toString()
-		))
-
-		return true
-	}
+	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = Destinations.playbackRewritePlayer(position)
+	override fun interceptPlayRequest(context: Context, item: BaseItemDto?): Boolean = false
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -1,17 +1,14 @@
 package org.jellyfin.androidtv.ui.playback
 
-import android.content.Context
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer
 import org.jellyfin.androidtv.ui.navigation.Destination
 import org.jellyfin.androidtv.ui.navigation.Destinations
-import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 
 interface PlaybackLauncher {
 	fun useExternalPlayer(itemType: BaseItemKind?): Boolean
 	fun getPlaybackDestination(itemType: BaseItemKind?, position: Int): Destination
-	fun interceptPlayRequest(context: Context, item: BaseItemDto?): Boolean
 }
 
 class GarbagePlaybackLauncher(
@@ -37,12 +34,9 @@ class GarbagePlaybackLauncher(
 		useExternalPlayer(itemType) -> Destinations.externalPlayer(position)
 		else -> Destinations.videoPlayer(position)
 	}
-
-	override fun interceptPlayRequest(context: Context, item: BaseItemDto?): Boolean = false
 }
 
 class RewritePlaybackLauncher : PlaybackLauncher {
 	override fun useExternalPlayer(itemType: BaseItemKind?) = false
 	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = Destinations.playbackRewritePlayer(position)
-	override fun interceptPlayRequest(context: Context, item: BaseItemDto?): Boolean = false
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -15,6 +16,7 @@ import org.jellyfin.androidtv.ui.ScreensaverViewModel
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.ui.PlayerSubtitleView
 import org.jellyfin.playback.core.ui.PlayerSurfaceView
 import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.android.ext.android.inject
@@ -74,9 +76,15 @@ class PlaybackRewriteFragment : Fragment() {
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		val view = PlayerSurfaceView(requireContext())
-		view.playbackManager = playbackManager
-		return view
+		return FrameLayout(requireContext()).apply {
+			addView(PlayerSurfaceView(requireContext()).also { view ->
+				view.playbackManager = playbackManager
+			})
+
+			addView(PlayerSubtitleView(requireContext()).also { view ->
+				view.playbackManager = playbackManager
+			})
+		}
 	}
 
 	override fun onPause() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
@@ -5,13 +5,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.ui.ScreensaverViewModel
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.ui.PlayerSurfaceView
 import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import timber.log.Timber
 
 /**
@@ -26,6 +33,9 @@ class PlaybackRewriteFragment : Fragment() {
 	private val videoQueueManager by inject<VideoQueueManager>()
 	private val playbackManager by inject<PlaybackManager>()
 	private val api by inject<ApiClient>()
+
+	private val screensaverViewModel by activityViewModel<ScreensaverViewModel>()
+	private var screensaverLock: (() -> Unit)? = null
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -47,6 +57,20 @@ class PlaybackRewriteFragment : Fragment() {
 
 		// Pause player until the initial resume
 		playbackManager.state.pause()
+
+		// Add lifecycle listeners
+		lifecycleScope.launch {
+			repeatOnLifecycle(Lifecycle.State.RESUMED) {
+				playbackManager.state.playState.onEach { playState ->
+					if (playState == PlayState.PLAYING && screensaverLock == null) {
+						screensaverLock = screensaverViewModel.addLifecycleLock(lifecycle)
+					} else if (playState != PlayState.PLAYING && screensaverLock != null) {
+						screensaverLock?.invoke()
+						screensaverLock = null
+					}
+				}.launchIn(this)
+			}
+		}
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
@@ -44,11 +44,32 @@ class PlaybackRewriteFragment : Fragment() {
 				playbackManager.state.queue.setIndex(position, false)
 			}
 		}
+
+		// Pause player until the initial resume
+		playbackManager.state.pause()
 	}
 
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		val view = PlayerSurfaceView(requireContext())
 		view.playbackManager = playbackManager
 		return view
+	}
+
+	override fun onPause() {
+		super.onPause()
+
+		playbackManager.state.pause()
+	}
+
+	override fun onResume() {
+		super.onResume()
+
+		playbackManager.state.unpause()
+	}
+
+	override fun onStop() {
+		super.onStop()
+
+		playbackManager.state.stop()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
@@ -4,26 +4,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.playback.core.PlaybackManager
-import org.jellyfin.playback.core.queue.Queue
-import org.jellyfin.playback.core.queue.QueueEntry
 import org.jellyfin.playback.core.ui.PlayerSurfaceView
-import org.jellyfin.playback.jellyfin.queue.createBaseItemQueueEntry
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.userLibraryApi
-import org.jellyfin.sdk.model.api.BaseItemDto
-import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 import timber.log.Timber
-import java.util.UUID
 
 /**
  * Temporary fragment used for testing the playback rewrite. This will eventually be replaced with a
@@ -31,7 +20,7 @@ import java.util.UUID
  */
 class PlaybackRewriteFragment : Fragment() {
 	companion object {
-		const val EXTRA_ITEM_ID: String = "item_id"
+		const val EXTRA_POSITION: String = "position"
 	}
 
 	private val videoQueueManager by inject<VideoQueueManager>()
@@ -41,41 +30,18 @@ class PlaybackRewriteFragment : Fragment() {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
-		// Try find the item id
-		val itemId = findItemId()
+		// Create a queue from the items added to the legacy video queue
+		val queue = RewriteMediaManager.BaseItemQueue(api)
+		queue.items.addAll(videoQueueManager.getCurrentVideoQueue())
+		Timber.i("Created a queue with ${queue.items.size} items")
+		playbackManager.state.queue.replaceQueue(queue)
 
-		if (itemId == null) {
-			Toast.makeText(
-				requireContext(),
-				"Could not find item to play (itemId=null)",
-				Toast.LENGTH_LONG
-			).show()
-			return
-		}
-
-		lifecycleScope.launch {
-			lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-				// Get fresh info from API in SDK format
-				val item by api.userLibraryApi.getItem(itemId = itemId)
-
-				// Log info
-				Toast.makeText(
-					requireContext(),
-					"Found item of type ${item.type} - ${item.name} (${item.id}",
-					Toast.LENGTH_LONG
-				).show()
-				Timber.i(item.toString())
-
-				// TODO: Dirty hack to create a single item queue
-				val queueEntry = createBaseItemQueueEntry(api, item)
-				playbackManager.state.queue.replaceQueue(object : Queue {
-					override val size: Int = 1
-
-					override suspend fun getItem(index: Int): QueueEntry? {
-						if (index == 0) return queueEntry
-						return null
-					}
-				})
+		// Set position
+		val position = arguments?.getInt(EXTRA_POSITION) ?: 0
+		if (position != 0) {
+			lifecycleScope.launch {
+				Timber.i("Skipping to queue item $position")
+				playbackManager.state.queue.setIndex(position, false)
 			}
 		}
 	}
@@ -84,21 +50,5 @@ class PlaybackRewriteFragment : Fragment() {
 		val view = PlayerSurfaceView(requireContext())
 		view.playbackManager = playbackManager
 		return view
-	}
-
-	private fun findItemId(): UUID? {
-		val extra = requireArguments().getString(EXTRA_ITEM_ID)?.toUUIDOrNull()
-
-		var first: BaseItemDto? = null
-		var best: BaseItemDto? = null
-
-		for (item in videoQueueManager.getCurrentVideoQueue()) {
-			if (first == null) first = item
-			if (item.type !== BaseItemKind.TRAILER) best = item
-
-			if (best != null) break
-		}
-
-		return extra ?: best?.id ?: first?.id
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -270,7 +270,11 @@ class RewriteMediaManager(
 		playbackManager.state.unpause()
 	}
 
-	private class BaseItemQueue(
+	/**
+	 * A simple [Queue] implementation for compatibility with existing UI/playback code. It contains
+	 * a mutable BaseItemDto list that is used to retrieve items from.
+	 */
+	class BaseItemQueue(
 		private val api: ApiClient,
 	) : Queue {
 		val items = mutableListOf<BaseItemDto>()

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -272,7 +272,6 @@ public class PlaybackHelper {
     public static void play(final org.jellyfin.sdk.model.api.BaseItemDto item, final int pos, final boolean shuffle, final Context activity) {
         PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
         NavigationRepository navigationRepository = KoinJavaComponent.<NavigationRepository>get(NavigationRepository.class);
-        if (playbackLauncher.interceptPlayRequest(activity, item)) return;
 
         getItemsToPlay(item, pos == 0 && item.getType() == BaseItemKind.MOVIE, shuffle, new Response<List<org.jellyfin.sdk.model.api.BaseItemDto>>() {
             @Override
@@ -343,9 +342,6 @@ public class PlaybackHelper {
     }
 
     public static void playInstantMix(Context context, org.jellyfin.sdk.model.api.BaseItemDto item) {
-        PlaybackLauncher playbackLauncher = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class);
-        if (playbackLauncher.interceptPlayRequest(context, item)) return;
-
         getInstantMixAsync(item.getId(), new Response<BaseItemDto[]>() {
             @Override
             public void onResponse(BaseItemDto[] response) {

--- a/playback/core/src/main/kotlin/backend/BackendService.kt
+++ b/playback/core/src/main/kotlin/backend/BackendService.kt
@@ -1,9 +1,10 @@
 package org.jellyfin.playback.core.backend
 
-import android.view.SurfaceView
 import androidx.core.view.doOnDetach
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.ui.PlayerSubtitleView
+import org.jellyfin.playback.core.ui.PlayerSurfaceView
 
 /**
  * Service keeping track of the current playback backend and its related surface view.
@@ -13,34 +14,57 @@ class BackendService {
 	val backend get() = _backend
 
 	private var listeners = mutableListOf<PlayerBackendEventListener>()
-	private var _surfaceView: SurfaceView? = null
+	private var _surfaceView: PlayerSurfaceView? = null
+	private var _subtitleView: PlayerSubtitleView? = null
 
 	fun switchBackend(backend: PlayerBackend) {
 		_backend?.stop()
 		_backend?.setListener(null)
-		_backend?.setSurface(null)
+		_backend?.setSurfaceView(null)
+		_backend?.setSubtitleView(null)
 
 		_backend = backend.apply {
-			_surfaceView?.let(::setSurface)
+			_surfaceView?.let(::setSurfaceView)
+			_subtitleView?.let(::setSubtitleView)
 			setListener(BackendEventListener())
 		}
 	}
 
-	fun attachSurfaceView(surfaceView: SurfaceView) {
+	fun attachSurfaceView(surfaceView: PlayerSurfaceView) {
 		// Remove existing surface view
 		if (_surfaceView != null) {
-			_backend?.setSurface(null)
+			_backend?.setSurfaceView(null)
 		}
 
 		// Apply new surface view
 		_surfaceView = surfaceView.apply {
-			_backend?.setSurface(surfaceView)
+			_backend?.setSurfaceView(surfaceView)
 
 			// Automatically detach
 			doOnDetach {
 				if (surfaceView == _surfaceView) {
 					_surfaceView = null
-					_backend?.setSurface(null)
+					_backend?.setSurfaceView(null)
+				}
+			}
+		}
+	}
+
+	fun attachSubtitleView(subtitleView: PlayerSubtitleView) {
+		// Remove existing surface view
+		if (_subtitleView != null) {
+			_backend?.setSubtitleView(null)
+		}
+
+		// Apply new surface view
+		_subtitleView = subtitleView.apply {
+			_backend?.setSubtitleView(subtitleView)
+
+			// Automatically detach
+			doOnDetach {
+				if (subtitleView == _subtitleView) {
+					_subtitleView = null
+					_backend?.setSubtitleView(null)
 				}
 			}
 		}

--- a/playback/core/src/main/kotlin/backend/PlayerBackend.kt
+++ b/playback/core/src/main/kotlin/backend/PlayerBackend.kt
@@ -1,10 +1,11 @@
 package org.jellyfin.playback.core.backend
 
-import android.view.SurfaceView
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PositionInfo
 import org.jellyfin.playback.core.support.PlaySupportReport
+import org.jellyfin.playback.core.ui.PlayerSubtitleView
+import org.jellyfin.playback.core.ui.PlayerSurfaceView
 import kotlin.time.Duration
 
 /**
@@ -16,7 +17,8 @@ interface PlayerBackend {
 	fun supportsStream(stream: MediaStream): PlaySupportReport
 
 	// UI
-	fun setSurface(surfaceView: SurfaceView?)
+	fun setSurfaceView(surfaceView: PlayerSurfaceView?)
+	fun setSubtitleView(surfaceView: PlayerSubtitleView?)
 
 	// Data retrieval
 

--- a/playback/core/src/main/kotlin/ui/PlayerSubtitleView.kt
+++ b/playback/core/src/main/kotlin/ui/PlayerSubtitleView.kt
@@ -2,16 +2,14 @@ package org.jellyfin.playback.core.ui
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.SurfaceView
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import org.jellyfin.playback.core.PlaybackManager
 
 /**
- * A view that is used to display the video output of the playing media.
+ * A view that is used to display the subtitle output of the playing media.
  * The [playbackManager] must be set when the view is initialized.
  */
-class PlayerSurfaceView @JvmOverloads constructor(
+class PlayerSubtitleView @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
 	defStyleAttr: Int = 0,
@@ -19,15 +17,11 @@ class PlayerSurfaceView @JvmOverloads constructor(
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 	lateinit var playbackManager: PlaybackManager
 
-	val surface = SurfaceView(context, attrs).apply {
-		addView(this, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-	}
-
 	override fun onAttachedToWindow() {
 		super.onAttachedToWindow()
 
 		if (!isInEditMode) {
-			playbackManager.backendService.attachSurfaceView(this)
+			playbackManager.backendService.attachSubtitleView(this)
 		}
 	}
 }

--- a/playback/exoplayer/build.gradle.kts
+++ b/playback/exoplayer/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 	implementation(libs.androidx.media3.exoplayer)
 	implementation(libs.androidx.media3.exoplayer.hls)
 	implementation(libs.jellyfin.androidx.media3.ffmpeg.decoder)
+	implementation(libs.androidx.media3.ui)
 
 	// Logging
 	implementation(libs.timber)

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -2,7 +2,7 @@ package org.jellyfin.playback.exoplayer
 
 import android.app.ActivityManager
 import android.content.Context
-import android.view.SurfaceView
+import android.view.ViewGroup
 import androidx.annotation.OptIn
 import androidx.core.content.getSystemService
 import androidx.media3.common.C
@@ -11,6 +11,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.VideoSize
+import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
@@ -18,12 +19,15 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ts.TsExtractor
+import androidx.media3.ui.SubtitleView
 import org.jellyfin.playback.core.backend.BasePlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PositionInfo
 import org.jellyfin.playback.core.support.PlaySupportReport
+import org.jellyfin.playback.core.ui.PlayerSubtitleView
+import org.jellyfin.playback.core.ui.PlayerSurfaceView
 import org.jellyfin.playback.exoplayer.support.getPlaySupportReport
 import org.jellyfin.playback.exoplayer.support.toFormat
 import timber.log.Timber
@@ -41,6 +45,7 @@ class ExoPlayerBackend(
 	}
 
 	private var currentStream: PlayableMediaStream? = null
+	private var subtitleView: SubtitleView? = null
 
 	private val exoPlayer by lazy {
 		ExoPlayer.Builder(context)
@@ -89,6 +94,10 @@ class ExoPlayerBackend(
 			listener?.onVideoSizeChange(size.width, size.height)
 		}
 
+		override fun onCues(cueGroup: CueGroup) {
+			subtitleView?.setCues(cueGroup.cues)
+		}
+
 		override fun onPlaybackStateChanged(playbackState: Int) {
 			onIsPlayingChanged(exoPlayer.isPlaying)
 		}
@@ -104,8 +113,18 @@ class ExoPlayerBackend(
 		stream: MediaStream
 	): PlaySupportReport = exoPlayer.getPlaySupportReport(stream.toFormat())
 
-	override fun setSurface(surfaceView: SurfaceView?) {
-		exoPlayer.setVideoSurfaceView(surfaceView)
+	override fun setSurfaceView(surfaceView: PlayerSurfaceView?) {
+		exoPlayer.setVideoSurfaceView(surfaceView?.surface)
+	}
+
+	override fun setSubtitleView(surfaceView: PlayerSubtitleView?) {
+		if (surfaceView != null) {
+			if (subtitleView == null) subtitleView = SubtitleView(surfaceView.context)
+			surfaceView.addView(subtitleView)
+		} else {
+			(subtitleView?.parent as? ViewGroup)?.removeView(subtitleView)
+			subtitleView = null
+		}
 	}
 
 	override fun prepareStream(stream: PlayableMediaStream) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Read items to play from legacy video queue
  Replaces the "play single item" behavior. There's still some cases where it won't play next episodes because of the weird queue behaviors in the old player.
- Remove interceptPlayRequest
- Add basic lifecycle events to PlaybackRewriteFragment
  Basically, stop playback when closing player
- Use screensaverLock in PlaybackRewriteFragment
  Don't show screensaver while playing
- Add initial subtitle implementation
  Uses the subtitle rendering from ExoPlayer (for text cues) and does **not** use our bad custom renderer.

**Issues**

Part of #1057 
