### PR TITLE
Fix crash when restoring DestinationFragmentView state

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
@@ -166,7 +166,7 @@ class DestinationFragmentView @JvmOverloads constructor(
 		// Save state
 		return bundleOf(
 			BUNDLE_SUPER to super.onSaveInstanceState(),
-			BUNDLE_HISTORY to history.toList(),
+			BUNDLE_HISTORY to ArrayList(history),
 		)
 	}
 


### PR DESCRIPTION
When changing the theme of the app, the app would always crash when closing preferences.. oops. Quite sure in other cases the crash didn't happen because the state was not loaded from memory.

**Changes**
- Fix crash when restoring DestinationFragmentView state
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
