### PR TITLE
Hide video player controls by default

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -121,11 +121,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private AudioManager mAudioManager;
 
     private boolean mFadeEnabled = false;
-    private boolean mIsVisible = true;
+    private boolean mIsVisible = false;
     private boolean mPopupPanelVisible = false;
     private boolean navigating = false;
 
-    private LeanbackOverlayFragment leanbackOverlayFragment;
+    protected LeanbackOverlayFragment leanbackOverlayFragment;
 
     private final Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
@@ -294,6 +294,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         // start playing
         playbackControllerContainer.getValue().getPlaybackController().play(startPos);
         leanbackOverlayFragment.updatePlayState();
+
+        // Set initial skip overlay state
+        binding.skipOverlay.setSkipUiEnabled(!mIsVisible && !mGuideVisible && !mPopupPanelVisible);
     }
 
     @Override
@@ -1209,7 +1212,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
     public void setFadingEnabled(boolean value) {
         mFadeEnabled = value;
-//        if (!mIsVisible) requireActivity().runOnUiThread(this::show);
         if (mFadeEnabled) {
             startFadeTimer();
         } else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1093,7 +1093,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     @Override
     public void onPrepared() {
         if (mPlaybackState == PlaybackState.BUFFERING) {
-            if (mFragment != null) mFragment.setFadingEnabled(true);
+            if (mFragment != null) mFragment.leanbackOverlayFragment.setShouldShowOverlay(false);
 
             mPlaybackState = PlaybackState.PLAYING;
             mCurrentTranscodeStartTime = mCurrentStreamInfo.getPlayMethod() == PlayMethod.Transcode ? Instant.now().toEpochMilli() : 0;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -3,7 +3,10 @@ package org.jellyfin.androidtv.ui.playback.overlay;
 import static org.koin.java.KoinJavaComponent.inject;
 
 import android.os.Bundle;
+import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.leanback.app.PlaybackSupportFragment;
 
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment;
@@ -34,6 +37,13 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
         playerAdapter = new VideoPlayerAdapter(playbackController, this);
         playerGlue = new CustomPlaybackTransportControlGlue(getContext(), playerAdapter, playbackController);
         playerGlue.setHost(new CustomPlaybackFragmentGlueHost(this));
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        super.hideControlsOverlay(false);
     }
 
     public void initFromView(CustomPlaybackOverlayFragment customPlaybackOverlayFragment) {

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -64,7 +64,8 @@
         android:layout_gravity="center_horizontal|top"
         android:layout_marginHorizontal="40dp"
         android:layout_marginTop="20dp"
-        android:clickable="false">
+        android:clickable="false"
+        android:visibility="gone">
 
         <org.jellyfin.androidtv.ui.AsyncImageView
             android:id="@+id/item_logo"


### PR DESCRIPTION
When the video player opens, you probably know what is gonna play already.. because you just opened it yourself. No reason to show the controls/title by default. So let's hide it!

**Changes**
- Hide video player controls by default
- Don't automatically show video controls when playback starts
- Fix "ask to skip" button showing on overlay on start

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
