### PR TITLE
Use dependency injection for ItemLauncher, KeyProcessor and ReportingHelper

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
@@ -47,6 +47,7 @@ class SocketHandler(
 	private val playbackControllerContainer: PlaybackControllerContainer,
 	private val navigationRepository: NavigationRepository,
 	private val audioManager: AudioManager,
+	private val itemLauncher: ItemLauncher,
 ) {
 	private val coroutineScope = CoroutineScope(Dispatchers.IO)
 
@@ -217,7 +218,7 @@ class SocketHandler(
 			BaseItemKind.USER_VIEW,
 			BaseItemKind.COLLECTION_FOLDER -> {
 				val item by api.userLibraryApi.getItem(itemId = itemId)
-				ItemLauncher.launchUserView(item)
+				itemLauncher.launchUserView(item)
 			}
 
 			else -> navigationRepository.navigate(Destinations.itemDetails(itemId))

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -38,6 +38,7 @@ import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
 import org.jellyfin.androidtv.util.KeyProcessor
 import org.jellyfin.androidtv.util.MarkdownRenderer
+import org.jellyfin.androidtv.util.apiclient.ReportingHelper
 import org.jellyfin.androidtv.util.sdk.legacy
 import org.jellyfin.apiclient.AppInfo
 import org.jellyfin.apiclient.android
@@ -130,6 +131,7 @@ val appModule = module {
 	single { MarkdownRenderer(get()) }
 	single { ItemLauncher() }
 	single { KeyProcessor() }
+	single { ReportingHelper() }
 
 	factory { (context: Context) -> SearchFragmentDelegate(context, get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -22,6 +22,7 @@ import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.data.repository.UserViewsRepositoryImpl
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.ScreensaverViewModel
+import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.navigation.NavigationRepositoryImpl
@@ -75,7 +76,7 @@ val appModule = module {
 		get<JellyfinSdk>().createApi()
 	}
 
-	single { SocketHandler(get(), get(), get(), get(), get(), get(), get()) }
+	single { SocketHandler(get(), get(), get(), get(), get(), get(), get(), get()) }
 
 	// Old apiclient
 	single {
@@ -126,6 +127,7 @@ val appModule = module {
 	single { BackgroundService(get(), get(), get(), get(), get()) }
 
 	single { MarkdownRenderer(get()) }
+	single { ItemLauncher() }
 
-	factory { (context: Context) -> SearchFragmentDelegate(context, get()) }
+	factory { (context: Context) -> SearchFragmentDelegate(context, get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -36,6 +36,7 @@ import org.jellyfin.androidtv.ui.search.SearchViewModel
 import org.jellyfin.androidtv.ui.startup.ServerAddViewModel
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
+import org.jellyfin.androidtv.util.KeyProcessor
 import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.androidtv.util.sdk.legacy
 import org.jellyfin.apiclient.AppInfo
@@ -128,6 +129,7 @@ val appModule = module {
 
 	single { MarkdownRenderer(get()) }
 	single { ItemLauncher() }
+	single { KeyProcessor() }
 
 	factory { (context: Context) -> SearchFragmentDelegate(context, get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ProgramGridCell.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.preference.LiveTvPreferences;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
-import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
@@ -74,23 +73,23 @@ public class ProgramGridCell extends RelativeLayout implements RecordingIndicato
         LiveTvPreferences liveTvPreferences = get(LiveTvPreferences.class);
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowNewIndicator()) && BaseItemExtensionsKt.isNew(ModelCompat.asSdk(program)) && (!liveTvPreferences.get(LiveTvPreferences.Companion.getShowPremiereIndicator()) || !Utils.isTrue(program.getIsPremiere()))) {
-            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_new), 10, Color.GRAY, R.drawable.dark_green_gradient);
+            addBlockText(context.getString(R.string.lbl_new), 10, Color.GRAY, R.drawable.dark_green_gradient);
         }
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowPremiereIndicator()) && Utils.isTrue(program.getIsPremiere())) {
-            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_premiere), 10, Color.GRAY, R.drawable.dark_green_gradient);
+            addBlockText(context.getString(R.string.lbl_premiere), 10, Color.GRAY, R.drawable.dark_green_gradient);
         }
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowRepeatIndicator()) && Utils.isTrue(program.getIsRepeat())) {
-            InfoLayoutHelper.addBlockText(context, mInfoRow, context.getString(R.string.lbl_repeat), 10, Color.GRAY, androidx.leanback.R.color.lb_default_brand_color);
+            addBlockText(context.getString(R.string.lbl_repeat), 10, Color.GRAY, androidx.leanback.R.color.lb_default_brand_color);
         }
 
         if (program.getOfficialRating() != null && !program.getOfficialRating().equals("0")) {
-            InfoLayoutHelper.addBlockText(context, mInfoRow, program.getOfficialRating(), 10, Color.BLACK, R.drawable.block_text_bg);
+            addBlockText(program.getOfficialRating(), 10, Color.BLACK, R.drawable.block_text_bg);
         }
 
         if (liveTvPreferences.get(LiveTvPreferences.Companion.getShowHDIndicator()) && Utils.isTrue(program.getIsHD())) {
-            InfoLayoutHelper.addBlockText(context, mInfoRow, "HD", 10, Color.BLACK, R.drawable.block_text_bg);
+            addBlockText("HD", 10, Color.BLACK, R.drawable.block_text_bg);
         }
 
         if (program.getSeriesTimerId() != null) {
@@ -109,6 +108,18 @@ public class ProgramGridCell extends RelativeLayout implements RecordingIndicato
             });
         }
 
+    }
+
+    private void addBlockText(String text, int size, int textColor, int backgroundRes) {
+        TextView view = new TextView(getContext());
+        view.setTextSize(size);
+        view.setTextColor(textColor);
+        view.setText(" " + text + " ");
+        view.setBackgroundResource(backgroundRes);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        params.setMargins(0, Utils.convertDpToPixel(getContext(), -2), 0, 0);
+        view.setLayoutParams(params);
+        mInfoRow.addView(view);
     }
 
     public void setCellBackground() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
@@ -32,6 +32,7 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 	protected var rows = mutableListOf<BrowseRowDef>()
 
 	private val backgroundService by inject<BackgroundService>()
+	private val itemLauncher by inject<ItemLauncher>()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -47,7 +48,7 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 		// Add event listeners
 		onItemViewClickedListener = OnItemViewClickedListener { _: Presenter.ViewHolder?, item: Any?, _: RowPresenter.ViewHolder?, row: Row ->
 			if (item is BaseRowItem) {
-				ItemLauncher.launch(
+				itemLauncher.launch(
 					item,
 					(row as ListRow).adapter as ItemRowAdapter,
 					item.index,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -123,6 +123,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     private final Lazy<UserRepository> userRepository = inject(UserRepository.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
+    private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
 
     private int mCardsScreenEst = 0;
     private int mCardsScreenStride = 0;
@@ -966,7 +967,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
 
             if (!(item instanceof BaseRowItem)) return;
-            ItemLauncher.launch((BaseRowItem) item, mAdapter, ((BaseRowItem) item).getIndex(), requireContext());
+            itemLauncher.getValue().launch((BaseRowItem) item, mAdapter, ((BaseRowItem) item).getIndex(), requireContext());
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -124,6 +124,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
+    private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
 
     private int mCardsScreenEst = 0;
     private int mCardsScreenStride = 0;
@@ -208,7 +209,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         if (event.getAction() != KeyEvent.ACTION_UP) return false;
-        return KeyProcessor.HandleKey(keyCode, mCurrentItem, mActivity);
+        return keyProcessor.getValue().handleKey(keyCode, mCurrentItem, mActivity);
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -103,6 +103,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<ApiClient> api = inject(ApiClient.class);
+    private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -464,7 +465,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
         public void onItemClicked(final Presenter.ViewHolder itemViewHolder, Object item, RowPresenter.ViewHolder rowViewHolder, Row row) {
             if (!(item instanceof BaseRowItem)) return;
 
-            ItemLauncher.launch((BaseRowItem) item, (ItemRowAdapter) ((ListRow) row).getAdapter(), ((BaseRowItem) item).getIndex(), requireContext());
+            itemLauncher.getValue().launch((BaseRowItem) item, (ItemRowAdapter) ((ListRow) row).getAdapter(), ((BaseRowItem) item).getIndex(), requireContext());
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -104,6 +104,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<ApiClient> api = inject(ApiClient.class);
     private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
+    private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -353,7 +354,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     @Override
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         if (event.getAction() != KeyEvent.ACTION_UP) return false;
-        return KeyProcessor.HandleKey(keyCode, mCurrentItem, requireActivity());
+        return keyProcessor.getValue().handleKey(keyCode, mCurrentItem, requireActivity());
     }
 
     private void refreshCurrentItem() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -71,6 +71,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	private val customMessageRepository by inject<CustomMessageRepository>()
 	private val navigationRepository by inject<NavigationRepository>()
 	private val itemLauncher by inject<ItemLauncher>()
+	private val keyProcessor by inject<KeyProcessor>()
 
 	private val helper by lazy { HomeFragmentHelper(requireContext(), userRepository, userViewsRepository) }
 
@@ -185,7 +186,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 
 	override fun onKey(v: View?, keyCode: Int, event: KeyEvent?): Boolean {
 		if (event?.action != KeyEvent.ACTION_UP) return false
-		return KeyProcessor.HandleKey(keyCode, currentItem, activity)
+		return keyProcessor.handleKey(keyCode, currentItem, activity)
 	}
 
 	override fun onResume() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -70,6 +70,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	private val dataRefreshService by inject<DataRefreshService>()
 	private val customMessageRepository by inject<CustomMessageRepository>()
 	private val navigationRepository by inject<NavigationRepository>()
+	private val itemLauncher by inject<ItemLauncher>()
 
 	private val helper by lazy { HomeFragmentHelper(requireContext(), userRepository, userViewsRepository) }
 
@@ -261,7 +262,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 			row: Row?,
 		) {
 			if (item !is BaseRowItem) return
-			ItemLauncher.launch(item, (row as ListRow).adapter as ItemRowAdapter, item.index, requireContext())
+			itemLauncher.launch(item, (row as ListRow).adapter as ItemRowAdapter, item.index, requireContext())
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -171,6 +171,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     private Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
+    private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
 
     @Nullable
     @Override
@@ -1515,7 +1516,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
 
             if (!(item instanceof BaseRowItem)) return;
-            ItemLauncher.launch((BaseRowItem) item, (ItemRowAdapter) ((ListRow)row).getAdapter(), ((BaseRowItem)item).getIndex(), requireContext());
+            itemLauncher.getValue().launch((BaseRowItem) item, (ItemRowAdapter) ((ListRow)row).getAdapter(), ((BaseRowItem)item).getIndex(), requireContext());
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -172,6 +172,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
+    private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
 
     @Nullable
     @Override
@@ -320,7 +321,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         if (event.getAction() != KeyEvent.ACTION_UP) return false;
 
         if (mCurrentItem != null) {
-            return KeyProcessor.HandleKey(keyCode, mCurrentItem, requireActivity());
+            return keyProcessor.getValue().handleKey(keyCode, mCurrentItem, requireActivity());
         } else if ((keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE || keyCode == KeyEvent.KEYCODE_MEDIA_PLAY) && BaseItemExtensionsKt.canPlay(ModelCompat.asSdk(mBaseItem))) {
             //default play action
             Long pos = mBaseItem.getUserData().getPlaybackPositionTicks() / 10000;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -110,6 +110,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
     private Lazy<VideoQueueManager> videoQueueManager = inject(VideoQueueManager.class);
     private Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
+    private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
 
     @Nullable
     @Override
@@ -274,7 +275,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             open.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
-                    ItemLauncher.launch(new BaseRowItem(row.getItem()), null, 0, requireContext());
+                    itemLauncher.getValue().launch(new BaseRowItem(row.getItem()), null, 0, requireContext());
                     return true;
                 }
             });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -31,25 +31,31 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import kotlin.Lazy;
 import timber.log.Timber;
 
 public class ItemLauncher {
-    public static void launchUserView(@Nullable final BaseItemDto baseItem) {
+    private final Lazy<NavigationRepository> navigationRepository = KoinJavaComponent.<NavigationRepository>inject(NavigationRepository.class);
+    private final Lazy<PreferencesRepository> preferencesRepository = KoinJavaComponent.<PreferencesRepository>inject(org.jellyfin.androidtv.preference.PreferencesRepository .class);
+    private final Lazy<MediaManager> mediaManager = KoinJavaComponent.<MediaManager>inject(MediaManager.class);
+    private final Lazy<VideoQueueManager> videoQueueManager = KoinJavaComponent.<VideoQueueManager>inject(VideoQueueManager.class);
+    private final Lazy<PlaybackLauncher> playbackLauncher = KoinJavaComponent.<PlaybackLauncher>inject(PlaybackLauncher.class);
+
+    public void launchUserView(@Nullable final BaseItemDto baseItem) {
         Timber.d("**** Collection type: %s", baseItem.getCollectionType());
 
-        NavigationRepository navigationRepository = KoinJavaComponent.<NavigationRepository>get(NavigationRepository.class);
         Destination destination = getUserViewDestination(baseItem);
 
-        navigationRepository.navigate(destination);
+        navigationRepository.getValue().navigate(destination);
     }
 
-    public static Destination.Fragment getUserViewDestination(@Nullable final BaseItemDto baseItem) {
+    public Destination.Fragment getUserViewDestination(@Nullable final BaseItemDto baseItem) {
         CollectionType collectionType = baseItem == null ? CollectionType.UNKNOWN : baseItem.getCollectionType();
 
         switch (collectionType) {
             case MOVIES:
             case TVSHOWS:
-                LibraryPreferences displayPreferences = KoinJavaComponent.<PreferencesRepository>get(PreferencesRepository.class).getLibraryPreferences(baseItem.getDisplayPreferencesId());
+                LibraryPreferences displayPreferences = preferencesRepository.getValue().getLibraryPreferences(baseItem.getDisplayPreferencesId());
                 boolean enableSmartScreen = displayPreferences.get(LibraryPreferences.Companion.getEnableSmartScreen());
 
                 if (!enableSmartScreen) return Destinations.INSTANCE.libraryBrowser(baseItem);
@@ -62,9 +68,7 @@ public class ItemLauncher {
         }
     }
 
-    public static void launch(final BaseRowItem rowItem, ItemRowAdapter adapter, int pos, final Context context) {
-        NavigationRepository navigationRepository = KoinJavaComponent.<NavigationRepository>get(NavigationRepository.class);
-
+    public void launch(final BaseRowItem rowItem, ItemRowAdapter adapter, int pos, final Context context) {
         switch (rowItem.getBaseRowType()) {
             case BaseItem:
                 BaseItemDto baseItem = rowItem.getBaseItem();
@@ -74,7 +78,6 @@ public class ItemLauncher {
                     //swallow it
                 }
 
-                MediaManager mediaManager = KoinJavaComponent.<MediaManager>get(MediaManager.class);
                 //specialized type handling
                 switch (baseItem.getType()) {
                     case USER_VIEW:
@@ -83,12 +86,12 @@ public class ItemLauncher {
                         return;
                     case SERIES:
                     case MUSIC_ARTIST:
-                        navigationRepository.navigate(Destinations.INSTANCE.itemDetails(baseItem.getId()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.itemDetails(baseItem.getId()));
                         return;
 
                     case MUSIC_ALBUM:
                     case PLAYLIST:
-                        navigationRepository.navigate(Destinations.INSTANCE.itemList(baseItem.getId()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.itemList(baseItem.getId()));
                         return;
 
                     case AUDIO:
@@ -97,13 +100,13 @@ public class ItemLauncher {
                             return;
 
                         // if the song currently playing is selected (and is the exact item - this only happens in the nowPlayingRow), open AudioNowPlayingActivity
-                        if (mediaManager.hasAudioQueueItems() && rowItem instanceof AudioQueueItem && rowItem.getBaseItem().getId().equals(mediaManager.getCurrentAudioItem().getId())) {
-                            navigationRepository.navigate(Destinations.INSTANCE.getNowPlaying());
-                        } else if (mediaManager.hasAudioQueueItems() && rowItem instanceof AudioQueueItem && pos < mediaManager.getCurrentAudioQueueSize()) {
+                        if (mediaManager.getValue().hasAudioQueueItems() && rowItem instanceof AudioQueueItem && rowItem.getBaseItem().getId().equals(mediaManager.getValue().getCurrentAudioItem().getId())) {
+                            navigationRepository.getValue().navigate(Destinations.INSTANCE.getNowPlaying());
+                        } else if (mediaManager.getValue().hasAudioQueueItems() && rowItem instanceof AudioQueueItem && pos < mediaManager.getValue().getCurrentAudioQueueSize()) {
                             Timber.d("playing audio queue item");
-                            mediaManager.playFrom(pos);
+                            mediaManager.getValue().playFrom(pos);
                         } else if (adapter.getQueryType() == QueryType.Search) {
-                            mediaManager.playNow(context, Arrays.asList(rowItem.getBaseItem()), 0, false);
+                            mediaManager.getValue().playNow(context, Arrays.asList(rowItem.getBaseItem()), 0, false);
                         } else {
                             Timber.d("playing audio item");
                             List<BaseItemDto> audioItemsAsList = new ArrayList<>();
@@ -112,20 +115,20 @@ public class ItemLauncher {
                                 if (item instanceof BaseRowItem && ((BaseRowItem) item).getBaseItem() != null)
                                     audioItemsAsList.add(((BaseRowItem) item).getBaseItem());
                             }
-                            mediaManager.playNow(context, audioItemsAsList, pos, false);
+                            mediaManager.getValue().playNow(context, audioItemsAsList, pos, false);
                         }
 
                         return;
                     case SEASON:
-                        navigationRepository.navigate(Destinations.INSTANCE.folderBrowser(baseItem));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.folderBrowser(baseItem));
                         return;
 
                     case BOX_SET:
-                        navigationRepository.navigate(Destinations.INSTANCE.collectionBrowser(baseItem));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.collectionBrowser(baseItem));
                         return;
 
                     case PHOTO:
-                        navigationRepository.navigate(Destinations.INSTANCE.pictureViewer(
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.pictureViewer(
                                 baseItem.getId(),
                                 false,
                                 adapter.getSortBy(),
@@ -144,12 +147,12 @@ public class ItemLauncher {
                         baseItem = JavaCompat.copyWithDisplayPreferencesId(baseItem, baseItem.getId().toString());
                     }
 
-                    navigationRepository.navigate(Destinations.INSTANCE.libraryBrowser(baseItem));
+                    navigationRepository.getValue().navigate(Destinations.INSTANCE.libraryBrowser(baseItem));
                 } else {
                     switch (rowItem.getSelectAction()) {
 
                         case ShowDetails:
-                            navigationRepository.navigate(Destinations.INSTANCE.itemDetails(baseItem.getId()));
+                            navigationRepository.getValue().navigate(Destinations.INSTANCE.itemDetails(baseItem.getId()));
                             break;
                         case Play:
                             //Just play it directly
@@ -157,9 +160,9 @@ public class ItemLauncher {
                             PlaybackHelper.getItemsToPlay(baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
                                 @Override
                                 public void onResponse(List<BaseItemDto> response) {
-                                    KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
-                                    Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(itemType, 0);
-                                    navigationRepository.navigate(destination);
+                                    videoQueueManager.getValue().setCurrentVideoQueue(response);
+                                    Destination destination = playbackLauncher.getValue().getPlaybackDestination(itemType, 0);
+                                    navigationRepository.getValue().navigate(destination);
                                 }
                             });
                             break;
@@ -167,7 +170,7 @@ public class ItemLauncher {
                 }
                 break;
             case Person:
-                navigationRepository.navigate(Destinations.INSTANCE.itemDetails(rowItem.getBasePerson().getId()));
+                navigationRepository.getValue().navigate(Destinations.INSTANCE.itemDetails(rowItem.getBasePerson().getId()));
 
                 break;
             case Chapter:
@@ -178,10 +181,10 @@ public class ItemLauncher {
                     public void onResponse(BaseItemDto response) {
                         List<BaseItemDto> items = new ArrayList<>();
                         items.add(response);
-                        KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
+                        videoQueueManager.getValue().setCurrentVideoQueue(items);
                         Long start = chapter.getStartPositionTicks() / 10000;
-                        Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(response.getType(), start.intValue());
-                        navigationRepository.navigate(destination);
+                        Destination destination = playbackLauncher.getValue().getPlaybackDestination(response.getType(), start.intValue());
+                        navigationRepository.getValue().navigate(destination);
                     }
                 });
 
@@ -192,7 +195,7 @@ public class ItemLauncher {
                 switch (rowItem.getSelectAction()) {
 
                     case ShowDetails:
-                        navigationRepository.navigate(Destinations.INSTANCE.channelDetails(program.getId(), program.getChannelId(), program));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.channelDetails(program.getId(), program.getChannelId(), program));
                         break;
                     case Play:
                         //Just play it directly - need to retrieve program channel via items api to convert to BaseItem
@@ -201,9 +204,9 @@ public class ItemLauncher {
                             public void onResponse(BaseItemDto response) {
                                 List<BaseItemDto> items = new ArrayList<>();
                                 items.add(response);
-                                KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
-                                Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(response.getType(), 0);
-                                navigationRepository.navigate(destination);
+                                videoQueueManager.getValue().setCurrentVideoQueue(items);
+                                Destination destination = playbackLauncher.getValue().getPlaybackDestination(response.getType(), 0);
+                                navigationRepository.getValue().navigate(destination);
 
                             }
                         });
@@ -219,9 +222,9 @@ public class ItemLauncher {
                         PlaybackHelper.getItemsToPlay(response, false, false, new Response<List<BaseItemDto>>() {
                             @Override
                             public void onResponse(List<BaseItemDto> response) {
-                                KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(response);
-                                Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(channel.getType(), 0);
-                                navigationRepository.navigate(destination);
+                                videoQueueManager.getValue().setCurrentVideoQueue(response);
+                                Destination destination = playbackLauncher.getValue().getPlaybackDestination(channel.getType(), 0);
+                                navigationRepository.getValue().navigate(destination);
                             }
                         });
                     }
@@ -232,7 +235,7 @@ public class ItemLauncher {
                 switch (rowItem.getSelectAction()) {
 
                     case ShowDetails:
-                        navigationRepository.navigate(Destinations.INSTANCE.itemDetails(rowItem.getBaseItem().getId()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.itemDetails(rowItem.getBaseItem().getId()));
                         break;
                     case Play:
                         //Just play it directly but need to retrieve as base item
@@ -241,9 +244,9 @@ public class ItemLauncher {
                             public void onResponse(BaseItemDto response) {
                                 List<BaseItemDto> items = new ArrayList<>();
                                 items.add(response);
-                                KoinJavaComponent.<VideoQueueManager>get(VideoQueueManager.class).setCurrentVideoQueue(items);
-                                Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(rowItem.getBaseItemType(), 0);
-                                navigationRepository.navigate(destination);
+                                videoQueueManager.getValue().setCurrentVideoQueue(items);
+                                Destination destination = playbackLauncher.getValue().getPlaybackDestination(rowItem.getBaseItemType(), 0);
+                                navigationRepository.getValue().navigate(destination);
                             }
                         });
                         break;
@@ -251,26 +254,26 @@ public class ItemLauncher {
                 break;
 
             case SeriesTimer:
-                navigationRepository.navigate(Destinations.INSTANCE.seriesTimerDetails(UUIDSerializerKt.toUUID(rowItem.getItemId()), ModelCompat.asSdk(rowItem.getSeriesTimerInfo())));
+                navigationRepository.getValue().navigate(Destinations.INSTANCE.seriesTimerDetails(UUIDSerializerKt.toUUID(rowItem.getItemId()), ModelCompat.asSdk(rowItem.getSeriesTimerInfo())));
                 break;
 
 
             case GridButton:
                 switch (rowItem.getGridButton().getId()) {
                     case LiveTvOption.LIVE_TV_GUIDE_OPTION_ID:
-                        navigationRepository.navigate(Destinations.INSTANCE.getLiveTvGuide());
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvGuide());
                         break;
 
                     case LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID:
-                        navigationRepository.navigate(Destinations.INSTANCE.getLiveTvRecordings());
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvRecordings());
                         break;
 
                     case LiveTvOption.LIVE_TV_SERIES_OPTION_ID:
-                        navigationRepository.navigate(Destinations.INSTANCE.librarySmartScreen(FakeBaseItem.INSTANCE.getSERIES_TIMERS()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.librarySmartScreen(FakeBaseItem.INSTANCE.getSERIES_TIMERS()));
                         break;
 
                     case LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID:
-                        navigationRepository.navigate(Destinations.INSTANCE.getLiveTvSchedule());
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvSchedule());
                         break;
                 }
                 break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -84,6 +84,7 @@ public class AudioNowPlayingFragment extends Fragment {
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
     private Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
+    private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
 
     private PopupMenu popupMenu;
 
@@ -376,7 +377,7 @@ public class AudioNowPlayingFragment extends Fragment {
                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
 
             if (!(item instanceof BaseRowItem)) return;
-            popupMenu = KeyProcessor.createItemMenu((BaseRowItem) item, ((BaseRowItem) item).getBaseItem().getUserData(), requireActivity());
+            popupMenu = keyProcessor.getValue().createItemMenu((BaseRowItem) item, ((BaseRowItem) item).getBaseItem().getUserData(), requireActivity());
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -71,6 +71,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private Lazy<VideoQueueManager> videoQueueManager = inject(VideoQueueManager.class);
     private Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
+    private Lazy<ReportingHelper> reportingHelper = inject(ReportingHelper.class);
 
     List<org.jellyfin.sdk.model.api.BaseItemDto> mItems;
     VideoManager mVideoManager;
@@ -813,7 +814,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         }, 750);
 
         dataRefreshService.getValue().setLastPlayedItem(item);
-        ReportingHelper.reportStart(item, mbPos);
+        reportingHelper.getValue().reportStart(item, mbPos);
     }
 
     public void startSpinner() {
@@ -1074,7 +1075,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
             if (mVideoManager != null && mVideoManager.isPlaying()) mVideoManager.stopPlayback();
             Long mbPos = mCurrentPosition * 10000;
-            ReportingHelper.reportStopped(getCurrentlyPlayingItem(), getCurrentStreamInfo(), mbPos);
+            reportingHelper.getValue().reportStopped(getCurrentlyPlayingItem(), getCurrentStreamInfo(), mbPos);
             clearPlaybackSessionOptions();
         }
     }
@@ -1293,7 +1294,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     private void startReportLoop() {
         stopReportLoop();
-        ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 10000, false);
+        reportingHelper.getValue().reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 10000, false);
         mReportLoop = new Runnable() {
             @Override
             public void run() {
@@ -1301,7 +1302,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     refreshCurrentPosition();
                     long currentTime = isLiveTv ? getTimeShiftedProgress() : mCurrentPosition;
 
-                    ReportingHelper.reportProgress(PlaybackController.this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), currentTime * 10000, false);
+                    reportingHelper.getValue().reportProgress(PlaybackController.this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), currentTime * 10000, false);
                 }
                 if (mPlaybackState != PlaybackState.UNDEFINED && mPlaybackState != PlaybackState.IDLE) {
                     mHandler.postDelayed(this, PROGRESS_REPORTING_INTERVAL);
@@ -1313,7 +1314,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     private void startPauseReportLoop() {
         stopReportLoop();
-        ReportingHelper.reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 10000, true);
+        reportingHelper.getValue().reportProgress(this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 10000, true);
         mReportLoop = new Runnable() {
             @Override
             public void run() {
@@ -1334,7 +1335,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     mFragment.setSecondaryTime(getRealTimeProgress());
                 }
 
-                ReportingHelper.reportProgress(PlaybackController.this, currentItem, getCurrentStreamInfo(), currentTime * 10000, true);
+                reportingHelper.getValue().reportProgress(PlaybackController.this, currentItem, getCurrentStreamInfo(), currentTime * 10000, true);
                 mHandler.postDelayed(this, PROGRESS_REPORTING_PAUSE_INTERVAL);
             }
         };

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragmentDelegate.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragmentDelegate.kt
@@ -18,6 +18,7 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 class SearchFragmentDelegate(
 	private val context: Context,
 	private val backgroundService: BackgroundService,
+	private val itemLauncher: ItemLauncher,
 ) {
 	val rowsAdapter = MutableObjectAdapter<Row>(CustomListRowPresenter())
 
@@ -43,7 +44,7 @@ class SearchFragmentDelegate(
 		if (item !is BaseRowItem) return@OnItemViewClickedListener
 		row as ListRow
 		val adapter = row.adapter as ItemRowAdapter
-		ItemLauncher.launch(item as BaseRowItem?, adapter, item.index, context)
+		itemLauncher.launch(item as BaseRowItem?, adapter, item.index, context)
 	}
 
 	val onItemViewSelectedListener = OnItemViewSelectedListener { _, item, _, _ ->

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -58,6 +58,7 @@ class StartupActivity : FragmentActivity() {
 	private val sessionRepository: SessionRepository by inject()
 	private val userRepository: UserRepository by inject()
 	private val navigationRepository: NavigationRepository by inject()
+	private val itemLauncher: ItemLauncher by inject()
 
 	private lateinit var binding: ActivityMainBinding
 
@@ -144,7 +145,7 @@ class StartupActivity : FragmentActivity() {
 			// User view item is requested
 			itemId != null && itemIsUserView -> {
 				val item by api.userLibraryApi.getItem(itemId = itemId)
-				ItemLauncher.getUserViewDestination(item)
+				itemLauncher.getUserViewDestination(item)
 			}
 			// Other item is requested
 			itemId != null -> Destinations.itemDetails(itemId)

--- a/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/InfoLayoutHelper.java
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.util;
 import android.content.Context;
 import android.view.View;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 import org.jellyfin.androidtv.ui.browsing.composable.inforow.BaseItemInfoRowView;
 import org.jellyfin.sdk.model.api.BaseItemDto;
@@ -30,17 +29,5 @@ public class InfoLayoutHelper {
         // Update item info
         baseItemInfoRowView.setItem(item);
         baseItemInfoRowView.setIncludeRuntime(includeRuntime);
-    }
-
-    public static void addBlockText(Context context, LinearLayout layout, String text, int size, int textColor, int backgroundRes) {
-        TextView view = new TextView(context);
-        view.setTextSize(size);
-        view.setTextColor(textColor);
-        view.setText(" " + text + " ");
-        view.setBackgroundResource(backgroundRes);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
-        params.setMargins(0, Utils.convertDpToPixel(context, -2), 0, 0);
-        view.setLayoutParams(params);
-        layout.addView(view);
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.util.apiclient;
 
-import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.MediaSourceInfo;
 import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
@@ -26,38 +25,7 @@ public class StreamHelper {
         return getStreams(mediaSource, MediaStreamType.AUDIO);
     }
 
-    public static List<MediaStream> getVideoStreams(MediaSourceInfo mediaSource) {
-        return getStreams(mediaSource, MediaStreamType.VIDEO);
-    }
-
-    public static MediaStream getFirstAudioStream(BaseItemDto item) {
-        return getFirstAudioStream(item, 0);
-    }
-
-    public static MediaStream getFirstAudioStream(BaseItemDto item, int mediaSourceIndex) {
-        return getFirstStreamOfType(item, MediaStreamType.AUDIO, mediaSourceIndex);
-    }
-
-    public static MediaStream getFirstVideoStream(BaseItemDto item) {
-        return getFirstVideoStream(item, 0);
-    }
-
-    public static MediaStream getFirstVideoStream(BaseItemDto item, int mediaSourceIndex) {
-        return getFirstStreamOfType(item, MediaStreamType.VIDEO, mediaSourceIndex);
-    }
-
-    public static MediaStream getFirstStreamOfType(BaseItemDto item, MediaStreamType streamType) {
-        return getFirstStreamOfType(item, streamType, 0);
-    }
-
-    public static MediaStream getFirstStreamOfType(BaseItemDto item, MediaStreamType streamType, int mediaSourceIndex) {
-        if (item.getMediaSources() == null || mediaSourceIndex > item.getMediaSources().size() - 1) return null;
-        List<MediaStream> streams = getStreams(item.getMediaSources().get(mediaSourceIndex), streamType);
-        if (streams == null || streams.size() < 1) return null;
-        return streams.get(0);
-    }
-
-    public static List<MediaStream> getStreams(MediaSourceInfo mediaSource, MediaStreamType type) {
+    private static List<MediaStream> getStreams(MediaSourceInfo mediaSource, MediaStreamType type) {
         if (mediaSource == null) return Collections.emptyList();
 
         List<MediaStream> streams = mediaSource.getMediaStreams();


### PR DESCRIPTION
Wanted to add replay gain support to playback rewrite but need to convert all item calls to use the SDK first so we can actually read the value from BaseItemDto. sad

**Changes**
- Use dependency injection for ItemLauncher
- Move addBlockText to ProgramGridCell
- Use dependency injection for KeyProcessor
- Use dependency injection for ReportingHelper
- Remove unused methods from StreamHelper

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
