### PR TITLE
Fix QuickConnect sticky login state

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/UserLoginViewModel.kt
@@ -64,6 +64,7 @@ class UserLoginViewModel(
 
 	fun clearLoginState() {
 		_loginState.value = null
+		_quickConnectState.value = UnknownQuickConnectState
 	}
 
 	/**


### PR DESCRIPTION
Right now we never get rid of the Quick Connect state. That means it only works as intended on the first selected server.

When we choose another server afterwards we display the same connect code. Even if the second server doesn't even support Quick Connect.

Use the clearLoginState method to clear the Quick Connect state as well.