### PR TITLE
Add option to adjust screensaver image display duration

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/DreamViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/DreamViewModel.kt
@@ -75,6 +75,7 @@ class DreamViewModel(
 	private val _libraryContent = flow {
 		// Load first library item after 2 seconds
 		// to force the logo at the start of the screensaver
+		val inAppTime = userPreferences[UserPreferences.screensaverInAppTime].milliseconds
 		emit(null)
 		delay(2.seconds)
 
@@ -82,7 +83,7 @@ class DreamViewModel(
 			val next = getRandomLibraryShowcase()
 			if (next != null) {
 				emit(next)
-				delay(30.seconds)
+				delay(inAppTime)
 			} else {
 				delay(3.seconds)
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -2,9 +2,12 @@ package org.jellyfin.androidtv.integration.dream.composable
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -12,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
@@ -49,19 +53,31 @@ fun DreamContentLibraryShowcase(
 			.align(Alignment.BottomStart)
 			.overscan(),
 	) {
-		if (content.logo != null) {
-			Image(
-				bitmap = content.logo.asImageBitmap(),
-				contentDescription = content.item.name,
-				modifier = Modifier
-					.height(75.dp)
-			)
-		} else {
+		Column {
+			if (content.logo != null) {
+				Image(
+					bitmap = content.logo.asImageBitmap(),
+					contentDescription = content.item.name,
+					modifier = Modifier
+						.height(100.dp)
+						.widthIn(max = 300.dp)
+						.fillMaxSize()
+						.fillMaxWidth()
+				)
+			} else {
+				Text(
+					text = content.item.name.orEmpty().uppercase(),
+					style = TextStyle(
+						color = Color.White,
+						fontSize = 32.sp
+					),
+				)
+			}
 			Text(
-				text = content.item.name.orEmpty(),
+				text = content.item.productionYear.toString(),
 				style = TextStyle(
 					color = Color.White,
-					fontSize = 32.sp
+					fontSize = 24.sp
 				),
 			)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -193,6 +193,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var screensaverInAppTimeout = longPreference("screensaver_inapp_timeout", 5.minutes.inWholeMilliseconds)
 
 		/**
+		 * Time for showing the screensaver images in app, depends on [screensaverInAppEnabled].
+		 */
+		var screensaverInAppTime = longPreference("screensaver_inapp_time", 30.seconds.inWholeMilliseconds)
+
+		/**
 		 * Age rating used to filter items in the screensaver. Use -1 to disable (omits parameter from requests).
 		 */
 		var screensaverAgeRatingMax = intPreference("screensaver_agerating_max", 13)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -122,6 +122,29 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 				depends { userPreferences[UserPreferences.screensaverInAppEnabled] }
 			}
 
+			@Suppress("MagicNumber")
+			list {
+				setTitle(R.string.pref_screensaver_inapp_time)
+
+				entries = mapOf(
+					5.seconds to context.getQuantityString(R.plurals.seconds, 5),
+					10.seconds to context.getQuantityString(R.plurals.seconds, 10),
+					15.seconds to context.getQuantityString(R.plurals.seconds, 15),
+					30.seconds to context.getQuantityString(R.plurals.seconds, 30),
+					1.minutes to context.getQuantityString(R.plurals.minutes, 1),
+					2.5.minutes to context.getQuantityString(R.plurals.minutes, 2.5),
+					5.minutes to context.getQuantityString(R.plurals.minutes, 5),
+				).mapKeys { it.key.inWholeMilliseconds.toString() }
+
+				bind {
+					get { userPreferences[UserPreferences.screensaverInAppTime].toString() }
+					set { value -> userPreferences[UserPreferences.screensaverInAppTime] = value.toLong() }
+					default { UserPreferences.screensaverInAppTime.defaultValue.toString() }
+				}
+
+				depends { userPreferences[UserPreferences.screensaverInAppEnabled] }
+			}
+
 			checkbox {
 				setTitle(R.string.pref_screensaver_ageratingrequired_title)
 				setContent(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,7 @@
     <string name="pref_screensaver_inapp_enabled">Use in-app screensaver</string>
     <string name="pref_screensaver_inapp_enabled_description">Show the Jellyfin screensaver while the app is open</string>
     <string name="pref_screensaver_inapp_timeout">Start screensaver after</string>
+    <string name="pref_screensaver_inapp_time">Show screensaver images for</string>
     <string name="enable_reactive_homepage">Enable reactive homepage</string>
     <string name="not_set">Not set</string>
     <string name="lbl_album_artists">Album artists</string>


### PR DESCRIPTION
<!--
Adds the ability to allow users to customize the display duration of images in the screensaver. Users can now set how long each image is shown before switching to the next one.
-->

**Changes**
Add settings to show screensaver images for different amount of times.
Updated logo handling to prevent stretching across the full screen.
Add production year under logo, great for larger movie collections.
Changed movie title to uppercase when no logo is present, aligning with standard logo styling.
