### PR TITLE
Fix ImageProvider always throwing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/provider/ImageProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/provider/ImageProvider.kt
@@ -12,6 +12,7 @@ import androidx.core.net.toUri
 import coil3.ImageLoader
 import coil3.asDrawable
 import coil3.request.ImageRequest
+import coil3.request.error
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.koin.android.ext.android.inject


### PR DESCRIPTION
Kotlin stdlib `error()` throws an `IllegalStateException`. Coil `ImageRequest.error()` sets the error resource. Guess what happens if the latter is not imported correctly.

**Changes**
- Fix a missing import from #4190

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
