### PR TITLE
Fix play after pause in MediaManager implementation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -168,9 +168,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             switch (keyCode) {
                 case KeyEvent.KEYCODE_MEDIA_PAUSE:
                 case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                    if (mediaManager.getValue().isPlayingAudio())
-                        mediaManager.getValue().pauseAudio();
-                    else mediaManager.getValue().resumeAudio();
+                    mediaManager.getValue().togglePlayPause();
                     return true;
                 case KeyEvent.KEYCODE_MEDIA_NEXT:
                 case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
@@ -142,9 +142,7 @@ public class MusicFavoritesListFragment extends Fragment implements View.OnKeyLi
             switch (keyCode) {
                 case KeyEvent.KEYCODE_MEDIA_PAUSE:
                 case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                    if (mediaManager.getValue().isPlayingAudio())
-                        mediaManager.getValue().pauseAudio();
-                    else mediaManager.getValue().resumeAudio();
+                    mediaManager.getValue().togglePlayPause();
                     return true;
                 case KeyEvent.KEYCODE_MEDIA_NEXT:
                 case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -113,8 +113,7 @@ public class AudioNowPlayingFragment extends Fragment {
         mPlayPauseButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (mediaManager.getValue().isPlayingAudio()) mediaManager.getValue().pauseAudio();
-                else mediaManager.getValue().resumeAudio();
+                mediaManager.getValue().togglePlayPause();
             }
         });
         mPlayPauseButton.setOnFocusChangeListener(mainAreaFocusListener);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/MediaManager.kt
@@ -33,6 +33,5 @@ interface MediaManager {
 	fun nextAudioItem(): Int
 	fun prevAudioItem(): Int
 	fun stopAudio(releasePlayer: Boolean)
-	fun pauseAudio()
-	fun resumeAudio()
+	fun togglePlayPause()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -268,12 +268,10 @@ class RewriteMediaManager(
 		playbackManager.state.stop()
 	}
 
-	override fun pauseAudio() {
-		playbackManager.state.pause()
-	}
-
-	override fun resumeAudio() {
-		playbackManager.state.unpause()
+	override fun togglePlayPause() {
+		val playState = playbackManager.state.playState.value
+		if (playState == PlayState.PAUSED) playbackManager.state.unpause()
+		else if (playState == PlayState.PLAYING) playbackManager.state.pause()
 	}
 
 	/**


### PR DESCRIPTION
Broke it back in January with #3322 and finally fixed it. The `isPlayingAudio` function is pretty much always `true` when music playback has started. Even when in a paused state.

**Changes**
- Fix play after pause in MediaManager implementation

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
