### PR TITLE
Fix Live TV program popup not populating when opening early

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -747,6 +747,10 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
         mDisplayDate.setText(TimeUtils.getFriendlyDate(requireContext(), mSelectedProgram.getStartDate()));
         String url = imageHelper.getValue().getPrimaryImageUrl(mSelectedProgram, null, ImageHelper.MAX_PRIMARY_IMAGE_HEIGHT);
         mImage.load(url, null, ContextCompat.getDrawable(requireContext(), R.drawable.blank10x10), 0, 0);
+
+        if (mDetailPopup != null && mDetailPopup.isShowing() && mSelectedProgramView != null) {
+            mDetailPopup.setContent(mSelectedProgram, ((ProgramGridCell) mSelectedProgramView));
+        }
     }
 
     public void setSelectedProgram(RelativeLayout programView) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1045,6 +1045,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         if (mSelectedProgram.getId() != null) {
             tvGuideBinding.displayDate.setText(TimeUtils.getFriendlyDate(requireContext(), mSelectedProgram.getStartDate()));
         }
+
+        if (mDetailPopup != null && mDetailPopup.isShowing() && mSelectedProgramView != null) {
+            mDetailPopup.setContent(mSelectedProgram, ((ProgramGridCell) mSelectedProgramView));
+        }
     }
 
     public void setSelectedProgram(RelativeLayout programView) {


### PR DESCRIPTION
When you open the popup before the detailUpdateTask completes, the value of mSelectedProgram is still incomplete. Add some additional logic to update the popup info when detailUpdateTask completes to fix this.

**Changes**
- Fix Live TV program popup not populating when opening early

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
