### PR TITLE
Add resolution codec check

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -24,12 +24,12 @@ import org.jellyfin.androidtv.preference.constant.AudioBehavior;
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior;
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
-import org.jellyfin.androidtv.util.DeviceUtils;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
 import org.jellyfin.androidtv.util.apiclient.StreamHelper;
 import org.jellyfin.androidtv.util.profile.ExoPlayerProfile;
+import org.jellyfin.androidtv.util.profile.MediaCodecCapabilitiesTest;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
@@ -509,6 +509,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     @NonNull
     private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item, int maxBitrate) {
+        MediaCodecCapabilitiesTest mediaCodecCapabilitiesTest = new MediaCodecCapabilitiesTest();
         VideoOptions internalOptions = new VideoOptions();
         internalOptions.setItemId(item.getId());
         internalOptions.setMediaSources(item.getMediaSources());
@@ -524,7 +525,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
                 userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
                 userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO,
-                !DeviceUtils.has4kVideoSupport()
+                !mediaCodecCapabilitiesTest.supports4KResolution()
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -29,7 +29,6 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
 import org.jellyfin.androidtv.util.apiclient.StreamHelper;
 import org.jellyfin.androidtv.util.profile.ExoPlayerProfile;
-import org.jellyfin.androidtv.util.profile.MediaCodecCapabilitiesTest;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.Response;
@@ -509,7 +508,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     @NonNull
     private VideoOptions buildExoPlayerOptions(@Nullable Integer forcedSubtitleIndex, BaseItemDto item, int maxBitrate) {
-        MediaCodecCapabilitiesTest mediaCodecCapabilitiesTest = new MediaCodecCapabilitiesTest();
         VideoOptions internalOptions = new VideoOptions();
         internalOptions.setItemId(item.getId());
         internalOptions.setMediaSources(item.getMediaSources());
@@ -524,8 +522,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 isLiveTv && !userPreferences.getValue().get(UserPreferences.Companion.getLiveTvDirectPlayEnabled()),
                 userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO,
-                !mediaCodecCapabilitiesTest.supports4KResolution()
+                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -7,7 +7,7 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
-import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pCodecProfile
+import org.jellyfin.androidtv.util.profile.ProfileHelper.maxResolutionCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
@@ -199,7 +199,7 @@ class ExoPlayerProfile(
 			// AV1 profile
 			add(deviceAV1CodecProfile)
 			// Limit video resolution support for older devices
-			add(max1080pCodecProfile)
+			add(maxResolutionCodecProfile)
 			// Audio channel profile
 			add(maxAudioChannelsCodecProfile(channels = if (downMixAudio) 2 else 8))
 		}.toTypedArray()

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -7,7 +7,7 @@ import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceAVCLevelCodecProfiles
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.deviceHevcLevelCodecProfiles
-import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pProfileConditions
+import org.jellyfin.androidtv.util.profile.ProfileHelper.max1080pCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.maxAudioChannelsCodecProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.photoDirectPlayProfile
 import org.jellyfin.androidtv.util.profile.ProfileHelper.subtitleProfile
@@ -27,8 +27,7 @@ import org.jellyfin.apiclient.model.dlna.TranscodingProfile
 class ExoPlayerProfile(
 	disableVideoDirectPlay: Boolean,
 	isAC3Enabled: Boolean,
-	downMixAudio: Boolean,
-	disable4KVideo: Boolean
+	downMixAudio: Boolean
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		Codec.Audio.AAC,
@@ -200,12 +199,7 @@ class ExoPlayerProfile(
 			// AV1 profile
 			add(deviceAV1CodecProfile)
 			// Limit video resolution support for older devices
-			if (disable4KVideo) {
-				add(CodecProfile().apply {
-					type = CodecType.Video
-					conditions = max1080pProfileConditions
-				})
-			}
+			add(max1080pCodecProfile)
 			// Audio channel profile
 			add(maxAudioChannelsCodecProfile(channels = if (downMixAudio) 2 else 8))
 		}.toTypedArray()

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -166,7 +166,10 @@ class MediaCodecCapabilitiesTest {
 		return false
 	}
 
-	fun supports4KResolution(): Boolean {
+	fun getMaxResolution(): Pair<Int, Int> {
+		var maxWidth = 0
+		var maxHeight = 0
+
 		for (info in mediaCodecList.codecInfos) {
 			if (info.isEncoder) continue
 
@@ -175,21 +178,17 @@ class MediaCodecCapabilitiesTest {
 				val videoCapabilities = capabilities.videoCapabilities
 
 				if (videoCapabilities != null) {
-					// Get the supported width and height ranges
-					val maxWidth = videoCapabilities.supportedWidths?.upper ?: 0
-					val maxHeight = videoCapabilities.supportedHeights?.upper ?: 0
+					val supportedWidth = videoCapabilities.supportedWidths?.upper ?: 0
+					val supportedHeight = videoCapabilities.supportedHeights?.upper ?: 0
 
-					// Check for 4K resolution support
-					if (maxWidth >= 3840 && maxHeight >= 2160) {
-						Timber.i("4K resolution is supported by codec %s", info.name)
-						return true
-					}
+					maxWidth = maxOf(maxWidth, supportedWidth)
+					maxHeight = maxOf(maxHeight, supportedHeight)
 				}
 			} catch (e: IllegalArgumentException) {
 				Timber.d(e, "Codec %s does not support video capabilities", info.name)
 			}
 		}
 
-		return false
+		return Pair(maxWidth, maxHeight)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -4,6 +4,7 @@ import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
+import android.util.Size
 import timber.log.Timber
 
 class MediaCodecCapabilitiesTest {
@@ -166,7 +167,7 @@ class MediaCodecCapabilitiesTest {
 		return false
 	}
 
-	fun getMaxResolution(): Pair<Int, Int> {
+	fun getMaxResolution(mime: String): Size {
 		var maxWidth = 0
 		var maxHeight = 0
 
@@ -174,21 +175,20 @@ class MediaCodecCapabilitiesTest {
 			if (info.isEncoder) continue
 
 			try {
-				val capabilities = info.getCapabilitiesForType(MediaFormat.MIMETYPE_VIDEO_AVC)
-				val videoCapabilities = capabilities.videoCapabilities
+				val capabilities = info.getCapabilitiesForType(mime)
+				val videoCapabilities = capabilities.videoCapabilities ?: continue
+				val supportedWidth = videoCapabilities.supportedWidths?.upper ?: continue
+				val supportedHeight = videoCapabilities.supportedHeights?.upper ?: continue
 
-				if (videoCapabilities != null) {
-					val supportedWidth = videoCapabilities.supportedWidths?.upper ?: 0
-					val supportedHeight = videoCapabilities.supportedHeights?.upper ?: 0
+				maxWidth = maxOf(maxWidth, supportedWidth)
+				maxHeight = maxOf(maxHeight, supportedHeight)
 
-					maxWidth = maxOf(maxWidth, supportedWidth)
-					maxHeight = maxOf(maxHeight, supportedHeight)
-				}
 			} catch (e: IllegalArgumentException) {
 				Timber.d(e, "Codec %s does not support video capabilities", info.name)
 			}
 		}
 
-		return Pair(maxWidth, maxHeight)
+		return Size(maxWidth, maxHeight)
 	}
+
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -165,4 +165,31 @@ class MediaCodecCapabilitiesTest {
 
 		return false
 	}
+
+	fun supports4KResolution(): Boolean {
+		for (info in mediaCodecList.codecInfos) {
+			if (info.isEncoder) continue
+
+			try {
+				val capabilities = info.getCapabilitiesForType(MediaFormat.MIMETYPE_VIDEO_AVC)
+				val videoCapabilities = capabilities.videoCapabilities
+
+				if (videoCapabilities != null) {
+					// Get the supported width and height ranges
+					val maxWidth = videoCapabilities.supportedWidths?.upper ?: 0
+					val maxHeight = videoCapabilities.supportedHeights?.upper ?: 0
+
+					// Check for 4K resolution support
+					if (maxWidth >= 3840 && maxHeight >= 2160) {
+						Timber.i("4K resolution is supported by codec %s", info.name)
+						return true
+					}
+				}
+			} catch (e: IllegalArgumentException) {
+				Timber.d(e, "Codec %s does not support video capabilities", info.name)
+			}
+		}
+
+		return false
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -15,6 +15,34 @@ import timber.log.Timber
 object ProfileHelper {
 	private val MediaTest by lazy { MediaCodecCapabilitiesTest() }
 
+	private val supports4K by lazy {
+		val (maxWidth, maxHeight) = MediaTest.getMaxResolution()
+		maxWidth >= 3840 && maxHeight >= 2160
+	}
+
+	val max1080pCodecProfile by lazy {
+		CodecProfile().apply {
+			type = CodecType.Video
+			conditions = if (supports4K) {
+				// No restriction if 4K is supported
+				arrayOf()
+			} else {
+				arrayOf(
+					ProfileCondition(
+						ProfileConditionType.LessThanEqual,
+						ProfileConditionValue.Width,
+						"1920"
+					),
+					ProfileCondition(
+						ProfileConditionType.LessThanEqual,
+						ProfileConditionValue.Height,
+						"1080"
+					)
+				)
+			}
+		}
+	}
+
 	val deviceAV1CodecProfile by lazy {
 		CodecProfile().apply {
 			type = CodecType.Video
@@ -249,21 +277,6 @@ object ProfileHelper {
 				}
 			}
 		}
-	}
-
-	val max1080pProfileConditions by lazy {
-		arrayOf(
-			ProfileCondition(
-				ProfileConditionType.LessThanEqual,
-				ProfileConditionValue.Width,
-				"1920"
-			),
-			ProfileCondition(
-				ProfileConditionType.LessThanEqual,
-				ProfileConditionValue.Height,
-				"1080"
-			)
-		)
 	}
 
 	val photoDirectPlayProfile by lazy {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -16,45 +16,6 @@ import timber.log.Timber
 object ProfileHelper {
 	private val MediaTest by lazy { MediaCodecCapabilitiesTest() }
 
-	private val resolution by lazy {
-		MediaTest.getMaxResolution(MediaFormat.MIMETYPE_VIDEO_AVC)
-	}
-
-	val max1080pCodecProfile by lazy {
-		CodecProfile().apply {
-			type = CodecType.Video
-			conditions = if (resolution.width >= 3840 && resolution.height >= 2160) {
-				// Allow resolutions up to 4K
-				arrayOf(
-					ProfileCondition(
-						ProfileConditionType.LessThanEqual,
-						ProfileConditionValue.Width,
-						"3840"
-					),
-					ProfileCondition(
-						ProfileConditionType.LessThanEqual,
-						ProfileConditionValue.Height,
-						"2160"
-					)
-				)
-			} else {
-				// Restrict resolution to 1080p if resolution is less than 4K
-				arrayOf(
-					ProfileCondition(
-						ProfileConditionType.LessThanEqual,
-						ProfileConditionValue.Width,
-						"1920"
-					),
-					ProfileCondition(
-						ProfileConditionType.LessThanEqual,
-						ProfileConditionValue.Height,
-						"1080"
-					)
-				)
-			}
-		}
-	}
-
 	val deviceAV1CodecProfile by lazy {
 		CodecProfile().apply {
 			type = CodecType.Video
@@ -288,6 +249,26 @@ object ProfileHelper {
 					})
 				}
 			}
+		}
+	}
+
+	val maxResolutionCodecProfile by lazy {
+		val maxResolution = MediaTest.getMaxResolution(MediaFormat.MIMETYPE_VIDEO_AVC)
+
+		CodecProfile().apply {
+			type = CodecType.Video
+			conditions = arrayOf(
+				ProfileCondition(
+					ProfileConditionType.LessThanEqual,
+					ProfileConditionValue.Width,
+					maxResolution.width.toString()
+				),
+				ProfileCondition(
+					ProfileConditionType.LessThanEqual,
+					ProfileConditionValue.Height,
+					maxResolution.height.toString()
+				)
+			)
 		}
 	}
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
This PR introduces a new check to verify resolution support, ensuring compatibility with 1080p devices. The update involves changes to `MediaCodecCapabilitiesTest`, `ProfileHelper`, `ExoPlayerProfile`, and `PlaybackController`, allowing playback options to be configured according to the codec's resolution capabilities of the device.


**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
1. MediaCodecCapabilitiesTest:
   - Added `getMaxResolution` method to return the maximum supported width and height.
2. ProfileHelper:
   - Added `maxResolutionCodecProfile`
     - Dynamically use the device’s maximum supported resolution obtained from `MediaTest.getMaxResolution`
   - Removed `max1080pProfileConditions`
3. ExoPlayerProfile:
   - Updates the `ExoPlayerProfile` to reflect changes in the handling of 1080p profiles and removes the `disable4KVideo `parameter.
5. PlaybackController:
   - Remove `!DeviceUtils.has4kVideoSupport` condition.
