### PR TITLE
Add subtitile position offset option for media3 renderer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -182,6 +182,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var subtitlesTextSize = floatPreference("subtitles_text_size", 1f)
 
 		/**
+		 * Subtitles offset
+		 */
+		var subtitlesOffset = floatPreference("subtitles_offset", 1f)
+
+		/**
 		 * Show screensaver in app
 		 */
 		var screensaverInAppEnabled = booleanPreference("screensaver_inapp_enabled", true)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -184,7 +184,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * Subtitles offset
 		 */
-		var subtitlesOffset = floatPreference("subtitles_offset", 1f)
+		var subtitlesOffset = floatPreference("subtitles_offset", 0f)
 
 		/**
 		 * Show screensaver in app

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -102,6 +102,7 @@ public class VideoManager {
                 null
         );
         mExoPlayerView.getSubtitleView().setFractionalTextSize(0.0533f *  userPreferences.get(UserPreferences.Companion.getSubtitlesTextSize()));
+        mExoPlayerView.getSubtitleView().setBottomPaddingFraction(userPreferences.get(UserPreferences.Companion.getSubtitlesOffset()));
         mExoPlayerView.getSubtitleView().setStyle(subtitleStyle);
         mExoPlayer.addListener(new Player.Listener() {
             @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -138,6 +138,22 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 					default { UserPreferences.subtitlesTextSize.defaultValue.toString() }
 				}
 			}
+
+			@Suppress("MagicNumber")
+			list {
+				setTitle("Subtitle offset")
+				entries = mapOf(
+					0.7f to "0.7",
+					0.8f to "0.8",
+					0.9f to "0.9"
+				).mapKeys { it.key.toString() }
+
+				bind {
+					get { userPreferences[UserPreferences.subtitlesOffset].toString() }
+					set { value -> userPreferences[UserPreferences.subtitlesOffset] = value.toFloat() }
+					default { UserPreferences.subtitlesOffset.defaultValue.toString() }
+				}
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -140,20 +140,20 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 			}
 
 			@Suppress("MagicNumber")
-			list {
-				setTitle("Subtitle offset")
-				entries = mapOf(
-					0.7f to "0.7",
-					0.8f to "0.8",
-					0.9f to "0.9"
-				).mapKeys { it.key.toString() }
+			seekbar {
+				setTitle(R.string.lbl_subtitle_position)
+				min = 0   // Represents 0.00
+				max = 100 // Represents 1.00
+				increment = 5 // Represents increments of 0.05
 
+				// Bind the user preferences for subtitle position offset (storing as floats).
 				bind {
-					get { userPreferences[UserPreferences.subtitlesOffset].toString() }
-					set { value -> userPreferences[UserPreferences.subtitlesOffset] = value.toFloat() }
-					default { UserPreferences.subtitlesOffset.defaultValue.toString() }
+					get { (userPreferences[UserPreferences.subtitlesOffset] * 100).toInt() } // Convert float to int for seekbar
+					set { value -> userPreferences[UserPreferences.subtitlesOffset] = value / 100f } // Convert int back to float
+					default { (UserPreferences.subtitlesOffset.defaultValue * 100).toInt() } // Handle the default value
 				}
 			}
+
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -142,18 +142,16 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 			@Suppress("MagicNumber")
 			seekbar {
 				setTitle(R.string.lbl_subtitle_position)
-				min = 0   // Represents 0.00
-				max = 100 // Represents 1.00
-				increment = 5 // Represents increments of 0.05
+				min = -10 
+				max = 100
+				increment = 1
 
-				// Bind the user preferences for subtitle position offset (storing as floats).
 				bind {
 					get { (userPreferences[UserPreferences.subtitlesOffset] * 100).toInt() } // Convert float to int for seekbar
 					set { value -> userPreferences[UserPreferences.subtitlesOffset] = value / 100f } // Convert int back to float
 					default { (UserPreferences.subtitlesOffset.defaultValue * 100).toInt() } // Handle the default value
 				}
 			}
-
 		}
 
 		category {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,14 +225,12 @@
     <string name="lbl_subtitle_text_color">Subtitle text color</string>
     <string name="lbl_subtitle_background_color">Subtitle background color</string>
     <string name="lbl_subtitle_text_stroke_color">Subtitle stroke color</string>
+    <string name="lbl_subtitle_position">Subtitle position offset</string>
     <string name="pref_subtitles_size_very_small">Very small</string>
     <string name="pref_subtitles_size_small">Small</string>
     <string name="pref_subtitles_size_normal">Normal</string>
     <string name="pref_subtitles_size_large">Large</string>
     <string name="pref_subtitles_size_very_large">Very large</string>
-    <string name="pref_subtitles_offset_07">0.7</string>
-    <string name="pref_subtitles_offset_08">0.8</string>
-    <string name="pref_subtitles_offset_09">0.9</string>
     <string name="lbl_resume_from">Resume from %1$s</string>
     <string name="lbl_more_like_this">More like this</string>
     <string name="lbl_previous_episode">Previous episode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,9 @@
     <string name="pref_subtitles_size_normal">Normal</string>
     <string name="pref_subtitles_size_large">Large</string>
     <string name="pref_subtitles_size_very_large">Very large</string>
+    <string name="pref_subtitles_offset_07">0.7</string>
+    <string name="pref_subtitles_offset_08">0.8</string>
+    <string name="pref_subtitles_offset_09">0.9</string>
     <string name="lbl_resume_from">Resume from %1$s</string>
     <string name="lbl_more_like_this">More like this</string>
     <string name="lbl_previous_episode">Previous episode</string>


### PR DESCRIPTION
This PR adds back subtitle position control after client lost it when sub custom renderer has been removed in https://github.com/jellyfin/jellyfin-androidtv/pull/3825

**Changes**

- Adjusted VideoManager.java to apply the offset value to the subtitle view using `setBottomPaddingFraction`.
- Added a seekbar for configuring subtitle position offset in the `PlaybackPreferencesScreen`.

