### PR TITLE
Fix race condition in PictureViewerViewModel

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
@@ -53,6 +53,8 @@ class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
 	// Album actions
 
 	fun showNext() {
+		if (album.isEmpty()) return
+
 		albumIndex++
 		if (albumIndex == album.size) albumIndex = 0
 
@@ -61,6 +63,8 @@ class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
 	}
 
 	fun showPrevious() {
+		if (album.isEmpty()) return
+
 		albumIndex--
 		if (albumIndex == -1) albumIndex = album.size - 1
 


### PR DESCRIPTION
Using the showNext/showPrevious functions while the album is still loading can cause an IndexOutOfBoundsException. Check if the album is empty (default value) first before trying to read from it to avoid these crashes.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix race condition in PictureViewerViewModel when using the next/previous button before album information is loaded

**Issues**

Fixes #3773
