### PR TITLE
Automatically disable subtitles when baking fails

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/GetPlaybackInfoResponse.java
@@ -8,7 +8,6 @@ import org.jellyfin.androidtv.util.sdk.compat.ModelCompat;
 import org.jellyfin.apiclient.interaction.ApiClient;
 import org.jellyfin.apiclient.interaction.QueryStringDictionary;
 import org.jellyfin.apiclient.interaction.Response;
-import org.jellyfin.apiclient.model.dlna.PlaybackErrorCode;
 import org.jellyfin.apiclient.model.dto.MediaSourceInfo;
 import org.jellyfin.apiclient.model.mediainfo.LiveStreamRequest;
 import org.jellyfin.apiclient.model.mediainfo.LiveStreamResponse;
@@ -164,14 +163,6 @@ public class GetPlaybackInfoResponse extends Response<PlaybackInfoResponse> {
             streamInfo.setPlayMethod(PlayMethod.Transcode);
             streamInfo.setContainer(mediaSourceInfo.getTranscodingContainer());
             streamInfo.setMediaUrl(apiClient.GetApiUrl(mediaSourceInfo.getTranscodingUrl()));
-        }
-
-        // A null url will crash the app, make sure to call onError instead
-        if (streamInfo.getMediaUrl() == null) {
-            PlaybackException exception = new PlaybackException();
-            exception.setErrorCode(PlaybackErrorCode.NoCompatibleStream);
-            response.onError(exception);
-            return;
         }
 
         playbackManager.SendResponse(response, streamInfo);


### PR DESCRIPTION
**Changes**

When subtitles are requested for baking but the bakery is not at home, the player would freeze and disabling subtitles did nothing. Now, when this happens the app will automatically turn off subtitles and retry. This fixes the scenario where the user does not have transcoding permissions and plays media with ass as default.

_Also the app can handle null as media url fine already._

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
