### PR TITLE
Implement normalization gain for music tracks

### DIFF
--- a/playback/core/src/main/kotlin/mediastream/normalizationGainElement.kt
+++ b/playback/core/src/main/kotlin/mediastream/normalizationGainElement.kt
@@ -1,0 +1,13 @@
+package org.jellyfin.playback.core.mediastream
+
+import org.jellyfin.playback.core.element.ElementKey
+import org.jellyfin.playback.core.element.element
+import org.jellyfin.playback.core.queue.QueueEntry
+
+private val normalizationGainKey = ElementKey<Float>("NormalizationGain")
+
+/**
+ * Get or set the normalization gain for this [QueueEntry]. A supported backend will use this to
+ * apply a gain to the audio output. The normalization gain must target a loudness of -23LUFS.
+ */
+var QueueEntry.normalizationGain by element(normalizationGainKey)

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerAudioPipeline.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerAudioPipeline.kt
@@ -1,0 +1,37 @@
+package org.jellyfin.playback.exoplayer
+
+import android.media.audiofx.LoudnessEnhancer
+import timber.log.Timber
+
+class ExoPlayerAudioPipeline {
+	private var loudnessEnhancer: LoudnessEnhancer? = null
+	var normalizationGain: Float? = null
+		set(value) {
+			Timber.d("Normalization gain changed to $value")
+			field = value
+			applyGain()
+		}
+
+	fun setAudioSessionId(audioSessionId: Int) {
+		Timber.d("Audio session id changed to $audioSessionId")
+
+		// Re-creare loudness enhancer for normalization gain
+		loudnessEnhancer?.release()
+		loudnessEnhancer = LoudnessEnhancer(audioSessionId)
+
+		// Re-apply current normalization gain
+		applyGain()
+	}
+
+	private fun applyGain() {
+		val targetGain = normalizationGain
+			// Convert to millibels
+			?.times(100f)
+			// Round to integer
+			?.toInt()
+
+		Timber.d("Applying gain (targetGain=$targetGain)")
+		loudnessEnhancer?.setEnabled(targetGain != null)
+		loudnessEnhancer?.setTargetGain(targetGain ?: 0)
+	}
+}

--- a/playback/jellyfin/src/main/kotlin/queue/createBaseItemQueueEntry.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/createBaseItemQueueEntry.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.playback.jellyfin.queue
 
+import org.jellyfin.playback.core.mediastream.normalizationGain
 import org.jellyfin.playback.core.queue.QueueEntry
 import org.jellyfin.playback.core.queue.QueueEntryMetadata
 import org.jellyfin.playback.core.queue.metadata
@@ -44,6 +45,7 @@ fun createBaseItemQueueEntry(api: ApiClient, baseItem: BaseItemDto): QueueEntry 
 		genre = baseItem.genres?.joinToString(", "),
 	)
 	entry.baseItem = baseItem
+	entry.normalizationGain = baseItem.normalizationGain
 	return entry
 }
 


### PR DESCRIPTION
First 10.9 feature!

**Changes**
- Add new "normalizationGain" element
- Populate normalization gain for BaseItemDto
  - Currently sets it for the playable item, so for music this means each track. Support for album gain will be possible once we switch queue building to the SDK (currently converts the generated queue from legacy playback)
- Add "audio pipeline" to ExoPlayer implementation. This will be used for all audio effects going forward. Currently implements the normalization gain element.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Part of #1057 
