### PR TITLE
Support new intent in StartupActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -109,6 +109,7 @@
             android:name=".ui.startup.StartupActivity"
             android:exported="true"
             android:noHistory="true"
+            android:launchMode="singleTask"
             android:screenOrientation="landscape"
             android:windowSoftInputMode="adjustNothing">
             <intent-filter>

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -184,4 +184,9 @@ class StartupActivity : FragmentActivity() {
 		replace<StartupToolbarFragment>(R.id.content_view)
 		add<SelectServerFragment>(R.id.content_view)
 	}
+
+	override fun onNewIntent(intent: Intent) {
+		super.onNewIntent(intent)
+		setIntent(intent)
+	}
 }


### PR DESCRIPTION
Although I couldn't reproduce the issue myself, I suspect it was a race condition. If the activity was loaded twice, the instance that was faster to launch the next activity wins.

**Changes**
- Only allow a single instance of StartupActivity

**Issues**

Most likely fixes #3536.
