### PR TITLE
Refactor subtitle profiles to be more readable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -351,6 +351,7 @@ public class VideoManager {
                             .setLabel(mediaStream.getDisplayTitle())
                             .setSelectionFlags(getSubtitleSelectionFlags(mediaStream))
                             .build();
+                    Timber.i("Adding subtitle track %s of type %s", subtitleConfiguration.uri, subtitleConfiguration.mimeType);
                     subtitleConfigurations.add(subtitleConfiguration);
                 }
             }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/ProfileHelper.kt
@@ -33,6 +33,7 @@ object ProfileHelper {
 						)
 					)
 				}
+
 				!MediaTest.supportsAV1Main10() -> {
 					Timber.i("*** Does NOT support AV1 10 bit")
 					arrayOf(
@@ -43,6 +44,7 @@ object ProfileHelper {
 						)
 					)
 				}
+
 				else -> {
 					// supports all AV1
 					Timber.i("*** Supports AV1 10 bit")
@@ -83,6 +85,7 @@ object ProfileHelper {
 						)
 					)
 				}
+
 				else -> {
 					// If AVC is supported, include all relevant profiles
 					Timber.i("*** Supports AVC")
@@ -184,6 +187,7 @@ object ProfileHelper {
 						)
 					)
 				}
+
 				else -> {
 					// If HEVC is supported, include all relevant profiles
 					Timber.i("*** Supports HEVC 10 bit")
@@ -309,5 +313,18 @@ object ProfileHelper {
 	) = SubtitleProfile().apply {
 		this.format = format
 		this.method = method
+	}
+
+	internal fun MutableList<SubtitleProfile>.subtitleProfile(
+		format: String,
+		embedded: Boolean = false,
+		external: Boolean = false,
+		hls: Boolean = false,
+		encode: Boolean = false,
+	) {
+		if (embedded) add(subtitleProfile(format, SubtitleDeliveryMethod.Embed))
+		if (external) add(subtitleProfile(format, SubtitleDeliveryMethod.External))
+		if (hls) add(subtitleProfile(format, SubtitleDeliveryMethod.Hls))
+		if (encode) add(subtitleProfile(format, SubtitleDeliveryMethod.Encode))
 	}
 }


### PR DESCRIPTION
**Changes**
- Log all external subtitle tracks that get added
- Refactor subtitleProfile utility function to be easier to work with
- Fix non-webvtt subtitles allowed in HLS, causing the server to convert SRT->WebVTT (#4191)
- Fix PGSSUB still added as external supported (oops) - also fixed with #4206
- Add TTML as supported
- Fix DVBSUB, IDX allowed as external (media3 does not support that)
- **Document the edge-cases in-code**

**Issues**
Fixes #4191