### PR TITLE
Remove refreshing of Live TV program data in player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1510,10 +1510,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 }
             }
 
-            if (isLiveTv && mCurrentProgramEnd != null && mCurrentProgramEnd.isAfter(LocalDateTime.now())) {
-                // crossed fire off an async routine to update the program info
-                updateTvProgramInfo();
-            }
             if (mFragment != null && finishedInitialSeek)
                 mFragment.updateSubtitles(mCurrentPosition - getSubtitleDelay());
         }


### PR DESCRIPTION
Unfortunately #3522 did not completely solve the issue for everyone. I've already made a ton of fixes related to datetime parsing in 0.17 that are not easily backportable, so remove this functionality for now in 0.16 only.

**Changes**
- Remove refreshing of Live TV program data in player

**Issues**

Fixes #3601