### PR TITLE
Fix video player not closing when fragment is stopped

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -686,6 +686,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             Timber.d("this fragment belongs to the current session, ending it");
             playbackControllerContainer.getValue().getPlaybackController().endPlayback();
         }
+
+        closePlayer();
     }
 
     public void show() {


### PR DESCRIPTION
When the video player fragment is closed and then later resumed, it would always reset the position to the timestamp send as argument. This is not desired as some people turn their TV off mid-movie (this should be illegal tbh).

**Changes**
- Always close the video player when the video player fragment stops, this causes the "item details" to pop up with a nice resume button when re-opening the app.

**Issues**

Fixes #4056