### PR TITLE
Fix authorization for transcoding

### DIFF
--- a/playback/jellyfin/src/main/kotlin/mediastream/AudioMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/AudioMediaStreamResolver.kt
@@ -102,7 +102,7 @@ class AudioMediaStreamResolver(
 					playSessionId = mediaInfo.playSessionId,
 					tag = mediaInfo.mediaSource.eTag,
 					segmentContainer = REMUX_SEGMENT_CONTAINER,
-				)
+				).appendAccessToken()
 			)
 		}
 

--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinStreamResolver.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.playback.jellyfin.mediastream
 
+import io.ktor.http.URLBuilder
 import org.jellyfin.playback.core.mediastream.MediaStreamResolver
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
@@ -55,5 +56,11 @@ abstract class JellyfinStreamResolver(
 			playSessionId = response.playSessionId.orEmpty(),
 			mediaSource = mediaSource
 		)
+	}
+
+	protected fun String.appendAccessToken() = let {
+		URLBuilder(it)
+			.apply { parameters.append("ApiKey", api.accessToken.orEmpty()) }
+			.buildString()
 	}
 }

--- a/playback/jellyfin/src/main/kotlin/mediastream/VideoMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/VideoMediaStreamResolver.kt
@@ -104,7 +104,7 @@ class VideoMediaStreamResolver(
 					segmentContainer = REMUX_SEGMENT_CONTAINER,
 					videoCodec = "h264",
 					audioCodec = "aac",
-				)
+				).appendAccessToken()
 			)
 		}
 


### PR DESCRIPTION
SDK 1.5 no longer adds ApiKey to query parameter. I don't want the app to that anywhere, but ExoPlayer doesn't support per-item request headers so implementing auth via headers is a bit of a challenge that I'm still working on. Dirty fix for now.

**Changes**
- Fix authorization for transcoding
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #3734 (although a proper fix would be to implement direct play for wav..)