### PR TITLE
Fix refreshing current playing item hiding play icon

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentNowPlayingRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentNowPlayingRow.kt
@@ -14,32 +14,26 @@ class HomeFragmentNowPlayingRow(
 ) : HomeFragmentRow {
 	private var row: ListRow? = null
 
-	override fun addToRowsAdapter(context: Context, cardPresenter: CardPresenter, rowsAdapter: MutableObjectAdapter<Row>) {
+	override fun addToRowsAdapter(
+		context: Context,
+		cardPresenter: CardPresenter,
+		rowsAdapter: MutableObjectAdapter<Row>
+	) {
 		update(context, rowsAdapter)
-	}
-
-	private fun add(context: Context, rowsAdapter: MutableObjectAdapter<Row>) {
-		if (row != null) return
-
-		row = ListRow(HeaderItem(context.getString(R.string.lbl_now_playing)), mediaManager.managedAudioQueue)
-		rowsAdapter.add(0, row!!)
-	}
-
-	private fun remove(rowsAdapter: MutableObjectAdapter<Row>) {
-		if (row == null) return
-
-		rowsAdapter.remove(row!!)
-		row = null
 	}
 
 	fun update(context: Context, rowsAdapter: MutableObjectAdapter<Row>) {
 		if (mediaManager.hasAudioQueueItems()) {
-			if (row != null) {
-				row = ListRow(HeaderItem(context.getString(R.string.lbl_now_playing)), mediaManager.managedAudioQueue)
-				rowsAdapter.set(0, row!!)
-			}
-			else add(context, rowsAdapter)
+			// Ensure row exists
+			if (row == null) row = ListRow(
+				HeaderItem(context.getString(R.string.lbl_now_playing)),
+				mediaManager.managedAudioQueue
+			)
+			// Add row if it wasn't added already
+			if (!rowsAdapter.contains(row!!)) rowsAdapter.add(0, row!!)
+		} else if (row != null) {
+			rowsAdapter.remove(row!!)
+			row = null
 		}
-		else remove(rowsAdapter)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -665,7 +665,7 @@ fun ItemRowAdapter.refreshItem(
 	currentBaseRowItem: BaseRowItem,
 	callback: () -> Unit = {}
 ) {
-	if (currentBaseRowItem !is BaseItemDtoBaseRowItem) return
+	if (currentBaseRowItem !is BaseItemDtoBaseRowItem || currentBaseRowItem is AudioQueueBaseRowItem) return
 	val currentBaseItem = currentBaseRowItem.baseItem ?: return
 
 	lifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
Whenever a fragment is resumed, it will try to refresh information for the currently selected item. It then replaces it with a new BaseItemDtoBaseRowItem.

The AudioQueueBaseRowItem class inherits from BaseItemDtoBaseRowItem, causing it to be replaced. This will then make the UI fail to show the "playing" icon.

**Changes**
- Fix refreshing current playing item hiding play icon
- Optimize HomeFragmentNowPlayingRow a bit by making it simpler

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
