### PR TITLE
Graduate reactive homepage to stable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -195,11 +195,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Whether items shown in the screensaver are required to have an age rating set.
 		 */
 		var screensaverAgeRatingRequired = booleanPreference("screensaver_agerating_required", true)
-
-		/**
-		 * Enable reactive homepage
-		 */
-		var homeReactive = booleanPreference("home_reactive", false)
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -166,15 +166,13 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 
 		lifecycleScope.launch {
 			lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-				if (userPreferences[UserPreferences.homeReactive]) {
-					api.webSocket.subscribe<UserDataChangedMessage>()
-						.onEach { refreshRows(force = true, delayed = false) }
-						.launchIn(this)
+				api.webSocket.subscribe<UserDataChangedMessage>()
+					.onEach { refreshRows(force = true, delayed = false) }
+					.launchIn(this)
 
-					api.webSocket.subscribe<LibraryChangedMessage>()
-						.onEach { refreshRows(force = true, delayed = false) }
-						.launchIn(this)
-				}
+				api.webSocket.subscribe<LibraryChangedMessage>()
+					.onEach { refreshRows(force = true, delayed = false) }
+					.launchIn(this)
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -39,12 +39,6 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 				}
 			}
 
-			checkbox {
-				setTitle(R.string.enable_reactive_homepage)
-				setContent(R.string.enable_playback_module_description)
-				bind(userPreferences, UserPreferences.homeReactive)
-			}
-
 			// Only show in debug mode
 			// some strings are hardcoded because these options don't show in beta/release builds
 			if (BuildConfig.DEVELOPMENT) {


### PR DESCRIPTION
The reactive homepage option subscribes to websocket messages for library updates and refreshes the homepage accordingly. This way, whenever a new episode is added to the server the next up section will update without re-opening the app. It also updates after something is watched etc.

This option was unstable in 0.16 but with the many SDK refactorings and item row improvements it has become stable in 0.17 and I somewhat forgot about it because it never caused issues.

A WebSocket connection is required for it to work, otherwise it will just do nothing.

**Changes**
- Remove experimental "reactive homepage" developer option
- Always enable reactive homepage
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
