### PR TITLE
Fix Detekt max line length not matching Editorconfig

### DIFF
--- a/detekt.yaml
+++ b/detekt.yaml
@@ -27,3 +27,5 @@ style:
     values: [ 'STOPSHIP:' ]
   ReturnCount:
     max: 6
+  MaxLineLength:
+    maxLineLength: 140


### PR DESCRIPTION
We use 140, Detekt defaults to 120.

**Changes**
- Fix Detekt max line length not matching Editorconfig
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
