### PR TITLE
Fix exo track id parsing for format change.

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -415,7 +415,11 @@ public class VideoManager {
                         if (trackFormat.id != null) {
                             int id;
                             try {
-                                id = Integer.parseInt(trackFormat.id);
+                                if (trackFormat.id.contains(":")) {
+                                    id = Integer.parseInt(trackFormat.id.split(":")[1]);
+                                } else {
+                                    id = Integer.parseInt(trackFormat.id);
+                                }
                             } catch (NumberFormatException e) {
                                 Timber.d("failed to parse track ID [%s]", trackFormat.id);
                                 break;
@@ -483,7 +487,11 @@ public class VideoManager {
 
                 int id;
                 try {
-                    id = Integer.parseInt(trackFormat.id);
+                    if (trackFormat.id.contains(":")) {
+                        id = Integer.parseInt(trackFormat.id.split(":")[1]);
+                    } else {
+                        id = Integer.parseInt(trackFormat.id);
+                    }
                     if (id != exoTrackID)
                         continue;
                 } catch (NumberFormatException e) {


### PR DESCRIPTION
Without this changing to other audio tracks fails, it just keeps playing the first one in the file. I was tipped off to the source of the problem by lines like this in logcat:

11-04 19:26:01.244 11669 11669 D VideoManager: failed to parse track ID [0:2]

It appears exoplayer changed from a simple number for trackid to two numbers separated by a colon. Haven't had any luck tracking down why, but the latter of the two appears to match the old single number so, just pull that out and use it.