### PR TITLE
Implement media segments

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -30,6 +30,8 @@ import org.jellyfin.androidtv.ui.navigation.NavigationRepositoryImpl
 import org.jellyfin.androidtv.ui.picture.PictureViewerViewModel
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepositoryImpl
 import org.jellyfin.androidtv.ui.search.SearchFragmentDelegate
 import org.jellyfin.androidtv.ui.search.SearchRepository
 import org.jellyfin.androidtv.ui.search.SearchRepositoryImpl
@@ -120,6 +122,7 @@ val appModule = module {
 	single<CustomMessageRepository> { CustomMessageRepositoryImpl() }
 	single<NavigationRepository> { NavigationRepositoryImpl(Destinations.home) }
 	single<SearchRepository> { SearchRepositoryImpl(get()) }
+	single<MediaSegmentRepository> { MediaSegmentRepositoryImpl(get(), get()) }
 
 	viewModel { StartupViewModel(get(), get(), get(), get()) }
 	viewModel { UserLoginViewModel(get(), get(), get(), get(defaultDeviceInfo)) }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -205,6 +205,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Delay when starting video playback after loading the video player.
 		 */
 		var videoStartDelay = longPreference("video_start_delay", 0)
+
+		/**
+		 * The actions to take for each media segment type. Managed by the [MediaSegmentRepository].
+		 */
+		var mediaSegmentActions = stringPreference("media_segment_actions", "")
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -639,23 +639,27 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             mVideoManager.setVideoPath(response.getMediaUrl());
         }
 
-        // Set video start delay
-        long videoStartDelay = userPreferences.getValue().get(UserPreferences.Companion.getVideoStartDelay());
-        if (videoStartDelay > 0) {
-            mHandler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    if (mVideoManager != null) {
-                        mVideoManager.start();
+        PlaybackControllerHelperKt.applyMediaSegments(this, item, () -> {
+            // Set video start delay
+            long videoStartDelay = userPreferences.getValue().get(UserPreferences.Companion.getVideoStartDelay());
+            if (videoStartDelay > 0) {
+                mHandler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (mVideoManager != null) {
+                            mVideoManager.start();
+                        }
                     }
-                }
-            }, videoStartDelay);
-        } else {
-            mVideoManager.start();
-        }
+                }, videoStartDelay);
+            } else {
+                mVideoManager.start();
+            }
 
-        dataRefreshService.getValue().setLastPlayedItem(item);
-        reportingHelper.getValue().reportStart(item, mbPos);
+            dataRefreshService.getValue().setLastPlayedItem(item);
+            reportingHelper.getValue().reportStart(item, mbPos);
+
+            return null;
+        });
     }
 
     public void startSpinner() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -1,10 +1,17 @@
 package org.jellyfin.androidtv.ui.playback
 
+import androidx.annotation.OptIn
 import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.util.UnstableApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.MediaSegmentDto
+import org.jellyfin.sdk.model.extensions.ticks
 import org.koin.android.ext.android.inject
 import java.util.UUID
 
@@ -21,4 +28,46 @@ fun PlaybackController.getLiveTvChannel(
 			callback(channel)
 		}
 	}
+}
+
+fun PlaybackController.applyMediaSegments(
+	item: BaseItemDto,
+	callback: () -> Unit,
+) {
+	val mediaSegmentRepository by fragment.inject<MediaSegmentRepository>()
+
+	fragment.lifecycleScope.launch {
+		val mediaSegments = runCatching {
+			mediaSegmentRepository.getSegmentsForItem(item)
+		}.getOrNull().orEmpty()
+
+		for (mediaSegment in mediaSegments) {
+			val action = mediaSegmentRepository.getMediaSegmentAction(mediaSegment)
+
+			when (action) {
+				MediaSegmentAction.SKIP -> addSkipAction(mediaSegment)
+				MediaSegmentAction.NOTHING -> Unit
+			}
+		}
+
+		callback()
+	}
+}
+
+@OptIn(UnstableApi::class)
+private fun PlaybackController.addSkipAction(mediaSegment: MediaSegmentDto) {
+	mVideoManager.mExoPlayer
+		.createMessage { messageType: Int, payload: Any? ->
+			// We can't seek directly on the ExoPlayer instance as not all media is seekable
+			// the seek function in the PlaybackController checks this and optionally starts a transcode
+			// at the requested position
+			fragment.lifecycleScope.launch(Dispatchers.Main) {
+				seek(mediaSegment.endTicks.ticks.inWholeMilliseconds)
+			}
+		}
+		// Segments at position 0 will never be hit by ExoPlayer so we need to add a minimum value
+		.setPosition(mediaSegment.startTicks.ticks.inWholeMilliseconds.coerceAtLeast(1))
+		.setPayload(mediaSegment)
+		.setDeleteAfterDelivery(false)
+		.send()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -64,7 +64,7 @@ public class VideoManager {
     private Limiter mLimiter;
     private PlaybackControllerNotifiable mPlaybackControllerNotifiable;
     private PlaybackOverlayFragmentHelper _helper;
-    private ExoPlayer mExoPlayer;
+    public ExoPlayer mExoPlayer;
     private PlayerView mExoPlayerView;
     private Handler mHandler = new Handler();
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentAction.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.androidtv.ui.playback.segment
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.preference.PreferenceEnum
+
+enum class MediaSegmentAction(
+	override val nameRes: Int,
+) : PreferenceEnum {
+	/**
+	 * Don't take any action for this segment.
+	 */
+	NOTHING(R.string.segment_action_nothing),
+
+	/**
+	 * Seek to the end of this segment (endTicks). If the duration of this segment is shorter than 1 second it should do nothing to avoid
+	 * lagg. The skip action will only execute when playing over the segment start, not when seeking into the segment block.
+	 */
+	SKIP(R.string.segment_action_skip),
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
@@ -1,0 +1,86 @@
+package org.jellyfin.androidtv.ui.playback.segment
+
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.mediaSegmentsApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.MediaSegmentDto
+import org.jellyfin.sdk.model.api.MediaSegmentType
+
+interface MediaSegmentRepository {
+	companion object {
+		/**
+		 * All media segments currently supported by the app. The order of these is used for the preferences UI.
+		 */
+		val SupportedTypes = listOf(
+			MediaSegmentType.INTRO,
+			MediaSegmentType.OUTRO,
+			MediaSegmentType.PREVIEW,
+			MediaSegmentType.RECAP,
+			MediaSegmentType.COMMERCIAL,
+		)
+	}
+
+	fun getDefaultSegmentTypeAction(type: MediaSegmentType): MediaSegmentAction
+	fun setDefaultSegmentTypeAction(type: MediaSegmentType, action: MediaSegmentAction)
+
+	suspend fun getSegmentsForItem(item: BaseItemDto): List<MediaSegmentDto>
+	fun getMediaSegmentAction(segment: MediaSegmentDto): MediaSegmentAction
+}
+
+class MediaSegmentRepositoryImpl(
+	private val userPreferences: UserPreferences,
+	private val api: ApiClient,
+) : MediaSegmentRepository {
+	private val mediaTypeActions = mutableMapOf<MediaSegmentType, MediaSegmentAction>()
+
+	init {
+		restoreMediaTypeActions()
+	}
+
+	private fun restoreMediaTypeActions() {
+		val restoredMediaTypeActions = userPreferences[UserPreferences.mediaSegmentActions]
+			.split(",")
+			.mapNotNull {
+				runCatching {
+					val (type, action) = it.split('=', limit = 2)
+					MediaSegmentType.fromName(type) to MediaSegmentAction.valueOf(action)
+				}.getOrNull()
+			}
+
+		mediaTypeActions.clear()
+		mediaTypeActions.putAll(restoredMediaTypeActions)
+	}
+
+	private fun saveMediaTypeActions() {
+		userPreferences[UserPreferences.mediaSegmentActions] = mediaTypeActions
+			.map { "${it.key.serialName}=${it.value.name}" }
+			.joinToString(",")
+	}
+
+	override fun getDefaultSegmentTypeAction(type: MediaSegmentType): MediaSegmentAction {
+		// Always return no action for unsupported types
+		if (!MediaSegmentRepository.SupportedTypes.contains(type)) return MediaSegmentAction.NOTHING
+
+		return mediaTypeActions.getOrDefault(type, MediaSegmentAction.NOTHING)
+	}
+
+	override fun setDefaultSegmentTypeAction(type: MediaSegmentType, action: MediaSegmentAction) {
+		// Don't allow modifying actions for unsupported types
+		if (!MediaSegmentRepository.SupportedTypes.contains(type)) return
+
+		mediaTypeActions[type] = action
+		saveMediaTypeActions()
+	}
+
+	override fun getMediaSegmentAction(segment: MediaSegmentDto): MediaSegmentAction {
+		return getDefaultSegmentTypeAction(segment.type)
+	}
+
+	override suspend fun getSegmentsForItem(item: BaseItemDto): List<MediaSegmentDto> = runCatching {
+		api.mediaSegmentsApi.getItemSegments(
+			itemId = item.id,
+			includeSegmentTypes = MediaSegmentRepository.SupportedTypes,
+		).content.items
+	}.getOrDefault(emptyList())
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -5,6 +5,8 @@ import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
@@ -14,10 +16,12 @@ import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.list
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.preference.dsl.seekbar
+import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.koin.android.ext.android.inject
 
 class PlaybackPreferencesScreen : OptionsFragment() {
 	private val userPreferences: UserPreferences by inject()
+	private val mediaSegmentRepository: MediaSegmentRepository by inject()
 
 	override val screen by optionsScreen {
 		setTitle(R.string.pref_playback)
@@ -136,6 +140,29 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 					get { userPreferences[UserPreferences.subtitlesTextSize].toString() }
 					set { value -> userPreferences[UserPreferences.subtitlesTextSize] = value.toFloat() }
 					default { UserPreferences.subtitlesTextSize.defaultValue.toString() }
+				}
+			}
+		}
+
+		category {
+			setTitle(R.string.pref_mediasegment_actions)
+
+			for (segmentType in MediaSegmentRepository.SupportedTypes) {
+				enum<MediaSegmentAction> {
+					when (segmentType) {
+						MediaSegmentType.UNKNOWN -> R.string.segment_type_unknown
+						MediaSegmentType.COMMERCIAL -> R.string.segment_type_commercial
+						MediaSegmentType.PREVIEW -> R.string.segment_type_preview
+						MediaSegmentType.RECAP -> R.string.segment_type_recap
+						MediaSegmentType.OUTRO -> R.string.segment_type_outro
+						MediaSegmentType.INTRO -> R.string.segment_type_intro
+					}.let(::setTitle)
+
+					bind {
+						get { mediaSegmentRepository.getDefaultSegmentTypeAction(segmentType) }
+						set { value -> mediaSegmentRepository.setDefaultSegmentTypeAction(segmentType, value) }
+						default { MediaSegmentAction.NOTHING }
+					}
 				}
 			}
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -517,6 +517,15 @@
     <string name="prefer_exoplayer_ffmpeg">Prefer FFmpeg for audio playback</string>
     <string name="prefer_exoplayer_ffmpeg_content">Use FFmpeg to decode audio, even if platform codecs are available.</string>
     <string name="video_start_delay">Video start delay</string>
+    <string name="pref_mediasegment_actions">Media segment actions</string>
+    <string name="segment_action_nothing">Do nothing</string>
+    <string name="segment_action_skip">Skip</string>
+    <string name="segment_type_commercial">Commercials</string>
+    <string name="segment_type_intro">Intros</string>
+    <string name="segment_type_outro">Outros</string>
+    <string name="segment_type_preview">Previews</string>
+    <string name="segment_type_recap">Recaps</string>
+    <string name="segment_type_unknown">Unknown segments</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
This adds the initial support for media segments with some of the actions I'd like still missing.

**Changes**
- Add new preference category "Media segment actions" in the playback section
  - Contains a preference for each supported segment type
- Add "nothing" action - does literally nothing, default for each segment
- Add "skip" action - skips to the end of the segment when the player seeks over the segment start position

The `MediaSegmentRepository` contains a hardcoded list of supported segment types that is always included when requesting segments. This way we can add new segment types on the backend without breaking existing app releases (SDK won't be able to parse an unknown enum). Additionally, I've opted to not support the "unknown" type in the client.

Future additions will include:
- Notification when a segment was skipped
- "ask to skip" action that shows a button to skip the segment
- "mute" action that mutes the audio during a segment
- "skip subsequent" action that plays a specific segment only once in a media queue (e.g. opening theme of a show on first episode and not in all subsequent episodes)

I'm not sure how many of these will be implemented within the current playback code as it's a bit finicky to work with.

**Screenshots**

![75ef3b7838451aa5](https://github.com/user-attachments/assets/c9e7ded1-6286-4cd4-983c-7961d3c73f2f)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
