### PR TITLE
Migrate to androidx.tv.material

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,6 +12,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
 import org.jellyfin.androidtv.ui.composable.ZoomBox
 import org.jellyfin.androidtv.ui.composable.overscan

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -24,13 +22,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
 import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.blurHashPainter
@@ -63,7 +62,8 @@ fun DreamContentNowPlaying(
 		else -> null to null
 	}
 
-	val imageBlurHash = imageTag?.let { tag -> item.imageBlurHashes?.get(ImageType.PRIMARY)?.get(tag) }
+	val imageBlurHash =
+		imageTag?.let { tag -> item.imageBlurHashes?.get(ImageType.PRIMARY)?.get(tag) }
 	if (imageBlurHash != null) {
 		Image(
 			painter = blurHashPainter(imageBlurHash, IntSize(32, 32)),
@@ -116,7 +116,9 @@ fun DreamContentNowPlaying(
 				text = item.run {
 					if (!artists.isNullOrEmpty()) return@run artists?.joinToString(", ")
 					val albumArtistNames = albumArtists?.mapNotNull { it.name }
-					if (!albumArtistNames.isNullOrEmpty()) return@run albumArtistNames.joinToString(", ")
+					if (!albumArtistNames.isNullOrEmpty()) return@run albumArtistNames.joinToString(
+						", "
+					)
 					return@run albumArtist
 				}.orEmpty(),
 				style = TextStyle(
@@ -143,12 +145,17 @@ fun DreamContentNowPlaying(
 				}
 			}
 
-			LinearProgressIndicator(
-				progress = progress,
-				color = Color.White,
-				backgroundColor = Color.White.copy(alpha = 0.2f),
-				strokeCap = StrokeCap.Round,
-				modifier = Modifier.fillMaxWidth()
+			Box(
+				modifier = Modifier
+					.fillMaxWidth()
+					.height(4.dp)
+					.clip(RoundedCornerShape(2.dp))
+					.drawWithContent {
+						// Background
+						drawRect(Color.White, alpha = 0.2f)
+						// Foreground
+						drawRect(Color.White, size = size.copy(width = size.width * progress))
+					}
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -114,13 +114,15 @@ fun DreamContentNowPlaying(
 
 			Text(
 				text = item.run {
-					if (!artists.isNullOrEmpty()) return@run artists?.joinToString(", ")
-					val albumArtistNames = albumArtists?.mapNotNull { it.name }
-					if (!albumArtistNames.isNullOrEmpty()) return@run albumArtistNames.joinToString(
-						", "
-					)
-					return@run albumArtist
-				}.orEmpty(),
+					val artistNames = artists.orEmpty()
+					val albumArtistNames = albumArtists?.mapNotNull { it.name }.orEmpty()
+
+					when {
+						artistNames.isNotEmpty() -> artistNames
+						albumArtistNames.isNotEmpty() -> albumArtistNames
+						else -> listOfNotNull(albumArtist)
+					}.joinToString(", ")
+				},
 				style = TextStyle(
 					color = Color(0.8f, 0.8f, 0.8f),
 					fontSize = 18.sp,

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.composable.overscan
 import org.jellyfin.androidtv.ui.composable.rememberCurrentTime

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -14,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Text
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,6 +17,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.tv.material3.ProvideTextStyle
 
 /**
  * A single item in the [BaseItemInfoRow].

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing.composable.inforow
 
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
 import java.text.NumberFormat
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -21,6 +20,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.leanback.widget.Presenter
+import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.GridButton
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -5,15 +5,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Card
-import androidx.compose.material.Text
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
@@ -26,6 +27,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -167,15 +170,16 @@ class SelectServerFragment : Fragment() {
 				for (notification in notifications) {
 					if (!notification.public) continue
 
-					Card(
+					Box(
 						modifier = Modifier
-							.fillMaxWidth(),
-						backgroundColor = colorResource(id = R.color.lb_basic_card_info_bg_color),
-						contentColor = colorResource(id = R.color.white),
+							.fillMaxWidth()
+							.clip(MaterialTheme.shapes.medium)
+							.background(colorResource(id = R.color.lb_basic_card_info_bg_color)),
 					) {
 						Text(
 							text = notification.message,
-							modifier = Modifier.padding(10.dp)
+							modifier = Modifier.padding(10.dp),
+							color = colorResource(id = R.color.white)
 						)
 					}
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SplashFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SplashFragment.kt
@@ -4,12 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,8 +24,8 @@ import org.jellyfin.androidtv.R
 
 @Composable
 fun SplashScreen() {
-	Surface(
-		color = colorResource(id = R.color.not_quite_black),
+	Box(
+		modifier = Modifier.background(colorResource(id = R.color.not_quite_black)),
 	) {
 		Column(
 			horizontalAlignment = Alignment.CenterHorizontally,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ androidx-appcompat = "1.6.1"
 androidx-cardview = "1.0.0"
 androidx-compose-compiler = "1.5.14"
 androidx-compose-foundation = "1.6.7"
-androidx-compose-material = "1.6.7"
 androidx-compose-ui = "1.6.7"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.13.1"
@@ -19,6 +18,7 @@ androidx-media3 = "1.3.1"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.3.2"
 androidx-startup = "1.1.1"
+androidx-tv = "1.0.0-beta01"
 androidx-tvprovider = "1.1.0-alpha01"
 androidx-window = "1.2.0"
 androidx-work = "2.9.0"
@@ -63,7 +63,6 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose-ui" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
@@ -80,6 +79,7 @@ androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "andr
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
+androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "androidx-tv" }
 androidx-tvprovider = { module = "androidx.tvprovider:tvprovider", version.ref = "androidx-tvprovider" }
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
@@ -132,8 +132,8 @@ acra = [
 ]
 androidx-compose = [
     "androidx-compose-foundation",
-    "androidx-compose-material",
-    "androidx-compose-ui-tooling"
+    "androidx-compose-ui-tooling",
+    "androidx-tv-material"
 ]
 androidx-lifecycle = [
     "androidx-lifecycle-process",


### PR DESCRIPTION
The androidx.compose.material library is for mobile/tablet. The androidx.tv.material library is for televisions. This PR switches our current compose over to the tv library, although it doesn't really affect much as we didn't really use material components (yey).

**Changes**
- Remove `androidx.compose.material`
- Add `androidx.tv.material`
  - Replace LinearProgressIndicator with Box + draw instructions
  - Replace Card with Box (the TV card is not usable for a message box)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
