### PR TITLE
Add codec panel and support for user-defined AVC/HEVC levels

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -102,6 +102,16 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var preferExoPlayerFfmpeg = booleanPreference("exoplayer_prefer_ffmpeg", defaultValue = false)
 
+		/**
+		 * User defined AVC levels for main and high 10.
+		 */
+		var userAVCLevel = stringPreference("user_avc_level", "auto")
+
+		/**
+		 * User defined HEVC levels for main and main 10.
+		 */
+		var userHEVCLevel = stringPreference("user_hevc_level", "auto")
+
 		/* Playback - Audio related */
 		/**
 		 * Preferred behavior for audio streaming.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -514,7 +514,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         DeviceProfile internalProfile = new ExoPlayerProfile(
                 !internalOptions.getEnableDirectStream(),
                 userPreferences.getValue().get(UserPreferences.Companion.getAc3Enabled()),
-                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO
+                userPreferences.getValue().get(UserPreferences.Companion.getAudioBehaviour()) == AudioBehavior.DOWNMIX_TO_STEREO,
+                userPreferences.getValue().get(UserPreferences.Companion.getUserAVCLevel()),
+                userPreferences.getValue().get(UserPreferences.Companion.getUserHEVCLevel())
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedCodecPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedCodecPreferencesScreen.kt
@@ -1,0 +1,66 @@
+package org.jellyfin.androidtv.ui.preference.screen
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.dsl.checkbox
+import org.jellyfin.androidtv.ui.preference.dsl.list
+import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.koin.android.ext.android.inject
+
+class PlaybackAdvancedCodecPreferencesScreen : OptionsFragment() {
+	private val userPreferences: UserPreferences by inject()
+
+	override val screen by optionsScreen {
+		setTitle(R.string.codec)
+
+		category {
+			setTitle(R.string.level_warning)
+
+			list {
+				setTitle(R.string.user_avc_level)
+				entries = mapOf(
+					// AVC levels as reported by ffprobe are multiplied by 10, e.g. level 4.1 is 41.
+					"auto" to "Auto",
+					"62" to "Level 6.2",
+					"61" to "Level 6.1",
+					"60" to "Level 6.0",
+					"52" to "Level 5.2",
+					"51" to "Level 5.1",
+					"50" to "Level 5.0",
+					"42" to "Level 4.2",
+					"41" to "Level 4.1",
+					"40" to "Level 4.0"
+				)
+				bind(userPreferences, UserPreferences.userAVCLevel)
+			}
+
+			list {
+				setTitle(R.string.user_hevc_level)
+				entries = mapOf(
+					// HEVC levels as reported by ffprobe are multiplied by 30, e.g. level 4.1 is 123.
+					"auto" to "Auto",
+					"186" to "Level 6.2",
+					"183" to "Level 6.1",
+					"180" to "Level 6.0",
+					"156" to "Level 5.2",
+					"153" to "Level 5.1",
+					"150" to "Level 5.0",
+					"123" to "Level 4.1",
+					"120" to "Level 4.0"
+				)
+				bind(userPreferences, UserPreferences.userHEVCLevel)
+			}
+		}
+
+		category {
+			setTitle(R.string.pref_audio)
+
+			checkbox {
+				setTitle(R.string.lbl_bitstream_ac3)
+				setContent(R.string.desc_bitstream_ac3)
+				bind(userPreferences, UserPreferences.ac3Enabled)
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -109,12 +109,6 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.audioNightMode)
 				depends { Build.VERSION.SDK_INT >= Build.VERSION_CODES.P }
 			}
-
-			checkbox {
-				setTitle(R.string.lbl_bitstream_ac3)
-				setContent(R.string.desc_bitstream_ac3)
-				bind(userPreferences, UserPreferences.ac3Enabled)
-			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -194,6 +194,12 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				icon = R.drawable.ic_more
 				withFragment<PlaybackAdvancedPreferencesScreen>()
 			}
+
+			link {
+				setTitle(R.string.codec_advanced)
+				icon = R.drawable.ic_more
+				withFragment<PlaybackAdvancedCodecPreferencesScreen>()
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -26,7 +26,9 @@ import org.jellyfin.apiclient.model.dlna.TranscodingProfile
 class ExoPlayerProfile(
 	disableVideoDirectPlay: Boolean,
 	isAC3Enabled: Boolean,
-	downMixAudio: Boolean
+	downMixAudio: Boolean,
+	userAVCLevel: String? = "auto",
+	userHEVCLevel: String? = "auto"
 ) : DeviceProfile() {
 	private val downmixSupportedAudioCodecs = arrayOf(
 		Codec.Audio.AAC,
@@ -153,8 +155,22 @@ class ExoPlayerProfile(
 
 		codecProfiles = buildList {
 			// H264 profile
-			add(deviceAVCCodecProfile)
-			addAll(deviceAVCLevelCodecProfiles)
+			if (userAVCLevel == "auto") {
+				add(deviceAVCCodecProfile)
+				addAll(deviceAVCLevelCodecProfiles)
+			} else {
+				add(CodecProfile().apply {
+					type = CodecType.Video
+					codec = Codec.Video.H264
+					conditions = arrayOf(
+						ProfileCondition(
+							ProfileConditionType.LessThanEqual,
+							ProfileConditionValue.VideoLevel,
+							userAVCLevel
+						)
+					)
+				})
+			}
 			// H264 ref frames profile
 			add(CodecProfile().apply {
 				type = CodecType.Video
@@ -194,8 +210,23 @@ class ExoPlayerProfile(
 				)
 			})
 			// HEVC profiles
-			add(deviceHevcCodecProfile)
-			addAll(deviceHevcLevelCodecProfiles)
+			if (userHEVCLevel == "auto") {
+				add(deviceHevcCodecProfile)
+				addAll(deviceHevcLevelCodecProfiles)
+			} else {
+				add(CodecProfile().apply {
+					type = CodecType.Video
+					codec = Codec.Video.HEVC
+					conditions = arrayOf(
+						ProfileCondition(
+							ProfileConditionType.LessThanEqual,
+							ProfileConditionValue.VideoLevel,
+							userHEVCLevel
+						)
+					)
+				})
+			}
+
 			// AV1 profile
 			add(deviceAV1CodecProfile)
 			// Limit video resolution support for older devices

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -526,6 +526,11 @@
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
+    <string name="codec_advanced">Advanced codec preferences</string>
+    <string name="codec">Codec</string>
+    <string name="user_avc_level">H.264 Level</string>
+    <string name="user_hevc_level">H.265 Level</string>
+    <string name="level_warning">Video\n\nSwitching from \'Auto\' could lead to playback issues</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->
This pull request introduces a new panel for advanced codec settings and updates the ExoPlayerProfile, PlaybackController, and UserPreferences to support user-defined AVC and HEVC codec levels. This enhancement allows users to bypass automatic codec profile levels and customize settings to their preference.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
1. **Added `PlaybackAdvancedCodecPreferencesScreen`:**
   - Introduced a new preferences screen for configuring AVC and HEVC codec levels and audio settings.
     - **AVC Codec Levels:** Users can select from predefined levels, with a default auto option.
     - **HEVC Codec Levels:** Users can select from predefined levels, with a default auto option.
     - **Audio Settings:** Moved the option to enable AC3 bitstream audio from `PlaybackAdvancedPreferencesScreen` to improve organization and clarity of codec-related settings.

2. **Updated `ExoPlayerProfile`:**
   - Enhanced to incorporate user-defined AVC and HEVC codec levels.
     - **New Parameters:**
       - `userAVCLevel: String? = "auto"`
       - `userHEVCLevel: String? = "auto"`
     - **Codec Profiles Adjustment:**
       - **AVC Codec Profiles:** Uses default profiles or user-defined level based on `userAVCLevel`.
       - **HEVC Codec Profiles:** Uses default profiles or user-defined level based on `userHEVCLevel`.
       - Added conditions to handle and apply user-defined AVC and HEVC levels in the `ExoPlayerProfile`.

3. **Modified `PlaybackController`:**
   - Updated to pass user-defined AVC and HEVC codec levels to the `ExoPlayerProfile`.



**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- Some devices may have codec profiles and levels beyond their advertised capabilities. This update allows users to bypass automatic detection, which can reduce unnecessary transcoding. 
- #3380
- #3401
