### PR TITLE
Fix Startup crash:Cannot initialize WorkManager in direct boot mode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -61,4 +61,8 @@ class JellyfinApplication : Application() {
 
 		TelemetryService.init(this)
 	}
+	/**
+	 * androidx.work causes a startup crash when it returns true
+	 */
+	override fun isDeviceProtectedStorage() = false
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
`override fun isDeviceProtectedStorage() = false` , androidx.work causes a startup crash when it returns true.

**Issues**
Fixes #3143
Fixes #2532