### PR TITLE
Fix isPlayingAudio behavior

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -215,7 +215,7 @@ class RewriteMediaManager(
 	}
 
 	override val isPlayingAudio: Boolean
-		get() = playbackManager.state.playState.value != PlayState.STOPPED
+		get() = playbackManager.state.playState.value == PlayState.PLAYING
 
 	override fun playNow(context: Context, items: List<BaseItemDto>, position: Int, shuffle: Boolean) {
 		val filteredItems = items.drop(position)


### PR DESCRIPTION
Previously, in the old MediaManager, the isPlayinAudio property would be true only when audio is actually currently playing. It would be false if paused/stopped. I accidentally introduced a behavior change in the rewrite where it would only return false when stopped. This caused some small appearance issues in the NowPlayingFragment where it would show the "pause" button when already paused.

**Changes**
- Fix isPlayingAudio behavior

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
