### PR TITLE
Rewrite media queuing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -252,7 +252,7 @@ public class AudioNowPlayingFragment extends Fragment {
 
         @Override
         public void onQueueStatusChanged(boolean hasQueue) {
-            Timber.d("Queue status changed");
+            Timber.d("Queue status changed (hasQueue=%s)", hasQueue);
             if (hasQueue) {
                 loadItem();
                 if (mediaManager.getValue().isAudioPlayerInitialized()) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/PlaybackRewriteFragment.kt
@@ -16,6 +16,7 @@ import org.jellyfin.androidtv.ui.ScreensaverViewModel
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.core.ui.PlayerSubtitleView
 import org.jellyfin.playback.core.ui.PlayerSurfaceView
 import org.jellyfin.sdk.api.client.ApiClient
@@ -43,17 +44,18 @@ class PlaybackRewriteFragment : Fragment() {
 		super.onCreate(savedInstanceState)
 
 		// Create a queue from the items added to the legacy video queue
-		val queue = RewriteMediaManager.BaseItemQueue(api)
-		queue.items.addAll(videoQueueManager.getCurrentVideoQueue())
-		Timber.i("Created a queue with ${queue.items.size} items")
-		playbackManager.state.queue.replaceQueue(queue)
+		val queueSupplier = RewriteMediaManager.BaseItemQueueSupplier(api)
+		queueSupplier.items.addAll(videoQueueManager.getCurrentVideoQueue())
+		Timber.i("Created a queue with ${queueSupplier.items.size} items")
+		playbackManager.queue.clear()
+		playbackManager.queue.addSupplier(queueSupplier)
 
 		// Set position
 		val position = arguments?.getInt(EXTRA_POSITION) ?: 0
 		if (position != 0) {
 			lifecycleScope.launch {
 				Timber.i("Skipping to queue item $position")
-				playbackManager.state.queue.setIndex(position, false)
+				playbackManager.queue.setIndex(position, false)
 			}
 		}
 

--- a/playback/core/src/main/kotlin/PlaybackManagerBuilder.kt
+++ b/playback/core/src/main/kotlin/PlaybackManagerBuilder.kt
@@ -5,8 +5,10 @@ import android.os.Build
 import androidx.core.content.getSystemService
 import org.jellyfin.playback.core.backend.PlayerBackend
 import org.jellyfin.playback.core.mediastream.MediaStreamResolver
+import org.jellyfin.playback.core.mediastream.MediaStreamService
 import org.jellyfin.playback.core.plugin.PlaybackPlugin
 import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.QueueService
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -28,6 +30,7 @@ class PlaybackManagerBuilder(context: Context) {
 		val services = mutableListOf<PlayerService>()
 		val mediaStreamResolvers = mutableListOf<MediaStreamResolver>()
 
+		// Add plugins
 		val installContext = object : PlaybackPlugin.InstallContext {
 			override fun provide(backend: PlayerBackend) {
 				backends.add(backend)
@@ -44,6 +47,10 @@ class PlaybackManagerBuilder(context: Context) {
 
 		for (factory in factories) factory.install(installContext)
 
+		// Add default services
+		services.add(QueueService())
+		services.add(MediaStreamService(mediaStreamResolvers))
+
 		// Only support a single backend right now
 		require(backends.size == 1)
 		val options = PlaybackManagerOptions(
@@ -51,7 +58,7 @@ class PlaybackManagerBuilder(context: Context) {
 			defaultRewindAmount = defaultRewindAmount ?: { 10.seconds },
 			defaultFastForwardAmount = defaultFastForwardAmount ?: { 10.seconds },
 		)
-		return PlaybackManager(backends.first(), services, mediaStreamResolvers, options)
+		return PlaybackManager(backends.first(), services, options)
 	}
 }
 

--- a/playback/core/src/main/kotlin/queue/EmptyQueue.kt
+++ b/playback/core/src/main/kotlin/queue/EmptyQueue.kt
@@ -1,6 +1,0 @@
-package org.jellyfin.playback.core.queue
-
-data object EmptyQueue : Queue {
-	override val size: Int = 0
-	override suspend fun getItem(index: Int): QueueEntry? = null
-}

--- a/playback/core/src/main/kotlin/queue/Queue.kt
+++ b/playback/core/src/main/kotlin/queue/Queue.kt
@@ -1,14 +1,85 @@
 package org.jellyfin.playback.core.queue
 
-/**
- * A queue contains all items in the current playback session. This includes already played items,
- * the currently playing item and future items.
- */
-interface Queue {
-	/**
-	 * The total size of the queue.
-	 */
-	val size: Int
+import kotlinx.coroutines.flow.StateFlow
+import org.jellyfin.playback.core.queue.supplier.QueueSupplier
 
-	suspend fun getItem(index: Int): QueueEntry?
+interface Queue {
+	companion object {
+		const val INDEX_NONE = -1
+	}
+
+	/**
+	 * Get an estimated size of the queue. This may be off when the used suppliers are guessing their size.
+	 */
+	val estimatedSize: Int
+
+	/**
+	 * Index of the currently playing entry, or -1 if none.
+	 */
+	val entryIndex: StateFlow<Int>
+
+	/**
+	 * Currently playing entry or null.
+	 */
+	val entry: StateFlow<QueueEntry?>
+
+	/**
+	 * Add a supplier of queue items to the end of the queue. Will automatically fetch the first item if there is no current entry.
+	 */
+	fun addSupplier(supplier: QueueSupplier)
+
+	/**
+	 * Clear all queue state, including suppliers, entries and currently playing entry.
+	 */
+	fun clear()
+
+	/**
+	 * Set the current entry to the previously played entry. Does nothing if there is no previous entry.
+	 */
+	suspend fun previous(): QueueEntry?
+
+	/**
+	 * Play the next entry in the queue.
+	 *
+	 * @param usePlaybackOrder Whether to use the playback order from the [PlayerState]. Default to true.
+	 * @param useRepeatMode Whether to use the repeat mode from the [PlayerState]. Default to false.
+	 */
+	suspend fun next(usePlaybackOrder: Boolean = true, useRepeatMode: Boolean = false): QueueEntry?
+
+	/**
+	 * Skip to the given index.
+	 *
+	 * @param index The index of the entry to play
+	 * @param saveHistory Whether to save the current entry to the play history
+	 */
+	suspend fun setIndex(index: Int, saveHistory: Boolean = false): QueueEntry?
+
+	/**
+	 * Get the previously playing entry or null if none.
+	 */
+	suspend fun peekPrevious(): QueueEntry?
+
+	/**
+	 * Get the next entry or null if none.
+	 *
+	 * @param usePlaybackOrder Whether to use the playback order from the [PlayerState]. Default to true.
+	 * @param useRepeatMode Whether to use the repeat mode from the [PlayerState]. Default to false.
+	 */
+	suspend fun peekNext(
+		usePlaybackOrder: Boolean = true,
+		useRepeatMode: Boolean = false,
+	): QueueEntry?
+
+	/**
+	 * Get the next n entries in the queue. Where n is the amount to fetch. The returned collection may be smaller or empty depending on
+	 * the entries in the queue.
+	 *
+	 * @param usePlaybackOrder Whether to use the playback order from the [PlayerState]. Default to true.
+	 * @param useRepeatMode Whether to use the repeat mode from the [PlayerState]. Default to false.
+	 */
+	suspend fun peekNext(
+		amount: Int,
+		usePlaybackOrder: Boolean = true,
+		useRepeatMode: Boolean = false,
+	): Collection<QueueEntry>
 }

--- a/playback/core/src/main/kotlin/queue/order/DefaultOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/DefaultOrderIndexProvider.kt
@@ -1,17 +1,16 @@
 package org.jellyfin.playback.core.queue.order
 
-import org.jellyfin.playback.core.queue.Queue
 import kotlin.math.min
 
 internal class DefaultOrderIndexProvider : OrderIndexProvider {
 	override fun provideIndices(
 		amount: Int,
-		queue: Queue,
+		size: Int,
 		playedIndices: Collection<Int>,
 		currentIndex: Int,
 	): Collection<Int> {
 		// No need to use currentQueueNextIndices because we can efficiently calculate the next items
-		val remainingItemsSize = queue.size - currentIndex - 1
+		val remainingItemsSize = size - currentIndex - 1
 
 		return if (remainingItemsSize <= 0) emptyList()
 		else Array(min(amount, remainingItemsSize)) { i -> currentIndex + i + 1 }.toList()

--- a/playback/core/src/main/kotlin/queue/order/OrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/OrderIndexProvider.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.playback.core.queue.order
 
-import org.jellyfin.playback.core.queue.PlayerQueueState
-import org.jellyfin.playback.core.queue.Queue
+import org.jellyfin.playback.core.queue.QueueService
 
 internal interface OrderIndexProvider {
 	/**
@@ -13,15 +12,15 @@ internal interface OrderIndexProvider {
 	 * Collect the next [amount] of indices to play.
 	 *
 	 * @param amount The maximum amount of indices to retrieve. May be less if there are none left.
-	 * @param queue The queue to generate indices for.
+	 * @param size The size of the queue to generate indices for.
 	 * @param playedIndices The previously played indices, this may include the [currentIndex].
-	 * @param currentIndex The currently playing index or [PlayerQueueState.INDEX_NONE].
+	 * @param currentIndex The currently playing index or [QueueService.INDEX_NONE].
 	 *
 	 * @return A collection no more than [amount] items of indices to play next.
 	 */
 	fun provideIndices(
 		amount: Int,
-		queue: Queue,
+		size: Int,
 		playedIndices: Collection<Int>,
 		currentIndex: Int,
 	): Collection<Int>

--- a/playback/core/src/main/kotlin/queue/order/RandomOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/RandomOrderIndexProvider.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.playback.core.queue.order
 
-import org.jellyfin.playback.core.queue.Queue
 import kotlin.random.Random
 
 internal class RandomOrderIndexProvider : OrderIndexProvider {
@@ -10,14 +9,14 @@ internal class RandomOrderIndexProvider : OrderIndexProvider {
 
 	override fun provideIndices(
 		amount: Int,
-		queue: Queue,
+		size: Int,
 		playedIndices: Collection<Int>,
 		currentIndex: Int,
 	) = List(amount) { i ->
 		if (i <= nextIndices.lastIndex) {
 			nextIndices[i]
 		} else {
-			val index = Random.nextInt(queue.size)
+			val index = Random.nextInt(size)
 			nextIndices.add(index)
 			index
 		}

--- a/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.playback.core.queue.order
 
-import org.jellyfin.playback.core.queue.Queue
 import kotlin.math.min
 
 internal class ShuffleOrderIndexProvider : OrderIndexProvider {
@@ -10,15 +9,15 @@ internal class ShuffleOrderIndexProvider : OrderIndexProvider {
 
 	override fun provideIndices(
 		amount: Int,
-		queue: Queue,
+		size: Int,
 		playedIndices: Collection<Int>,
 		currentIndex: Int,
 	): Collection<Int> {
-		val remainingItemsSize = queue.size - playedIndices.size
+		val remainingItemsSize = size - playedIndices.size
 		return if (remainingItemsSize <= 0) {
 			emptyList()
 		} else {
-			val remainingIndices = (0..queue.size).filterNot {
+			val remainingIndices = (0..size).filterNot {
 				it in playedIndices || it in nextIndices
 			}
 

--- a/playback/core/src/main/kotlin/queue/supplier/PagedQueueSupplier.kt
+++ b/playback/core/src/main/kotlin/queue/supplier/PagedQueueSupplier.kt
@@ -1,12 +1,18 @@
-package org.jellyfin.playback.core.queue
+package org.jellyfin.playback.core.queue.supplier
 
-abstract class PagedQueue(
+import org.jellyfin.playback.core.queue.QueueEntry
+
+abstract class PagedQueueSupplier(
 	private val pageSize: Int = 10,
-) : Queue {
+) : QueueSupplier {
+	companion object {
+		const val MAX_SIZE = 100
+	}
+
 	private val buffer: MutableList<QueueEntry> = mutableListOf()
 
 	override suspend fun getItem(index: Int): QueueEntry? {
-		require(index in 0 until SequenceQueue.MAX_SIZE)
+		require(index in 0 until MAX_SIZE)
 
 		var page: Collection<QueueEntry>
 		var pageOffset = buffer.size

--- a/playback/core/src/main/kotlin/queue/supplier/QueueSupplier.kt
+++ b/playback/core/src/main/kotlin/queue/supplier/QueueSupplier.kt
@@ -1,0 +1,16 @@
+package org.jellyfin.playback.core.queue.supplier
+
+import org.jellyfin.playback.core.queue.QueueEntry
+
+/**
+ * A queue contains all items in the current playback session. This includes already played items,
+ * the currently playing item and future items.
+ */
+interface QueueSupplier {
+	/**
+	 * The total size of the queue.
+	 */
+	val size: Int
+
+	suspend fun getItem(index: Int): QueueEntry?
+}

--- a/playback/core/src/main/kotlin/queue/supplier/SequenceQueueSupplier.kt
+++ b/playback/core/src/main/kotlin/queue/supplier/SequenceQueueSupplier.kt
@@ -1,6 +1,8 @@
-package org.jellyfin.playback.core.queue
+package org.jellyfin.playback.core.queue.supplier
 
-abstract class SequenceQueue : Queue {
+import org.jellyfin.playback.core.queue.QueueEntry
+
+abstract class SequenceQueueSupplier : QueueSupplier {
 	companion object {
 		const val MAX_SIZE = 100
 	}

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
@@ -10,6 +10,7 @@ import org.jellyfin.playback.core.mediastream.mediaStream
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
@@ -58,14 +59,14 @@ class PlaySessionService(
 	private suspend fun getQueue(): List<QueueItem> {
 		// The queues are lazy loaded so we only load a small amount of items to set as queue on the
 		// backend.
-		return state.queue
+		return manager.queue
 			.peekNext(15)
 			.mapNotNull { it.baseItem }
 			.map { QueueItem(id = it.id, playlistItemId = it.playlistItemId) }
 	}
 
 	private suspend fun sendStreamStart() {
-		val entry = state.queue.entry.value ?: return
+		val entry = manager.queue.entry.value ?: return
 		val stream = entry.mediaStream ?: return
 		val item = entry.baseItem ?: return
 
@@ -93,7 +94,7 @@ class PlaySessionService(
 	}
 
 	private suspend fun sendStreamUpdate() {
-		val entry = state.queue.entry.value ?: return
+		val entry = manager.queue.entry.value ?: return
 		val stream = entry.mediaStream ?: return
 		val item = entry.baseItem ?: return
 
@@ -121,7 +122,7 @@ class PlaySessionService(
 	}
 
 	private suspend fun sendStreamStop() {
-		val entry = state.queue.entry.value ?: return
+		val entry = manager.queue.entry.value ?: return
 		val stream = entry.mediaStream ?: return
 		val item = entry.baseItem ?: return
 

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionSocketService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionSocketService.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.sockets.subscribe
 import org.jellyfin.sdk.api.sockets.subscribeGeneralCommand
@@ -28,8 +29,8 @@ class PlaySessionSocketService(
 					PlaystateCommand.STOP -> state.stop()
 					PlaystateCommand.PAUSE -> state.pause()
 					PlaystateCommand.UNPAUSE -> state.unpause()
-					PlaystateCommand.NEXT_TRACK -> state.queue.next()
-					PlaystateCommand.PREVIOUS_TRACK -> state.queue.previous()
+					PlaystateCommand.NEXT_TRACK -> manager.queue.next()
+					PlaystateCommand.PREVIOUS_TRACK -> manager.queue.previous()
 					PlaystateCommand.SEEK -> {
 						val to = message.data?.seekPositionTicks?.ticks ?: Duration.ZERO
 						state.seek(to)

--- a/playback/jellyfin/src/main/kotlin/queue/AudioAlbumQueueSupplier.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioAlbumQueueSupplier.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.playback.jellyfin.queue
 
-import org.jellyfin.playback.core.queue.PagedQueue
 import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.supplier.PagedQueueSupplier
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -10,10 +10,10 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaType
 
-class AudioAlbumQueue(
+class AudioAlbumQueueSupplier(
 	private val album: BaseItemDto,
 	private val api: ApiClient,
-) : PagedQueue() {
+) : PagedQueueSupplier() {
 	init {
 		require(album.type == BaseItemKind.MUSIC_ALBUM)
 	}

--- a/playback/jellyfin/src/main/kotlin/queue/AudioInstantMixQueueSupplier.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioInstantMixQueueSupplier.kt
@@ -1,17 +1,17 @@
 package org.jellyfin.playback.jellyfin.queue
 
-import org.jellyfin.playback.core.queue.PagedQueue
 import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.supplier.PagedQueueSupplier
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.instantMixApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ItemFields
 
-class AudioInstantMixQueue(
+class AudioInstantMixQueueSupplier(
 	private val item: BaseItemDto,
 	private val api: ApiClient,
-) : PagedQueue() {
+) : PagedQueueSupplier() {
 	companion object {
 		val instantMixableItems = arrayOf(
 			BaseItemKind.MUSIC_GENRE,

--- a/playback/jellyfin/src/main/kotlin/queue/AudioTrackQueueSupplier.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/AudioTrackQueueSupplier.kt
@@ -1,16 +1,16 @@
 package org.jellyfin.playback.jellyfin.queue
 
-import org.jellyfin.playback.core.queue.PagedQueue
 import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.supplier.PagedQueueSupplier
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 
-class AudioTrackQueue(
+class AudioTrackQueueSupplier(
 	private val item: BaseItemDto,
 	private val api: ApiClient,
-) : PagedQueue() {
+) : PagedQueueSupplier() {
 	init {
 		require(item.type == BaseItemKind.AUDIO)
 	}

--- a/playback/jellyfin/src/main/kotlin/queue/EpisodeQueueSupplier.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/EpisodeQueueSupplier.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.playback.jellyfin.queue
 
-import org.jellyfin.playback.core.queue.PagedQueue
 import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.supplier.PagedQueueSupplier
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -10,10 +10,10 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaType
 
-class EpisodeQueue(
+class EpisodeQueueSupplier(
 	private val episode: BaseItemDto,
 	private val api: ApiClient,
-) : PagedQueue() {
+) : PagedQueueSupplier() {
 	init {
 		require(episode.type == BaseItemKind.EPISODE)
 	}

--- a/playback/media3/session/src/main/kotlin/MediaSessionService.kt
+++ b/playback/media3/session/src/main/kotlin/MediaSessionService.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.onEach
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.queue.QueueEntry
 import org.jellyfin.playback.core.queue.metadata
+import org.jellyfin.playback.core.queue.queue
 
 class MediaSessionService(
 	private val androidContext: Context,
@@ -34,7 +35,7 @@ class MediaSessionService(
 			setSessionActivity(options.openIntent)
 		}.build()
 
-		state.queue.entry.onEach { item ->
+		manager.queue.entry.onEach { item ->
 			if (item != null) updateNotification(session, item)
 			else if (notifiedNotificationId != null) {
 				notificationManager.cancel(notifiedNotificationId!!)


### PR DESCRIPTION
Update the architecture of playback queues to have a single queue(service) per playback manager which is filled with entries via suppliers. This is required for some upcoming functionality to support more upcoming functionality that is needed for lyric loading (and eventually media segments and other fancy stuff).

**Changes**
- Rename current `Queue` to `QueueSupplier`
- Add a new `QueueService` which is based on the previous `QueueState`
	- This is a required service and automatically added in the `PlaybackManagerBuilder`
- Refactor `MediaStreamState` to `MediaStreamService`
	- This is a required service and automatically added in the `PlaybackManagerBuilder`

<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Part of #1057 