### PR TITLE
Catch errors in ExoPlayerAudioPipeline

### DIFF
--- a/playback/exoplayer/src/main/kotlin/ExoPlayerAudioPipeline.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerAudioPipeline.kt
@@ -17,13 +17,20 @@ class ExoPlayerAudioPipeline {
 
 		// Re-creare loudness enhancer for normalization gain
 		loudnessEnhancer?.release()
-		loudnessEnhancer = LoudnessEnhancer(audioSessionId)
+		loudnessEnhancer = runCatching { LoudnessEnhancer(audioSessionId) }
+			.onFailure { Timber.w(it, "Failed to create LoudnessEnhancer") }
+			.getOrNull()
 
 		// Re-apply current normalization gain
 		applyGain()
 	}
 
 	private fun applyGain() {
+		if (loudnessEnhancer == null) {
+			Timber.d("LoudnessEnhancer is not initialized")
+			return
+		}
+
 		val targetGain = normalizationGain
 			// Convert to millibels
 			?.times(100f)


### PR DESCRIPTION
In some cases initializing an audio effect in Android can fail. I was not able to find good documentation on this so this fix will fallback to NO-OP for now when initialization fails.

**Changes**
- Catch errors in ExoPlayerAudioPipeline
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Crash on some Android devices reported via Matrix.