### PR TITLE
Fix incorrectly navigating on resume

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : FragmentActivity() {
 		if (savedInstanceState == null && navigationRepository.canGoBack) navigationRepository.reset(clearHistory = true)
 
 		navigationRepository.currentAction
-			.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+			.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
 			.onEach { action ->
 				handleNavigationAction(action)
 				backPressedCallback.isEnabled = navigationRepository.canGoBack


### PR DESCRIPTION
When the MainActivity resumes we should **not** execute the current navigation action as this will cause the current fragment to reset. Therefor we should use the started lifecycle state instead of resumed.

**Changes**
- Fix incorrectly navigating on resume
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Fixes #4026
