### PR TITLE
Add app notification to notify about upcoming server requirement

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -22,6 +22,7 @@ import org.jellyfin.sdk.api.client.extensions.brandingApi
 import org.jellyfin.sdk.api.client.extensions.systemApi
 import org.jellyfin.sdk.discovery.RecommendedServerInfo
 import org.jellyfin.sdk.discovery.RecommendedServerInfoScore
+import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.BrandingOptions
 import org.jellyfin.sdk.model.api.ServerDiscoveryInfo
 import org.jellyfin.sdk.model.serializer.toUUID
@@ -47,6 +48,8 @@ interface ServerRepository {
 	companion object {
 		val minimumServerVersion = Jellyfin.minimumVersion.copy(build = null)
 		val recommendedServerVersion = Jellyfin.apiVersion.copy(build = null)
+
+		val upcomingMinimumServerVersion = ServerVersion(10, 9, 0)
 	}
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/NotificationsRepository.kt
@@ -5,15 +5,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.model.Server
+import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.data.model.AppNotification
 import org.jellyfin.androidtv.preference.SystemPreferences
 import org.jellyfin.androidtv.util.isTvDevice
+import org.jellyfin.sdk.model.ServerVersion
 
 interface NotificationsRepository {
 	val notifications: StateFlow<List<AppNotification>>
 
 	fun dismissNotification(item: AppNotification)
 	fun addDefaultNotifications()
+	fun updateServerNotifications(server: Server?)
 }
 
 class NotificationsRepositoryImpl(
@@ -32,15 +36,28 @@ class NotificationsRepositoryImpl(
 		addBetaNotification()
 	}
 
-	private fun addNotification(message: String, public: Boolean = false, dismiss: () -> Unit = {}) {
-		notifications.value = notifications.value + AppNotification(message, dismiss, public)
+	private fun addNotification(
+		message: String,
+		public: Boolean = false,
+		dismiss: () -> Unit = {}
+	): AppNotification {
+		val notification = AppNotification(message, dismiss, public)
+		notifications.value += notification
+		return notification
+	}
+
+	private fun removeNotification(notification: AppNotification) {
+		notifications.value -= notification
 	}
 
 	private fun addUiModeNotification() {
 		val disableUiModeWarning = systemPreferences[SystemPreferences.disableUiModeWarning]
 
 		if (!context.isTvDevice() && !disableUiModeWarning) {
-			addNotification(context.getString(R.string.app_notification_uimode_invalid), public = true)
+			addNotification(
+				context.getString(R.string.app_notification_uimode_invalid),
+				public = true
+			)
 		}
 	}
 
@@ -51,8 +68,28 @@ class NotificationsRepositoryImpl(
 
 		if (isBeta && currentVersion != dismissedVersion) {
 			addNotification(context.getString(R.string.app_notification_beta, currentVersion)) {
-				systemPreferences[SystemPreferences.dismissedBetaNotificationVersion] = currentVersion
+				systemPreferences[SystemPreferences.dismissedBetaNotificationVersion] =
+					currentVersion
 			}
+		}
+	}
+
+	// Update server notification
+	private var _updateServerNotification: AppNotification? = null
+	override fun updateServerNotifications(server: Server?) {
+		// Remove current update notification
+		_updateServerNotification?.let(::removeNotification)
+
+		val currentServerVersion = server?.version?.let(ServerVersion::fromString) ?: return
+		if (currentServerVersion < ServerRepository.upcomingMinimumServerVersion) {
+			_updateServerNotification =
+				addNotification(
+					message = context.getString(
+						R.string.app_notification_update_soon,
+						currentServerVersion,
+						ServerRepository.upcomingMinimumServerVersion
+					),
+				)
 		}
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,7 +476,7 @@
     <string name="crash_report_toast">Oops! Something went wrong, a crash report was sent to your Jellyfin server.</string>
     <string name="server_setup_incomplete">The setup of this server has not been completed. Open Jellyfin in a web browser to finish setup before signing in.</string>
     <string name="episode_name_special">special</string>
-    <string name="app_notification_beta">App updated to %1$s\nThank you for participating in the Jellyfin beta program</string>
+    <string name="app_notification_beta">App updated to %1$s\nThank you for participating in the Jellyfin beta program.</string>
     <string name="item_deleted">%1$s deleted</string>
     <string name="item_deletion_failed">Unable to delete %1$s</string>
     <string name="pref_enable_media_management">Enable media management</string>
@@ -516,6 +516,7 @@
     <string name="pref_screensaver_ageratingrequired_enabled">Only showing items with an age rating set</string>
     <string name="pref_screensaver_ageratingrequired_disabled">Showing all items</string>
     <string name="all_channels">All channels</string>
+    <string name="app_notification_update_soon">Update your server from %1$s to at least %2$s to continue using the app after the next update.</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
**Changes**
- Add a new app notification that notifies the user about upcoming Jellyfin server version requirements. Currently set to 10.9.0 (ATV 0.17), will have no effect on master branch as that already requires 10.9.0 to sign in.

![9200000351](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/04fd9a4f-49a7-460f-b37d-18a4f764b6ad)

_Sample screenshot with higher version requirement for testing purposes_

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
