### PR TITLE
Rewrite details row with constraint layout

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -423,8 +423,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             String primaryImageUrl = imageHelper.getValue().getLogoImageUrl(mBaseItem, 600, true);
             if (primaryImageUrl == null) {
                 primaryImageUrl = imageHelper.getValue().getPrimaryImageUrl(mBaseItem, false, null, posterHeight);
-                if (item.getRunTimeTicks() != null && item.getRunTimeTicks() > 0 && item.getUserData() != null && item.getUserData().getPlaybackPositionTicks() > 0)
-                    mDetailsOverviewRow.setProgress(((int) (item.getUserData().getPlaybackPositionTicks() * 100.0 / item.getRunTimeTicks())));
             }
 
             mDetailsOverviewRow.setSummary(item.getOverview());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -14,7 +14,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
-import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
@@ -115,12 +114,6 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
         mSummary = detailsBinding.fdSummaryText;
         mItemList = binding.songs;
         mScrollView = binding.scrollView;
-
-        //adjust left frame
-        RelativeLayout leftFrame = detailsBinding.leftFrame;
-        ViewGroup.LayoutParams params = leftFrame.getLayoutParams();
-        params.width = Utils.convertDpToPixel(requireContext(), 100);
-
 
         mMetrics = new DisplayMetrics();
         requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MusicFavoritesListFragment.java
@@ -12,7 +12,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
-import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
@@ -75,11 +74,6 @@ public class MusicFavoritesListFragment extends Fragment implements View.OnKeyLi
         mButtonRow = detailsBinding.fdButtonRow;
         mItemList = binding.songs;
         mScrollView = binding.scrollView;
-
-        //adjust left frame
-        RelativeLayout leftFrame = detailsBinding.leftFrame;
-        ViewGroup.LayoutParams params = leftFrame.getLayoutParams();
-        params.width = Utils.convertDpToPixel(requireContext(), 100);
 
         mMetrics = new DisplayMetrics();
         requireActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
@@ -10,7 +10,6 @@ class MyDetailsOverviewRow @JvmOverloads constructor(
 	val item: BaseItemDto,
 	var imageDrawable: String? = null,
 	var summary: String? = null,
-	var progress: Int = 0,
 	var infoItem1: InfoItem? = null,
 	var infoItem2: InfoItem? = null,
 	var infoItem3: InfoItem? = null,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/MyDetailsOverviewRowPresenter.kt
@@ -1,15 +1,12 @@
 package org.jellyfin.androidtv.ui.presentation
 
 import android.view.ViewGroup
-import android.widget.RelativeLayout
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.leanback.widget.RowPresenter
 import org.jellyfin.androidtv.ui.DetailRowView
 import org.jellyfin.androidtv.ui.itemdetail.MyDetailsOverviewRow
 import org.jellyfin.androidtv.util.InfoLayoutHelper
 import org.jellyfin.androidtv.util.MarkdownRenderer
-import org.jellyfin.androidtv.util.dp
 import org.jellyfin.sdk.model.api.BaseItemKind
 
 class MyDetailsOverviewRowPresenter(
@@ -38,24 +35,11 @@ class MyDetailsOverviewRowPresenter(
 
 			binding.mainImage.load(row.imageDrawable, null, null, 1.0, 0)
 
-			if (row.progress > 0 && row.imageDrawable != null) {
-				binding.fdProgress.progress = row.progress
-				binding.fdProgress.isVisible = true
-			}
-
 			setSummary(row.summary)
 
 			if (row.item.type == BaseItemKind.PERSON) {
-				binding.fdSummaryText.updateLayoutParams<RelativeLayout.LayoutParams> {
-					topMargin = 10
-					height = 185.dp(view.context)
-				}
-
 				binding.fdSummaryText.maxLines = 9
 				binding.fdGenreRow.isVisible = false
-				binding.leftFrame.updateLayoutParams<RelativeLayout.LayoutParams> {
-					width = 100.dp(view.context)
-				}
 			}
 
 			binding.fdButtonRow.removeAllViews()
@@ -69,11 +53,6 @@ class MyDetailsOverviewRowPresenter(
 
 		fun setTitle(title: String?) {
 			binding.fdTitle.text = title
-			if (binding.fdTitle.text.length > 28) {
-				binding.fdTitle.updateLayoutParams<RelativeLayout.LayoutParams> {
-					topMargin = 55.dp(view.context)
-				}
-			}
 		}
 
 		fun setSummary(summary: String?) {

--- a/app/src/main/res/drawable/expanded_text.xml
+++ b/app/src/main/res/drawable/expanded_text.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape android:shape="rectangle">
+            <corners android:radius="?attr/cardRounding" />
             <solid android:color="@color/black_transparent" />
         </shape>
     </item>

--- a/app/src/main/res/layout/view_row_details.xml
+++ b/app/src/main/res/layout/view_row_details.xml
@@ -1,182 +1,212 @@
-<?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <RelativeLayout
-        android:id="@+id/leftFrame"
-        android:layout_width="170dp"
-        android:layout_height="420dp"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/infoTitle1"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_top"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginTop="185dp"
-            android:textAlignment="viewEnd"
-            android:textAllCaps="true"
-            android:textSize="14sp" />
+            android:orientation="horizontal"
+            app:layout_constraintGuide_begin="180dp"
+            app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
-            android:id="@+id/infoValue1"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_left_end"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/infoTitle1"
-            android:layout_alignParentEnd="true"
-            android:alpha=".6"
-            android:textAlignment="viewEnd"
-            android:textSize="14sp" />
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="150dp" />
 
-        <TextView
-            android:id="@+id/infoTitle2"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_main_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/infoValue1"
-            android:layout_alignParentEnd="true"
-            android:layout_marginTop="20dp"
-            android:textAlignment="viewEnd"
-            android:textAllCaps="true"
-            android:textSize="14sp" />
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="170dp" />
 
-        <TextView
-            android:id="@+id/infoValue2"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_main_end"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/infoTitle2"
-            android:layout_alignParentEnd="true"
-            android:alpha=".6"
-            android:textAlignment="viewEnd"
-            android:textSize="14sp" />
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="240dp" />
 
-        <TextView
-            android:id="@+id/infoTitle3"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_right_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/infoValue2"
-            android:layout_alignParentEnd="true"
-            android:layout_marginTop="20dp"
-            android:textAlignment="viewEnd"
-            android:textAllCaps="true"
-            android:textSize="14sp" />
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="220dp" />
 
-        <TextView
-            android:id="@+id/infoValue3"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_right_end"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/infoTitle3"
-            android:layout_alignParentEnd="true"
-            android:alpha=".6"
-            android:textAlignment="viewEnd"
-            android:textSize="14sp" />
-    </RelativeLayout>
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="50dp" />
 
-    <RelativeLayout
-        android:id="@+id/middleFrame"
-        android:layout_width="480dp"
-        android:layout_height="420dp"
-        android:layout_alignParentTop="true"
-        android:layout_toEndOf="@+id/leftFrame">
-
+        <!-- Top -->
         <TextView
             android:id="@+id/fdTitle"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_above="@id/fdMainInfoRow"
-            android:layout_alignParentStart="true"
-            android:layout_marginStart="40sp"
             android:ellipsize="end"
             android:fontFamily="sans-serif-light"
-            android:gravity="bottom"
             android:maxLines="2"
-            android:text="Main Title"
-            android:textSize="32sp" />
+            android:textSize="30sp"
+            app:layout_constraintBottom_toTopOf="@id/fdMainInfoRow"
+            app:layout_constraintEnd_toEndOf="@id/guide_right_end"
+            app:layout_constraintStart_toStartOf="@id/guide_main_start"
+            tools:text="fdTitle" />
 
         <LinearLayout
             android:id="@+id/fdMainInfoRow"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="20sp"
-            android:layout_above="@+id/fdGenreRow"
-            android:layout_alignStart="@+id/fdTitle"
             android:dividerPadding="4sp"
-            android:orientation="horizontal" />
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@id/fdGenreRow"
+            app:layout_constraintEnd_toEndOf="@id/guide_right_end"
+            app:layout_constraintStart_toStartOf="@id/guide_main_start" />
 
         <TextView
             android:id="@+id/fdGenreRow"
-            android:layout_width="fill_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_above="@+id/fdSummaryText"
-            android:layout_alignStart="@+id/fdMainInfoRow"
-            android:minHeight="22sp" />
+            app:layout_constraintBottom_toTopOf="@id/guide_top"
+            app:layout_constraintEnd_toEndOf="@id/guide_right_end"
+            app:layout_constraintStart_toStartOf="@id/guide_main_start"
+            tools:text="fdGenreRow" />
+
+        <!-- Left -->
+
+        <TextView
+            android:id="@+id/infoTitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAlignment="viewEnd"
+            android:textAllCaps="true"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="@id/guide_left_end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/guide_top"
+            tools:text="infoTitle1" />
+
+        <TextView
+            android:id="@+id/infoValue1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:alpha=".6"
+            android:textAlignment="viewEnd"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/guide_left_end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/infoTitle1"
+            tools:text="infoValue1" />
+
+        <TextView
+            android:id="@+id/infoTitle2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:textAlignment="viewEnd"
+            android:textAllCaps="true"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/guide_left_end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/infoValue1"
+            tools:text="infoTitle2" />
+
+        <TextView
+            android:id="@+id/infoValue2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:alpha=".6"
+            android:textAlignment="viewEnd"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/guide_left_end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/infoTitle2"
+            tools:text="infoValue2" />
+
+        <TextView
+            android:id="@+id/infoTitle3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:textAlignment="viewEnd"
+            android:textAllCaps="true"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/guide_left_end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/infoValue2"
+            tools:text="infoTitle3" />
+
+        <TextView
+            android:id="@+id/infoValue3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:alpha=".6"
+            android:textAlignment="viewEnd"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/guide_left_end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/infoTitle3"
+            tools:text="infoValue3" />
+
+        <!-- Main -->
 
         <org.jellyfin.androidtv.ui.ExpandableTextView
             android:id="@+id/fdSummaryText"
-            android:layout_width="match_parent"
-            android:layout_height="135dp"
-            android:layout_above="@id/fdButtonRow"
-            android:layout_alignStart="@id/fdTitle"
-            android:layout_marginTop="15dp"
-            android:layout_marginBottom="10dp"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:ellipsize="end"
             android:fontFamily="sans-serif-light"
             android:maxLines="6"
             android:textSize="16sp"
-            android:transitionName="summary" />
+            app:layout_constraintBottom_toBottomOf="@id/infoValue3"
+            app:layout_constraintEnd_toEndOf="@id/guide_main_end"
+            app:layout_constraintStart_toStartOf="@id/guide_main_start"
+            app:layout_constraintTop_toBottomOf="@id/fdGenreRow"
+            tools:text="fdSummaryText" />
 
         <LinearLayout
             android:id="@+id/fdButtonRow"
-            android:layout_width="fill_parent"
+            android:layout_width="0dp"
             android:layout_height="70dp"
-            android:layout_alignStart="@+id/fdTitle"
-            android:layout_alignParentBottom="true"
-            android:layout_marginBottom="20dp"
+            android:layout_marginTop="10dp"
             android:divider="@drawable/blank10x10"
-            android:gravity="start"
             android:orientation="horizontal"
             android:showDividers="none"
+            app:layout_constraintEnd_toEndOf="@id/guide_main_end"
+            app:layout_constraintStart_toStartOf="@id/guide_main_start"
+            app:layout_constraintTop_toBottomOf="@id/fdSummaryText" />
 
-            />
-    </RelativeLayout>
+        <!-- Right -->
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="420dp"
-        android:layout_alignParentTop="true"
-        android:layout_toEndOf="@+id/middleFrame">
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="@id/fdButtonRow"
+            app:layout_constraintEnd_toEndOf="@id/guide_right_end"
+            app:layout_constraintStart_toStartOf="@id/guide_right_start"
+            app:layout_constraintTop_toTopOf="@id/guide_top"
+            app:layout_constraintVertical_bias="0">
 
-        <org.jellyfin.androidtv.ui.AsyncImageView
-            android:id="@+id/mainImage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:layout_marginStart="50dp"
-            android:layout_marginTop="140dp"
-            android:layout_marginEnd="50dp"
-            android:layout_marginBottom="30dp"
-            android:background="@drawable/shape_card"
-            android:contentDescription="@null"
-            android:foregroundGravity="fill_horizontal"
-            android:scaleType="centerInside"
-            app:srcCompat="@drawable/blank30x30"
-            tools:srcCompat="@drawable/app_icon" />
-
-        <ProgressBar
-            android:id="@+id/fdProgress"
-            style="@style/overlay_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignStart="@+id/mainImage"
-            android:layout_alignEnd="@+id/mainImage"
-            android:layout_alignBottom="@+id/mainImage"
-            android:layout_margin="5dp"
-            android:max="100"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
-    </RelativeLayout>
+            <org.jellyfin.androidtv.ui.AsyncImageView
+                android:id="@+id/mainImage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:background="@drawable/shape_card"
+                android:scaleType="centerInside"
+                tools:srcCompat="@drawable/app_banner" />
+        </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </RelativeLayout>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Add rounding to ExpandableTextView focus background
- Rewrite DetailsRowView with a constraint layout
	- Mostly looks the same, with some small differences
	- Content area is now wider (e.g. item description)
	- Title/infoview/genres are now wider
	- Remove progress overlay in DetailsRowView (resume button already indicates progress and it was hidden items with logos already)

**Screenshots**
![9750000385](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/32edb54d-bacd-4e63-9e21-b9e8ac25ad97)
![9220000386](https://github.com/jellyfin/jellyfin-androidtv/assets/2305178/f233d36b-37be-470e-a3cc-6d96ee06daae)



**Issues**

Fixes #3721