### PR TITLE
Unset playing item once the playback queue ends

### DIFF
--- a/playback/core/src/main/kotlin/queue/QueueService.kt
+++ b/playback/core/src/main/kotlin/queue/QueueService.kt
@@ -54,7 +54,8 @@ class QueueService internal constructor() : PlayerService(), Queue {
 			override fun onVideoSizeChange(width: Int, height: Int) = Unit
 			override fun onMediaStreamEnd(mediaStream: PlayableMediaStream) {
 				coroutineScope.launch {
-					next(usePlaybackOrder = true, useRepeatMode = true)
+					val nextItem = next(usePlaybackOrder = true, useRepeatMode = true)
+					if (nextItem == null && _entryIndex.value != Queue.INDEX_NONE) setIndex(Queue.INDEX_NONE, true)
 				}
 			}
 		})
@@ -91,7 +92,7 @@ class QueueService internal constructor() : PlayerService(), Queue {
 		}
 
 		// Return item or null if not found
-		return if (index < fetchedItems.size) fetchedItems[index]
+		return if (index >= 0 && index < fetchedItems.size) fetchedItems[index]
 		else null
 	}
 
@@ -144,7 +145,7 @@ class QueueService internal constructor() : PlayerService(), Queue {
 	}
 
 	override suspend fun setIndex(index: Int, saveHistory: Boolean): QueueEntry? {
-		if (index < 0) return null
+		if (index < 0 && index != Queue.INDEX_NONE) return null
 
 		// Save previous index
 		if (saveHistory && _entryIndex.value != Queue.INDEX_NONE) {


### PR DESCRIPTION
should've implemented this earlier

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
With this change the queue index will always reset to -1 (INDEX_NONE) once the last item in the queue ends instead of leaving the last queue item active. This solves various issues in the UI (like the screensaver) where it keeps showing the last item when nothing is playing

- Allow `INDEX_NONE` in `Queue.setIndex`
- Fix crash when `getOrSupplyItem` is invoked with a lower then 0 index (couldn't happen before this PR though)
- Set queue index to `INDEX_NONE` once last queue item finishes

**Issues**

Fixes #4214
Part of #1057 