### PR TITLE
Fix HEVC allowed in transcode profile when not supported

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -11,6 +11,7 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditio
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.supportsHevc
 import org.jellyfin.apiclient.model.dlna.CodecProfile
 import org.jellyfin.apiclient.model.dlna.CodecType
 import org.jellyfin.apiclient.model.dlna.DeviceProfile
@@ -76,7 +77,7 @@ class ExoPlayerProfile(
 				this.context = EncodingContext.Streaming
 				container = Codec.Container.TS
 				videoCodec = buildList {
-					if (deviceHevcCodecProfile.ContainsCodec(Codec.Video.HEVC, Codec.Container.TS)) add(Codec.Video.HEVC)
+					if (supportsHevc) add(Codec.Video.HEVC)
 					add(Codec.Video.H264)
 				}.joinToString(",")
 				audioCodec = when (downMixAudio) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -63,13 +63,17 @@ object ProfileHelper {
 		}
 	}
 
+	val supportsHevc by lazy {
+		MediaTest.supportsHevc()
+	}
+
 	val deviceHevcCodecProfile by lazy {
 		CodecProfile().apply {
 			type = CodecType.Video
 			codec = Codec.Video.HEVC
 
 			conditions = when {
-				!MediaTest.supportsHevc() -> {
+				!supportsHevc -> {
 					// The following condition is a method to exclude all HEVC
 					Timber.i("*** Does NOT support HEVC")
 					arrayOf(

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -111,7 +111,7 @@ object ProfileHelper {
 
 	val deviceHevcLevelCodecProfiles by lazy {
 		buildList {
-			if (MediaTest.supportsHevc()) {
+			if (supportsHevc) {
 				add(CodecProfile().apply {
 					type = CodecType.Video
 					codec = Codec.Video.HEVC


### PR DESCRIPTION
Excludes Fire TV 1st Gen from requesting HEVC transcodes by device model.

**Changes**
The Fire TV 1st Gen doesn't support HEVC. jellyfin-androidtv detects as such but currently still ends up requesting a transcode to it. This MR offers working video+stereo audio, but despite support for 5.1 EAC3 & AAC only downmixing to stereo works.

**Issues**
Fixes #3842
