### PR TITLE
Add Google Chromecast HD limitation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
  - [sparky3387](https://github.com/sparky3387)
  - [mohd-akram](https://github.com/mohd-akram)
  - [3l0w](https://github.com/3l0w)
+ - [MajMongoose](https://github.com/majmongoose)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -27,7 +27,7 @@ object DeviceUtils {
 	private const val SHIELD_TV_MODEL = "SHIELD Android TV"
 
 	// Google Chromecast HD Model
-	private const val GOOGLE_CHROMECAST_HD_MODEL = "Chromecast HD" // Reports to support 4K - Cannot downscale in device in realtime
+	private const val GOOGLE_CHROMECAST_HD_MODEL = "Chromecast HD"
 
 	@JvmStatic
 	val isFireTv: Boolean = Build.MODEL.startsWith(FIRE_TV_PREFIX)

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -49,9 +49,6 @@ object DeviceUtils {
 	val isShieldTv: Boolean = Build.MODEL == SHIELD_TV_MODEL
 
 	@JvmStatic
-	val isChromecastHD: Boolean = Build.MODEL == GOOGLE_CHROMECAST_HD_MODEL
-
-	@JvmStatic
 	// These devices only support a max video resolution of 1080p
 	fun has4kVideoSupport(): Boolean = Build.MODEL !in listOf(
 		FIRE_STICK_MODEL_GEN_1,

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -27,7 +27,7 @@ object DeviceUtils {
 	private const val SHIELD_TV_MODEL = "SHIELD Android TV"
 
 	// Google Chromecast HD Model
-	private const val GOOGLE_CHROMECAST_HD_MODEL = "Chromecast HD"
+	private const val GOOGLE_CHROMECAST_HD_MODEL = "Chromecast HD" // Reports to support 4K - Cannot downscale in device in realtime
 
 	@JvmStatic
 	val isFireTv: Boolean = Build.MODEL.startsWith(FIRE_TV_PREFIX)

--- a/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DeviceUtils.kt
@@ -26,6 +26,9 @@ object DeviceUtils {
 	// Nvidia Shield TV Model
 	private const val SHIELD_TV_MODEL = "SHIELD Android TV"
 
+	// Google Chromecast HD Model
+	private const val GOOGLE_CHROMECAST_HD_MODEL = "Chromecast HD"
+
 	@JvmStatic
 	val isFireTv: Boolean = Build.MODEL.startsWith(FIRE_TV_PREFIX)
 
@@ -46,6 +49,9 @@ object DeviceUtils {
 	val isShieldTv: Boolean = Build.MODEL == SHIELD_TV_MODEL
 
 	@JvmStatic
+	val isChromecastHD: Boolean = Build.MODEL == GOOGLE_CHROMECAST_HD_MODEL
+
+	@JvmStatic
 	// These devices only support a max video resolution of 1080p
 	fun has4kVideoSupport(): Boolean = Build.MODEL !in listOf(
 		FIRE_STICK_MODEL_GEN_1,
@@ -53,6 +59,7 @@ object DeviceUtils {
 		FIRE_STICK_MODEL_GEN_3,
 		FIRE_STICK_LITE_MODEL,
 		FIRE_TV_MODEL_GEN_1,
-		FIRE_TV_MODEL_GEN_2
+		FIRE_TV_MODEL_GEN_2,
+		GOOGLE_CHROMECAST_HD_MODEL
 	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -1,8 +1,6 @@
 package org.jellyfin.androidtv.util.profile
 
 import android.content.Context
-import android.os.Build
-import android.util.Log
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.androidtv.util.profile
 
 import android.content.Context
+import android.os.Build
+import android.util.Log
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.DeviceUtils
 import org.jellyfin.androidtv.util.Utils


### PR DESCRIPTION
**Changes**
Added the Google Chromecast HD to the list of devices unable to support 4K, as it reports it is capable of downscaling but is incapable of doing so in realtime. Change has been discussed with Niels in the discord.

**Note**
There still may be a bug on the jellyfin server, as the tv app is telling it to send a maximum of 1920x1080 (verified via tcpdump [TCPDump Data](https://pastebin.com/SdWGmyzP)) but it is still streaming 4k.