### PR TITLE
Fix audio track selection when baking subtitles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -500,7 +500,13 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         internalOptions.setMaxBitrate(maxBitrate);
         if (playbackRetries > 0 || (isLiveTv && !directStreamLiveTv)) internalOptions.setEnableDirectStream(false);
         if (playbackRetries > 1) internalOptions.setEnableDirectPlay(false);
-        internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
+        if (mCurrentOptions != null) {
+            internalOptions.setSubtitleStreamIndex(mCurrentOptions.getSubtitleStreamIndex());
+            internalOptions.setAudioStreamIndex(mCurrentOptions.getAudioStreamIndex());
+        }
+        if (forcedSubtitleIndex != null) {
+            internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
+        }
         MediaSourceInfo currentMediaSource = getCurrentMediaSource();
         if (!isLiveTv && currentMediaSource != null) {
             internalOptions.setMediaSourceId(currentMediaSource.getId());


### PR DESCRIPTION
Hopefully this doesn't introduce a bunch of other issues again, didn't really have the time to test all cases.

**Changes**

- Fix current audio track selection not set when baking subtitles

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
