### PR TITLE
Add ability to remember audio and subtitle selection settings

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -61,6 +61,16 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var mediaQueuingEnabled = booleanPreference("pref_enable_tv_queuing", true)
 
 		/**
+		 * Set audio track to match previous video
+		 */
+		var rememberAudio = booleanPreference("pref_remember_audio", true)
+
+		/**
+		 * Set subtitle track to match previous video
+		 */
+		var rememberSubtitle = booleanPreference("pref_remember_subtitle", true)
+
+		/**
 		 * Enable the next up screen or not
 		 */
 		var nextUpBehavior = enumPreference("next_up_behavior", NextUpBehavior.EXTENDED)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -43,6 +43,18 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.lbl_tv_queuing)
 				bind(userPreferences, UserPreferences.mediaQueuingEnabled)
 			}
+
+			checkbox {
+				setTitle(R.string.lbl_remember_audio)
+				setContent(R.string.desc_remember_audio)
+				bind(userPreferences, UserPreferences.rememberAudio)
+			}
+
+			checkbox {
+				setTitle(R.string.lbl_remember_subtitle)
+				setContent(R.string.desc_remember_subtitle)
+				bind(userPreferences, UserPreferences.rememberSubtitle)
+			}
 		}
 
 		category {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,10 @@
     <string name="lbl_no_items">No items</string>
     <string name="lbl_empty">Empty</string>
     <string name="lbl_tv_queuing">Play next episode automatically</string>
+    <string name="lbl_remember_audio">Set audio tracked based on previous item</string>
+    <string name="desc_remember_audio">Try to set the audio track to the closest match to the last video</string>
+    <string name="lbl_remember_subtitle">Set subtitle tracked based on previous item</string>
+    <string name="desc_remember_subtitle">Try to set the subtitle track to the closest match to the last video</string>
     <string name="lbl_search_hint">Search text (select for keyboard)</string>
     <string name="lbl_play_first_unwatched">Play first unwatched</string>
     <string name="lbl_mark_unplayed">Mark unplayed</string>


### PR DESCRIPTION
**Changes**
Adds two new settings under advanced playback settings to remember the previously selected audio and subtitle track. If these settings are enabled, the player will find the audio and/or subtitle track that matches what was selected in the previous episode. If the audio/subtitle tracks don't align 1-to-1, it makes a best effort guess by looking through the display name and language value for the media streams and makes a selection.

**Issues**
Fixes my own frustrations with this discrepancy between the web and Android TV versions of the app
