### PR TITLE
Enhance AVC and High 10 Profile Support 

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -3,10 +3,10 @@ package org.jellyfin.androidtv.util.profile
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.util.profile.ProfileHelper.audioDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAV1CodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCCodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
-import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoLevelProfileCondition
-import org.jellyfin.androidtv.util.profile.ProfileHelper.h264VideoProfileCondition
 import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditions
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
@@ -154,15 +154,8 @@ class ExoPlayerProfile(
 
 		codecProfiles = buildList {
 			// H264 profile
-			add(CodecProfile().apply {
-				type = CodecType.Video
-				codec = Codec.Video.H264
-				conditions = buildList {
-					add(h264VideoProfileCondition)
-					add(h264VideoLevelProfileCondition)
-					if (disable4KVideo) addAll(max1080pProfileConditions)
-				}.toTypedArray()
-			})
+			add(deviceAVCCodecProfile)
+			addAll(deviceAVCLevelCodecProfiles)
 			// H264 ref frames profile
 			add(CodecProfile().apply {
 				type = CodecType.Video

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -9,6 +9,27 @@ import timber.log.Timber
 class MediaCodecCapabilitiesTest {
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
 
+	// AVC levels as reported by ffprobe are multiplied by 10, e.g. level 4.1 is 41. Level 1b is set to 9
+	private val avcLevelStrings = listOf(
+		CodecProfileLevel.AVCLevel1b to "9",
+		CodecProfileLevel.AVCLevel1 to "10",
+		CodecProfileLevel.AVCLevel11 to "11",
+		CodecProfileLevel.AVCLevel12 to "12",
+		CodecProfileLevel.AVCLevel13 to "13",
+		CodecProfileLevel.AVCLevel2 to "20",
+		CodecProfileLevel.AVCLevel21 to "21",
+		CodecProfileLevel.AVCLevel22 to "22",
+		CodecProfileLevel.AVCLevel3 to "30",
+		CodecProfileLevel.AVCLevel31 to "31",
+		CodecProfileLevel.AVCLevel32 to "32",
+		CodecProfileLevel.AVCLevel4 to "40",
+		CodecProfileLevel.AVCLevel41 to "41",
+		CodecProfileLevel.AVCLevel42 to "42",
+		CodecProfileLevel.AVCLevel5 to "50",
+		CodecProfileLevel.AVCLevel51 to "51",
+		CodecProfileLevel.AVCLevel52 to "52",
+	)
+
 	// HEVC levels as reported by ffprobe are multiplied by 30, e.g. level 4.1 is 123
 	private val hevcLevelStrings = listOf(
 		CodecProfileLevel.HEVCMainTierLevel1 to "30",
@@ -36,6 +57,30 @@ class MediaCodecCapabilitiesTest {
 			CodecProfileLevel.AV1Level5
 		)
 
+	fun supportsAVC(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AVC)
+
+	fun supportsAVCHigh10(): Boolean = hasDecoder(
+		MediaFormat.MIMETYPE_VIDEO_AVC,
+		CodecProfileLevel.AVCProfileHigh10,
+		CodecProfileLevel.AVCLevel4
+	)
+
+	fun getAVCMainLevel(): String = getAVCLevelString(
+		CodecProfileLevel.AVCProfileMain
+	)
+
+	fun getAVCHigh10Level(): String = getAVCLevelString(
+		CodecProfileLevel.AVCProfileHigh10
+	)
+
+	private fun getAVCLevelString(profile: Int): String {
+		val level = getDecoderLevel(MediaFormat.MIMETYPE_VIDEO_AVC, profile)
+
+		return avcLevelStrings.asReversed().find { item: Pair<Int, String> ->
+			level >= item.first
+		}?.second ?: "0"
+	}
+
 	fun supportsHevc(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_HEVC)
 
 	fun supportsHevcMain10(): Boolean = hasDecoder(
@@ -50,12 +95,6 @@ class MediaCodecCapabilitiesTest {
 
 	fun getHevcMain10Level(): String = getHevcLevelString(
 		CodecProfileLevel.HEVCProfileMain10
-	)
-
-	fun supportsAVCHigh10(): Boolean = hasDecoder(
-		MediaFormat.MIMETYPE_VIDEO_AVC,
-		CodecProfileLevel.AVCProfileHigh10,
-		CodecProfileLevel.AVCLevel4
 	)
 
 	private fun getHevcLevelString(profile: Int): String {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
This PR enhances the handling of AVC (H.264) and High 10 profile support. It introduces improvements to how codec profiles are evaluated and managed.

1. Enhanced AVC Profile and level mapping:
    -	Mapped AVC levels using `CodecProfileLevel` constants to align with ffprobe reporting format.
3. Added lazy initialization for checks methods:
    -  `supportsAVC` `supportsAVCHigh10`
4. Updated  codec profile & level conditions:
   - Removed `h264VideoLevelProfileCondition` & `h264VideoProfileCondition`, which had hard-coded data.
   - Added `deviceAvcCodecProfile ` &  `deviceAvcLevelCodecProfiles` to manage AVC codec profile and level conditions.
   

