### PR TITLE
Fix VLC marked as watched

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -125,7 +125,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
             if (data.hasExtra(API_MX_RESULT_POSITION)) {
                 pos = data.getIntExtra(API_MX_RESULT_POSITION, 0);
             } else if (data.hasExtra(API_VLC_RESULT_POSITION)) {
-                pos = data.getIntExtra(API_VLC_RESULT_POSITION, 0);
+                pos = (int) data.getLongExtra(API_VLC_RESULT_POSITION, 0);
             } else if (data.hasExtra(API_VIMU_RESULT_POSITION)) {
                 pos = data.getIntExtra(API_VIMU_RESULT_POSITION, 0);
             }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Updated the code that retrieves the playback position from VLC to use long instead of int. Using long for the position aligns with the data type expected from [VLC](https://wiki.videolan.org/Android_Player_Intents/).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> Fixes #4027
