### PR TITLE
Fix "Add server" button not visible when there are too many servers

### DIFF
--- a/app/src/main/res/layout/fragment_select_server.xml
+++ b/app/src/main/res/layout/fragment_select_server.xml
@@ -20,13 +20,16 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/saved_servers"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/stored_servers"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:ignore="NestedWeights"
             tools:itemCount="3"
             tools:listitem="@layout/view_button_server" />
 


### PR DESCRIPTION
The average user has 1 Jellyfin server configured. That's why I have 7, because I'm above average.

**Changes**
- Fix the visibility of the "Enter server address" button in the server selection screen when there are 5+ servers (Will be 5px tall with 6 and gone with 7 or more).
- This effectively moves the "enter server address" button down to the bottom of the screen when you have only 1 server configured. It's something I can live with though.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
