### PR TITLE
Set seek parameter for D-Pad to 10 seconds

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
@@ -8,7 +8,7 @@ class CustomSeekProvider(
 	private val videoPlayerAdapter: VideoPlayerAdapter,
 ) : PlaybackSeekDataProvider() {
 	companion object {
-		private const val SEEK_LENGTH = 30000L
+		private const val SEEK_LENGTH = 10000L
 	}
 
 	override fun getSeekPositions(): LongArray {

--- a/app/src/test/kotlin/ui/playback/overlay/CustomSeekProviderTests.kt
+++ b/app/src/test/kotlin/ui/playback/overlay/CustomSeekProviderTests.kt
@@ -9,21 +9,21 @@ class CustomSeekProviderTests : FunSpec({
 	test("CustomSeekProvider.seekPositions with simple duration") {
 		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
 			every { canSeek() } returns true
-			every { duration } returns 90000L
+			every { duration } returns 30000L
 		}
 		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter)
 
-		customSeekProvider.seekPositions shouldBe arrayOf(0L, 30000L, 60000L, 90000L)
+		customSeekProvider.seekPositions shouldBe arrayOf(0L, 10000L, 20000L, 30000L)
 	}
 
 	test("CustomSeekProvider.seekPositions with odd duration") {
 		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
 			every { canSeek() } returns true
-			every { duration } returns 130000L
+			every { duration } returns 45000L
 		}
 		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter)
 
-		customSeekProvider.seekPositions shouldBe arrayOf(0L, 30000, 60000, 90000, 120000, 130000)
+		customSeekProvider.seekPositions shouldBe arrayOf(0L, 10000, 20000, 30000, 40000, 45000)
 	}
 
 	test("CustomSeekProvider.seekPositions with seek disabled") {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Attempts to mitigate #3033 somewhat by changing the `SEEK_LENGTH` in `CustomSeekProvider` to a more granular 10 seconds.

Tested on Chromecast running Google TV on Android 12.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

#3033 (leaving it open)