### PR TITLE
Fix crash when item doesn't have a default audio/subtitle stream

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -139,8 +139,8 @@ fun InfoRowSeasonEpisode(item: BaseItemDto) {
 
 private fun List<MediaStream>.getDefault(type: MediaStreamType, defaultIndex: Int? = null): MediaStream? {
 	if (defaultIndex != null) {
-		val byIndex = get(defaultIndex)
-		if (byIndex.type == type) return byIndex
+		val byIndex = getOrNull(defaultIndex)
+		if (byIndex?.type == type) return byIndex
 	}
 
 	return firstOrNull { it.type == type }


### PR DESCRIPTION
In some cases the defaultAudioStreamIndex or defaultSubtitleStreamIndex can be `-1` instead of null. Use the `getOrNull` function to avoid an ArrayIndexOutOfBoundsException.

**Changes**

- Fix crash when item doesn't have a default audio/subtitle stream

**Issues**

Fixes #3880