### PR TITLE
Fix race condition in player backdrop

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -487,6 +487,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     }
 
     public void setBaseItem(BaseItemDto item) {
+        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+
         mBaseItem = item;
         backgroundService.getValue().setBackground(item);
         if (mBaseItem != null) {


### PR DESCRIPTION
When the "next up" screen hides, the previous screen will activate for a brief moment (limitation of how our current navigation code works). If you opened the video player via the FullDetailsFragment this will cause the item to reload, and once that loading finishes it will set a backdrop. However, during this asynchronous operation the app will already have started the video player again. This ends up showing the backdrop in the video player... oops

**Changes**
- Validate lifecycle in FullDetailsFragment.setBaseItem

**Issues**
Fixes #3728