### PR TITLE
Add missing audioCodec to music transcode

### DIFF
--- a/playback/jellyfin/src/main/kotlin/mediastream/AudioMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/AudioMediaStreamResolver.kt
@@ -21,7 +21,8 @@ class AudioMediaStreamResolver(
 ) : JellyfinStreamResolver(api, profile) {
 	companion object {
 		private val REMUX_CONTAINERS = arrayOf("mp3", "ogg", "mkv")
-		private const val REMUX_SEGMENT_CONTAINER = "mp3"
+		private const val TRANSCODE_SEGMENT_CONTAINER = "mp4"
+		private const val TRANSCODE_CODEC = "aac"
 	}
 
 	private fun MediaInfo.getDirectPlayStream() = BasicMediaStream(
@@ -101,7 +102,8 @@ class AudioMediaStreamResolver(
 					mediaSourceId = requireNotNull(mediaInfo.mediaSource.id),
 					playSessionId = mediaInfo.playSessionId,
 					tag = mediaInfo.mediaSource.eTag,
-					segmentContainer = REMUX_SEGMENT_CONTAINER,
+					segmentContainer = TRANSCODE_SEGMENT_CONTAINER,
+					audioCodec = TRANSCODE_CODEC,
 				).appendAccessToken()
 			)
 		}


### PR DESCRIPTION
Starting with 10.10 the transcode for music started to fail. After investigating (jellyfin/jellyfin#12926) we found various issues, and this code shouldn't have worked with 10.9 as well (unable to test as I don't have a 10.9 server anymore).
Adding the audio codec to the HLS playlist request fixes transcoding for the sample file I received.

**Changes**
- Add missing audio codec to audio/music transcode request
- Use mp4+aac instead of mp3

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
