### PR TITLE
Fix "other" items in ByLetterFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.kt
@@ -18,7 +18,7 @@ class ByLetterFragment : BrowseFolderFragment() {
 			parentId = folder?.id,
 			sortBy = setOf(ItemSortBy.SORT_NAME),
 			includeItemTypes = includeType?.let(BaseItemKind::fromNameOrNull)?.let(::setOf),
-			nameStartsWith = letters.substring(0, 1),
+			nameLessThan = letters.substring(0, 1),
 			recursive = true,
 			fields = setOf(
 				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,


### PR DESCRIPTION
Copy-paste developer

**Changes**
- Fix "other" items in ByLetterFragment not using `nameLessThan`

**Issues**
Fixes #3796