### PR TITLE
Start series from first unwatched in "play next up"

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1443,6 +1443,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     }
 
     void play(final List<BaseItemDto> items, final int pos, final boolean shuffle) {
+        if (items.isEmpty()) return;
         if (shuffle) Collections.shuffle(items);
         videoQueueManager.getValue().setCurrentVideoQueue(items);
         Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(items.get(0).getType(), pos);


### PR DESCRIPTION
**Changes**
- Fix FullDetailsFragment crashing when play is called with empty list
- Query for first unwatched episode instead of using the next up API when using the "play next up" button. This is a slight behavior difference compare to before but it is the behavior I would expect when using that button.
  - The item query is based on the query that is internally executed in the server (TVSeriesManager)

**Issues**

Fixes #3626