### PR TITLE
Rewrite all subtitle behavior

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -1,13 +1,11 @@
 package org.jellyfin.androidtv.data.compat;
 
-import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.apiclient.model.dlna.DeviceProfile;
 import org.jellyfin.apiclient.model.dlna.EncodingContext;
 import org.jellyfin.apiclient.model.dlna.SubtitleDeliveryMethod;
 import org.jellyfin.apiclient.model.dlna.SubtitleProfile;
 import org.jellyfin.apiclient.model.dlna.TranscodeSeekInfo;
 import org.jellyfin.apiclient.model.session.PlayMethod;
-import org.jellyfin.sdk.model.api.MediaProtocol;
 import org.jellyfin.sdk.model.api.MediaSourceInfo;
 import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
@@ -64,16 +62,6 @@ public class StreamInfo {
 
     public final void setContainer(String value) {
         Container = value;
-    }
-
-    private long StartPositionTicks;
-
-    public final long getStartPositionTicks() {
-        return StartPositionTicks;
-    }
-
-    public final void setStartPositionTicks(long value) {
-        StartPositionTicks = value;
     }
 
     private DeviceProfile DeviceProfile;
@@ -139,15 +127,13 @@ public class StreamInfo {
     public final ArrayList<SubtitleStreamInfo> getSubtitleProfiles(boolean includeSelectedTrackOnly, boolean enableAllProfiles, String baseUrl, String accessToken) {
         ArrayList<SubtitleStreamInfo> list = new ArrayList<SubtitleStreamInfo>();
 
-        // HLS will preserve timestamps so we can just grab the full subtitle stream
-        long startPositionTicks = getPlayMethod() == PlayMethod.Transcode ? getStartPositionTicks() : 0;
-
         if (!includeSelectedTrackOnly) {
             if (getMediaSource() == null) return list;
 
             for (org.jellyfin.sdk.model.api.MediaStream stream : getMediaSource().getMediaStreams()) {
                 if (stream.getType() == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE) {
-                    addSubtitleProfiles(list, stream, enableAllProfiles, baseUrl, accessToken, startPositionTicks);
+                    SubtitleStreamInfo info = getSubtitleStreamInfo(stream, getDeviceProfile().getSubtitleProfiles());
+                    list.add(info);
                 }
             }
         }
@@ -155,43 +141,15 @@ public class StreamInfo {
         return list;
     }
 
-    private void addSubtitleProfiles(ArrayList<SubtitleStreamInfo> list, org.jellyfin.sdk.model.api.MediaStream stream, boolean enableAllProfiles, String baseUrl, String accessToken, long startPositionTicks) {
-        if (enableAllProfiles) {
-            for (SubtitleProfile profile : getDeviceProfile().getSubtitleProfiles()) {
-                SubtitleStreamInfo info = getSubtitleStreamInfo(stream, baseUrl, accessToken, startPositionTicks, new SubtitleProfile[]{profile});
-
-                list.add(info);
-            }
-        } else {
-            SubtitleStreamInfo info = getSubtitleStreamInfo(stream, baseUrl, accessToken, startPositionTicks, getDeviceProfile().getSubtitleProfiles());
-
-            list.add(info);
-        }
-    }
-
-    private SubtitleStreamInfo getSubtitleStreamInfo(org.jellyfin.sdk.model.api.MediaStream stream, String baseUrl, String accessToken, long startPositionTicks, SubtitleProfile[] subtitleProfiles) {
+    private SubtitleStreamInfo getSubtitleStreamInfo(org.jellyfin.sdk.model.api.MediaStream stream, SubtitleProfile[] subtitleProfiles) {
         SubtitleProfile subtitleProfile = StreamBuilder.getSubtitleProfile(stream, subtitleProfiles, getPlayMethod());
-        SubtitleStreamInfo tempVar = new SubtitleStreamInfo();
+        SubtitleStreamInfo info = new SubtitleStreamInfo();
         String tempVar2 = stream.getLanguage();
-        tempVar.setName((tempVar2 != null) ? tempVar2 : "Unknown");
-        tempVar.setFormat(subtitleProfile.getFormat());
-        tempVar.setIndex(stream.getIndex());
-        tempVar.setDeliveryMethod(subtitleProfile.getMethod());
-        tempVar.setDisplayTitle(stream.getDisplayTitle());
-        SubtitleStreamInfo info = tempVar;
-
-        if (info.getDeliveryMethod() == SubtitleDeliveryMethod.External) {
-            if (getMediaSource().getProtocol() == MediaProtocol.FILE || !stream.getCodec().equalsIgnoreCase(subtitleProfile.getFormat())) {
-                info.setUrl(String.format("%1$s/Videos/%2$s/%3$s/Subtitles/%4$s/%5$s/Stream.%6$s", baseUrl, getItemId(), getMediaSourceId(), String.valueOf(stream.getIndex()), String.valueOf(startPositionTicks), subtitleProfile.getFormat()));
-
-                if (!Utils.isEmpty(accessToken)) {
-                    info.setUrl(info.getUrl() + "?api_key=" + accessToken);
-                }
-            } else {
-                info.setUrl(stream.getPath());
-            }
-        }
-
+        info.setName((tempVar2 != null) ? tempVar2 : "Unknown");
+        info.setFormat(subtitleProfile.getFormat());
+        info.setIndex(stream.getIndex());
+        info.setDeliveryMethod(subtitleProfile.getMethod());
+        info.setDisplayTitle(stream.getDisplayTitle());
         return info;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
@@ -16,6 +16,7 @@ import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer
+import org.jellyfin.androidtv.ui.playback.setSubtitleIndex
 import org.jellyfin.androidtv.util.PlaybackHelper
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
@@ -104,7 +105,7 @@ class SocketHandler(
 					val index = message["index"]?.toIntOrNull() ?: return@onEach
 
 					withContext(Dispatchers.Main) {
-						playbackControllerContainer.playbackController?.switchSubtitleStream(index)
+						playbackControllerContainer.playbackController?.setSubtitleIndex(index)
 					}
 				}
 				.launchIn(coroutineScope)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
@@ -26,9 +26,8 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
     private AudioOptions options;
     private Response<StreamInfo> response;
     private boolean isVideo;
-    private Long startPositionTicks;
 
-    public GetPlaybackInfoResponse(PlaybackManager playbackManager, DeviceInfo deviceInfo, ApiClient apiClient, AudioOptions options, Response<StreamInfo> response, boolean isVideo, Long startPositionTicks) {
+    public GetPlaybackInfoResponse(PlaybackManager playbackManager, DeviceInfo deviceInfo, ApiClient apiClient, AudioOptions options, Response<StreamInfo> response, boolean isVideo) {
         super(response);
         this.playbackManager = playbackManager;
         this.deviceInfo = deviceInfo;
@@ -36,7 +35,6 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
         this.options = options;
         this.response = response;
         this.isVideo = isVideo;
-        this.startPositionTicks = startPositionTicks;
     }
 
     @Override
@@ -96,7 +94,6 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
         streamInfo.setItemId(options.getItemId());
         streamInfo.setDeviceProfile(options.getProfile());
         streamInfo.setPlaySessionId(playbackInfo.getPlaySessionId());
-        streamInfo.setStartPositionTicks(startPositionTicks);
 
         if (options.getEnableDirectPlay() && mediaSourceInfo.getSupportsDirectPlay()){
             if (canDirectPlay(mediaSourceInfo)) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1098,8 +1098,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             if (!burningSubs) {
                 // Make sure the requested subtitles are enabled when external/embedded
                 Integer currentSubtitleIndex = mCurrentOptions.getSubtitleStreamIndex();
-
-                if (currentSubtitleIndex != null && currentSubtitleIndex != -1) {
+                if (currentSubtitleIndex != null) {
                     PlaybackControllerHelperKt.setSubtitleIndex(this, currentSubtitleIndex, true);
                 }
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -2,6 +2,8 @@ package org.jellyfin.androidtv.ui.playback
 
 import androidx.annotation.OptIn
 import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.C
+import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -13,7 +15,10 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MediaSegmentDto
+import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.koin.android.ext.android.inject
+import timber.log.Timber
 import java.util.UUID
 
 fun PlaybackController.getLiveTvChannel(
@@ -27,6 +32,99 @@ fun PlaybackController.getLiveTvChannel(
 			api.liveTvApi.getChannel(id).content
 		}.onSuccess { channel ->
 			callback(channel)
+		}
+	}
+}
+
+@OptIn(UnstableApi::class)
+@JvmOverloads
+fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
+	Timber.i("Switching subtitles from index ${mCurrentOptions.subtitleStreamIndex} to $index")
+
+	// Already using this subtitle index
+	if (mCurrentOptions.subtitleStreamIndex == index && !force) return
+
+	// Disable subtitles
+	if (index == -1) {
+		mCurrentOptions.subtitleStreamIndex = -1
+
+		if (burningSubs) {
+			Timber.i("Disabling subtitle baking")
+
+			stop()
+			burningSubs = false
+			play(mCurrentPosition, -1)
+		} else {
+			Timber.i("Disabling subtitles")
+
+			with(mVideoManager.mExoPlayer.trackSelector!!) {
+				parameters = parameters.buildUpon()
+					.clearOverridesOfType(C.TRACK_TYPE_TEXT)
+					.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+					.build()
+			}
+		}
+	} else if (burningSubs) {
+		Timber.i("Restarting playback to disable subtitle baking")
+
+		// If we're currently burning subs and want to switch streams we need some special behavior
+		// to stop the current baked subs. We can just stop & start with the new subtitle index for that
+		stop()
+		burningSubs = true
+		mCurrentOptions.subtitleStreamIndex = index
+		play(mCurrentPosition, index)
+	} else {
+		val stream = currentMediaSource.mediaStreams?.first { it.type == MediaStreamType.SUBTITLE && it.index == index }
+		if (stream == null) {
+			Timber.w("Failed to find correct media stream")
+			return setSubtitleIndex(-1)
+		}
+
+		when (stream.deliveryMethod) {
+			SubtitleDeliveryMethod.ENCODE -> {
+				Timber.i("Restarting playback for subtitle baking")
+
+				stop()
+				burningSubs = true
+				mCurrentOptions.subtitleStreamIndex = index
+				play(mCurrentPosition, index)
+			}
+
+			SubtitleDeliveryMethod.EXTERNAL,
+			SubtitleDeliveryMethod.EMBED,
+			SubtitleDeliveryMethod.HLS -> {
+				// External subtitles need to be resolved differently
+				val group = if (stream.deliveryMethod == SubtitleDeliveryMethod.EXTERNAL) {
+					mVideoManager.mExoPlayer.currentTracks.groups.firstOrNull { group ->
+						// Verify this is a group with a single format (the subtitles) that is added by us. Because ExoPlayer uses a
+						// MergingMediaSource, each external subtitle format id is prefixed with its source index (normally starting at 1,
+						// increasing for each external subttitle). So we only check the end of the id
+						group.length == 1 && group.getTrackFormat(0).id?.endsWith(":JF_EXTERNAL:$index") == true
+					}
+				} else {
+					mVideoManager.mExoPlayer.currentTracks.groups.getOrNull(stream.index)
+				}?.mediaTrackGroup
+
+				if (group == null) {
+					Timber.w("Failed to find correct subtitle group for method ${stream.deliveryMethod}")
+					return setSubtitleIndex(-1)
+				}
+
+				Timber.i("Enabling subtitle group $index via method ${stream.deliveryMethod}")
+				mCurrentOptions.subtitleStreamIndex = index
+				with(mVideoManager.mExoPlayer.trackSelector!!) {
+					parameters = parameters.buildUpon()
+						.clearOverridesOfType(C.TRACK_TYPE_TEXT)
+						.addOverride(TrackSelectionOverride(group, 0))
+						.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+						.build()
+				}
+			}
+
+			SubtitleDeliveryMethod.DROP, null -> {
+				Timber.i("Dropping subtitles")
+				setSubtitleIndex(-1)
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.java
@@ -58,15 +58,12 @@ public class PlaybackManager {
             request.setAudioStreamIndex(audioIdx);
         }
         Integer subIdx = options.getSubtitleStreamIndex();
-        if (subIdx != null) {
-            request.setSubtitleStreamIndex(subIdx);
-        }
+        if (subIdx != null) request.setSubtitleStreamIndex(subIdx);
 
         request.setAllowVideoStreamCopy(true);
         request.setAllowAudioStreamCopy(true);
 
-        apiClient.GetPlaybackInfoWithPost(request, new GetPlaybackInfoResponse(this, deviceInfo, apiClient, options, response, true, startPositionTicks));
-
+        apiClient.GetPlaybackInfoWithPost(request, new GetPlaybackInfoResponse(this, deviceInfo, apiClient, options, response, true));
     }
 
     public void changeVideoStream(final StreamInfo currentStreamInfo, DeviceInfo deviceInfo, final VideoOptions options, Long startPositionTicks, ApiClient apiClient, final Response<StreamInfo> response) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/ClosedCaptionsAction.kt
@@ -8,8 +8,9 @@ import android.widget.Toast
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.playback.PlaybackController
 import org.jellyfin.androidtv.ui.playback.overlay.CustomPlaybackTransportControlGlue
-import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment
 import org.jellyfin.androidtv.ui.playback.overlay.VideoPlayerAdapter
+import org.jellyfin.androidtv.ui.playback.setSubtitleIndex
+import org.jellyfin.sdk.model.api.MediaStreamType
 import timber.log.Timber
 
 class ClosedCaptionsAction(
@@ -35,7 +36,9 @@ class ClosedCaptionsAction(
 		videoPlayerAdapter.leanbackOverlayFragment.setFading(false)
 		PopupMenu(context, view, Gravity.END).apply {
 			with(menu) {
-				for (sub in playbackController.subtitleStreams) {
+				for (sub in playbackController.currentMediaSource.mediaStreams.orEmpty()) {
+					if (sub.type != MediaStreamType.SUBTITLE) continue
+
 					add(0, sub.index, sub.index, sub.displayTitle).apply {
 						isChecked = sub.index == playbackController.subtitleStreamIndex
 					}
@@ -49,7 +52,7 @@ class ClosedCaptionsAction(
 			}
 			setOnDismissListener { videoPlayerAdapter.leanbackOverlayFragment.setFading(true) }
 			setOnMenuItemClickListener { item ->
-				playbackController.switchSubtitleStream(item.itemId)
+				playbackController.setSubtitleIndex(item.itemId)
 				true
 			}
 		}.show()

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/StreamHelper.java
@@ -9,14 +9,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class StreamHelper {
-    public static MediaStream getMediaStream(MediaSourceInfo mediaSource, int index) {
-        if (mediaSource.getMediaStreams() == null || mediaSource.getMediaStreams().size() == 0) return null;
-        for (MediaStream stream : mediaSource.getMediaStreams()) {
-            if (stream.getIndex() == index) return stream;
-        }
-        return null;
-    }
-
     public static List<MediaStream> getSubtitleStreams(MediaSourceInfo mediaSource) {
         return getStreams(mediaSource, MediaStreamType.SUBTITLE);
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -214,11 +214,11 @@ class ExoPlayerProfile(
 				Codec.Subtitle.PGSSUB,
 				Codec.Subtitle.DVBSUB,
 				Codec.Subtitle.VTT,
-				Codec.Subtitle.SUB,
 				Codec.Subtitle.IDX,
 			).forEach { codec ->
 				add(subtitleProfile(codec, SubtitleDeliveryMethod.Embed))
 				add(subtitleProfile(codec, SubtitleDeliveryMethod.Hls))
+				add(subtitleProfile(codec, SubtitleDeliveryMethod.External))
 			}
 
 			// Require baking

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/audio.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/audio.kt
@@ -5,8 +5,8 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegAudioMimeType(codec: String): String {
-	return ffmpegAudioMimeTypes[codec]
+fun getFfmpegAudioMimeType(codec: String) = codec.lowercase().let { codec ->
+	ffmpegAudioMimeTypes[codec]
 		?: MimeTypes.getAudioMediaMimeType(codec)
 		?: codec
 }

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/container.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/container.kt
@@ -5,8 +5,8 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegContainerMimeType(codec: String): String {
-	return ffmpegContainerMimeTypes[codec]
+fun getFfmpegContainerMimeType(codec: String) = codec.lowercase().let { codec ->
+	ffmpegContainerMimeTypes[codec]
 		?: ffmpegVideoMimeTypes[codec]
 		?: ffmpegAudioMimeTypes[codec]
 		?: MimeTypes.getMediaMimeType(codec)

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/subtitle.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/subtitle.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.playback.media3.exoplayer.mapping
+
+import androidx.annotation.OptIn
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+
+@OptIn(UnstableApi::class)
+fun getFfmpegSubtitleMimeType(codec: String): String {
+	return ffmpegSubtitleMimeTypes[codec]
+		?: MimeTypes.getTextMediaMimeType(codec)
+		?: codec
+}
+
+@OptIn(UnstableApi::class)
+val ffmpegSubtitleMimeTypes = mapOf(
+	"mp4" to MimeTypes.VIDEO_MP4,
+	"ass" to MimeTypes.TEXT_SSA,
+	"dvbsub" to MimeTypes.APPLICATION_DVBSUBS,
+	"idx" to MimeTypes.APPLICATION_VOBSUB,
+	"pgs" to MimeTypes.APPLICATION_PGS,
+	"pgssub" to MimeTypes.APPLICATION_PGS,
+	"srt" to MimeTypes.APPLICATION_SUBRIP,
+	"ssa" to MimeTypes.TEXT_SSA,
+	"subrip" to MimeTypes.APPLICATION_SUBRIP,
+	"vtt" to MimeTypes.TEXT_VTT,
+	"ttml" to MimeTypes.APPLICATION_TTML,
+	"webvtt" to MimeTypes.TEXT_VTT,
+)

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/subtitle.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/subtitle.kt
@@ -5,8 +5,8 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegSubtitleMimeType(codec: String): String {
-	return ffmpegSubtitleMimeTypes[codec]
+fun getFfmpegSubtitleMimeType(codec: String): String = codec.lowercase().let { codec ->
+	ffmpegSubtitleMimeTypes[codec]
 		?: MimeTypes.getTextMediaMimeType(codec)
 		?: codec
 }

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/video.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/video.kt
@@ -5,8 +5,8 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegVideoMimeType(codec: String): String {
-	return ffmpegVideoMimeTypes[codec]
+fun getFfmpegVideoMimeType(codec: String) = codec.lowercase().let { codec ->
+	ffmpegVideoMimeTypes[codec]
 		?: MimeTypes.getVideoMediaMimeType(codec)
 		?: codec
 }


### PR DESCRIPTION
In #3825 I made the initial changes to no longer require external subtitles. This came with a few issues; there was no longer support for external subtitles, switching subtitles didn't work a lot of times and the app didn't track which subtitles were playing properly. This pull request aims to fix all the issues by rewriting the subtitle logic.

The new logic relies on the server providing the delivery method for subs. For example, when transcoding the delivery method is set to HLS but on direct-play it is Embedded or External. The client will then decide the appropriate method to loading subtitles based on that information.

In my testing everything appears to work correctly but I'd appreciate some additional testing for:

- Playback starts with the correct subtitles when they are embedded/external/baked
- Switching subtitles from baking to external/embedded

There should be sufficient logging to troubleshoot issues.

**Changes**
- Rewrite subtitle switching
- Support external subtitles
 - Uses the URL provided by server instead of manually constructing it
- Unsupport "sub" codec as I couldn't figure out which media type in ExoPlayer it belongs to so it probably never worked before

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
