### PR TITLE
Fix transcoding issues on devices without HEVC Main 10 support

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -157,9 +157,13 @@ object ProfileHelper {
 			}
 		}
 	}
-	
+
 	val supportsHevc by lazy {
 		MediaTest.supportsHevc()
+	}
+
+	val supportsHevcMain10 by lazy {
+		MediaTest.supportsHevcMain10()
 	}
 
 	val deviceHevcCodecProfile by lazy {
@@ -179,24 +183,17 @@ object ProfileHelper {
 						)
 					)
 				}
-				!MediaTest.supportsHevcMain10() -> {
-					Timber.i("*** Does NOT support HEVC 10 bit")
-					arrayOf(
-						ProfileCondition(
-							ProfileConditionType.NotEquals,
-							ProfileConditionValue.VideoProfile,
-							"Main 10"
-						)
-					)
-				}
 				else -> {
-					// supports all HEVC
+					// If HEVC is supported, include all relevant profiles
 					Timber.i("*** Supports HEVC 10 bit")
 					arrayOf(
 						ProfileCondition(
-							ProfileConditionType.NotEquals,
+							ProfileConditionType.EqualsAny,
 							ProfileConditionValue.VideoProfile,
-							"none"
+							listOfNotNull(
+								"Main",
+								if (supportsHevcMain10) "Main 10" else null
+							).joinToString("|")
 						)
 					)
 				}
@@ -228,7 +225,7 @@ object ProfileHelper {
 					)
 				})
 
-				if (MediaTest.supportsHevcMain10()) {
+				if (supportsHevcMain10) {
 					add(CodecProfile().apply {
 						type = CodecType.Video
 						codec = Codec.Video.HEVC


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
Files played on devices that lacked HEVC Main 10 support were not being transcoded, leading to potential playback issues. This issue was identified in the `ProfileHelper` class and has been addressed with the following changes:

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
1. Added support for HEVC Main 10 check:
   - Introduced a new property `supportsHevcMain10` to determine HEVC Main 10 support, mirroring the approach used for other codecs.

2. Updated `deviceHevcCodecProfile`:
   - Modified the `conditions` property to use `ProfileConditionType.EqualsAny` when HEVC is supported. This ensures that profiles for both "Main" and "Main 10" are considered based on support availability, preventing issues with files not transcoding on devices lacking HEVC Main 10 support.

3. Refactored `deviceHevcLevelCodecProfiles`

4. Adjusted logging messages and comments.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->Fixes #3923