### PR TITLE
Add Flow for passwordless authentication

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -72,10 +72,10 @@ class AuthenticationRepositoryImpl(
 		if (authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]) return flowOf(RequireSignInState)
 
 		val authStoreUser = authenticationStore.getUser(server.id, user.id)
-		// Try login without password
-		return if (!user.requirePassword) authenticateCredential(server, user.name, "")
 		// Try login with access token
-		else if (authStoreUser?.accessToken != null) authenticateToken(server, user.withToken(authStoreUser.accessToken))
+		return if (authStoreUser?.accessToken != null) authenticateToken(server, user.withToken(authStoreUser.accessToken))
+		// Try login without password
+		else if (!user.requirePassword) authenticateCredential(server, user.name, "")
 		// Require login
 		else flowOf(RequireSignInState)
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -72,10 +72,10 @@ class AuthenticationRepositoryImpl(
 		if (authenticationPreferences[AuthenticationPreferences.alwaysAuthenticate]) return flowOf(RequireSignInState)
 
 		val authStoreUser = authenticationStore.getUser(server.id, user.id)
-		// Try login with access token
-		return if (authStoreUser?.accessToken != null) authenticateToken(server, user.withToken(authStoreUser.accessToken))
 		// Try login without password
-		else if (!user.requirePassword) authenticateCredential(server, user.name, "")
+		return if (!user.requirePassword) authenticateCredential(server, user.name, "")
+		// Try login with access token
+		else if (authStoreUser?.accessToken != null) authenticateToken(server, user.withToken(authStoreUser.accessToken))
 		// Require login
 		else flowOf(RequireSignInState)
 	}


### PR DESCRIPTION
The access token method is inferior to password login for a non-password account because the default fallback for an invalid/expired token is the require sign in screen.

Should fix #3567.