### PR TITLE
Fix PlaybackController not always disabling default track

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1098,9 +1098,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             if (!burningSubs) {
                 // Make sure the requested subtitles are enabled when external/embedded
                 Integer currentSubtitleIndex = mCurrentOptions.getSubtitleStreamIndex();
-                if (currentSubtitleIndex != null) {
-                    PlaybackControllerHelperKt.setSubtitleIndex(this, currentSubtitleIndex, true);
-                }
+                if (currentSubtitleIndex == null) currentSubtitleIndex = -1;
+                PlaybackControllerHelperKt.setSubtitleIndex(this, currentSubtitleIndex, true);
             }
 
             // select an audio track


### PR DESCRIPTION
`null` means no, just like `-1`.

**Changes**
- Fix PlaybackController not always disabling default track

**Issues**
https://github.com/jellyfin/jellyfin-androidtv/pull/4094#issuecomment-2425131644
