### PR TITLE
Sync custom controls with built-in controls in leanback overlay

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -121,7 +121,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private AudioManager mAudioManager;
 
     private boolean mFadeEnabled = false;
-    private boolean mIsVisible = false;
+    private boolean mIsVisible = true;
     private boolean mPopupPanelVisible = false;
     private boolean navigating = false;
 
@@ -168,7 +168,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // setup fade task
         mHideTask = () -> {
             if (mIsVisible) {
-                hide();
                 leanbackOverlayFragment.hideOverlay();
             }
         };
@@ -203,9 +202,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         tvGuideBinding.getRoot().setVisibility(View.GONE);
 
         binding.getRoot().setOnTouchListener((v, event) -> {
-            //if we're not visible, show us
-            if (!mIsVisible) show();
-
             //and then manage our fade timer
             if (mFadeEnabled) startFadeTimer();
 
@@ -298,7 +294,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // start playing
         playbackControllerContainer.getValue().getPlaybackController().play(startPos);
         leanbackOverlayFragment.updatePlayState();
-
     }
 
     @Override
@@ -600,9 +595,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                             playbackControllerContainer.getValue().getPlaybackController().playPause();
                             return true;
                         }
-
-                        //if we're not visible, show us
-                        show();
                     }
 
                     //and then manage our fade timer
@@ -704,12 +696,18 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     }
 
     public void show() {
+        // Already showing!
+        if (mIsVisible) return;
+
         binding.topPanel.startAnimation(slideDown);
         mIsVisible = true;
         binding.skipOverlay.setSkipUiEnabled(!mIsVisible && !mGuideVisible && !mPopupPanelVisible);
     }
 
     public void hide() {
+        // Can't hide what's already hidden
+        if (!mIsVisible) return;
+
         mIsVisible = false;
         binding.topPanel.startAnimation(fadeOut);
         binding.skipOverlay.setSkipUiEnabled(!mIsVisible && !mGuideVisible && !mPopupPanelVisible);
@@ -1211,7 +1209,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
     public void setFadingEnabled(boolean value) {
         mFadeEnabled = value;
-        if (!mIsVisible) requireActivity().runOnUiThread(this::show);
+//        if (!mIsVisible) requireActivity().runOnUiThread(this::show);
         if (mFadeEnabled) {
             startFadeTimer();
         } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -45,7 +45,14 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
     public void showControlsOverlay(boolean runAnimation) {
         if (shouldShowOverlay) {
             super.showControlsOverlay(runAnimation);
+            playerAdapter.getMasterOverlayFragment().show();
         }
+    }
+
+    @Override
+    public void hideControlsOverlay(boolean runAnimation) {
+        super.hideControlsOverlay(runAnimation);
+        playerAdapter.getMasterOverlayFragment().hide();
     }
 
     public void updateCurrentPosition() {

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -64,8 +64,7 @@
         android:layout_gravity="center_horizontal|top"
         android:layout_marginHorizontal="40dp"
         android:layout_marginTop="20dp"
-        android:clickable="false"
-        android:visibility="invisible">
+        android:clickable="false">
 
         <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/item_logo"


### PR DESCRIPTION
So we have an unmaintained library that implements like 60% of the player user interface, but on top of that we have a bunch of hacky code. Simply said, the player UI has a bottom-region with the buttons etc. which is implemented by leanback and a top-region that is implemented by us.

Whenever the controls are shown or hidden these would **never** be in sync, sometimes the title would randomly appear during seeking etc. This is super annoying and especially with the "ask to skip" media segment action it was just painful.

So I synced them. _and probably introduced new bugs_

**Changes**
- Show "topPanel" by default, just like the leanback overlay
- Hide/show "topPanel" when leanback overlay is shown/hidden
- Added checks to "topPanel" to not show when already shown or hide when already hidden, this caused the animations to replay which looked weird and stupid
- Increased headache by 40%

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
