### PR TITLE
Never load PGS externally

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ExoPlayerProfile.kt
@@ -210,7 +210,6 @@ class ExoPlayerProfile(
 			arrayOf(
 				Codec.Subtitle.SRT,
 				Codec.Subtitle.SUBRIP,
-				Codec.Subtitle.PGS,
 				Codec.Subtitle.PGSSUB,
 				Codec.Subtitle.DVBSUB,
 				Codec.Subtitle.VTT,
@@ -219,6 +218,14 @@ class ExoPlayerProfile(
 				add(subtitleProfile(codec, SubtitleDeliveryMethod.Embed))
 				add(subtitleProfile(codec, SubtitleDeliveryMethod.Hls))
 				add(subtitleProfile(codec, SubtitleDeliveryMethod.External))
+			}
+
+			// Rendering supported, but needs to be embedded
+			arrayOf(
+				Codec.Subtitle.PGS,
+			).forEach { codec ->
+				add(subtitleProfile(codec, SubtitleDeliveryMethod.Embed))
+				add(subtitleProfile(codec, SubtitleDeliveryMethod.Hls))
 			}
 
 			// Require baking


### PR DESCRIPTION
Not sure why, everything seems correct, but media3 won't render PGS when loaded externally.

**Changes**
- Never load PGS externally

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/4183
Maybe fixes https://github.com/jellyfin/jellyfin-androidtv/issues/4182