### PR TITLE
Reordering the trailer button

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1271,8 +1271,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         List<TextUnderButton> actionsList = new ArrayList<>();
         // added in order of priority (should match res/menu/menu_details_more.xml)
         if (queueButton != null) actionsList.add(queueButton);
-        if (shuffleButton != null) actionsList.add(shuffleButton);
         if (trailerButton != null) actionsList.add(trailerButton);
+        if (shuffleButton != null) actionsList.add(shuffleButton);
         if (favButton != null) actionsList.add(favButton);
         if (goToSeriesButton != null) actionsList.add(goToSeriesButton);
 


### PR DESCRIPTION
Moved the Play Trailer(s) button so it should no longer get hidden in the other options menu when going into a show.

Fixes #3450 
