### PR TITLE
Change 'Queue all subsequent episodes' setting to queue all episodes in a series

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -42,7 +42,6 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 
 			checkbox {
 				setTitle(R.string.lbl_tv_queuing)
-				setContent(R.string.sum_tv_queuing)
 				bind(userPreferences, UserPreferences.mediaQueuingEnabled)
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -78,7 +78,6 @@ class SdkPlaybackHelper(
 			if (userPreferences[UserPreferences.mediaQueuingEnabled] && seriesId != null) {
 				val response by api.tvShowsApi.getEpisodes(
 					seriesId = seriesId,
-					seasonId = mainItem.seasonId,
 					startItemId = mainItem.id,
 					isMissing = false,
 					limit = ITEM_QUERY_LIMIT,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,8 +92,7 @@
     <string name="msg_cannot_play">This item cannot be played</string>
     <string name="lbl_no_items">No items</string>
     <string name="lbl_empty">Empty</string>
-    <string name="lbl_tv_queuing">Queue all subsequent episodes</string>
-    <string name="sum_tv_queuing">Add the rest of the season to the queue when playing an episode</string>
+    <string name="lbl_tv_queuing">Play next episode automatically</string>
     <string name="lbl_search_hint">Search text (select for keyboard)</string>
     <string name="lbl_play_first_unwatched">Play first unwatched</string>
     <string name="lbl_mark_unplayed">Mark unplayed</string>


### PR DESCRIPTION
**Changes**
This setting I think was intended to match the `Play next episode automatically` setting like in the web interface. I updated the language to match that setting, and it not will queue the entire series, vs just the current season. Behavior is maintained when the setting is disabled.

**Issues**
Addresses #3389
