### PR TITLE
Use direct stream as default audio behavior

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -97,7 +97,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Preferred behavior for audio streaming.
 		 */
-		var audioBehaviour = enumPreference("audio_behavior", AudioBehavior.DOWNMIX_TO_STEREO)
+		var audioBehaviour = enumPreference("audio_behavior", AudioBehavior.DIRECT_STREAM)
 
 		/**
 		 * Preferred behavior for audio streaming.


### PR DESCRIPTION
In 0.17 I changed the default audio behavior to downmix by default while refactoring out device model checks (previously it only downmixed by default on ccwgtv). In hindsight this wasn't a great idea because that only allows AAC, MP3 and MP2 to direct play, causing a lot of remux/transcode requests.

This change sets the default to be always direct play, which should cause less issues.

**Changes**
- Use "direct play" as default audio behavior

**Issues**

Fixes #3838
Fixes #3834