### PR TITLE
Remove context requirement from ExoPlayerProfile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -20,9 +20,11 @@ import org.jellyfin.androidtv.data.compat.VideoOptions;
 import org.jellyfin.androidtv.data.model.DataRefreshService;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.UserSettingPreferences;
+import org.jellyfin.androidtv.preference.constant.AudioBehavior;
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior;
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
+import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
@@ -516,16 +518,16 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         internalOptions.setMaxBitrate(maxBitrate);
         if (exoErrorEncountered || (isLiveTv && !directStreamLiveTv))
             internalOptions.setEnableDirectStream(false);
-        internalOptions.setMaxAudioChannels(Utils.downMixAudio(mFragment.getContext()) ? 2 : null); //have to downmix at server
         internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
         MediaSourceInfo currentMediaSource = getCurrentMediaSource();
         if (!isLiveTv && currentMediaSource != null) {
             internalOptions.setMediaSourceId(currentMediaSource.getId());
         }
         DeviceProfile internalProfile = new ExoPlayerProfile(
-                mFragment.getContext(),
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled())
+                userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
+                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO,
+                !DeviceUtils.has4kVideoSupport()
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.kt
@@ -1,16 +1,11 @@
 package org.jellyfin.androidtv.util
 
 import android.content.Context
-import android.media.AudioManager
 import android.widget.Toast
 import org.jellyfin.androidtv.preference.UserPreferences
-import org.jellyfin.androidtv.preference.UserPreferences.Companion.audioBehaviour
-import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.sdk.model.api.UserDto
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
-import timber.log.Timber
 import java.util.UUID
 import kotlin.math.roundToInt
 
@@ -96,17 +91,6 @@ object Utils : KoinComponent {
 		val themeColor = styledAttributes.getColor(0, 0)
 		styledAttributes.recycle()
 		return themeColor
-	}
-
-	@JvmStatic
-	fun downMixAudio(context: Context): Boolean {
-		val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-		if (am.isBluetoothA2dpOn) {
-			Timber.i("Downmixing audio due to wired headset")
-			return true
-		}
-
-		return get<UserPreferences>()[audioBehaviour] === AudioBehavior.DOWNMIX_TO_STEREO
 	}
 
 	@JvmStatic


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Remove usages of utils/deviceutils from ExoPlayerProfile and move all behavior changing variables to constructor parameters. This will make it easier to read/maintain the legacy profile.
- Remove `utils.downMixAudio` and use preference directly

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
