### PR TITLE
Fix crash when refreshing current item

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -674,8 +674,12 @@ fun ItemRowAdapter.refreshItem(
 		}.fold(
 			onSuccess = { refreshedBaseItem ->
 				withContext(Dispatchers.Main) {
+					val index = indexOf(currentBaseRowItem)
+					// Item could be removed while API was loading, check if the index is valid first
+					if (index == -1) return@withContext
+
 					set(
-						index = indexOf(currentBaseRowItem),
+						index = index,
 						element = BaseItemDtoBaseRowItem(
 							item = refreshedBaseItem,
 							preferParentThumb = currentBaseRowItem.preferParentThumb,


### PR DESCRIPTION
race conditions etc

**Changes**
- Fix crash when refreshing current item
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

```log
java.lang.ArrayIndexOutOfBoundsException: length=10; index=-1
	at java.util.ArrayList.set(ArrayList.java:455)
	at org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter.set(MutableObjectAdapter.kt:40)
	at org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapterHelperKt$refreshItem$2$2$1.invokeSuspend(ItemRowAdapterHelper.kt:677)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:223)
	at android.app.ActivityThread.main(ActivityThread.java:7668)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@3f39b90, Dispatchers.IO]

```  