### PR TITLE
Fix skipping to next episode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -123,6 +123,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private boolean mFadeEnabled = false;
     private boolean mIsVisible = false;
     private boolean mPopupPanelVisible = false;
+    private boolean navigating = false;
 
     private LeanbackOverlayFragment leanbackOverlayFragment;
 
@@ -484,9 +485,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     // Hide with seek
                     if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
-                        playbackControllerContainer.getValue().getPlaybackController().seek(binding.skipOverlay.getTargetPositionMs());
+                        playbackControllerContainer.getValue().getPlaybackController().seek(binding.skipOverlay.getTargetPositionMs(), true);
                         leanbackOverlayFragment.setShouldShowOverlay(false);
-                        binding.skipOverlay.setTargetPositionMs(null);
+                        if (binding != null) binding.skipOverlay.setTargetPositionMs(null);
                         return true;
                     }
                 }
@@ -658,11 +659,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // Close player when resuming without a valid playback controller
         PlaybackController playbackController = playbackControllerContainer.getValue().getPlaybackController();
         if (playbackController == null || !playbackController.hasFragment()) {
-            if (navigationRepository.getValue().getCanGoBack()) {
-                navigationRepository.getValue().goBack();
-            } else {
-                navigationRepository.getValue().reset(Destinations.INSTANCE.getHome());
-            }
+            closePlayer();
 
             return;
         }
@@ -1291,6 +1288,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     public void closePlayer() {
+        if (navigating) return;
+        navigating = true;
+
         if (navigationRepository.getValue().getCanGoBack()) {
             navigationRepository.getValue().goBack();
         } else {
@@ -1299,6 +1299,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     public void showNextUp(@NonNull UUID id) {
+        if (navigating) return;
+        navigating = true;
+
         navigationRepository.getValue().navigate(Destinations.INSTANCE.nextUp(id), true);
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -933,7 +933,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     public void seek(long pos) {
-        pos = Utils.getSafeSeekPosition(pos, getDuration());
+        seek(pos, false);
+    }
+
+    public void seek(long pos, boolean skipToNext) {
+        if (pos <= 0) pos = 0;
 
         Timber.d("Trying to seek from %s to %d", mCurrentPosition, pos);
         Timber.d("Container: %s", mCurrentStreamInfo == null ? "unknown" : mCurrentStreamInfo.getContainer());
@@ -951,6 +955,14 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
         wasSeeking = true;
+
+        // Stop playback when the requested seek position is at the end of the video
+        if (skipToNext && pos >= (getDuration() - 100)) {
+            itemComplete();
+            return;
+        }
+
+        if (pos >= getDuration()) pos = getDuration();
 
         // set seekPosition so real position isn't used until playback starts again
         mSeekPosition = pos;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -64,7 +64,7 @@ private fun PlaybackController.addSkipAction(mediaSegment: MediaSegmentDto) {
 			// the seek function in the PlaybackController checks this and optionally starts a transcode
 			// at the requested position
 			fragment.lifecycleScope.launch(Dispatchers.Main) {
-				seek(mediaSegment.end.inWholeMilliseconds)
+				seek(mediaSegment.end.inWholeMilliseconds, true)
 			}
 		}
 		// Segments at position 0 will never be hit by ExoPlayer so we need to add a minimum value


### PR DESCRIPTION
When a media segment skips to the end of the video, the app would misbehave and often just close the player instead of going to the next item. This change adds a fast-path to prevent this from happening.

**Changes**
- Prevent CustomPlaybackOverlayFragment from navigating multiple times
- Add "skipToNext" option to PlaybackController.seek to allow skipping to a next queue item if the position is at the end of the current item (`>= duration - 100ms`)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
