### PR TITLE
Shrink BaseItemInfoRowRuntime size

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -17,9 +18,9 @@ import androidx.tv.material3.Text
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
-import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.ui.composable.getResolutionName
+import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.androidtv.util.sdk.getProgramSubText
 import org.jellyfin.androidtv.util.sdk.getSeasonEpisodeName
 import org.jellyfin.androidtv.util.sdk.isNew
@@ -34,9 +35,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoUnit
-import kotlin.math.max
 import kotlin.time.Duration
-import kotlin.time.toJavaDuration
 
 @Composable
 fun InfoRowDate(
@@ -115,22 +114,12 @@ fun InfoRowSeriesStatus(
 @Composable
 fun BaseItemInfoRowRuntime(
 	runTime: Duration,
-	endTime: LocalDateTime?,
 ) {
-	InfoRowItem(contentDescription = null) {
-		Text(buildString {
-			// Run time
-			val runTimeMinutes = max(1, runTime.inWholeMinutes.toInt())
-			append(pluralStringResource(R.plurals.minutes, runTimeMinutes, runTimeMinutes))
-
-			// End time
-			if (endTime != null) {
-				// Format: (Ends 14:50)
-				append(" (", stringResource(R.string.lbl_ends), " ")
-				append(endTime.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)))
-				append(")")
-			}
-		})
+	InfoRowItem(
+		icon = painterResource(id = R.drawable.ic_time),
+		contentDescription = null,
+	) {
+		Text(TimeUtils.formatMillis(runTime.inWholeMilliseconds))
 	}
 }
 
@@ -235,20 +224,8 @@ fun BaseItemInfoRow(
 	val userPreferences = koinInject<UserPreferences>()
 	val ratingType = userPreferences[UserPreferences.defaultRatingType]
 
-	val endTime = when (userPreferences[UserPreferences.clockBehavior]) {
-		ClockBehavior.ALWAYS,
-		ClockBehavior.IN_MENUS -> {
-			val runTime = item.runTimeTicks?.ticks
-			val progress = item.userData?.playbackPositionTicks?.ticks ?: Duration.ZERO
-			if (runTime != null) LocalDateTime.now() + (runTime - progress).toJavaDuration()
-			else null
-		}
-
-		else -> null
-	}
-
 	Row(
-		horizontalArrangement = Arrangement.spacedBy(10.dp),
+		horizontalArrangement = Arrangement.spacedBy(8.dp),
 		verticalAlignment = Alignment.CenterVertically,
 	) {
 		if (ratingType != RatingType.RATING_HIDDEN) {
@@ -260,7 +237,7 @@ fun BaseItemInfoRow(
 			BaseItemKind.EPISODE -> {
 				InfoRowSeasonEpisode(item)
 				InfoRowDate(item)
-				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it, endTime) }
+				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it) }
 				item.officialRating?.let { InfoRowParentalRating(it) }
 				InfoRowMediaDetails(item)
 			}
@@ -278,14 +255,14 @@ fun BaseItemInfoRow(
 					}
 				}
 				val runtime = item.cumulativeRunTimeTicks ?: item.runTimeTicks
-				if (includeRuntime) runtime?.ticks?.let { BaseItemInfoRowRuntime(it, endTime) }
+				if (includeRuntime) runtime?.ticks?.let { BaseItemInfoRowRuntime(it) }
 				item.officialRating?.let { InfoRowParentalRating(it) }
 				InfoRowMediaDetails(item)
 			}
 
 			BaseItemKind.SERIES -> {
 				InfoRowDate(item)
-				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it, null) }
+				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it) }
 				InfoRowSeriesStatus(item)
 				item.officialRating?.let { InfoRowParentalRating(it) }
 				InfoRowMediaDetails(item)
@@ -324,7 +301,7 @@ fun BaseItemInfoRow(
 					}
 				}
 
-				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it, endTime) }
+				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it) }
 				item.officialRating?.let { InfoRowParentalRating(it) }
 				InfoRowMediaDetails(item)
 			}
@@ -364,14 +341,14 @@ fun BaseItemInfoRow(
 				}
 
 				val runtime = item.cumulativeRunTimeTicks ?: item.runTimeTicks
-				if (includeRuntime) runtime?.ticks?.let { BaseItemInfoRowRuntime(it, endTime) }
+				if (includeRuntime) runtime?.ticks?.let { BaseItemInfoRowRuntime(it) }
 				item.officialRating?.let { InfoRowParentalRating(it) }
 				InfoRowMediaDetails(item)
 			}
 
 			else -> {
 				InfoRowDate(item)
-				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it, endTime) }
+				if (includeRuntime) item.runTimeTicks?.ticks?.let { BaseItemInfoRowRuntime(it) }
 				item.officialRating?.let { InfoRowParentalRating(it) }
 				InfoRowMediaDetails(item)
 			}


### PR DESCRIPTION
We've added quite some stuff to the BaseItemInfoRow over time. With 0.17 there's now enough to have it overflow in some scenarios. Let's shrink it down!

**Changes**
- Remove "ends at" in BaseItemInfoRow
  - Note that it still shows this information in the FullScreenDetails & player
- Shorten duration format
- Add clock icon to duration

![9270000381](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/551708c6-177a-4394-be04-97d5e8f70919)


**Issues**

