### PR TITLE
Use "Ask to skip" by default for intros and outros

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -11,6 +11,8 @@ import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.preference.constant.ZoomMode
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
+import org.jellyfin.androidtv.ui.playback.segment.toMediaSegmentActionsString
 import org.jellyfin.preference.booleanPreference
 import org.jellyfin.preference.enumPreference
 import org.jellyfin.preference.floatPreference
@@ -18,6 +20,7 @@ import org.jellyfin.preference.intPreference
 import org.jellyfin.preference.longPreference
 import org.jellyfin.preference.store.SharedPreferenceStore
 import org.jellyfin.preference.stringPreference
+import org.jellyfin.sdk.model.api.MediaSegmentType
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -210,7 +213,13 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		/**
 		 * The actions to take for each media segment type. Managed by the [MediaSegmentRepository].
 		 */
-		var mediaSegmentActions = stringPreference("media_segment_actions", "")
+		var mediaSegmentActions = stringPreference(
+			key = "media_segment_actions",
+			defaultValue = mapOf(
+				MediaSegmentType.INTRO to MediaSegmentAction.ASK_TO_SKIP,
+				MediaSegmentType.OUTRO to MediaSegmentAction.ASK_TO_SKIP,
+			).toMediaSegmentActionsString()
+		)
 
 		/**
 		 * Preferred behavior for player aspect ratio (zoom mode).

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
@@ -45,6 +45,10 @@ interface MediaSegmentRepository {
 	fun getMediaSegmentAction(segment: MediaSegmentDto): MediaSegmentAction
 }
 
+fun Map<MediaSegmentType, MediaSegmentAction>.toMediaSegmentActionsString() =
+	map { "${it.key.serialName}=${it.value.name}" }
+		.joinToString(",")
+
 class MediaSegmentRepositoryImpl(
 	private val userPreferences: UserPreferences,
 	private val api: ApiClient,
@@ -70,9 +74,7 @@ class MediaSegmentRepositoryImpl(
 	}
 
 	private fun saveMediaTypeActions() {
-		userPreferences[UserPreferences.mediaSegmentActions] = mediaTypeActions
-			.map { "${it.key.serialName}=${it.value.name}" }
-			.joinToString(",")
+		userPreferences[UserPreferences.mediaSegmentActions] = mediaTypeActions.toMediaSegmentActionsString()
 	}
 
 	override fun getDefaultSegmentTypeAction(type: MediaSegmentType): MediaSegmentAction {


### PR DESCRIPTION
This change is aimed to the (non-admin) users to have media segments work by default with sensible defaults. Automatically skipping should never be done, but asking to skip something can't hurt. I opted to enable this for intros/outros only as I expect those to be the segments people want to skip most often.



**Changes**
- Use "Ask to skip" by default for intros and outros

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
