### PR TITLE
Fix NullPointerException in LeanbackOverlayFragment.onPause

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -88,7 +88,9 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
     @Override
     public void onPause() {
         super.onPause();
-        playerAdapter.getMasterOverlayFragment().onPause();
+        if (playerAdapter != null) {
+            playerAdapter.getMasterOverlayFragment().onPause();
+        }
     }
 
     public CustomPlaybackTransportControlGlue getPlayerGlue() {


### PR DESCRIPTION
**Changes**

* Fix NullPointerException in CustomPlaybackOverlayFragment.onResume

**Issues**

Fixes the second crash of #3835
