### PR TITLE
Improve behavior when no playable items found

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1186,6 +1186,10 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             @Override
             public void onResponse(List<BaseItemDto> response) {
                 if (!getActive()) return;
+                if (response.isEmpty()) {
+                    Timber.e("No items to play - ignoring play request.");
+                    return;
+                }
 
                 if (item.getType() == BaseItemKind.MUSIC_ARTIST) {
                     mediaManager.getValue().playNow(requireContext(), response, 0, shuffle);
@@ -1196,7 +1200,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 }
             }
         });
-
     }
 
     void play(final List<BaseItemDto> items, final int pos, final boolean shuffle) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -55,7 +55,9 @@ class SdkPlaybackHelper(
 	) {
 		getScope(context).launch {
 			runCatching {
-				getItems(mainItem, allowIntros, shuffle)
+				val items = getItems(mainItem, allowIntros, shuffle)
+				if (items.isEmpty() && !mainItem.mediaSources.isNullOrEmpty()) listOf(mainItem)
+				else items
 			}.fold(
 				onSuccess = { items -> outerResponse.onResponse(items) },
 				onFailure = { exception ->


### PR DESCRIPTION
In some cases the `getItemsToPlay` function won't find any items to play. This PR tries to improve this slightly.

**Changes**
- Don't attempt to open video player when there are no playable items
- Try to fallback to the input item when there are no playable items

**Issues**

Should fix #3910