### PR TITLE
(0.17.z) Fix playing subsequent episode not working

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -132,6 +132,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private boolean mFadeEnabled = false;
     private boolean mIsVisible = false;
     private boolean mPopupPanelVisible = false;
+    private boolean navigating = false;
 
     private LeanbackOverlayFragment leanbackOverlayFragment;
 
@@ -683,12 +684,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // Close player when resuming without a valid playback contoller
         PlaybackController playbackController = playbackControllerContainer.getValue().getPlaybackController();
         if (playbackController == null || !playbackController.hasFragment()) {
-            if (navigationRepository.getValue().getCanGoBack()) {
-                navigationRepository.getValue().goBack();
-            } else {
-                navigationRepository.getValue().reset(Destinations.INSTANCE.getHome());
-            }
-
+            closePlayer();
             return;
         }
 
@@ -1308,6 +1304,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     public void closePlayer() {
+        if (navigating) return;
+        navigating = true;
+
         if (navigationRepository.getValue().getCanGoBack()) {
             navigationRepository.getValue().goBack();
         } else {
@@ -1316,6 +1315,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     public void showNextUp(@NonNull UUID id) {
+        if (navigating) return;
+        navigating = true;
+
         navigationRepository.getValue().navigate(Destinations.INSTANCE.nextUp(id), true);
     }
 


### PR DESCRIPTION
(targets release branch)

#4057 introduced an issue where the next episode wouldn't play because of multiple navigations executing at once. This issue didn't happen on master due to other changes so I didn't catch it in time.

**Changes**
- Backport part of #4072
  - Prevent CustomPlaybackOverlayFragment from navigating multiple times

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #4089
