### PR TITLE
Update targetSdk to 34

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.androidtv"
-	compileSdk = 34
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
 
 	defaultConfig {
-		minSdk = 21
-		targetSdk = 33
+		minSdk = libs.versions.android.minSdk.get().toInt()
+		targetSdk = libs.versions.android.targetSdk.get().toInt()
 
 		// Release version
 		applicationId = namespace

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,11 @@
 [versions]
 aboutlibraries = "11.2.2"
 acra = "5.11.3"
+android-compileSdk = "34"
 android-desugar = "2.0.4"
 android-gradle = "8.5.1"
+android-minSdk = "21"
+android-targetSdk = "34"
 androidx-activity = "1.9.1"
 androidx-appcompat = "1.7.0"
 androidx-cardview = "1.0.0"

--- a/playback/core/build.gradle.kts
+++ b/playback/core/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.playback.core"
-	compileSdk = 34
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
 
 	defaultConfig {
-		minSdk = 21
+		minSdk = libs.versions.android.minSdk.get().toInt()
 	}
 
 	compileOptions {

--- a/playback/jellyfin/build.gradle.kts
+++ b/playback/jellyfin/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.playback.jellyfin"
-	compileSdk = 34
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
 
 	defaultConfig {
-		minSdk = 21
+		minSdk = libs.versions.android.minSdk.get().toInt()
 	}
 
 	compileOptions {

--- a/playback/media3/exoplayer/build.gradle.kts
+++ b/playback/media3/exoplayer/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.playback.exoplayer"
-	compileSdk = 34
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
 
 	defaultConfig {
-		minSdk = 21
+		minSdk = libs.versions.android.minSdk.get().toInt()
 	}
 
 	lint {

--- a/playback/media3/session/build.gradle.kts
+++ b/playback/media3/session/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.playback.media3.session"
-	compileSdk = 34
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
 
 	defaultConfig {
-		minSdk = 21
+		minSdk = libs.versions.android.minSdk.get().toInt()
 	}
 
 	lint {

--- a/preference/build.gradle.kts
+++ b/preference/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
 	namespace = "org.jellyfin.preference"
-	compileSdk = 34
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
 
 	defaultConfig {
-		minSdk = 21
+		minSdk = libs.versions.android.minSdk.get().toInt()
 	}
 
 	buildFeatures {


### PR DESCRIPTION
We already compiled with SDK 34 but still targetted SDK 33.

**Changes**
- Update targetSdk to 34
- Move minSdk, compileSdk and targetSdk to version catalog
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
