### PR TITLE
Remove FakeBaseItem hack

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Extras.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Extras.kt
@@ -2,5 +2,6 @@ package org.jellyfin.androidtv.constant
 
 object Extras {
 	const val Folder = "folder"
+	const val IsLiveTvSeriesRecordings = "is_livetv_series_recordings"
 	const val IncludeType = "type_include"
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -448,7 +448,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 break;
 
             default:
-                if (mFolder.getId() == FakeBaseItem.INSTANCE.getSERIES_TIMERS_ID()) {
+                if (mFolder.getId() == FakeBaseItem.INSTANCE.getSERIES_TIMERS().getId()) {
                     mRows.add(new BrowseRowDef(getString(R.string.lbl_series_recordings), new SeriesTimerQuery()));
                     rowLoader.loadRows(mRows);
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -10,6 +10,7 @@ import androidx.leanback.widget.Row;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.constant.ChangeTriggerType;
+import org.jellyfin.androidtv.constant.Extras;
 import org.jellyfin.androidtv.constant.LiveTvOption;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.querying.StdItemQuery;
@@ -21,7 +22,6 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse;
-import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.model.dto.BaseItemDto;
 import org.jellyfin.apiclient.model.dto.BaseItemType;
@@ -60,7 +60,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
     @Override
     protected void setupQueries(final RowLoader rowLoader) {
-        CollectionType type = mFolder.getCollectionType() != null ? mFolder.getCollectionType() : CollectionType.UNKNOWN;
+        CollectionType type = mFolder != null && mFolder.getCollectionType() != null ? mFolder.getCollectionType() : CollectionType.UNKNOWN;
         switch (type) {
             case MOVIES:
                 itemType = BaseItemKind.MOVIE;
@@ -448,7 +448,8 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 break;
 
             default:
-                if (mFolder.getId() == FakeBaseItem.INSTANCE.getSERIES_TIMERS().getId()) {
+                boolean isRecordingsView = getArguments().getBoolean(Extras.IsLiveTvSeriesRecordings, false);
+                if (isRecordingsView) {
                     mRows.add(new BrowseRowDef(getString(R.string.lbl_series_recordings), new SeriesTimerQuery()));
                     rowLoader.loadRows(mRows);
                 } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -432,7 +432,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                         break;
 
                     case FAVSONGS:
-                        navigationRepository.getValue().navigate(Destinations.INSTANCE.itemList(FakeBaseItem.INSTANCE.getFAV_SONGS_ID(), mFolder.getId()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.itemList(FakeBaseItem.INSTANCE.getFAV_SONGS().getId(), mFolder.getId()));
                         break;
 
                     case SERIES:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -87,8 +87,6 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     protected boolean showViews = true;
     protected boolean justLoaded = true;
 
-    protected BaseRowItem favSongsRowItem;
-
     protected RowsSupportFragment mRowsFragment;
     protected CompositeClickedListener mClickedListener = new CompositeClickedListener();
     protected CompositeSelectedListener mSelectedListener = new CompositeSelectedListener();
@@ -109,7 +107,6 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        favSongsRowItem = new BaseRowItem(FakeBaseItem.INSTANCE.getFAV_SONGS());
 
         mRowsAdapter = new MutableObjectAdapter<Row>(new PositionableListRowPresenter());
 
@@ -474,15 +471,12 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
         @Override
         public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
                                    RowPresenter.ViewHolder rowViewHolder, Row row) {
-            if (item instanceof GridButton && ((GridButton) item).getId() == FAVSONGS) {
-                // Set to specialized item
-                mCurrentItem = favSongsRowItem;
-            }
-
             if (!(item instanceof BaseRowItem)) {
                 mTitle.setText(mFolder != null ? mFolder.getName() : "");
                 mInfoRow.removeAllViews();
                 mSummary.setText("");
+                mCurrentItem = null;
+                mCurrentRow = null;
                 // Fill in default background
                 backgroundService.getValue().clearBackgrounds();
                 return;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -432,7 +432,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
                         break;
 
                     case FAVSONGS:
-                        navigationRepository.getValue().navigate(Destinations.INSTANCE.itemList(FakeBaseItem.INSTANCE.getFAV_SONGS().getId(), mFolder.getId()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.musicFavorites(mFolder.getId()));
                         break;
 
                     case SERIES:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -53,7 +53,6 @@ import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.MarkdownRenderer;
 import org.jellyfin.androidtv.util.apiclient.LifecycleAwareResponse;
-import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.sdk.api.client.ApiClient;
 import org.jellyfin.sdk.model.api.BaseItemDto;
@@ -292,7 +291,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     }
 
     protected void addAdditionalRows(MutableObjectAdapter<Row> rowAdapter) {
-        if (!showViews) return;
+        if (!showViews || itemType == null) return;
 
         HeaderItem gridHeader = new HeaderItem(rowAdapter.size(), getString(R.string.lbl_views));
         GridButtonPresenter mGridPresenter = new GridButtonPresenter();
@@ -434,7 +433,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
                     case SERIES:
                     case LiveTvOption.LIVE_TV_SERIES_OPTION_ID:
-                        navigationRepository.getValue().navigate(Destinations.INSTANCE.librarySmartScreen(FakeBaseItem.INSTANCE.getSERIES_TIMERS()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvSeriesRecordings());
                         break;
 
                     case SCHEDULE:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRow.kt
@@ -19,7 +19,6 @@ import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.jellyfin.androidtv.util.Utils
-import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem
 
 class HomeFragmentLiveTVRow(
 	private val activity: Activity,
@@ -51,7 +50,7 @@ class HomeFragmentLiveTVRow(
 			LiveTvOption.LIVE_TV_GUIDE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvGuide)
 			LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSchedule)
 			LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvRecordings)
-			LiveTvOption.LIVE_TV_SERIES_OPTION_ID -> navigationRepository.navigate(Destinations.librarySmartScreen(FakeBaseItem.SERIES_TIMERS))
+			LiveTvOption.LIVE_TV_SERIES_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSeriesRecordings)
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -346,7 +346,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
     };
 
     private void updatePoster(BaseItemDto item){
-        if (FakeBaseItem.INSTANCE.getFAV_SONGS_ID().equals(mBaseItem.getId())) {
+        if (FakeBaseItem.INSTANCE.getFAV_SONGS().getId().equals(mBaseItem.getId())) {
             mPoster.setImageResource(R.drawable.favorites);
         } else {
             Double aspect = ImageUtils.getImageAspectRatio(item, false);
@@ -463,7 +463,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             });
         }
 
-        if (!FakeBaseItem.INSTANCE.getFAV_SONGS_ID().equals(mBaseItem.getId())) {
+        if (!FakeBaseItem.INSTANCE.getFAV_SONGS().getId().equals(mBaseItem.getId())) {
             //Favorite
             TextUnderButton fav = TextUnderButton.create(requireContext(), R.drawable.ic_heart, buttonSize,2, getString(R.string.lbl_favorite), new View.OnClickListener() {
                 @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -117,12 +117,12 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         //adjust left frame
         RelativeLayout leftFrame = detailsBinding.leftFrame;
         ViewGroup.LayoutParams params = leftFrame.getLayoutParams();
-        params.width = Utils.convertDpToPixel(requireContext(),100);
+        params.width = Utils.convertDpToPixel(requireContext(), 100);
 
 
         mMetrics = new DisplayMetrics();
         requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
-        mBottomScrollThreshold = (int)(mMetrics.heightPixels *.6);
+        mBottomScrollThreshold = (int) (mMetrics.heightPixels * .6);
 
         //Item list listeners
         mItemList.setRowSelectedListener(new ItemRowView.RowSelectedListener() {
@@ -130,7 +130,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             public void onRowSelected(ItemRowView row) {
                 mCurrentRow = row;
                 //Keep selected row in center of screen
-                int[] location = new int[] {0,0};
+                int[] location = new int[]{0, 0};
                 row.getLocationOnScreen(location);
                 int y = location[1];
                 if (y > mBottomScrollThreshold) {
@@ -166,7 +166,8 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             switch (keyCode) {
                 case KeyEvent.KEYCODE_MEDIA_PAUSE:
                 case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                    if (mediaManager.getValue().isPlayingAudio()) mediaManager.getValue().pauseAudio();
+                    if (mediaManager.getValue().isPlayingAudio())
+                        mediaManager.getValue().pauseAudio();
                     else mediaManager.getValue().resumeAudio();
                     return true;
                 case KeyEvent.KEYCODE_MEDIA_NEXT:
@@ -206,7 +207,8 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
                 new Handler().postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+                        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED))
+                            return;
 
                         ItemListViewHelperKt.refresh(mItemList);
                         lastUpdated = Instant.now();
@@ -246,14 +248,16 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         }
 
         @Override
-        public void onQueueStatusChanged(boolean hasQueue) {}
+        public void onQueueStatusChanged(boolean hasQueue) {
+        }
 
         @Override
-        public void onQueueReplaced() { }
+        public void onQueueReplaced() {
+        }
     };
 
     private void showMenu(final ItemRowView row, boolean showOpen) {
-        PopupMenu menu = new PopupMenu(requireContext(), row != null? row : requireActivity().getCurrentFocus(), Gravity.END);
+        PopupMenu menu = new PopupMenu(requireContext(), row != null ? row : requireActivity().getCurrentFocus(), Gravity.END);
         int order = 0;
         if (showOpen) {
             MenuItem open = menu.getMenu().add(0, 0, order++, R.string.lbl_open);
@@ -278,7 +282,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         play.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                play(mItems.subList(row.getIndex(), row.getIndex()+1), false);
+                play(mItems.subList(row.getIndex(), row.getIndex() + 1), false);
                 return true;
             }
         });
@@ -315,7 +319,6 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         addGenres(mGenreRow);
         addButtons(BUTTON_SIZE);
         mSummary.setText(mBaseItem.getOverview());
-
 
         Double aspect = ImageUtils.getImageAspectRatio(item, false);
         String primaryImageUrl = ImageUtils.getPrimaryImageUrl(item);
@@ -456,7 +459,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         }
 
         //Favorite
-        TextUnderButton fav = TextUnderButton.create(requireContext(), R.drawable.ic_heart, buttonSize,2, getString(R.string.lbl_favorite), new View.OnClickListener() {
+        TextUnderButton fav = TextUnderButton.create(requireContext(), R.drawable.ic_heart, buttonSize, 2, getString(R.string.lbl_favorite), new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
                 ItemListFragmentHelperKt.toggleFavorite(ItemListFragment.this, mBaseItem, (BaseItemDto updatedItem) -> {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragmentHelper.kt
@@ -32,9 +32,9 @@ fun ItemListFragment.loadItem(itemId: UUID) {
 	val api by inject<ApiClient>()
 
 	//Special case handling
-	if (FakeBaseItem.FAV_SONGS_ID == itemId) {
+	if (FakeBaseItem.FAV_SONGS.id == itemId) {
 		val item = BaseItemDto(
-			id = FakeBaseItem.FAV_SONGS_ID,
+			id = FakeBaseItem.FAV_SONGS.id,
 			name = getString(R.string.lbl_favorites),
 			overview = getString(R.string.desc_automatic_fav_songs),
 			mediaType = MediaType.AUDIO,
@@ -58,7 +58,7 @@ fun ItemListFragment.getPlaylist(
 
 	lifecycleScope.launch {
 		val result by when {
-			item.id == FakeBaseItem.FAV_SONGS_ID -> api.itemsApi.getItems(
+			item.id == FakeBaseItem.FAV_SONGS.id -> api.itemsApi.getItems(
 				parentId = arguments?.getString("ParentId")?.toUUIDOrNull(),
 				includeItemTypes = setOf(BaseItemKind.AUDIO),
 				recursive = true,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
@@ -1,0 +1,295 @@
+package org.jellyfin.androidtv.ui.itemdetail;
+
+import static org.koin.java.KoinJavaComponent.inject;
+
+import android.os.Bundle;
+import android.util.DisplayMetrics;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.PopupMenu;
+import android.widget.RelativeLayout;
+import android.widget.ScrollView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import org.jellyfin.androidtv.R;
+import org.jellyfin.androidtv.databinding.FragmentItemListBinding;
+import org.jellyfin.androidtv.databinding.ViewRowDetailsBinding;
+import org.jellyfin.androidtv.ui.ItemListView;
+import org.jellyfin.androidtv.ui.ItemRowView;
+import org.jellyfin.androidtv.ui.TextUnderButton;
+import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
+import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
+import org.jellyfin.androidtv.ui.playback.AudioEventListener;
+import org.jellyfin.androidtv.ui.playback.MediaManager;
+import org.jellyfin.androidtv.ui.playback.PlaybackController;
+import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
+import org.jellyfin.sdk.model.api.BaseItemDto;
+import org.jellyfin.sdk.model.api.BaseItemKind;
+import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import kotlin.Lazy;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
+import timber.log.Timber;
+
+public class MusicFavoritesListFragment extends Fragment implements View.OnKeyListener {
+    private LinearLayout mButtonRow;
+    private ItemListView mItemList;
+    private ScrollView mScrollView;
+    private ItemRowView mCurrentRow;
+
+    private ItemRowView mCurrentlyPlayingRow;
+
+    private List<BaseItemDto> mItems = new ArrayList<>();
+
+    private int mBottomScrollThreshold;
+
+    private DisplayMetrics mMetrics;
+
+    private Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        FragmentItemListBinding binding = FragmentItemListBinding.inflate(getLayoutInflater(), container, false);
+
+        ViewRowDetailsBinding detailsBinding = binding.details.getBinding();
+        detailsBinding.fdTitle.setText(getString(R.string.lbl_favorites));
+        detailsBinding.mainImage.setImageResource(R.drawable.favorites);;
+        detailsBinding.fdSummaryText.setText(getString(R.string.desc_automatic_fav_songs));
+        mButtonRow = detailsBinding.fdButtonRow;
+        mItemList = binding.songs;
+        mScrollView = binding.scrollView;
+
+        //adjust left frame
+        RelativeLayout leftFrame = detailsBinding.leftFrame;
+        ViewGroup.LayoutParams params = leftFrame.getLayoutParams();
+        params.width = Utils.convertDpToPixel(requireContext(), 100);
+
+        mMetrics = new DisplayMetrics();
+        requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        mBottomScrollThreshold = (int) (mMetrics.heightPixels * .6);
+
+        //Item list listeners
+        mItemList.setRowSelectedListener(new ItemRowView.RowSelectedListener() {
+            @Override
+            public void onRowSelected(ItemRowView row) {
+                mCurrentRow = row;
+                //Keep selected row in center of screen
+                int[] location = new int[]{0, 0};
+                row.getLocationOnScreen(location);
+                int y = location[1];
+                if (y > mBottomScrollThreshold) {
+                    // too close to bottom - scroll down
+                    mScrollView.smoothScrollBy(0, y - mBottomScrollThreshold);
+                }
+            }
+        });
+
+        mItemList.setRowClickedListener(new ItemRowView.RowClickedListener() {
+            @Override
+            public void onRowClicked(ItemRowView row) {
+                showMenu(row, row.getItem().getType() != BaseItemKind.AUDIO);
+            }
+        });
+
+        TextUnderButton play = TextUnderButton.create(requireContext(), R.drawable.ic_play, Utils.convertDpToPixel(requireContext(), 35), 2, getString(R.string.lbl_play_all), new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                play(mItems, 0, false);
+            }
+        });
+        play.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) mScrollView.smoothScrollTo(0, 0);
+        });
+        mButtonRow.addView(play);
+        play.requestFocus();
+
+        TextUnderButton shuffle = TextUnderButton.create(requireContext(), R.drawable.ic_shuffle, Utils.convertDpToPixel(requireContext(), 35), 2, getString(R.string.lbl_shuffle_all), new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                play(mItems, 0, true);
+            }
+        });
+        mButtonRow.addView(shuffle);
+        shuffle.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) mScrollView.smoothScrollTo(0, 0);
+        });
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (event.getAction() != KeyEvent.ACTION_UP) return false;
+
+        if (mediaManager.getValue().isPlayingAudio()) {
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_MEDIA_PAUSE:
+                case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+                    if (mediaManager.getValue().isPlayingAudio())
+                        mediaManager.getValue().pauseAudio();
+                    else mediaManager.getValue().resumeAudio();
+                    return true;
+                case KeyEvent.KEYCODE_MEDIA_NEXT:
+                case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+                    mediaManager.getValue().nextAudioItem();
+                    return true;
+                case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                case KeyEvent.KEYCODE_MEDIA_REWIND:
+                    mediaManager.getValue().prevAudioItem();
+                    return true;
+                case KeyEvent.KEYCODE_MENU:
+                    showMenu(mCurrentRow, false);
+                    return true;
+            }
+        } else if (mCurrentRow != null) {
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_MEDIA_PLAY:
+                case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+                case KeyEvent.KEYCODE_MENU:
+                    showMenu(mCurrentRow, false);
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        mediaManager.getValue().addAudioEventListener(mAudioEventListener);
+        // and fire it to be sure we're updated
+        mAudioEventListener.onPlaybackStateChange(mediaManager.getValue().isPlayingAudio() ? PlaybackController.PlaybackState.PLAYING : PlaybackController.PlaybackState.IDLE, mediaManager.getValue().getCurrentAudioItem());
+
+        UUID parentId = UUIDSerializerKt.toUUIDOrNull(getArguments().getString("ParentId"));
+        ItemListFragmentHelperKt.getFavoritePlaylist(this, parentId, itemResponse);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mediaManager.getValue().removeAudioEventListener(mAudioEventListener);
+    }
+
+    private AudioEventListener mAudioEventListener = new AudioEventListener() {
+        @Override
+        public void onPlaybackStateChange(@NonNull PlaybackController.PlaybackState newState, @Nullable BaseItemDto currentItem) {
+            Timber.i("Got playback state change event %s for item %s", newState.toString(), currentItem != null ? currentItem.getName() : "<unknown>");
+
+            if (newState != PlaybackController.PlaybackState.PLAYING || currentItem == null) {
+                if (mCurrentlyPlayingRow != null) mCurrentlyPlayingRow.updateCurrentTime(-1);
+                mCurrentlyPlayingRow = mItemList.updatePlaying(null);
+            } else {
+                mCurrentlyPlayingRow = mItemList.updatePlaying(currentItem.getId());
+            }
+        }
+
+        @Override
+        public void onProgress(long pos) {
+            if (mCurrentlyPlayingRow != null) {
+                mCurrentlyPlayingRow.updateCurrentTime(pos);
+            }
+        }
+
+        @Override
+        public void onQueueStatusChanged(boolean hasQueue) {
+        }
+
+        @Override
+        public void onQueueReplaced() {
+        }
+    };
+
+    private void showMenu(final ItemRowView row, boolean showOpen) {
+        PopupMenu menu = new PopupMenu(requireContext(), row != null ? row : requireActivity().getCurrentFocus(), Gravity.END);
+        int order = 0;
+        if (showOpen) {
+            MenuItem open = menu.getMenu().add(0, 0, order++, R.string.lbl_open);
+            open.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+                @Override
+                public boolean onMenuItemClick(MenuItem item) {
+                    itemLauncher.getValue().launch(new BaseRowItem(row.getItem()), null, 0, requireContext());
+                    return true;
+                }
+            });
+
+        }
+        MenuItem playFromHere = menu.getMenu().add(0, 0, order++, R.string.lbl_play_from_here);
+        playFromHere.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                play(mItems, row.getIndex(), false);
+                return true;
+            }
+        });
+        MenuItem play = menu.getMenu().add(0, 1, order++, R.string.lbl_play);
+        play.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                play(mItems.subList(row.getIndex(), row.getIndex() + 1), 0, false);
+                return true;
+            }
+        });
+        if (row.getItem().getType() == BaseItemKind.AUDIO) {
+            MenuItem queue = menu.getMenu().add(0, 2, order++, R.string.lbl_add_to_queue);
+            queue.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+                @Override
+                public boolean onMenuItemClick(MenuItem item) {
+                    mediaManager.getValue().queueAudioItem(row.getItem());
+                    return true;
+                }
+            });
+
+            MenuItem mix = menu.getMenu().add(0, 1, order++, R.string.lbl_instant_mix);
+            mix.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+                @Override
+                public boolean onMenuItemClick(MenuItem item) {
+                    PlaybackHelper.playInstantMix(requireContext(), row.getItem());
+                    return true;
+                }
+            });
+
+        }
+
+        menu.show();
+    }
+
+    private Function1<List<BaseItemDto>, Unit> itemResponse = (List<BaseItemDto> items) -> {
+        if (!items.isEmpty()) {
+            mItems = new ArrayList<>();
+            int i = 0;
+            for (BaseItemDto item : items) {
+                mItemList.addItem(item, i++);
+                mItems.add(item);
+            }
+            if (mediaManager.getValue().isPlayingAudio()) {
+                //update our status
+                mAudioEventListener.onPlaybackStateChange(PlaybackController.PlaybackState.PLAYING, mediaManager.getValue().getCurrentAudioItem());
+            }
+        }
+        return null;
+    };
+
+    private void play(List<BaseItemDto> items, int ndx, boolean shuffle) {
+        Timber.d("play items: %d, ndx: %d, shuffle: %b", items.size(), ndx, shuffle);
+
+        mediaManager.getValue().playNow(requireContext(), items, ndx, shuffle);
+    }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
@@ -69,7 +69,7 @@ public class MusicFavoritesListFragment extends Fragment implements View.OnKeyLi
 
         ViewRowDetailsBinding detailsBinding = binding.details.getBinding();
         detailsBinding.fdTitle.setText(getString(R.string.lbl_favorites));
-        detailsBinding.mainImage.setImageResource(R.drawable.favorites);;
+        detailsBinding.mainImage.setImageResource(R.drawable.favorites);
         detailsBinding.fdSummaryText.setText(getString(R.string.desc_automatic_fav_songs));
         mButtonRow = detailsBinding.fdButtonRow;
         mItemList = binding.songs;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -17,7 +17,6 @@ import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
-import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.Response;
@@ -269,7 +268,7 @@ public class ItemLauncher {
                         break;
 
                     case LiveTvOption.LIVE_TV_SERIES_OPTION_ID:
-                        navigationRepository.getValue().navigate(Destinations.INSTANCE.librarySmartScreen(FakeBaseItem.INSTANCE.getSERIES_TIMERS()));
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvSeriesRecordings());
                         break;
 
                     case LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -140,6 +140,7 @@ object Destinations {
 	val liveTvGuide = fragmentDestination<LiveTvGuideFragment>()
 	val liveTvSchedule = fragmentDestination<BrowseScheduleFragment>()
 	val liveTvRecordings = fragmentDestination<BrowseRecordingsFragment>()
+	val liveTvSeriesRecordings = fragmentDestination<BrowseViewFragment>(Extras.IsLiveTvSeriesRecordings to true)
 	val liveTvGuideFilterPreferences = preferenceDestination<GuideFiltersScreen>()
 	val liveTvGuideOptionPreferences = preferenceDestination<GuideOptionsScreen>()
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.ui.browsing.SuggestedMoviesFragment
 import org.jellyfin.androidtv.ui.home.HomeFragment
 import org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragment
 import org.jellyfin.androidtv.ui.itemdetail.ItemListFragment
+import org.jellyfin.androidtv.ui.itemdetail.MusicFavoritesListFragment
 import org.jellyfin.androidtv.ui.livetv.GuideFiltersScreen
 import org.jellyfin.androidtv.ui.livetv.GuideOptionsScreen
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideFragment
@@ -131,8 +132,7 @@ object Destinations {
 		"ItemId" to item.toString(),
 	)
 
-	fun itemList(item: UUID, parent: UUID) = fragmentDestination<ItemListFragment>(
-		"ItemId" to item.toString(),
+	fun musicFavorites(parent: UUID) = fragmentDestination<MusicFavoritesListFragment>(
 		"ParentId" to parent.toString(),
 	)
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -297,14 +297,14 @@ public class KeyProcessor {
         public boolean onMenuItemClick(MenuItem menuItem) {
             switch (menuItem.getItemId()) {
                 case MENU_PLAY:
-                    if (item.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS_ID().toString())) {
+                    if (item.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS().getId().toString())) {
                         PlaybackHelper.play(item, 0, false, activity);
                     } else {
                         PlaybackHelper.retrieveAndPlay(item.getId(), false, activity);
                     }
                     return true;
                 case MENU_PLAY_SHUFFLE:
-                    if (item.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS_ID().toString())) {
+                    if (item.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS().getId().toString())) {
                         PlaybackHelper.play(item, 0, false, activity);
                     } else {
                         PlaybackHelper.retrieveAndPlay(item.getId(), true, activity);

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -21,7 +21,6 @@ import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.util.apiclient.PlaybackHelper;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
-import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
 import org.jellyfin.apiclient.model.entities.SortOrder;
@@ -297,18 +296,10 @@ public class KeyProcessor {
         public boolean onMenuItemClick(MenuItem menuItem) {
             switch (menuItem.getItemId()) {
                 case MENU_PLAY:
-                    if (item.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS().getId().toString())) {
-                        PlaybackHelper.play(item, 0, false, activity);
-                    } else {
-                        PlaybackHelper.retrieveAndPlay(item.getId(), false, activity);
-                    }
+                    PlaybackHelper.retrieveAndPlay(item.getId(), false, activity);
                     return true;
                 case MENU_PLAY_SHUFFLE:
-                    if (item.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS().getId().toString())) {
-                        PlaybackHelper.play(item, 0, false, activity);
-                    } else {
-                        PlaybackHelper.retrieveAndPlay(item.getId(), true, activity);
-                    }
+                    PlaybackHelper.retrieveAndPlay(item.getId(), true, activity);
                     return true;
                 case MENU_ADD_QUEUE:
                     PlaybackHelper.getItemsToPlay(item, false, false, new Response<List<BaseItemDto>>() {

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -14,7 +14,6 @@ import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
-import org.jellyfin.androidtv.util.sdk.compat.FakeBaseItem;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
@@ -24,7 +23,6 @@ import org.jellyfin.apiclient.model.dto.BaseItemType;
 import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.querying.EpisodeQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
-import org.jellyfin.apiclient.model.querying.ItemFilter;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.querying.SimilarItemsQuery;
@@ -162,11 +160,7 @@ public class PlaybackHelper {
                 });
                 break;
             case PLAYLIST:
-                if (mainItem.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS().getId().toString())) {
-                    query.setFilters(new ItemFilter[] {ItemFilter.IsFavoriteOrLikes});
-                } else {
-                    query.setParentId(mainItem.getId().toString());
-                }
+                query.setParentId(mainItem.getId().toString());
                 query.setIsMissing(false);
                 query.setIsVirtualUnaired(false);
                 if (shuffle) query.setSortBy(new String[] {ItemSortBy.RANDOM.getSerialName()});

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/PlaybackHelper.java
@@ -162,7 +162,7 @@ public class PlaybackHelper {
                 });
                 break;
             case PLAYLIST:
-                if (mainItem.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS_ID().toString())) {
+                if (mainItem.getId().equals(FakeBaseItem.INSTANCE.getFAV_SONGS().getId().toString())) {
                     query.setFilters(new ItemFilter[] {ItemFilter.IsFavoriteOrLikes});
                 } else {
                     query.setParentId(mainItem.getId().toString());

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
@@ -44,15 +44,6 @@ fun MediaSourceInfo.getVideoStream() = mediaStreams?.firstOrNull {
 }
 
 object FakeBaseItem {
-	private val FAV_SONGS_ID = UUID.fromString("11111111-0000-0000-0000-000000000001")
-	val FAV_SONGS = BaseItemDto(
-		id = FAV_SONGS_ID,
-		type = BaseItemKind.PLAYLIST,
-		mediaType = MediaType.UNKNOWN,
-		isFolder = true,
-		displayPreferencesId = FAV_SONGS_ID.toString(),
-	)
-
 	private val SERIES_TIMERS_ID = UUID.fromString("11111111-0000-0000-0000-000000000002")
 	val SERIES_TIMERS = BaseItemDto(
 		id = SERIES_TIMERS_ID,

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
@@ -3,11 +3,8 @@
 package org.jellyfin.androidtv.util.sdk.compat
 
 import org.jellyfin.sdk.model.api.BaseItemDto
-import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaSourceInfo
-import org.jellyfin.sdk.model.api.MediaType
 import java.time.LocalDateTime
-import java.util.UUID
 import org.jellyfin.apiclient.model.dto.BaseItemDto as LegacyBaseItemdto
 
 fun BaseItemDto.copyWithDisplayPreferencesId(
@@ -41,14 +38,4 @@ fun Array<LegacyBaseItemdto>.mapBaseItemArray(): List<BaseItemDto> = map { it.as
 
 fun MediaSourceInfo.getVideoStream() = mediaStreams?.firstOrNull {
 	it.type == org.jellyfin.sdk.model.api.MediaStreamType.VIDEO
-}
-
-object FakeBaseItem {
-	private val SERIES_TIMERS_ID = UUID.fromString("11111111-0000-0000-0000-000000000002")
-	val SERIES_TIMERS = BaseItemDto(
-		id = SERIES_TIMERS_ID,
-		type = BaseItemKind.FOLDER,
-		mediaType = MediaType.UNKNOWN,
-		displayPreferencesId = SERIES_TIMERS_ID.toString(),
-	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
@@ -44,7 +44,7 @@ fun MediaSourceInfo.getVideoStream() = mediaStreams?.firstOrNull {
 }
 
 object FakeBaseItem {
-	val FAV_SONGS_ID = UUID.fromString("11111111-0000-0000-0000-000000000001")
+	private val FAV_SONGS_ID = UUID.fromString("11111111-0000-0000-0000-000000000001")
 	val FAV_SONGS = BaseItemDto(
 		id = FAV_SONGS_ID,
 		type = BaseItemKind.PLAYLIST,
@@ -53,7 +53,7 @@ object FakeBaseItem {
 		displayPreferencesId = FAV_SONGS_ID.toString(),
 	)
 
-	val SERIES_TIMERS_ID = UUID.fromString("11111111-0000-0000-0000-000000000002")
+	private val SERIES_TIMERS_ID = UUID.fromString("11111111-0000-0000-0000-000000000002")
 	val SERIES_TIMERS = BaseItemDto(
 		id = SERIES_TIMERS_ID,
 		type = BaseItemKind.FOLDER,


### PR DESCRIPTION
The primary goal here was to remove the FakeBaseItem hack. Bunch of related sacrifices had to be made to complete this pentagram though.

**Changes**
- Split MusicFavoritesListFragment from ItemListFragment
  - Basically a glorified duplicate fragment class with obsolete code removed
- Add an extra to BrowseViewFragment to indicate it should show series timers instead of a fake base item
  - And some related changes in places that would crash if item is null
- Fix context menu showing for last selected base item when opening on gridbutton (e.g. music favorites button)
- Remove FakeBaseItem
- Dropped tears from eyes

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
