### PR TITLE
Fix JSON decode crash in PictureViewerFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerFragment.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.databinding.FragmentPictureViewerBinding
 import org.jellyfin.androidtv.ui.AsyncImageView
@@ -60,10 +59,10 @@ class PictureViewerFragment : Fragment(), View.OnKeyListener {
 		lifecycleScope.launch {
 			val itemId = requireNotNull(arguments?.getString(ARGUMENT_ITEM_ID)?.toUUIDOrNull())
 			val albumSortBy = arguments?.getString(ARGUMENT_ALBUM_SORT_BY)?.let {
-				Json.Default.decodeFromString<ItemSortBy>(it)
+				ItemSortBy.fromNameOrNull(it)
 			} ?: ItemSortBy.SORT_NAME
 			val albumSortOrder = arguments?.getString(ARGUMENT_ALBUM_SORT_ORDER)?.let {
-				Json.Default.decodeFromString<SortOrder>(it)
+				SortOrder.fromNameOrNull(it)
 			} ?: SortOrder.ASCENDING
 			pictureViewerViewModel.loadItem(itemId, setOf(albumSortBy), albumSortOrder)
 


### PR DESCRIPTION
The arguments for sorting are provided as a String, not as JSON. Attemping to decode the String crashes the app. Fix it by using the SDK provided methods to convert to an enum instead.

Trigger crash:
1. Open an image from an image library

Stack trace:
```
E  ACRA caught a JsonDecodingException for org.jellyfin.androidtv.debug
                                                                                                    kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 0: Expected quotation mark '"', but had 'S' instead at path: $
                                                                                                    JSON input: SortName
                                                                                                    	at kotlinx.serialization.json.internal.JsonExceptionsKt.JsonDecodingException(JsonExceptions.kt:24)
                                                                                                    	at kotlinx.serialization.json.internal.JsonExceptionsKt.JsonDecodingException(JsonExceptions.kt:32)
                                                                                                    	at kotlinx.serialization.json.internal.AbstractJsonLexer.fail(AbstractJsonLexer.kt:598)
                                                                                                    	at kotlinx.serialization.json.internal.AbstractJsonLexer.fail$default(AbstractJsonLexer.kt:596)
                                                                                                    	at kotlinx.serialization.json.internal.AbstractJsonLexer.fail$kotlinx_serialization_json(AbstractJsonLexer.kt:233)
                                                                                                    	at kotlinx.serialization.json.internal.AbstractJsonLexer.fail$kotlinx_serialization_json$default(AbstractJsonLexer.kt:228)
                                                                                                    	at kotlinx.serialization.json.internal.AbstractJsonLexer.unexpectedToken(AbstractJsonLexer.kt:225)
                                                                                                    	at kotlinx.serialization.json.internal.StringJsonLexer.consumeNextToken(StringJsonLexer.kt:74)
                                                                                                    	at kotlinx.serialization.json.internal.StringJsonLexer.consumeKeyString(StringJsonLexer.kt:86)
                                                                                                    	at kotlinx.serialization.json.internal.AbstractJsonLexer.consumeString(AbstractJsonLexer.kt:383)
                                                                                                    	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeString(StreamingJsonDecoder.kt:339)
                                                                                                    	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeEnum(StreamingJsonDecoder.kt:352)
                                                                                                    	at kotlinx.serialization.internal.EnumSerializer.deserialize(Enums.kt:139)
                                                                                                    	at kotlinx.serialization.internal.EnumSerializer.deserialize(Enums.kt:105)
                                                                                                    	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
                                                                                                    	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:107)
                                                                                                    	at org.jellyfin.androidtv.ui.picture.PictureViewerFragment$onCreate$1.invokeSuspend(PictureViewerFragment.kt:229)
                                                                                                    	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                                                                                                    	at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:363)
                                                                                                    	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
                                                                                                    	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
                                                                                                    	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
                                                                                                    	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
                                                                                                    	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
                                                                                                    	at kotlinx.coroutines.BuildersKt.launch(Unknown Source:1)
                                                                                                    	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
                                                                                                    	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source:1)
                                                                                                    	at org.jellyfin.androidtv.ui.picture.PictureViewerFragment.onCreate(PictureViewerFragment.kt:60)
                                                                                                    	at androidx.fragment.app.Fragment.performCreate(Fragment.java:3095)
                                                                                                    	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:516)
                                                                                                    	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:274)
                                                                                                    	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2103)
                                                                                                    	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1998)
                                                                                                    	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1941)
                                                                                                    	at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:661)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:958)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205)
                                                                                                    	at android.os.Looper.loop(Looper.java:294)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```