### PR TITLE
Fix intros showing next up screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -217,9 +217,10 @@ class SdkPlaybackHelper(
 			val addIntros = allowIntros && userPreferences[UserPreferences.cinemaModeEnabled]
 
 			if (addIntros) {
-				val intros = runCatching {
-					api.userLibraryApi.getIntros(mainItem.id).content.items
-				}.getOrNull().orEmpty()
+				val intros = runCatching { api.userLibraryApi.getIntros(mainItem.id).content.items }.getOrNull()
+					.orEmpty()
+					// Force the type to be trailer as the legacy playback UI uses it to determine if it should show the next up screen
+					.map { it.copy(type = BaseItemKind.TRAILER) }
 
 				intros + parts
 			} else {


### PR DESCRIPTION
Bring back some 0.16 behavior, when fetching intros we should set the type to be a trailer because the PlaybackController uses that

**Changes**
- Force the type to be trailer as the legacy playback UI uses it to determine if it should show the next up screen
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #3864