### PR TITLE
Fix login with pruned sessions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -66,7 +66,7 @@ class AuthenticationRepositoryImpl(
 	}
 
 	private fun authenticateAutomatic(server: Server, user: User): Flow<LoginState> {
-		Timber.i("Authenticating user %s", user)
+		Timber.i("Authenticating user ${user.id}")
 
 		// Automatic logic is disabled when the always authenticate preference is enabled
 		if (authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]) return flowOf(RequireSignInState)

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
@@ -141,11 +141,6 @@ class SessionRepositoryImpl(
 			val applied = userApiClient.applySession(session, deviceInfo)
 
 			if (applied && session != null) {
-				// Update crash reporting URL
-				val crashReportUrl = userApiClient.clientLogApi.logFileUrl()
-				telemetryPreferences[TelemetryPreferences.crashReportUrl] = crashReportUrl
-				telemetryPreferences[TelemetryPreferences.crashReportToken] = session.accessToken
-
 				try {
 					val user by userApiClient.userApi.getCurrentUser()
 					userRepository.updateCurrentUser(user)
@@ -154,6 +149,11 @@ class SessionRepositoryImpl(
 					destroyCurrentSession()
 					return false
 				}
+
+				// Update crash reporting URL
+				val crashReportUrl = userApiClient.clientLogApi.logFileUrl()
+				telemetryPreferences[TelemetryPreferences.crashReportUrl] = crashReportUrl
+				telemetryPreferences[TelemetryPreferences.crashReportToken] = session.accessToken
 			} else {
 				userRepository.updateCurrentUser(null)
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/UserRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/UserRepository.kt
@@ -17,6 +17,6 @@ class UserRepositoryImpl : UserRepository {
 	override val currentUser = MutableStateFlow<UserDto?>(null)
 
 	override fun updateCurrentUser(user: UserDto?) {
-		if (currentUser.value !== user) currentUser.value = user
+		currentUser.value = user
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -15,9 +15,11 @@ import androidx.fragment.app.replace
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.JellyfinApplication
@@ -101,8 +103,9 @@ class StartupActivity : FragmentActivity() {
 	private fun onPermissionsGranted() = sessionRepository.state
 		.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
 		.filter { it == SessionRepositoryState.READY }
-		.onEach {
-			val session = sessionRepository.currentSession.value
+		.map { sessionRepository.currentSession.value }
+		.distinctUntilChanged()
+		.onEach { session ->
 			if (session != null) {
 				Timber.i("Found a session in the session repository, waiting for the currentUser in the application class.")
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginViewModel.kt
@@ -76,8 +76,10 @@ class UserLoginViewModel(
 		val server = server.value ?: return
 		_quickConnectState.emit(UnknownQuickConnectState)
 		quickConnectSecret = null
-		quickConnectApi.baseUrl = server.address
-		quickConnectApi.deviceInfo = defaultDeviceInfo.forUser(UUID.randomUUID())
+		quickConnectApi.update(
+			baseUrl = server.address,
+			deviceInfo = defaultDeviceInfo.forUser(UUID.randomUUID()),
+		)
 
 		try {
 			val response by quickConnectApi.quickConnectApi.initiateQuickConnect()


### PR DESCRIPTION
Few login related issues found while trying to fix one of them. In short, when you remove a session from the Jellyfin dashboard the app can no longer sign into that account due to race conditions, magic and more.

**Changes**
- Fix UserLoginFragment not using lifecycle correctly
- Fix AuthenticationRepository leaking access token to logs
- Fix SessionRepository applying crash reporting information before validating token
- Fix StartupActivity preventing invalid login from opening login fragment
- Remove redundant if statement in UserRepository
- Use ApiClient.update in UserLoginViewModel (not backportable)
- 
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
