### PR TITLE
Add ARC audio output mode with updated codec profiles and transcoding

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/AudioBehavior.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/AudioBehavior.kt
@@ -15,4 +15,9 @@ enum class AudioBehavior(
 	 * Downnmix audio to stereo. Disables the AC3, EAC3 and AAC_LATM audio codecs.
 	 */
 	DOWNMIX_TO_STEREO(R.string.pref_audio_compat),
+
+	/**
+	 * Stream AC3, EAC3, and DTS directly. Disables TrueHD and caps other codecs to stereo.
+	 */
+	HDMI_ARC_OUTPUT(R.string.audio_hdmi_arc)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -514,7 +514,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
                 userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO
+                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO,
+                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.HDMI_ARC_OUTPUT
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -525,6 +525,7 @@
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
+    <string name="audio_hdmi_arc">HDMI ARC</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
This PR adds an HDMI ARC audio output mode to address playback issues with high-resolution and uncompressed audio formats over an ARC connection in Jellyfin. Updates to the `ExoPlayerProfile` class and incorporates a new audio output preference. The PR ensures compatibility with PCM and TrueHD formats by transcoding unsupported surround sound formats to AC3, maintaining surround sound capabilities.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
1. Preference Option:
    - Added `HDMI_ARC_OUTPUT` option in `AudioBehavior` to allow users to enable HDMI ARC audio output.

2. New Parameter: 
   - Added `enableARCAudio` parameter to `ExoPlayerProfile`.
   - Added `AudioBehavior.HDMI_ARC_OUTPUT` condition to `PlaybackController`.

5. Updated Audio Codecs:
   - Added `downmixARCSupportedAudioCodecs` for ARC audio.
   - Adjusted `allSupportedAudioCodecs` to include/exclude codecs based on `enableARCAudio`.
   - Updated audio codec selection for transcoding and direct play profiles based on new settings.
   - Added maximum audio channel profiles specifically for ARC audio.
  

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> Fixes: #3900 #3903 #2991
