### PR TITLE
Add preferences to configure buffering behaviour

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -195,6 +195,40 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Whether items shown in the screensaver are required to have an age rating set.
 		 */
 		var screensaverAgeRatingRequired = booleanPreference("screensaver_agerating_required", true)
+
+		/**
+		 * Enable reactive homepage
+		 */
+		var homeReactive = booleanPreference("home_reactive", false)
+
+		/**
+		 * Minimum duration of media that the player will attempt to ensure is buffered at all times.
+		 *
+		 * Default value in androidx-media3 v1.4.0 is 50 seconds.
+		 */
+		var minBufferMs = intPreference("min_buffer_ms", 50_000)
+
+		/**
+		 * Maximum duration of media that the player will attempt to buffer
+		 *
+		 * Default value in androidx-media3 v1.4.0 is 50 seconds.
+		 */
+		var maxBufferMs = intPreference("max_buffer_ms", 50_000)
+
+		/**
+		 * Duration of media that must be buffered for playback to start or resume following a user action such as a seek.
+		 *
+		 * Default value in androidx-media3 v1.4.0 is 2.5 seconds.
+		 */
+		var bufferForPlaybackMs = intPreference("buffer_for_playback_ms", 2_500)
+
+		/**
+		 * duration of media that must be buffered for playback to resume after a rebuffer
+		 * (a rebuffer is defined to be caused by buffer depletion rather than a user action).
+		 *
+		 * Default value in androidx-media3 v1.4.0 is 5 seconds.
+		 */
+		var bufferForPlaybackAfterRebufferMs = intPreference("buffer_for_playback_after_rebuffer_ms", 5_000)
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemSeekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsItemSeekbar.kt
@@ -32,6 +32,7 @@ class OptionsItemSeekbar(
 			it.isEnabled = dependencyCheckFun() && enabled
 			it.isVisible = visible
 			it.title = title
+			it.summary = content
 			it.min = min
 			it.max = max
 			it.seekBarIncrement = increment

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -98,6 +98,7 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 		category {
 			setTitle(R.string.pref_buffering_section_title)
 
+			@Suppress("MagicNumber")
 			seekbar {
 				setTitle(R.string.pref_buffering_min_buffer_ms_label)
 				setContent(R.string.pref_buffering_min_buffer_ms_description)
@@ -113,6 +114,7 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.minBufferMs)
 			}
 
+			@Suppress("MagicNumber")
 			seekbar {
 				setTitle(R.string.pref_buffering_max_buffer_ms_label)
 				setContent(R.string.pref_buffering_max_buffer_ms_description)
@@ -128,6 +130,7 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.maxBufferMs)
 			}
 
+			@Suppress("MagicNumber")
 			seekbar {
 				setTitle(R.string.pref_buffering_buffer_for_playback_ms_label)
 				setContent(R.string.pref_buffering_buffer_for_playback_ms_description)
@@ -143,6 +146,7 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.bufferForPlaybackMs)
 			}
 
+			@Suppress("MagicNumber")
 			seekbar {
 				setTitle(R.string.pref_buffering_buffer_for_playback_after_rebuffer_ms_label)
 				setContent(R.string.pref_buffering_buffer_for_playback_after_rebuffer_ms_description)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -5,11 +5,13 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.getQualityProfiles
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
+import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.enum
 import org.jellyfin.androidtv.ui.preference.dsl.list
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.androidtv.ui.preference.dsl.seekbar
 import org.jellyfin.androidtv.util.TimeUtils
 import org.koin.android.ext.android.inject
 
@@ -90,6 +92,70 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.lbl_bitstream_ac3)
 				setContent(R.string.desc_bitstream_ac3)
 				bind(userPreferences, UserPreferences.ac3Enabled)
+			}
+		}
+
+		category {
+			setTitle(R.string.pref_buffering_section_title)
+
+			seekbar {
+				setTitle(R.string.pref_buffering_min_buffer_ms_label)
+				setContent(R.string.pref_buffering_min_buffer_ms_description)
+
+				min = 0
+				max = userPreferences[UserPreferences.maxBufferMs]
+				increment = 1_000
+
+				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
+					override fun display(value: Int): String = "${value / 1000}s"
+				}
+
+				bind(userPreferences, UserPreferences.minBufferMs)
+			}
+
+			seekbar {
+				setTitle(R.string.pref_buffering_max_buffer_ms_label)
+				setContent(R.string.pref_buffering_max_buffer_ms_description)
+
+				min = userPreferences[UserPreferences.minBufferMs]
+				max = 300_000
+				increment = 1_000
+
+				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
+					override fun display(value: Int): String = "${value / 1000}s"
+				}
+
+				bind(userPreferences, UserPreferences.maxBufferMs)
+			}
+
+			seekbar {
+				setTitle(R.string.pref_buffering_buffer_for_playback_ms_label)
+				setContent(R.string.pref_buffering_buffer_for_playback_ms_description)
+
+				min = 0
+				max = userPreferences[UserPreferences.minBufferMs]
+				increment = 500
+
+				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
+					override fun display(value: Int): String = "${value.toDouble() / 1000}s"
+				}
+
+				bind(userPreferences, UserPreferences.bufferForPlaybackMs)
+			}
+
+			seekbar {
+				setTitle(R.string.pref_buffering_buffer_for_playback_after_rebuffer_ms_label)
+				setContent(R.string.pref_buffering_buffer_for_playback_after_rebuffer_ms_description)
+
+				min = 0
+				max = userPreferences[UserPreferences.minBufferMs]
+				increment = 1_000
+
+				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
+					override fun display(value: Int): String = "${value / 1000}s"
+				}
+
+				bind(userPreferences, UserPreferences.bufferForPlaybackAfterRebufferMs)
 			}
 		}
 	}

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -564,3 +564,13 @@
     <string name="pref_subtitles_size_large">Grande</string>
     <string name="pref_subtitles_size_very_large">Molto grande</string>
 </resources>
+    <string name="pref_buffering_section_title">Buffering</string>
+    <string name="pref_buffering_min_buffer_ms_label">Secondi minimi di buffer</string>
+    <string name="pref_buffering_min_buffer_ms_description">Durata minima di contenuto che il player cercherà di mantenere nel buffer.</string>
+    <string name="pref_buffering_max_buffer_ms_label">Secondi massimi di buffer</string>
+    <string name="pref_buffering_max_buffer_ms_description">Durata massima di contenuto che il player può bufferizzare.</string>
+    <string name="pref_buffering_buffer_for_playback_ms_label">Buffer per la riproduzione</string>
+    <string name="pref_buffering_buffer_for_playback_ms_description">Durata di contenuto che dev\'essere stata bufferizzata per poter iniziare o riprendere la riproduzione a seguito di un\'azione dell\'utente (ad esempio un seek).</string>
+    <string name="pref_buffering_buffer_for_playback_after_rebuffer_ms_label">Buffer per la riproduzione dopo un rebuffer</string>
+    <string name="pref_buffering_buffer_for_playback_after_rebuffer_ms_description">Durata di contenuto che dev\'essere stata bufferizzata per poter riprendere la riproduzione a seguito di un\'interruzione per esaurimento del buffer.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -514,6 +514,15 @@
     <string name="past_week">Past week</string>
     <string name="scheduled_in_next_24_hours">Scheduled in next 24 hours</string>
     <string name="past_24_hours">Past 24 hours</string>
+    <string name="pref_buffering_section_title">Buffering</string>
+    <string name="pref_buffering_min_buffer_ms_label">Min buffer seconds</string>
+    <string name="pref_buffering_min_buffer_ms_description">Minimum duration of media that the player will attempt to ensure is buffered at all times.</string>
+    <string name="pref_buffering_max_buffer_ms_label">Max buffer seconds</string>
+    <string name="pref_buffering_max_buffer_ms_description">Maximum duration of media that the player will attempt to buffer.</string>
+    <string name="pref_buffering_buffer_for_playback_ms_label">Buffer for playback</string>
+    <string name="pref_buffering_buffer_for_playback_ms_description">Duration of media that must be buffered for playback to start or resume following a user action such as a seek.</string>
+    <string name="pref_buffering_buffer_for_playback_after_rebuffer_ms_label">Buffer for playback after rebuffer</string>
+    <string name="pref_buffering_buffer_for_playback_after_rebuffer_ms_description">Duration of media that must be buffered for playback to resume following buffer depletion.</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add 4 new preferences to configure parameters of [`DefaultLoadControl.Builder#setBufferDurationsMs()`](https://developer.android.com/reference/androidx/media3/exoplayer/DefaultLoadControl.Builder?hl=en#setBufferDurationsMs(int,int,int,int))

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
May be helpful for #2855 (although this PR only configures buffering durations, not the size).