### PR TITLE
Improve intro loading in SdkPlaybackHelper

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -212,14 +212,19 @@ class SdkPlaybackHelper(
 			}
 		}
 
-		else -> if (allowIntros && !playbackLauncher.useExternalPlayer(mainItem.type) && userPreferences[UserPreferences.cinemaModeEnabled]) {
-			val response by api.userLibraryApi.getIntros(mainItem.id)
-			buildList {
-				addAll(response.items.orEmpty())
-				addAll(getParts(mainItem))
+		else -> {
+			val parts = getParts(mainItem)
+			val addIntros = allowIntros && userPreferences[UserPreferences.cinemaModeEnabled]
+
+			if (addIntros) {
+				val intros = runCatching {
+					api.userLibraryApi.getIntros(mainItem.id).content.items
+				}.getOrNull().orEmpty()
+
+				intros + parts
+			} else {
+				parts
 			}
-		} else {
-			getParts(mainItem)
 		}
 	}
 


### PR DESCRIPTION
Someone mentioned playback didn't work for them when "cinema mode" is enabled. The only part where that preference is used is in the SdkPlaybackHelper to determine whether to load intros or not.

**Changes**
- Improve intro loading in SdkPlaybackHelper

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
