### PR TITLE
Fix video restarting immediately when baking subtitles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -542,6 +542,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     if (mVideoManager == null)
                         return;
                     mCurrentOptions = internalOptions;
+                    if (internalOptions.getSubtitleStreamIndex() == null) burningSubs = internalResponse.getSubtitleDeliveryMethod() == SubtitleDeliveryMethod.Encode;
                     startItem(item, position, internalResponse);
                 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -119,8 +119,8 @@ class MediaCodecCapabilitiesTest {
 						maxLevel = maxOf(maxLevel, profileLevel.level)
 					}
 				}
-			} catch (e: IllegalArgumentException) {
-				Timber.d(e, "Decoder %s does not support %s", info.name, mime)
+			} catch (_: IllegalArgumentException) {
+				// Decoder not supported - ignore
 			}
 		}
 
@@ -146,8 +146,8 @@ class MediaCodecCapabilitiesTest {
 
 					if (profileLevel.level >= level) return true
 				}
-			} catch (e: IllegalArgumentException) {
-				Timber.w(e)
+			} catch (_: IllegalArgumentException) {
+				// Decoder not supported - ignore
 			}
 		}
 
@@ -183,8 +183,8 @@ class MediaCodecCapabilitiesTest {
 				maxWidth = maxOf(maxWidth, supportedWidth)
 				maxHeight = maxOf(maxHeight, supportedHeight)
 
-			} catch (e: IllegalArgumentException) {
-				Timber.d(e, "Codec %s does not support video capabilities", info.name)
+			} catch (_: IllegalArgumentException) {
+				// Decoder not supported - ignore
 			}
 		}
 


### PR DESCRIPTION
In some cases there is no preferred subtitle track client side, but the server does have one. When this track needs baking (SSA/ASS) there was a tiny bug in the client where it would restart playback because it thought it had to switch subtitle tracks.

**Changes**
- Fix video restarting immediately when baking subtitles
- Remove log spam from MediaCodecCapabilitiesTest

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
