### PR TITLE
Fix audio now playing screen always showing "1 of x" instead of the actual queue position

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -54,7 +54,7 @@ class RewriteMediaManager(
 		get() = playbackManager.state.positionInfo.active.inWholeMilliseconds
 
 	override val currentAudioQueueDisplayPosition: String
-		get() = (currentAudioQueuePosition + 1).toString()
+		get() = (playbackManager.queue.entryIndex.value + 1).toString()
 
 	override val currentAudioQueueDisplaySize: String
 		get() = playbackManager.queue.estimatedSize.toString()


### PR DESCRIPTION
currentAudioQueuePosition is always either 1 or 0

**Changes**
- Fix audio now playing screen always showing "1 of x" instead of the actual queue position
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Fixes #4213