### PR TITLE
Use SDK for FilterOptions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/model/FilterOptions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/model/FilterOptions.kt
@@ -1,18 +1,15 @@
 package org.jellyfin.androidtv.data.model
 
-import org.jellyfin.apiclient.model.querying.ItemFilter
+import org.jellyfin.sdk.model.api.ItemFilter
+
 
 class FilterOptions {
 	var isFavoriteOnly = false
 	var isUnwatchedOnly = false
 
-	val filters: Array<ItemFilter>
-		get() {
-			if (!isUnwatchedOnly && !isFavoriteOnly) return emptyArray()
-
-			return buildList {
-				if (isFavoriteOnly) add(ItemFilter.IsFavorite)
-				if (isUnwatchedOnly) add(ItemFilter.IsUnplayed)
-			}.toTypedArray()
+	val filters: Set<ItemFilter>
+		get() = buildSet {
+			if (isFavoriteOnly) add(ItemFilter.IS_FAVORITE)
+			if (isUnwatchedOnly) add(ItemFilter.IS_UNPLAYED)
 		}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -33,7 +33,6 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.ui.presentation.TextItemPresenter;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.EmptyLifecycleAwareResponse;
-import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemPerson;
 import org.jellyfin.sdk.model.api.ItemSortBy;
@@ -401,13 +400,13 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
         mFilters = filters;
         switch (queryType) {
             case Artists:
-                mArtistsQuery = ItemRowAdapterHelperKt.setArtistsFilter(mArtistsQuery, ModelCompat.asSdk(filters.getFilters()));
+                mArtistsQuery = ItemRowAdapterHelperKt.setArtistsFilter(mArtistsQuery, filters.getFilters());
                 break;
             case AlbumArtists:
-                mAlbumArtistsQuery = ItemRowAdapterHelperKt.setAlbumArtistsFilter(mAlbumArtistsQuery, ModelCompat.asSdk(filters.getFilters()));
+                mAlbumArtistsQuery = ItemRowAdapterHelperKt.setAlbumArtistsFilter(mAlbumArtistsQuery, filters.getFilters());
                 break;
             default:
-                mQuery = ItemRowAdapterHelperKt.setItemsFilter(mQuery, ModelCompat.asSdk(filters.getFilters()));
+                mQuery = ItemRowAdapterHelperKt.setItemsFilter(mQuery, filters.getFilters());
         }
         removeRow();
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/JavaCompat.kt
@@ -54,7 +54,6 @@ fun BaseItemDto.copyWithUserData(
 fun BaseItemDto.getResumePositionTicks() = userData?.playbackPositionTicks ?: 0
 
 fun Collection<LegacyBaseItemdto>.mapBaseItemCollection(): List<BaseItemDto> = map { it.asSdk() }
-fun Array<LegacyBaseItemdto>.mapBaseItemArray(): List<BaseItemDto> = map { it.asSdk() }
 
 fun MediaSourceInfo.getVideoStream() = mediaStreams?.firstOrNull {
 	it.type == org.jellyfin.sdk.model.api.MediaStreamType.VIDEO

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/compat/ModelCompat.kt
@@ -36,7 +36,6 @@ import org.jellyfin.apiclient.model.entities.MediaStream as LegacyMediaStream
 import org.jellyfin.apiclient.model.entities.MediaStreamType as LegacyMediaStreamType
 import org.jellyfin.apiclient.model.entities.MediaUrl as LegacyMediaUrl
 import org.jellyfin.apiclient.model.entities.MetadataFields as LegacyMetadataFields
-import org.jellyfin.apiclient.model.entities.SortOrder as LegacySortOrder
 import org.jellyfin.apiclient.model.entities.Video3DFormat as LegacyVideo3DFormat
 import org.jellyfin.apiclient.model.entities.VideoType as LegacyVideoType
 import org.jellyfin.apiclient.model.library.PlayAccess as LegacyPlayAccess
@@ -49,7 +48,6 @@ import org.jellyfin.apiclient.model.livetv.SeriesTimerInfoDto as LegacySeriesTim
 import org.jellyfin.apiclient.model.mediainfo.MediaProtocol as LegacyMediaProtocol
 import org.jellyfin.apiclient.model.mediainfo.TransportStreamTimestamp as LegacyTransportStreamTimestamp
 import org.jellyfin.apiclient.model.providers.ExternalUrl as LegacyExternalUrl
-import org.jellyfin.apiclient.model.querying.ItemFilter as LegacyItemFilter
 import org.jellyfin.sdk.model.api.BaseItemDto as ModernBaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemPerson as ModernBaseItemPerson
 import org.jellyfin.sdk.model.api.ChannelType as ModernChannelType
@@ -60,7 +58,6 @@ import org.jellyfin.sdk.model.api.ExternalUrl as ModernExternalUrl
 import org.jellyfin.sdk.model.api.ImageOrientation as ModernImageOrientation
 import org.jellyfin.sdk.model.api.ImageType as ModernImageType
 import org.jellyfin.sdk.model.api.IsoType as ModernIsoType
-import org.jellyfin.sdk.model.api.ItemFilter as ModernItemFilter
 import org.jellyfin.sdk.model.api.KeepUntil as ModernKeepUntil
 import org.jellyfin.sdk.model.api.LocationType as ModernLocationType
 import org.jellyfin.sdk.model.api.MediaProtocol as ModernMediaProtocol
@@ -75,7 +72,6 @@ import org.jellyfin.sdk.model.api.NameIdPair as ModernNameIdPair
 import org.jellyfin.sdk.model.api.PlayAccess as ModernPlayAccess
 import org.jellyfin.sdk.model.api.ProgramAudio as ModernProgramAudio
 import org.jellyfin.sdk.model.api.SeriesTimerInfoDto as ModernSeriesTimerInfoDto
-import org.jellyfin.sdk.model.api.SortOrder as ModernSortOrder
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod as ModernSubtitleDeliveryMethod
 import org.jellyfin.sdk.model.api.TransportStreamTimestamp as ModernTransportStreamTimestamp
 import org.jellyfin.sdk.model.api.UserItemDataDto as ModernUserItemDataDto
@@ -652,22 +648,3 @@ fun LegacyChannelInfoDto.asSdk() = ModernBaseItemDto(
 	currentProgram = this.currentProgram?.asSdk(),
 	primaryImageAspectRatio = this.primaryImageAspectRatio,
 )
-
-fun LegacyItemFilter.asSdk() = when (this) {
-	LegacyItemFilter.IsFolder -> ModernItemFilter.IS_FOLDER
-	LegacyItemFilter.IsNotFolder -> ModernItemFilter.IS_NOT_FOLDER
-	LegacyItemFilter.IsUnplayed -> ModernItemFilter.IS_UNPLAYED
-	LegacyItemFilter.IsPlayed -> ModernItemFilter.IS_PLAYED
-	LegacyItemFilter.IsFavorite -> ModernItemFilter.IS_FAVORITE
-	LegacyItemFilter.IsResumable -> ModernItemFilter.IS_RESUMABLE
-	LegacyItemFilter.Likes -> ModernItemFilter.LIKES
-	LegacyItemFilter.Dislikes -> ModernItemFilter.DISLIKES
-	LegacyItemFilter.IsFavoriteOrLikes -> ModernItemFilter.IS_FAVORITE_OR_LIKES
-}
-
-fun Array<LegacyItemFilter>.asSdk() = map { it.asSdk() }
-
-fun ModernSortOrder.asLegacy(): LegacySortOrder = when (this) {
-	ModernSortOrder.ASCENDING -> LegacySortOrder.Ascending
-	ModernSortOrder.DESCENDING -> LegacySortOrder.Descending
-}


### PR DESCRIPTION
**Changes**
- Use SDK version of ItemFilter in FilterOptions now that all usages are migrated
- Remove some unused code from JavaCompat/ModelCompat

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
