### PR TITLE
Add Option to Disable HLS

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -92,6 +92,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var refreshRateSwitchingBehavior = enumPreference("refresh_rate_switching_behavior", RefreshRateSwitchingBehavior.DISABLED)
 
+		/**
+		 * Disable HLS to fix subtitle sync issues
+		 */
+		var disableHLS = booleanPreference("disable_hls", false)
+
 		/* Playback - Audio related */
 		/**
 		 * Preferred behavior for audio streaming.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -527,7 +527,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 mFragment.getContext(),
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
+                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
+                userPreferences.getValue().get(UserPreferences.Companion.getDisableHLS())
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -64,6 +64,12 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.pref_external_player)
 				bind(userPreferences, UserPreferences.useExternalPlayer)
 			}
+
+			checkbox {
+				setTitle(R.string.pref_disable_hls)
+				setContent(R.string.desc_disable_hls)
+				bind(userPreferences, UserPreferences.disableHLS)
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -237,6 +237,8 @@ class ExoPlayerProfile(
 		subtitleProfiles = arrayOf(
 			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.External),
 			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.External),
+			subtitleProfile(Codec.Subtitle.SRT, SubtitleDeliveryMethod.Embed),
+			subtitleProfile(Codec.Subtitle.SUBRIP, SubtitleDeliveryMethod.Embed),
 			subtitleProfile(Codec.Subtitle.ASS, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.SSA, SubtitleDeliveryMethod.Encode),
 			subtitleProfile(Codec.Subtitle.PGS, SubtitleDeliveryMethod.Embed),

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -30,6 +30,7 @@ class ExoPlayerProfile(
 	context: Context,
 	disableVideoDirectPlay: Boolean = false,
 	isAC3Enabled: Boolean = false,
+	disableHLS: Boolean = false,
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		Codec.Audio.AAC,
@@ -72,21 +73,39 @@ class ExoPlayerProfile(
 		maxStaticBitrate = 10_000_0000 // 10 mbps
 
 		transcodingProfiles = arrayOf(
-			// TS video profile
-			TranscodingProfile().apply {
-				type = DlnaProfileType.Video
-				this.context = EncodingContext.Streaming
-				container = Codec.Container.TS
-				videoCodec = buildList {
-					if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
-					add(Codec.Video.H264)
-				}.joinToString(",")
-				audioCodec = when {
-					Utils.downMixAudio(context) -> downmixSupportedAudioCodecs
-					else -> allSupportedAudioCodecsWithoutFFmpegExperimental
-				}.joinToString(",")
-				protocol = "hls"
-				copyTimestamps = false
+			if (disableHLS) {
+				// MKV video profile
+				TranscodingProfile().apply {
+					type = DlnaProfileType.Video
+					this.context = EncodingContext.Streaming
+					container = Codec.Container.MKV
+					videoCodec = buildList {
+						if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.MKV)) add(Codec.Video.HEVC)
+						add(Codec.Video.H264)
+					}.joinToString(",")
+					audioCodec = when {
+						Utils.downMixAudio(context) -> downmixSupportedAudioCodecs
+						else -> allSupportedAudioCodecsWithoutFFmpegExperimental
+					}.joinToString(",")
+					copyTimestamps = true
+				}
+			} else {
+				// TS video profile
+				TranscodingProfile().apply {
+					type = DlnaProfileType.Video
+					this.context = EncodingContext.Streaming
+					container = Codec.Container.TS
+					videoCodec = buildList {
+						if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
+						add(Codec.Video.H264)
+					}.joinToString(",")
+					audioCodec = when {
+						Utils.downMixAudio(context) -> downmixSupportedAudioCodecs
+						else -> allSupportedAudioCodecsWithoutFFmpegExperimental
+					}.joinToString(",")
+					protocol = "hls"
+					copyTimestamps = false
+				}
 			},
 			// MP3 audio profile
 			TranscodingProfile().apply {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,8 @@
     <string name="pref_theme_emerald">Classic emerald</string>
     <string name="pref_about_title">About</string>
     <string name="pref_external_player">Use external player</string>
+    <string name="pref_disable_hls">Disable HLS</string>
+    <string name="desc_disable_hls">Potential fix for subtitle sync issues</string>
     <string name="pref_next_up_timeout_summary">How long to wait before playing the next item</string>
     <string name="pref_next_up_timeout_title">Next up timer duration</string>
     <string name="pref_next_up_timeout_disabled">∞</string>


### PR DESCRIPTION
**Changes**
Adds an option in settings to disable HLS with exoplayer.

**Issues**
This is a workaround for subtitles getting out of sync when skipping around/resuming certain video files when using HLS
(issue https://github.com/jellyfin/jellyfin-androidtv/issues/3492).
