### PR TITLE
Reset display mode when exiting video player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -7,12 +7,14 @@ import android.content.Context;
 import android.graphics.Color;
 import android.media.AudioManager;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.LinearLayout;
@@ -1281,5 +1283,12 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // Show system bars
         WindowCompat.setDecorFitsSystemWindows(requireActivity().getWindow(), true);
         WindowCompat.getInsetsController(requireActivity().getWindow(), requireActivity().getWindow().getDecorView()).show(WindowInsetsCompat.Type.systemBars());
+
+        // Reset display mode
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            WindowManager.LayoutParams params = getActivity().getWindow().getAttributes();
+            params.preferredDisplayModeId = 0;
+            getActivity().getWindow().setAttributes(params);
+        }
     }
 }


### PR DESCRIPTION
Previously (in 0.16) the video player was its own activity, so when it closed it would automagically reset the display mode. Now that we have it integrated as fragment together with the other screens it would no longer do this.

**Changes**
- Reset display mode when exiting video player
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #3870