### PR TITLE
Fix adding music to existing queue

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -709,7 +709,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     }
                 });
             } else {
-                mediaManager.getValue().addToAudioQueue(Arrays.asList(baseItem));
+                mediaManager.getValue().queueAudioItem(baseItem);
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -188,12 +188,7 @@ class RewriteMediaManager(
 	override fun addToAudioQueue(items: List<BaseItemDto>) {
 		if (items.isEmpty()) return
 
-		val addIndex = when (playbackManager.state.playState.value) {
-			PlayState.PLAYING -> playbackManager.queue.entryIndex.value + 1
-			else -> 0
-		}
-
-		queueSupplier.items.addAll(addIndex, items)
+		queueSupplier.items.addAll(items)
 
 		if (playbackManager.state.playState.value != PlayState.PLAYING) {
 			playbackManager.state.setPlaybackOrder(if (isShuffleMode) PlaybackOrder.SHUFFLE else PlaybackOrder.DEFAULT)


### PR DESCRIPTION
I'm honestly not sure why it was implemented as "add to start or after currently playing item"...

**Changes**
- Fix adding music to existing queue
- Update one usage of addToAudioQueue to use queueAudioItem instead

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
