### PR TITLE
Fix FullDetailsFragment duplicating buttons on resume

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -661,7 +661,10 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     }
 
     private void updateInfo(BaseItemDto item) {
-        if (buttonTypeList.contains(item.getType())) addButtons(BUTTON_SIZE);
+        if (buttonTypeList.contains(item.getType())) {
+            mDetailsOverviewRow.clearActions();
+            addButtons(BUTTON_SIZE);
+        }
 
         mLastUpdated = Instant.now();
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/MyDetailsOverviewRow.kt
@@ -19,5 +19,6 @@ class MyDetailsOverviewRow @JvmOverloads constructor(
 	val actions get() = _actions.toList()
 	val visibleActions get() = _actions.count { it.isVisible }
 
+	fun clearActions() = _actions.clear()
 	fun addAction(button: TextUnderButton) = _actions.add(button)
 }


### PR DESCRIPTION
In some specific scenarios a race condition could cause the actions in the FullDetailsFragment to duplicate. Make sure to clear the list of actions first before adding new ones.

**Changes**
- Fix FullDetailsFragment duplicating buttons on resume

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #3772