### PR TITLE
Don't close player with invalid state in onCreate

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -155,11 +155,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         requireActivity().setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
         mItemsToPlay = videoQueueManager.getValue().getCurrentVideoQueue();
-        if (mItemsToPlay == null || mItemsToPlay.size() == 0) {
-            Utils.showToast(requireContext(), getString(R.string.msg_no_playable_items));
-            closePlayer();
-            return;
-        }
+        if (mItemsToPlay == null || mItemsToPlay.isEmpty()) return;
 
         int mediaPosition = videoQueueManager.getValue().getCurrentMediaPosition();
 
@@ -216,6 +212,12 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        if (mItemsToPlay == null || mItemsToPlay.isEmpty()) {
+            Utils.showToast(requireContext(), getString(R.string.msg_no_playable_items));
+            closePlayer();
+            return;
+        }
+
         if (playbackControllerContainer.getValue().getPlaybackController() != null) {
             playbackControllerContainer.getValue().getPlaybackController().init(new VideoManager((requireActivity()), view, helper), this);
         }
@@ -233,7 +235,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        if (mItemsToPlay == null || mItemsToPlay.size() == 0) return;
+        if (mItemsToPlay == null || mItemsToPlay.isEmpty()) return;
 
         prepareOverlayFragment();
 
@@ -673,6 +675,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     @Override
     public void onPause() {
         super.onPause();
+        if (mItemsToPlay == null || mItemsToPlay.isEmpty()) return;
 
         setPlayPauseActionState(0);
 


### PR DESCRIPTION
When you shut down your device with the video player open, then start it up again. The OS will resume the app. When this happens the app state is also reset so we don't have anything to play. Closing the player is the way to go! You can't however create a fragment transaction during a fragment transaction, this is what happened because the fragment is being initialized when oCcreate is called. Delay the closing a bit to avoid crashing.

**Changes**
- Move player closing when there are no items to the onViewCreated method instead of invoking it in onCreate

**Issues**

Fixes #4099