### PR TITLE
Change upcomingMinimumServerVersion to 10.10.0 to warn about upcoming 10.10 requirement

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -49,7 +49,7 @@ interface ServerRepository {
 		val minimumServerVersion = Jellyfin.minimumVersion.copy(build = null)
 		val recommendedServerVersion = Jellyfin.apiVersion.copy(build = null)
 
-		val upcomingMinimumServerVersion = ServerVersion(10, 9, 11)
+		val upcomingMinimumServerVersion = ServerVersion(10, 10, 0)
 	}
 }
 


### PR DESCRIPTION
The 0.18 release of the app will require Jellyfin 10.10 (see #4040). To warn users about this upcoming requirement we'll start warning them to update.

**Changes**
- Change upcomingMinimumServerVersion to 10.10.0

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
