### PR TITLE
Migrate "next up" row to SDK

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRowDef.java
@@ -12,17 +12,17 @@ import org.jellyfin.apiclient.model.livetv.SeriesTimerQuery;
 import org.jellyfin.apiclient.model.querying.ArtistsQuery;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
 import org.jellyfin.apiclient.model.querying.LatestItemsQuery;
-import org.jellyfin.apiclient.model.querying.NextUpQuery;
 import org.jellyfin.apiclient.model.querying.PersonsQuery;
 import org.jellyfin.apiclient.model.querying.SeasonQuery;
 import org.jellyfin.apiclient.model.querying.SimilarItemsQuery;
 import org.jellyfin.apiclient.model.querying.UpcomingEpisodesQuery;
+import org.jellyfin.sdk.model.api.request.GetNextUpRequest;
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest;
 
 public class BrowseRowDef {
     private String headerText;
     private ItemQuery query;
-    private NextUpQuery nextUpQuery;
+    private GetNextUpRequest nextUpQuery;
     private UpcomingEpisodesQuery upcomingQuery;
     private SimilarItemsQuery similarQuery;
     private LatestItemsQuery latestItemsQuery;
@@ -97,7 +97,7 @@ public class BrowseRowDef {
         this.changeTriggers = changeTriggers;
     }
 
-    public BrowseRowDef(String header, NextUpQuery query) {
+    public BrowseRowDef(String header, GetNextUpRequest query) {
         headerText = header;
         this.nextUpQuery = query;
         this.queryType = QueryType.NextUp;
@@ -110,7 +110,7 @@ public class BrowseRowDef {
         this.queryType = QueryType.SeriesTimer;
     }
 
-    public BrowseRowDef(String header, NextUpQuery query, ChangeTriggerType[] changeTriggers) {
+    public BrowseRowDef(String header, GetNextUpRequest query, ChangeTriggerType[] changeTriggers) {
         headerText = header;
         this.nextUpQuery = query;
         this.queryType = QueryType.NextUp;
@@ -221,7 +221,7 @@ public class BrowseRowDef {
         return query;
     }
 
-    public NextUpQuery getNextUpQuery() {
+    public GetNextUpRequest getNextUpQuery() {
         return nextUpQuery;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -37,11 +37,11 @@ import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemFilter;
 import org.jellyfin.apiclient.model.querying.ItemsResult;
 import org.jellyfin.apiclient.model.querying.LatestItemsQuery;
-import org.jellyfin.apiclient.model.querying.NextUpQuery;
 import org.jellyfin.apiclient.model.results.TimerInfoDtoResult;
 import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.jellyfin.sdk.model.api.CollectionType;
 import org.jellyfin.sdk.model.api.ItemSortBy;
+import org.jellyfin.sdk.model.api.request.GetNextUpRequest;
 import org.koin.java.KoinJavaComponent;
 
 import java.time.Instant;
@@ -153,19 +153,8 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
                 mRows.add(new BrowseRowDef(getString(R.string.lbl_continue_watching), resumeEpisodes, 0, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
 
                 //Next up
-                NextUpQuery nextUpQuery = new NextUpQuery();
-                nextUpQuery.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
-                nextUpQuery.setLimit(50);
-                nextUpQuery.setParentId(mFolder.getId().toString());
-                nextUpQuery.setImageTypeLimit(1);
-                nextUpQuery.setFields(new ItemFields[]{
-                        ItemFields.PrimaryImageAspectRatio,
-                        ItemFields.Overview,
-                        ItemFields.ChildCount,
-                        ItemFields.MediaSources,
-                        ItemFields.MediaStreams
-                });
-                mRows.add(new BrowseRowDef(getString(R.string.lbl_next_up), nextUpQuery, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
+                GetNextUpRequest getNextUpRequest = BrowsingUtils.createGetNextUpRequest(mFolder.getId());
+                mRows.add(new BrowseRowDef(getString(R.string.lbl_next_up), getNextUpRequest, new ChangeTriggerType[]{ChangeTriggerType.TvPlayback}));
 
                 //Premieres
                 if (KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getPremieresEnabled())) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
@@ -8,8 +8,11 @@ import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.request.GetNextUpRequest
 import timber.log.Timber
+import java.util.UUID
 
 object BrowsingUtils {
 	@JvmStatic
@@ -31,4 +34,27 @@ object BrowsingUtils {
 			}
 		}
 	}
+
+	@JvmStatic
+	fun createGetNextUpRequest(parentId: UUID) = GetNextUpRequest(
+		limit = 50,
+		parentId = parentId,
+		imageTypeLimit = 1,
+		fields = setOf(
+			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
+			ItemFields.OVERVIEW,
+			ItemFields.CHILD_COUNT,
+			ItemFields.MEDIA_SOURCES,
+			ItemFields.MEDIA_STREAMS,
+		)
+	)
+
+	@JvmStatic
+	fun createSeriesGetNextUpRequest(parentId: UUID) = GetNextUpRequest(
+		seriesId = parentId,
+		fields = setOf(
+			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
+			ItemFields.CHILD_COUNT,
+		)
+	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -9,10 +9,11 @@ import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.apiclient.model.livetv.RecommendedProgramQuery
 import org.jellyfin.apiclient.model.livetv.RecordingQuery
-import org.jellyfin.apiclient.model.querying.ItemFields
-import org.jellyfin.apiclient.model.querying.NextUpQuery
+import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.MediaType
+import org.jellyfin.sdk.model.api.request.GetNextUpRequest
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
+import org.jellyfin.apiclient.model.querying.ItemFields as LegacyItemFields
 import org.jellyfin.sdk.model.api.ItemFields as SdkItemFields
 
 class HomeFragmentHelper(
@@ -58,9 +59,9 @@ class HomeFragmentHelper(
 	fun loadLatestLiveTvRecordings(): HomeFragmentRow {
 		val query = RecordingQuery().apply {
 			fields = arrayOf(
-				ItemFields.Overview,
-				ItemFields.PrimaryImageAspectRatio,
-				ItemFields.ChildCount
+				LegacyItemFields.Overview,
+				LegacyItemFields.PrimaryImageAspectRatio,
+				LegacyItemFields.ChildCount
 			)
 
 			userId = userRepository.currentUser.value!!.id.toString()
@@ -72,16 +73,16 @@ class HomeFragmentHelper(
 	}
 
 	fun loadNextUp(): HomeFragmentRow {
-		val query = NextUpQuery().apply {
-			userId = userRepository.currentUser.value!!.id.toString()
-			imageTypeLimit = 1
-			limit = ITEM_LIMIT_NEXT_UP
-			fields = arrayOf(
-				ItemFields.PrimaryImageAspectRatio,
-				ItemFields.Overview,
-				ItemFields.ChildCount
+		val query = GetNextUpRequest(
+			imageTypeLimit = 1,
+			limit = ITEM_LIMIT_NEXT_UP,
+			enableResumable = false,
+			fields = setOf(
+				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
+				ItemFields.OVERVIEW,
+				ItemFields.CHILD_COUNT,
 			)
-		}
+		)
 
 		return HomeFragmentBrowseRowDefRow(BrowseRowDef(context.getString(R.string.lbl_next_up), query, arrayOf(ChangeTriggerType.TvPlayback)))
 	}
@@ -90,10 +91,10 @@ class HomeFragmentHelper(
 		val query = RecommendedProgramQuery().apply {
 			isAiring = true
 			fields = arrayOf(
-				ItemFields.Overview,
-				ItemFields.PrimaryImageAspectRatio,
-				ItemFields.ChannelInfo,
-				ItemFields.ChildCount
+				LegacyItemFields.Overview,
+				LegacyItemFields.PrimaryImageAspectRatio,
+				LegacyItemFields.ChannelInfo,
+				LegacyItemFields.ChildCount
 			)
 			userId = userRepository.currentUser.value!!.id.toString()
 			imageTypeLimit = 1

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -55,6 +55,7 @@ import org.jellyfin.androidtv.preference.constant.PreferredVideoPlayer;
 import org.jellyfin.androidtv.ui.RecordPopup;
 import org.jellyfin.androidtv.ui.RecordingIndicatorView;
 import org.jellyfin.androidtv.ui.TextUnderButton;
+import org.jellyfin.androidtv.ui.browsing.BrowsingUtils;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
@@ -89,7 +90,6 @@ import org.jellyfin.apiclient.model.livetv.ChannelInfoDto;
 import org.jellyfin.apiclient.model.livetv.TimerQuery;
 import org.jellyfin.apiclient.model.querying.ItemFields;
 import org.jellyfin.apiclient.model.querying.ItemQuery;
-import org.jellyfin.apiclient.model.querying.NextUpQuery;
 import org.jellyfin.apiclient.model.querying.SeasonQuery;
 import org.jellyfin.apiclient.model.querying.SimilarItemsQuery;
 import org.jellyfin.apiclient.model.querying.UpcomingEpisodesQuery;
@@ -678,14 +678,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 break;
             case SERIES:
-                NextUpQuery nextUpQuery = new NextUpQuery();
-                nextUpQuery.setUserId(KoinJavaComponent.<UserRepository>get(UserRepository.class).getCurrentUser().getValue().getId().toString());
-                nextUpQuery.setSeriesId(mBaseItem.getId().toString());
-                nextUpQuery.setFields(new ItemFields[]{
-                        ItemFields.PrimaryImageAspectRatio,
-                        ItemFields.ChildCount
-                });
-                ItemRowAdapter nextUpAdapter = new ItemRowAdapter(requireContext(), nextUpQuery, false, new CardPresenter(true, 130), adapter);
+                ItemRowAdapter nextUpAdapter = new ItemRowAdapter(requireContext(), BrowsingUtils.createSeriesGetNextUpRequest(mBaseItem.getId()), false, new CardPresenter(true, 130), adapter);
                 addItemRow(adapter, nextUpAdapter, 0, getString(R.string.lbl_next_up));
 
                 SeasonQuery seasons = new SeasonQuery();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.InvalidStatusException
 import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.model.api.request.GetNextUpRequest
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
 import timber.log.Timber
 import kotlin.math.min
@@ -44,20 +46,80 @@ fun <T : Any> ItemRowAdapter.setItems(
 
 fun ItemRowAdapter.retrieveResumeItems(api: ApiClient, query: GetResumeItemsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
-		val response by api.itemsApi.getResumeItems(query)
+		runCatching {
+			val response by api.itemsApi.getResumeItems(query)
 
-		setItems(
-			items = response.items.orEmpty().toTypedArray(),
-			transform = { item, i ->
-				BaseItemDtoBaseRowItem(
-					item,
-					preferParentThumb,
-					isStaticHeight
-				)
-			}
+			setItems(
+				items = response.items.orEmpty().toTypedArray(),
+				transform = { item, i ->
+					BaseItemDtoBaseRowItem(
+						item,
+						preferParentThumb,
+						isStaticHeight
+					)
+				}
+			)
+
+			if (response.items.isNullOrEmpty()) removeRow()
+		}.fold(
+			onSuccess = { notifyRetrieveFinished() },
+			onFailure = { error -> notifyRetrieveFinished(error as? Exception) }
 		)
+	}
+}
 
-		if (response.items.isNullOrEmpty()) removeRow()
+fun ItemRowAdapter.retrieveNextUpItems(api: ApiClient, query: GetNextUpRequest) {
+	ProcessLifecycleOwner.get().lifecycleScope.launch {
+		runCatching {
+			val response by api.tvShowsApi.getNextUp(query)
+
+			// Some special flavor for series, used in FullDetailsFragment
+			val firstNextUp = response.items?.firstOrNull()
+			if (query.seriesId != null && response.items?.size == 1 && firstNextUp?.seasonId != null && firstNextUp.indexNumber != null) {
+				// If we have exactly 1 episode returned, the series is currently partially watched
+				// we want to query the server for all episodes in the same season starting from
+				// this one to create a list of all unwatched episodes
+				val episodesResponse by api.itemsApi.getItems(
+					parentId = firstNextUp.seasonId,
+					startIndex = firstNextUp.indexNumber,
+				)
+
+				// Combine the next up episode with the additionally retrieved episodes
+				val items = buildList {
+					add(firstNextUp)
+					episodesResponse.items?.let { addAll(it) }
+				}.toTypedArray()
+
+				setItems(
+					items = items,
+					transform = { item, i ->
+						BaseItemDtoBaseRowItem(
+							item,
+							preferParentThumb,
+							false
+						)
+					}
+				)
+
+				if (items.isEmpty()) removeRow()
+			} else {
+				setItems(
+					items = response.items.orEmpty().toTypedArray(),
+					transform = { item, i ->
+						BaseItemDtoBaseRowItem(
+							item,
+							preferParentThumb,
+							isStaticHeight
+						)
+					}
+				)
+
+				if (response.items.isNullOrEmpty()) removeRow()
+			}
+		}.fold(
+			onSuccess = { notifyRetrieveFinished() },
+			onFailure = { error -> notifyRetrieveFinished(error as? Exception) }
+		)
 	}
 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Use the SDK to retrieve "next up" requests for the home fragment and series details screens
- Set `enableResumable=false` for home next up row to prevent episodes from showing in both the continue watching and next up rows
- Add error handling to retrieveResumeItems in ItemRowAdapterHelper
- Fix notifyRetrieveFinished never called in retrieveResumeItems in ItemRowAdapterHelper
- Cry a lot

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
