### PR TITLE
Fix skipping to end of video reports wrong end time

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -888,8 +888,10 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (skipToNext && pos >= (getDuration() - 100)) {
             // Since we've skipped ahead, set the current position so the PlaybackStopInfo will report the correct end time
             mCurrentPosition = getDuration();
-            // Make sure we also set the seek position so it won't get overwritten in refreshCurrentPosition()
+            // Make sure we also set the seek positions so mCurrentPosition won't get overwritten in refreshCurrentPosition()
+            currentSkipPos = mCurrentPosition;
             mSeekPosition = mCurrentPosition;
+            // Finalize item playback
             itemComplete();
             return;
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix skipping to end of video reports wrong end time
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Third time is the charm? Fixes #4165