### PR TITLE
Fix crash when item has no media sources

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -520,8 +520,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             internalOptions.setEnableDirectStream(false);
         internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
         internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
-        if (!isLiveTv) {
-            internalOptions.setMediaSourceId(getCurrentMediaSource().getId());
+        MediaSourceInfo currentMediaSource = getCurrentMediaSource();
+        if (!isLiveTv && currentMediaSource != null) {
+            internalOptions.setMediaSourceId(currentMediaSource.getId());
         }
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),


### PR DESCRIPTION
When the playback actually starts we query the server for the playback stuff so we don't use current media source for that.

**Changes**
- Fix crash when item has no media sources

**Issues**

Fix #3730 (crash)