### PR TITLE
Implement lyrics

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
 import org.jellyfin.androidtv.ui.composable.ZoomBox
-import org.jellyfin.androidtv.ui.composable.overscan
+import org.jellyfin.androidtv.ui.composable.modifier.overscan
 
 @Composable
 fun DreamContentLibraryShowcase(

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.ui.composable.overscan
+import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.composable.rememberCurrentTime
 
 @Composable

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/model/DreamContent.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/model/DreamContent.kt
@@ -2,9 +2,10 @@ package org.jellyfin.androidtv.integration.dream.model
 
 import android.graphics.Bitmap
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.LyricDto
 
 sealed interface DreamContent {
 	data object Logo : DreamContent
 	data class LibraryShowcase(val item: BaseItemDto, val backdrop: Bitmap, val logo: Bitmap?) : DreamContent
-	data class NowPlaying(val item: BaseItemDto?) : DreamContent
+	data class NowPlaying(val item: BaseItemDto, val lyrics: LyricDto?) : DreamContent
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
@@ -1,0 +1,235 @@
+package org.jellyfin.androidtv.ui.composable
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measured
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.LocalTextStyle
+import androidx.tv.material3.Text
+import org.jellyfin.sdk.model.api.LyricDto
+import org.jellyfin.sdk.model.extensions.ticks
+import kotlin.time.Duration
+
+data class TimedLine(
+	val timestamp: Duration,
+	val text: String,
+)
+
+private data class LyricsBoxContentMeasurements(
+	val size: Size,
+	val items: List<Measured>,
+)
+
+private fun Collection<TimedLine>.indexAtTimestamp(timestamp: Duration) = indexOfLast { it.timestamp <= timestamp }.takeIf { it != -1 }
+
+@Composable
+private fun LyricsLine(
+	text: String,
+	fontSize: TextUnit,
+	color: Color,
+	active: Boolean = false,
+	gap: Dp = 15.dp,
+) {
+	val color by animateColorAsState(
+		targetValue = if (active) color else color.copy(alpha = 0.5f),
+		animationSpec = tween(),
+		label = "LyricsLineColor",
+	)
+
+	val scale by animateFloatAsState(
+		targetValue = if (active) 1.5f else 1f,
+		animationSpec = tween(),
+		label = "LyricsLineScale",
+	)
+
+	Text(
+		text = text,
+		textAlign = TextAlign.Center,
+		fontSize = fontSize,
+		color = color,
+		modifier = Modifier
+			.padding(bottom = gap)
+			.scale(scale)
+	)
+}
+
+@Composable
+private fun <T> LyricsBoxContent(
+	items: Collection<T>,
+	modifier: Modifier = Modifier,
+	onMeasured: ((measurements: LyricsBoxContentMeasurements) -> Unit)? = null,
+	itemContent: @Composable (item: T, index: Int) -> Unit,
+) = Layout(
+	modifier = modifier,
+	measurePolicy = { measurables, constraints ->
+		val placeables = measurables.map { measurable ->
+			measurable.measure(constraints.copy(minWidth = constraints.maxWidth))
+		}
+		if (onMeasured != null) {
+			val totalHeight = placeables.sumOf { it.height }.toFloat()
+			onMeasured(LyricsBoxContentMeasurements(Size(1f, totalHeight), placeables))
+		}
+
+		layout(constraints.maxWidth, constraints.maxHeight) {
+			// Start at the offset until the active line and half the height of this container to vertically center the item
+			var yOffset = constraints.maxHeight / 2
+
+			for (placeable in placeables) {
+				placeable.placeRelative(
+					x = 0,
+					y = yOffset,
+				)
+
+				yOffset += placeable.height
+			}
+		}
+	},
+
+	content = {
+		items.forEachIndexed { index, item ->
+			itemContent(item, index)
+		}
+	},
+)
+
+@Composable
+fun LyricsBox(
+	lines: List<TimedLine>,
+	currentTimestamp: Duration = Duration.ZERO,
+	fontSize: TextUnit = LocalTextStyle.current.fontSize,
+	color: Color = LocalTextStyle.current.color,
+) {
+	var lineMeasurements by remember { mutableStateOf<List<Measured>>(emptyList()) }
+	val activeLine = lines.indexAtTimestamp(currentTimestamp)
+	val activeLineOffsetAnimation = remember { Animatable(0f) }
+
+	LaunchedEffect(activeLine) {
+		var offset = 0f
+
+		if (activeLine != null) {
+			// Add offset for all previous items
+			offset += lineMeasurements.take(activeLine).sumOf { it.measuredHeight }
+			// Add offset for half-height to center item
+			offset += lineMeasurements.getOrNull(activeLine)?.measuredHeight?.div(2) ?: 0
+		}
+
+		activeLineOffsetAnimation.animateTo(offset)
+	}
+
+	LyricsBoxContent(
+		items = lines,
+		modifier = Modifier.graphicsLayer {
+			translationY = -activeLineOffsetAnimation.value
+		},
+		onMeasured = { measurements -> lineMeasurements = measurements.items }
+	) { line, index ->
+		LyricsLine(
+			text = line.text,
+			active = index == activeLine,
+			fontSize = fontSize,
+			color = color,
+		)
+	}
+}
+
+@Composable
+fun LyricsBox(
+	lines: List<String>,
+	modifier: Modifier = Modifier,
+	currentTimestamp: Duration = Duration.ZERO,
+	duration: Duration = Duration.ZERO,
+	paused: Boolean = false,
+	fontSize: TextUnit = LocalTextStyle.current.fontSize,
+	color: Color = LocalTextStyle.current.color,
+) = Box(modifier) {
+	var totalHeight by remember { mutableFloatStateOf(0f) }
+	val activeLineOffsetAnimation = remember { Animatable(0f) }
+
+	LaunchedEffect(paused, duration, totalHeight) {
+		if (duration == Duration.ZERO) {
+			activeLineOffsetAnimation.snapTo(0f)
+		} else {
+			val progress = (currentTimestamp.inWholeMilliseconds.toFloat() / duration.inWholeMilliseconds.toFloat()).coerceIn(0f, 1f)
+
+			activeLineOffsetAnimation.snapTo(-(progress * totalHeight))
+		}
+
+		if (!paused) {
+			activeLineOffsetAnimation.animateTo(
+				targetValue = -totalHeight,
+				animationSpec = tween(
+					durationMillis = (duration - currentTimestamp).inWholeMilliseconds.toInt(),
+					easing = LinearEasing,
+				)
+			)
+		}
+	}
+
+	LyricsBoxContent(
+		items = lines,
+		modifier = Modifier.graphicsLayer {
+			translationY = activeLineOffsetAnimation.value
+		},
+		onMeasured = { measurements -> totalHeight = measurements.size.height }
+	) { line, index ->
+		LyricsLine(
+			text = line,
+			fontSize = fontSize,
+			color = color,
+		)
+	}
+}
+
+@Composable
+fun LyricsDtoBox(
+	lyricDto: LyricDto,
+	modifier: Modifier = Modifier,
+	currentTimestamp: Duration = Duration.ZERO,
+	duration: Duration = Duration.ZERO,
+	paused: Boolean = false,
+	fontSize: TextUnit = LocalTextStyle.current.fontSize,
+	color: Color = LocalTextStyle.current.color,
+) = Box(modifier) {
+	val lyrics = lyricDto.lyrics
+	val isTimed = lyrics.firstOrNull()?.start != null
+	if (isTimed) {
+		LyricsBox(
+			lines = lyrics.map {
+				TimedLine(it.start?.ticks ?: Duration.ZERO, it.text)
+			},
+			currentTimestamp = currentTimestamp,
+			fontSize = fontSize,
+			color = color,
+		)
+	} else {
+		LyricsBox(
+			lines = lyrics.map { it.text },
+			currentTimestamp = currentTimestamp,
+			duration = duration,
+			paused = paused,
+			fontSize = fontSize,
+			color = color,
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/modifier/fadingEdges.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/modifier/fadingEdges.kt
@@ -1,0 +1,115 @@
+package org.jellyfin.androidtv.ui.composable.modifier
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+fun Modifier.fadingEdges(
+	all: Dp
+) = fadingEdges(
+	start = all,
+	top = all,
+	end = all,
+	bottom = all,
+)
+
+fun Modifier.fadingEdges(
+	vertical: Dp = 0.dp,
+	horizontal: Dp = 0.dp,
+) = fadingEdges(
+	start = horizontal,
+	top = vertical,
+	end = horizontal,
+	bottom = vertical,
+)
+
+fun Modifier.fadingEdges(
+	start: Dp = 0.dp,
+	top: Dp = 0.dp,
+	end: Dp = 0.dp,
+	bottom: Dp = 0.dp,
+) = then(
+	Modifier
+		.graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+		.drawWithContent {
+			drawContent()
+
+			// Start edge
+			if (start.value > 0) {
+				drawRect(
+					brush = Brush.horizontalGradient(
+						0f to Color.Transparent,
+						1f to Color.Black,
+						endX = start.toPx(),
+					),
+					blendMode = BlendMode.DstIn,
+				)
+			}
+
+			// Top edge
+			if (top.value > 0) {
+				drawRect(
+					brush = Brush.verticalGradient(
+						0f to Color.Transparent,
+						1f to Color.Black,
+						endY = top.toPx(),
+					),
+					blendMode = BlendMode.DstIn,
+				)
+			}
+
+			// End edge
+			if (end.value > 0) {
+				drawRect(
+					brush = Brush.horizontalGradient(
+						0f to Color.Black,
+						1f to Color.Transparent,
+						startX = size.width - end.toPx(),
+					),
+					blendMode = BlendMode.DstIn,
+				)
+			}
+
+			// Bottom edge
+			if (bottom.value > 0) {
+				drawRect(
+					brush = Brush.verticalGradient(
+						0f to Color.Black,
+						1f to Color.Transparent,
+						startY = size.height - bottom.toPx(),
+					),
+					blendMode = BlendMode.DstIn
+				)
+			}
+		}
+)
+
+@Preview
+@Composable
+private fun FadingEdgePreview() {
+	Box(
+		modifier = Modifier
+			.size(100.dp)
+			.background(Color.Red)
+	) {
+		Box(
+			modifier = Modifier
+				.size(50.dp)
+				.fadingEdges(10.dp, 0.dp, 25.dp, 3.dp)
+				.background(Color.Blue)
+				.align(Alignment.Center)
+		) { }
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/modifier/overscan.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/modifier/overscan.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.androidtv.ui.composable
+package org.jellyfin.androidtv.ui.composable.modifier
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -42,6 +42,7 @@ import org.jellyfin.androidtv.util.ImageHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
+import org.jellyfin.playback.core.PlaybackManager;
 
 import java.util.List;
 
@@ -84,6 +85,7 @@ public class AudioNowPlayingFragment extends Fragment {
 
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+    private final Lazy<PlaybackManager> playbackManager = inject(PlaybackManager.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
@@ -107,6 +109,7 @@ public class AudioNowPlayingFragment extends Fragment {
         mCurrentNdx = binding.track;
         mScrollView = binding.mainScroller;
         mCounter = binding.counter;
+        AudioNowPlayingFragmentHelperKt.initializeLyricsView(binding.poster, binding.lyrics, playbackManager.getValue());
 
         mPlayPauseButton = binding.playPauseBtn;
         mPlayPauseButton.setContentDescription(getString(R.string.lbl_pause));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -1,0 +1,82 @@
+package org.jellyfin.androidtv.ui.playback
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import org.jellyfin.androidtv.ui.AsyncImageView
+import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
+import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.playback.jellyfin.lyricsFlow
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+fun initializeLyricsView(
+	coverView: AsyncImageView,
+	lyricsView: ComposeView,
+	playbackManager: PlaybackManager,
+) {
+	lyricsView.setContent {
+		val lyrics by remember {
+			@OptIn(ExperimentalCoroutinesApi::class)
+			playbackManager.queue.entry.flatMapLatest { entry ->
+				entry?.lyricsFlow ?: emptyFlow()
+			}
+		}.collectAsState(null)
+
+		// Animate cover view alpha
+		val coverViewAlpha by animateFloatAsState(
+			label = "CoverViewAlpha",
+			targetValue = if (lyrics == null) 1f else 0.2f,
+		)
+		LaunchedEffect(coverViewAlpha) { coverView.alpha = coverViewAlpha }
+
+		// Track playback position & duration
+		var playbackPosition by remember { mutableStateOf(Duration.ZERO) }
+		var playbackDuration by remember { mutableStateOf(Duration.ZERO) }
+		val playState by remember { playbackManager.state.playState }.collectAsState()
+
+		LaunchedEffect(lyrics, playState) {
+			while (true) {
+				val positionInfo = playbackManager.state.positionInfo
+				playbackPosition = positionInfo.active
+				playbackDuration = positionInfo.duration
+
+				delay(1.seconds)
+			}
+		}
+
+		// Display lyrics overlay
+		if (lyrics != null) {
+			LyricsDtoBox(
+				lyricDto = lyrics!!,
+				currentTimestamp = playbackPosition,
+				duration = playbackDuration,
+				paused = playState != PlayState.PLAYING,
+				fontSize = 12.sp,
+				color = Color.White,
+				modifier = Modifier
+					.fillMaxSize()
+					.fadingEdges(vertical = 50.dp)
+					.padding(horizontal = 15.dp),
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
@@ -36,7 +36,7 @@ import androidx.tv.material3.Surface
 import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.ui.composable.overscan
+import org.jellyfin.androidtv.ui.composable.modifier.overscan
 
 @Composable
 private fun ConnectHelpAlert(

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -209,6 +209,14 @@
                 android:layout_marginEnd="60dp"
                 android:background="@drawable/shape_card" />
 
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/lyrics"
+                android:layout_width="250dp"
+                android:layout_height="250dp"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="60dp"
+                android:background="@drawable/shape_card" />
+
             <FrameLayout
                 android:id="@+id/rowsFragment"
                 android:layout_width="match_parent"

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -42,4 +42,6 @@ fun jellyfinPlugin(
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)
 	provide(PlaySessionSocketService(api, playSessionService))
+
+	provide(LyricsPlayerService(api))
 }

--- a/playback/jellyfin/src/main/kotlin/lyrics.kt
+++ b/playback/jellyfin/src/main/kotlin/lyrics.kt
@@ -1,0 +1,46 @@
+package org.jellyfin.playback.jellyfin
+
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.jellyfin.playback.core.element.ElementKey
+import org.jellyfin.playback.core.element.element
+import org.jellyfin.playback.core.element.elementFlow
+import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.lyricsApi
+import org.jellyfin.sdk.model.api.LyricDto
+
+private val lyricsKey = ElementKey<LyricDto>("LyricDto")
+
+/**
+ * Get or set the [LyricDto] for this [QueueEntry].
+ */
+var QueueEntry.lyrics by element(lyricsKey)
+val QueueEntry.lyricsFlow by elementFlow(lyricsKey)
+
+class LyricsPlayerService(
+	private val api: ApiClient,
+) : PlayerService() {
+	override suspend fun onInitialize() {
+		// Load lyrics for an item as soon as it becomes the currently playing item
+		manager.queue.entry
+			.onEach { entry -> entry?.let { fetchLyrics(entry) } }
+			.launchIn(coroutineScope)
+	}
+
+	private suspend fun fetchLyrics(entry: QueueEntry) {
+		// Already has lyrics!
+		if (entry.lyrics != null) return
+
+		// BaseItem doesn't exist or doesn't have lyrics
+		val baseItem = entry.baseItem ?: return
+		if (baseItem.hasLyrics != true) return
+
+		// Get via API
+		val lyrics by api.lyricsApi.getLyrics(baseItem.id)
+		entry.lyrics = lyrics
+	}
+}


### PR DESCRIPTION
After months of ~~procrastinating~~work, we now have 🎤 Lyrics in the app!

Supports both synced (highlight current line) and unsynced (continuous scroll) lyrics. It does introduce a tiny display bug with the seekbar in the screensaver, I'll fix that later.

**Changes**
- Load lyrics for queue items and add them to the new lyrics element
- Add lyric display in screensaver
- Add (small) lyric display in now playing view (on top of album art)
- Move overscan modifier to a new "modifier" subpackage
- Add new "fadingEdges" modifier that adds a fade-out edge

**Screenshots**

No screenshots for now because we don't have lyrics on the demo server :(

**Issues**

Part of #1057 
Closes #3742
Closes #2988