### PR TITLE
Use parcelable array list in DestinationFragmentView saved state

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
@@ -166,7 +166,7 @@ class DestinationFragmentView @JvmOverloads constructor(
 		// Save state
 		return bundleOf(
 			BUNDLE_SUPER to super.onSaveInstanceState(),
-			BUNDLE_HISTORY to history.toTypedArray()
+			BUNDLE_HISTORY to history.toList(),
 		)
 	}
 
@@ -177,11 +177,10 @@ class DestinationFragmentView @JvmOverloads constructor(
 		// Call parent
 		@Suppress("DEPRECATION")
 		val parent = state.getParcelable<Parcelable>(BUNDLE_SUPER)
-		if (parent != null) super.onRestoreInstanceState(parent)
+		super.onRestoreInstanceState(parent)
 
 		// Restore history
-		@Suppress("UNCHECKED_CAST")
-		val savedHistory = BundleCompat.getParcelableArray(state, BUNDLE_HISTORY, HistoryEntry::class.java) as Array<HistoryEntry>?
+		val savedHistory = BundleCompat.getParcelableArrayList(state, BUNDLE_HISTORY, HistoryEntry::class.java)
 		if (savedHistory != null) {
 			history.clear()
 			history.addAll(savedHistory)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- In DestinationFragmentView
  - Always call parent onRestoreInstanceState
  - Use ParcelableArrayList which is type-safe so we don't need the unsafe cast

**Issues**
Maybe fixes #4073
