### PR TITLE
Limit audio channels to 6 in video transcoding profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -86,6 +86,7 @@ class ExoPlayerProfile(
 				protocol = "hls"
 				copyTimestamps = false
 				enableSubtitlesInManifest = true
+				maxAudioChannels = "6"
 			},
 			// MP3 audio profile
 			TranscodingProfile().apply {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->This PR modifies the ExoPlayerProfile to limit the maximum number of audio channels to 6 in the video transcoding profile. Remuxing 7.1 audio with transcoded video  leads to low frame rates, resulting in poor playback quality and player errors. This change aims to optimize compatibility by ensuring that 7.1 audio is transcoded when the video stream is transcoded.<br>
<br>

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added `maxAudioChannels`: Set to "6" in the TS video profile for improved audio  handling when transcoding.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # --> Addresses issues brought up on the forum. 
