### PR TITLE
Use custom logic for fragment back stack

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,8 +108,8 @@
         <activity
             android:name=".ui.startup.StartupActivity"
             android:exported="true"
-            android:noHistory="true"
             android:launchMode="singleTask"
+            android:noHistory="true"
             android:screenOrientation="landscape"
             android:windowSoftInputMode="adjustNothing">
             <intent-filter>
@@ -132,6 +132,7 @@
         <!-- Main application -->
         <activity
             android:name=".ui.browsing.MainActivity"
+            android:launchMode="singleTask"
             android:screenOrientation="landscape"
             android:windowSoftInputMode="adjustNothing" />
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
@@ -1,0 +1,184 @@
+package org.jellyfin.androidtv.ui.browsing
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.core.os.BundleCompat
+import androidx.core.os.ParcelCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.navigation.NavigationAction
+import java.util.Stack
+
+private class HistoryEntry(
+	val name: Class<out Fragment>,
+	val arguments: Bundle = bundleOf(),
+
+	var fragment: Fragment? = null,
+	var savedState: Fragment.SavedState? = null,
+) : Parcelable {
+	override fun describeContents(): Int = 0
+
+	override fun writeToParcel(dest: Parcel, flags: Int) {
+		dest.writeString(name.name)
+		dest.writeBundle(arguments)
+		dest.writeParcelable(savedState, 0)
+	}
+
+	companion object CREATOR : Parcelable.Creator<HistoryEntry> {
+		@Suppress("UNCHECKED_CAST")
+		override fun createFromParcel(parcel: Parcel): HistoryEntry = HistoryEntry(
+			name = Class.forName(parcel.readString()!!) as Class<out Fragment>,
+			arguments = parcel.readBundle(this::class.java.classLoader)!!,
+			fragment = null,
+			savedState = ParcelCompat.readParcelable(parcel, this::class.java.classLoader, Fragment.SavedState::class.java)!!,
+		)
+
+		override fun newArray(size: Int): Array<HistoryEntry?> = arrayOfNulls(size)
+	}
+}
+
+class DestinationFragmentView @JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+) : FrameLayout(context, attrs) {
+	private companion object {
+		private const val FRAGMENT_TAG_CONTENT = "content"
+		private const val BUNDLE_SUPER = "super"
+		private const val BUNDLE_HISTORY = "history"
+	}
+
+	private val fragmentManager by lazy {
+		FragmentManager.findFragmentManager(this)
+	}
+
+	private val container by lazy {
+		FragmentContainerView(context).also { view ->
+			view.id = R.id.container
+			addView(view)
+		}
+	}
+
+	private val history = Stack<HistoryEntry>()
+
+	fun navigate(action: NavigationAction.NavigateFragment) {
+		val entry = HistoryEntry(action.destination.fragment.java, action.destination.arguments)
+
+		// Create the base transaction so we can mutate everything at once
+		val transaction = fragmentManager.beginTransaction()
+
+		if (action.clear) {
+			// Clear all current fragments from the history before adding the new entry
+			history.mapNotNull { it.fragment }.forEach { transaction.remove(it) }
+			history.clear()
+			history.push(entry)
+		} else if (action.replace && action.addToBackStack && history.isNotEmpty()) {
+			// Remove the top-most entry before replacing it with the next
+			val currentFragment = history[history.size - 1].fragment
+			if (currentFragment != null) transaction.remove(currentFragment)
+			history[history.size - 1] = entry
+		} else {
+			// Add to the end of the history
+			saveCurrentFragmentState()
+			history.push(entry)
+		}
+
+		activateHistoryEntry(entry, transaction)
+	}
+
+	fun goBack(): Boolean {
+		// Require at least 2 items (current & previous) to go back
+		if (history.size < 2) return false
+
+		// Remove current entry
+		history.pop()
+
+		// Read & set previous entry
+		val entry = history.last()
+		activateHistoryEntry(entry)
+
+		return true
+	}
+
+	private fun saveCurrentFragmentState() {
+		if (history.isEmpty()) return
+
+		// Update the top-most history entry with state from current fragment
+		val fragment = requireNotNull(fragmentManager.findFragmentByTag(FRAGMENT_TAG_CONTENT))
+		history[history.size - 1].savedState = fragmentManager.saveFragmentInstanceState(fragment)
+	}
+
+	@SuppressLint("CommitTransaction")
+	private fun activateHistoryEntry(
+		entry: HistoryEntry,
+		transaction: FragmentTransaction = fragmentManager.beginTransaction(),
+	) {
+		var fragment = entry.fragment
+
+		// Create if there is no existing fragment
+		if (fragment == null) {
+			fragment = fragmentManager.fragmentFactory.instantiate(context.classLoader, entry.name.name).apply {
+				setInitialSavedState(entry.savedState)
+			}
+			entry.fragment = fragment
+		}
+
+		// Update arguments
+		fragment.arguments = entry.arguments
+
+		transaction.apply {
+			// Set options
+			setReorderingAllowed(true)
+			setCustomAnimations(R.anim.fade_in, R.anim.fade_out, R.anim.fade_in, R.anim.fade_out)
+
+			// Detach current fragment
+			fragmentManager.findFragmentByTag(FRAGMENT_TAG_CONTENT)?.let(::detach)
+
+			// Attach or add next fragment
+			if (fragment.isDetached) attach(fragment)
+			else add(container.id, fragment, FRAGMENT_TAG_CONTENT)
+		}
+
+		// Commit
+		if (fragmentManager.isStateSaved) transaction.commitNowAllowingStateLoss()
+		else transaction.commitNow()
+	}
+
+	override fun onSaveInstanceState(): Parcelable {
+		// Always retrieve current state before writing
+		saveCurrentFragmentState()
+
+		// Save state
+		return bundleOf(
+			BUNDLE_SUPER to super.onSaveInstanceState(),
+			BUNDLE_HISTORY to history.toTypedArray()
+		)
+	}
+
+	override fun onRestoreInstanceState(state: Parcelable?) {
+		// Ignore if not a bundle
+		if (state !is Bundle) return super.onRestoreInstanceState(state)
+
+		// Call parent
+		@Suppress("DEPRECATION")
+		val parent = state.getParcelable<Parcelable>(BUNDLE_SUPER)
+		if (parent != null) super.onRestoreInstanceState(parent)
+
+		// Restore history
+		@Suppress("UNCHECKED_CAST")
+		val savedHistory = BundleCompat.getParcelableArray(state, BUNDLE_HISTORY, HistoryEntry::class.java) as Array<HistoryEntry>?
+		if (savedHistory != null) {
+			history.clear()
+			history.addAll(savedHistory)
+			if (history.isNotEmpty()) activateHistoryEntry(history.last())
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -27,7 +27,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.SessionRepositoryState
 import org.jellyfin.androidtv.auth.repository.UserRepository
-import org.jellyfin.androidtv.databinding.ActivityMainBinding
+import org.jellyfin.androidtv.databinding.ActivityStartupBinding
 import org.jellyfin.androidtv.ui.background.AppBackground
 import org.jellyfin.androidtv.ui.browsing.MainActivity
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher
@@ -62,7 +62,7 @@ class StartupActivity : FragmentActivity() {
 	private val navigationRepository: NavigationRepository by inject()
 	private val itemLauncher: ItemLauncher by inject()
 
-	private lateinit var binding: ActivityMainBinding
+	private lateinit var binding: ActivityStartupBinding
 
 	private val networkPermissionsRequester = registerForActivityResult(
 		ActivityResultContracts.RequestMultiplePermissions()
@@ -83,7 +83,7 @@ class StartupActivity : FragmentActivity() {
 
 		super.onCreate(savedInstanceState)
 
-		binding = ActivityMainBinding.inflate(layoutInflater)
+		binding = ActivityStartupBinding.inflate(layoutInflater)
 		binding.background.setContent { AppBackground() }
 		binding.screensaver.isVisible = false
 		setContentView(binding.root)
@@ -156,7 +156,7 @@ class StartupActivity : FragmentActivity() {
 			else -> null
 		}
 
-		navigationRepository.reset(destination)
+		navigationRepository.reset(destination, true)
 
 		val intent = Intent(this, MainActivity::class.java)
 		// Clear navigation history

--- a/app/src/main/res/layout/activity_startup.xml
+++ b/app/src/main/res/layout/activity_startup.xml
@@ -13,10 +13,11 @@
         android:descendantFocusability="blocksDescendants"
         android:focusable="false" />
 
-    <org.jellyfin.androidtv.ui.browsing.DestinationFragmentView
+    <LinearLayout
         android:id="@+id/content_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/screensaver"


### PR DESCRIPTION
This is a custom implementation of the back stack for our destinations. Previously, we used the back stack from the fragment manager but this didn't really work for us.

The problem was that we had to work around some shortcomings in the fragment manager due to how our destinations work. Specifically the "replace" action, mostly used when going from video player -> next up -> video player.

The way we made the replace action work was to pop the last item from the back stack, and then add a new item. This would result in the fragment before the video player (often the details page) to be resumed to then be replaced with the video player immediately after, because popping cannot be done in a transaction.

By replacing the back stack with our own implementation we have more control over this behavior and we can directly replace the fragment instead. Most of this logic is implemented in a custom view.

**Changes**
- Refactor navigation logic to create our own backstack instead of relying on the fragment manager to allow proper destination replacement

**Issues**

Fixes #3950
Fixes #3926
Fixes #2800
Fixes #3931