### PR TITLE
Improve InfoRow colors/font readability

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowColors.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowColors.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.Color
  */
 object InfoRowColors {
 	val Transparent = Color.Transparent to Color.White
-	val Default = Color(0x80FFFFFF) to Color.Black
-	val Green = Color(0x8034D97C) to Color.Black
-	val Red = Color(0x80F2364D) to Color.Black
+	val Default = Color(0xB3FFFFFF) to Color.Black
+	val Green = Color(0xB3089562) to Color.White
+	val Red = Color(0xB3F2364D) to Color.White
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.ProvideTextStyle
@@ -46,6 +47,7 @@ fun InfoRowItem(
 		value = TextStyle(
 			color = foregroundColor,
 			fontSize = if (backgroundColor.alpha > 0f) 12.sp else 16.sp,
+			fontWeight = if (backgroundColor.alpha > 0f) FontWeight.W600 else FontWeight.W500,
 		)
 	) {
 		Row(


### PR DESCRIPTION
The info row changes in 0.17 changed the colors of the badges, these new colors make the text harder to read for some users. This PR updates the design to make it more readable by changing the font weight (for all text) and updating the colors for a higher contrast.

**Screenshots**

Note: these screenshots show all badges for testing purposes, that's not part of the code changes here :)

![94500003bb](https://github.com/user-attachments/assets/b5a1f45d-f909-48ee-b51a-cbde983f4f13)
![91200003bc](https://github.com/user-attachments/assets/fe585975-def7-4494-8394-083b60907417)


**Issues**

Fixes #3852