### PR TITLE
Restore forced aspect ratio for poster types on video items

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -184,6 +184,8 @@ public class CardPresenter extends Presenter {
                         case VIDEO:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_video);
                             showProgress = true;
+                            if (imageType.equals(ImageType.POSTER))
+                                aspect = ImageHelper.ASPECT_RATIO_2_3;
                             break;
                         default:
                             mDefaultCardImage = ContextCompat.getDrawable(mCardView.getContext(), R.drawable.tile_port_video);


### PR DESCRIPTION
Found an issue where the image of season 1 of Pioneer One on our demo server wouldn't show properly while trying to reproduce #4062, not sure if it fixes that issue too though. The image logic is a mess.

**Changes**
- Restore forced aspect ratio for poster types on video items

**Issues**

Maybe fixes #4062
Reverts a part of #4015 (@Bond-009 hopefully this doesn't break you images again)