### PR TITLE
Add "ask to skip" media segment action

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/overscan.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/overscan.kt
@@ -1,10 +1,16 @@
 package org.jellyfin.androidtv.ui.composable
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 /**
- * Apply a [padding] with the default overscan values of 48 horizontal and 27 vertical display pixels.
+ * Default overscan values of 48 horizontal and 27 vertical display pixels.
  */
-fun Modifier.overscan(): Modifier = then(padding(48.dp, 27.dp))
+val overscanPaddingValues = PaddingValues(48.dp, 27.dp)
+
+/**
+ * Apply a [padding] with [overscanPaddingValues].
+ */
+fun Modifier.overscan(): Modifier = padding(overscanPaddingValues)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
@@ -19,6 +19,7 @@ import org.koin.android.ext.android.inject
 import timber.log.Timber
 import java.time.Instant
 import java.util.UUID
+import kotlin.time.Duration
 
 fun CustomPlaybackOverlayFragment.toggleFavorite() {
 	val header = mSelectedProgramView as? GuideChannelHeader
@@ -173,4 +174,8 @@ fun CustomPlaybackOverlayFragment.recordProgram(program: BaseItemDto, isSeries: 
 			}
 		)
 	}
+}
+
+fun CustomPlaybackOverlayFragment.askToSkip(position: Duration) {
+	binding.skipOverlay.targetPosition = position
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -1,0 +1,137 @@
+package org.jellyfin.androidtv.ui.playback.overlay
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@Composable
+fun SkipOverlayComposable(
+	visible: Boolean,
+) {
+	Box(
+		contentAlignment = Alignment.BottomEnd,
+		modifier = Modifier
+			.padding(48.dp, 48.dp)
+	) {
+		AnimatedVisibility(visible, enter = fadeIn(), exit = fadeOut()) {
+			Row(
+				modifier = Modifier
+					.clip(RoundedCornerShape(6.dp))
+					.background(colorResource(R.color.popup_menu_background).copy(alpha = 0.6f))
+					.padding(10.dp),
+				horizontalArrangement = Arrangement.spacedBy(8.dp),
+				verticalAlignment = Alignment.CenterVertically,
+			) {
+				Image(
+					painter = painterResource(R.drawable.ic_control_select),
+					contentDescription = null,
+				)
+
+				Text(
+					text = stringResource(R.string.segment_action_skip),
+					color = colorResource(R.color.button_default_normal_text),
+					fontSize = 18.sp,
+				)
+			}
+		}
+	}
+}
+
+class SkipOverlayView @JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+	defStyle: Int = 0
+) : AbstractComposeView(context, attrs, defStyle) {
+	private val _currentPosition = MutableStateFlow(Duration.ZERO)
+	private val _targetPosition = MutableStateFlow<Duration?>(null)
+	private val _skipUiEnabled = MutableStateFlow(true)
+
+	var currentPosition: Duration
+		get() = _currentPosition.value
+		set(value) {
+			_currentPosition.value = value
+		}
+
+	var currentPositionMs: Long
+		get() = _currentPosition.value.inWholeMilliseconds
+		set(value) {
+			_currentPosition.value = value.milliseconds
+		}
+
+	var targetPosition: Duration?
+		get() = _targetPosition.value
+		set(value) {
+			_targetPosition.value = value
+		}
+
+	var targetPositionMs: Long?
+		get() = _targetPosition.value?.inWholeMilliseconds
+		set(value) {
+			_targetPosition.value = value?.milliseconds
+		}
+
+	var skipUiEnabled: Boolean
+		get() = _skipUiEnabled.value
+		set(value) {
+			_skipUiEnabled.value = value
+		}
+
+	val visible: Boolean
+		get() {
+			val enabled = _skipUiEnabled.value
+			val targetPosition = _targetPosition.value
+			val currentPosition = _currentPosition.value
+
+			return enabled && targetPosition != null && currentPosition <= (targetPosition - MediaSegmentRepository.SkipMinDuration)
+		}
+
+	@Composable
+	override fun Content() {
+		val skipUiEnabled by _skipUiEnabled.collectAsState()
+		val currentPosition by _currentPosition.collectAsState()
+		val targetPosition by _targetPosition.collectAsState()
+
+		val visible by remember(skipUiEnabled, currentPosition, targetPosition) {
+			derivedStateOf { visible }
+		}
+
+		// Auto hide
+		LaunchedEffect(skipUiEnabled, targetPosition) {
+			delay(MediaSegmentRepository.AskToSkipAutoHideDuration)
+			_targetPosition.value = null
+		}
+
+		SkipOverlayComposable(visible)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentAction.kt
@@ -16,4 +16,10 @@ enum class MediaSegmentAction(
 	 * lagg. The skip action will only execute when playing over the segment start, not when seeking into the segment block.
 	 */
 	SKIP(R.string.segment_action_skip),
+
+	/**
+	 * Ask the user if they want to skip this segment. When the user agrees this behaves like [SKIP]. Confirmation should only be asked for
+	 * segments with a duration of at least 3 seconds to avoid UI flickering.
+	 */
+	ASK_TO_SKIP(R.string.segment_action_ask_to_skip),
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
@@ -26,6 +26,16 @@ interface MediaSegmentRepository {
 		 * The minimum duration for a media segment to allow the [MediaSegmentAction.SKIP] action.
 		 */
 		val SkipMinDuration = 1.seconds
+
+		/**
+		 * The minimum duration for a media segment to allow the [MediaSegmentAction.ASK_TO_SKIP] action.
+		 */
+		val AskToSkipMinDuration = 3.seconds
+
+		/**
+		 * The duration to wait before automatically hiding the "ask to skip" UI.
+		 */
+		val AskToSkipAutoHideDuration = 8.seconds
 	}
 
 	fun getDefaultSegmentTypeAction(type: MediaSegmentType): MediaSegmentAction
@@ -84,6 +94,8 @@ class MediaSegmentRepositoryImpl(
 		val action = getDefaultSegmentTypeAction(segment.type)
 		// Skip the skip action if timespan is too short
 		if (action == MediaSegmentAction.SKIP && segment.duration < MediaSegmentRepository.SkipMinDuration) return MediaSegmentAction.NOTHING
+		// Skip the ask to skip action if timespan is too short
+		if (action == MediaSegmentAction.ASK_TO_SKIP && segment.duration < MediaSegmentRepository.AskToSkipMinDuration) return MediaSegmentAction.NOTHING
 		return action
 	}
 

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -115,4 +115,9 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <org.jellyfin.androidtv.ui.playback.overlay.SkipOverlayView
+        android:id="@+id/skip_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,6 +518,7 @@
     <string name="prefer_exoplayer_ffmpeg_content">Use FFmpeg to decode audio, even if platform codecs are available.</string>
     <string name="video_start_delay">Video start delay</string>
     <string name="pref_mediasegment_actions">Media segment actions</string>
+    <string name="segment_action_ask_to_skip">Ask to skip</string>
     <string name="segment_action_nothing">Do nothing</string>
     <string name="segment_action_skip">Skip</string>
     <string name="segment_type_commercial">Commercials</string>


### PR DESCRIPTION
Addition to #4052. This one adds a new action "ask to skip". When enabled for a segment type, this action will show a message on-screen to suggest skipping the segment. This only shows when the segment is at least 3 seconds long and the message disappears 1 second before the segment ends or 8 seconds after it is shown. Opening/closing the playback overlay also resets that timer as the skipping functionality is **not** working when any other UI is open.

The implementation is a bit of a hack as the player UI is partially leanback, partially custom and now partially compose. When we rewrite the player UI with compose we can make it a bit more integrated with less hacks.

**Changes**
- Add "ask to skip" media segment action

**Screenshots**
![971000042c](https://github.com/user-attachments/assets/690a4bad-c32f-438f-9150-918cde14aae5)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
