### PR TITLE
Fix aspect ratio specials

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -104,7 +104,7 @@ public class CardPresenter extends Presenter {
                     } else if (imageType.equals(ImageType.THUMB)) {
                         aspect = ImageHelper.ASPECT_RATIO_16_9;
                     } else {
-                        aspect = Utils.getSafeValue(imageHelper.getValue().getImageAspectRatio(itemDto, m.getPreferParentThumb()), ImageHelper.ASPECT_RATIO_7_9);
+                        aspect = imageHelper.getValue().getImageAspectRatio(itemDto, m.getPreferParentThumb());
                     }
                     switch (itemDto.getType()) {
                         case AUDIO:
@@ -183,8 +183,6 @@ public class CardPresenter extends Presenter {
                         case MOVIE:
                         case VIDEO:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_video);
-                            if (imageType.equals(ImageType.POSTER))
-                                aspect = ImageHelper.ASPECT_RATIO_2_3;
                             showProgress = true;
                             break;
                         default:

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -25,18 +25,19 @@ class ImageHelper(
 		const val MAX_PRIMARY_IMAGE_HEIGHT: Int = 370
 	}
 
-	fun getImageAspectRatio(item: BaseItemDto, preferParentThumb: Boolean): Double? {
+	fun getImageAspectRatio(item: BaseItemDto, preferParentThumb: Boolean): Double {
 		if (preferParentThumb && (item.parentThumbItemId != null || item.seriesThumbImageTag != null)) {
 			return ASPECT_RATIO_16_9
 		}
 
+		val primaryAspectRatio = item.primaryImageAspectRatio;
 		if (item.type == BaseItemKind.EPISODE) {
-			if (item.primaryImageAspectRatio != null) return item.primaryImageAspectRatio
+			if (primaryAspectRatio != null) return primaryAspectRatio
 			if (item.parentThumbItemId != null || item.seriesThumbImageTag != null) return ASPECT_RATIO_16_9
 		}
 
 		if (item.type == BaseItemKind.USER_VIEW && item.imageTags?.containsKey(ImageType.PRIMARY) == true) return ASPECT_RATIO_16_9
-		return item.primaryImageAspectRatio ?: ASPECT_RATIO_7_9
+		return primaryAspectRatio ?: ASPECT_RATIO_7_9
 	}
 
 	fun getPrimaryImageUrl(item: BaseItemPerson, maxHeight: Int? = null): String? {


### PR DESCRIPTION
Don't overwrite the aspect ratio for videos
Change return value of ImageHelper.getImageAspectRatio to not be nullable

Fixes #1192
Possibly a regression from #830

