### PR TITLE
Increase ExoPlayer HTTP timeouts

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -17,9 +17,11 @@ import org.jellyfin.androidtv.ui.playback.RewritePlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
 import org.jellyfin.playback.core.playbackManager
+import org.jellyfin.playback.exoplayer.ExoPlayerOptions
 import org.jellyfin.playback.exoplayer.exoPlayerPlugin
 import org.jellyfin.playback.exoplayer.session.MediaSessionOptions
 import org.jellyfin.playback.jellyfin.jellyfinPlugin
+import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.scope.Scope
 import org.koin.dsl.module
@@ -60,8 +62,14 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 		channelId = notificationChannelId,
 		notificationId = 1,
 		iconSmall = R.drawable.app_icon_foreground,
-		openIntent = pendingIntent,)
-	install(exoPlayerPlugin(get(), mediaSessionOptions))
+		openIntent = pendingIntent,
+	)
+	val api = get<ApiClient>()
+	val exoPlayerOptions = ExoPlayerOptions(
+		httpConnectTimeout = api.httpClientOptions.connectTimeout,
+		httpReadTimeout = api.httpClientOptions.requestTimeout
+	)
+	install(exoPlayerPlugin(get(), mediaSessionOptions, exoPlayerOptions))
 	install(jellyfinPlugin(get()))
 
 	// Options

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -26,6 +26,8 @@ import androidx.media3.common.TrackSelectionOverride;
 import androidx.media3.common.TrackSelectionParameters;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
@@ -177,8 +179,13 @@ public class VideoManager {
         );
         exoPlayerBuilder.setTrackSelector(trackSelector);
 
-        DefaultExtractorsFactory defaultExtractorsFactory = new DefaultExtractorsFactory().setTsExtractorTimestampSearchBytes(TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES * 3);
-        exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(context, defaultExtractorsFactory));
+        DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory().setTsExtractorTimestampSearchBytes(TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES * 3);
+        DefaultHttpDataSource.Factory httpDataSourceFactory = new DefaultHttpDataSource.Factory();
+        // Note: default values from Kotlin SDK 1.5
+        httpDataSourceFactory.setConnectTimeoutMs(6 * 1000);
+        httpDataSourceFactory.setReadTimeoutMs(30 * 1000);
+        DefaultDataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, httpDataSourceFactory);
+        exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory));
 
         return exoPlayerBuilder;
     }

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerOptions.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerOptions.kt
@@ -1,0 +1,8 @@
+package org.jellyfin.playback.exoplayer
+
+import kotlin.time.Duration
+
+data class ExoPlayerOptions(
+	val httpConnectTimeout: Duration? = null,
+	val httpReadTimeout: Duration? = null,
+)

--- a/playback/exoplayer/src/main/kotlin/ExoPlayerPlugin.kt
+++ b/playback/exoplayer/src/main/kotlin/ExoPlayerPlugin.kt
@@ -8,7 +8,8 @@ import org.jellyfin.playback.exoplayer.session.MediaSessionService
 fun exoPlayerPlugin(
 	androidContext: Context,
 	mediaSessionOptions: MediaSessionOptions,
+	exoPlayerOptions: ExoPlayerOptions = ExoPlayerOptions(),
 ) = playbackPlugin {
-	provide(ExoPlayerBackend(androidContext))
+	provide(ExoPlayerBackend(androidContext, exoPlayerOptions))
 	provide(MediaSessionService(androidContext, mediaSessionOptions))
 }


### PR DESCRIPTION
By default media3.exoplayer uses a 8 second timeout for connecting & reading. In some cases the Jellyfin server will take longer to respond. @Bond-009 pointed out this is particularly the case with BDMV. This PR sets our own timeouts based on the values in the Kotlin SDK.

The new playback code reads the values from the SDK, the old code got it hardcoded because it's end of life anyway.

**Changes**
- Add new ExoPlayerOptions
  - Re-use HTTP timeouts from ApiClient for ExoPlayer
- Set HTTP timeouts in VideoManager ExoPlayer

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
