### PR TITLE
Fix back press callback in CustomPlaybackOverlayFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -292,14 +292,19 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             return null;
         });
 
-        requireActivity().getOnBackPressedDispatcher().addCallback(backPressedCallback);
-
         int startPos = getArguments().getInt("Position", 0);
 
         // start playing
         playbackControllerContainer.getValue().getPlaybackController().play(startPos);
         leanbackOverlayFragment.updatePlayState();
 
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        requireActivity().getOnBackPressedDispatcher().addCallback(this, backPressedCallback);
     }
 
     private void prepareOverlayFragment() {
@@ -379,7 +384,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     };
 
     private OnBackPressedCallback backPressedCallback = new OnBackPressedCallback(true) {
-
         @Override
         public void handleOnBackPressed() {
             if (mPopupPanelVisible) {
@@ -675,10 +679,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         if (leanbackOverlayFragment != null)
             leanbackOverlayFragment.setOnKeyInterceptListener(null);
-        if (backPressedCallback != null) {
-            backPressedCallback.remove();
-            backPressedCallback = null;
-        }
 
         // end playback from here if this fragment belongs to the current session.
         // if it doesn't, playback has already been stopped elsewhere, and the references to this have been replaced


### PR DESCRIPTION
**Changes**
- Register the back press callback in CustomPlaybackOverlayFragment in the onAttach function, according to the androidx documentation
  - Additionally add the lifecycle owner (this) so it will be removed automatically

**Issues**

Fixes #3993