### PR TITLE
Fix capitalization in video profiles causing invalid transcodes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -38,7 +38,7 @@ object ProfileHelper {
 						ProfileCondition(
 							ProfileConditionType.NotEquals,
 							ProfileConditionValue.VideoProfile,
-							"Main 10"
+							"main 10"
 						)
 					)
 				}
@@ -90,11 +90,11 @@ object ProfileHelper {
 							ProfileConditionType.EqualsAny,
 							ProfileConditionValue.VideoProfile,
 							listOfNotNull(
-								"High",
-								"Main",
-								"Baseline",
-								"Constrained Baseline",
-								if (supportsAVCHigh10) "High 10" else null
+								"high",
+								"main",
+								"baseline",
+								"constrained baseline",
+								if (supportsAVCHigh10) "high 10" else null
 							).joinToString("|")
 						)
 					)
@@ -115,10 +115,10 @@ object ProfileHelper {
 							ProfileConditionType.EqualsAny,
 							ProfileConditionValue.VideoProfile,
 							listOfNotNull(
-								"High",
-								"Main",
-								"Baseline",
-								"Constrained Baseline"
+								"high",
+								"main",
+								"baseline",
+								"constrained baseline"
 							).joinToString("|")
 						)
 					)
@@ -141,7 +141,7 @@ object ProfileHelper {
 							ProfileCondition(
 								ProfileConditionType.Equals,
 								ProfileConditionValue.VideoProfile,
-								"High 10"
+								"high 10"
 							)
 						)
 
@@ -191,8 +191,8 @@ object ProfileHelper {
 							ProfileConditionType.EqualsAny,
 							ProfileConditionValue.VideoProfile,
 							listOfNotNull(
-								"Main",
-								if (supportsHevcMain10) "Main 10" else null
+								"main",
+								if (supportsHevcMain10) "main 10" else null
 							).joinToString("|")
 						)
 					)
@@ -212,7 +212,7 @@ object ProfileHelper {
 						ProfileCondition(
 							ProfileConditionType.Equals,
 							ProfileConditionValue.VideoProfile,
-							"Main"
+							"main"
 						)
 					)
 
@@ -234,7 +234,7 @@ object ProfileHelper {
 							ProfileCondition(
 								ProfileConditionType.Equals,
 								ProfileConditionValue.VideoProfile,
-								"Main 10"
+								"main 10"
 							)
 						)
 


### PR DESCRIPTION
After merging #3932 some videos stopped playing for me with this error:

```
[hevc_nvenc @ 0000023043dc9f40] [Eval @ 00000039cbdfe4b0] Undefined constant or missing '(' in 'Main'
[hevc_nvenc @ 0000023043dc9f40] Unable to parse option value "Main"
[hevc_nvenc @ 0000023043dc9f40] Error setting option profile to value Main.
[vost#0:0/hevc_nvenc @ 000002303caf3700] Error initializing output stream: Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
[libfdk_aac @ 000002303cae4500] 2 frames left in the queue on closing
Conversion failed!
```

Turns out, our server doesn't sanitize shit and de nvenc encoder expects fully lowercase profiles. The server itself compares those strings everywhere ignoring casing though. Ideally this must be fixed serverside too.

**Changes**
- Fix capitalization in video profiles causing invalid transcodes

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
