### PR TITLE
Remove hasPassword support

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreUser.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/AuthenticationStoreUser.kt
@@ -11,7 +11,6 @@ import java.time.Instant
 data class AuthenticationStoreUser(
 	val name: String,
 	@SerialName("last_used") val lastUsed: Long = Instant.now().toEpochMilli(),
-	@SerialName("require_password") val requirePassword: Boolean = true,
 	@SerialName("image_tag") val imageTag: String? = null,
 	@SerialName("access_token") val accessToken: String? = null,
 )

--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/User.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/User.kt
@@ -10,7 +10,6 @@ sealed class User {
 	abstract val serverId: UUID
 	abstract val name: String
 	abstract val accessToken: String?
-	abstract val requirePassword: Boolean
 	abstract val imageTag: String?
 
 	abstract fun withToken(accessToken: String): User
@@ -34,7 +33,6 @@ data class PrivateUser(
 	override val serverId: UUID,
 	override val name: String,
 	override val accessToken: String?,
-	override val requirePassword: Boolean,
 	override val imageTag: String?,
 	val lastUsed: Long,
 ) : User() {
@@ -49,7 +47,6 @@ data class PublicUser(
 	override val serverId: UUID,
 	override val name: String,
 	override val accessToken: String?,
-	override val requirePassword: Boolean,
 	override val imageTag: String?,
 ) : User() {
 	override fun withToken(accessToken: String) = copy(accessToken = accessToken)

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -74,8 +74,6 @@ class AuthenticationRepositoryImpl(
 		val authStoreUser = authenticationStore.getUser(server.id, user.id)
 		// Try login with access token
 		return if (authStoreUser?.accessToken != null) authenticateToken(server, user.withToken(authStoreUser.accessToken))
-		// Try login without password
-		else if (!user.requirePassword) authenticateCredential(server, user.name, "")
 		// Require login
 		else flowOf(RequireSignInState)
 	}
@@ -124,7 +122,6 @@ class AuthenticationRepositoryImpl(
 			serverId = server.id,
 			name = userInfo.name!!,
 			accessToken = result.accessToken,
-			requirePassword = userInfo.hasPassword,
 			imageTag = userInfo.primaryImageTag,
 			lastUsed = Instant.now().toEpochMilli(),
 		)
@@ -166,12 +163,10 @@ class AuthenticationRepositoryImpl(
 		val updatedUser = currentUser?.copy(
 			name = userInfo.name!!,
 			lastUsed = Instant.now().toEpochMilli(),
-			requirePassword = userInfo.hasPassword,
 			imageTag = userInfo.primaryImageTag,
 			accessToken = accessToken,
 		) ?: AuthenticationStoreUser(
 			name = userInfo.name!!,
-			requirePassword = userInfo.hasPassword,
 			imageTag = userInfo.primaryImageTag,
 			accessToken = accessToken,
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerUserRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerUserRepository.kt
@@ -35,7 +35,6 @@ class ServerUserRepositoryImpl(
 				serverId = server.id,
 				name = userInfo.name,
 				accessToken = authInfo?.accessToken,
-				requirePassword = userInfo.requirePassword,
 				imageTag = userInfo.imageTag,
 				lastUsed = userInfo.lastUsed,
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/ModelExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/ModelExtensions.kt
@@ -25,7 +25,6 @@ fun UserDto.toPublicUser(): PublicUser? {
 		name = name ?: return null,
 		serverId = serverId?.toUUIDOrNull() ?: return null,
 		accessToken = null,
-		requirePassword = hasPassword,
 		imageTag = primaryImageTag
 	)
 }


### PR DESCRIPTION
Remove support for the "hasPassword" flag in the authentication code. We're planning to remove this from the server in 10.10 as it's unsafe to publicly declare a user as having a password or not.

This will cause the login screen to pop-up for users without a password set, as the app no longer knows if it can skip this step.

**Changes**
- Remove hasPassword support

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
