### PR TITLE
Fix position on playback stop reporting when skipping to playback end

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -886,6 +886,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         // Stop playback when the requested seek position is at the end of the video
         if (skipToNext && pos >= (getDuration() - 100)) {
+            // Since we've skipped ahead, set the current position so the PlaybackStopInfo will report the correct end time
+            mCurrentPosition = getDuration();
             itemComplete();
             return;
         }


### PR DESCRIPTION
We have a special case in the PlaybackController.seek() method that stops playback if the requested seek is higher then the video duration. When this happens we should make sure the duration is set as progress so the reporting helper correctly reports the end time, otherwise it would report the time before seeking/skipping a segment.

**Changes**
- Fix position on playback stop reporting when skipping to playback end

**Issues**

Fixes #4165