### PR TITLE
Fix crash when viewing audio now playing while using Emerald theme

### DIFF
--- a/app/src/main/res/drawable/audio_now_playing_album_background.xml
+++ b/app/src/main/res/drawable/audio_now_playing_album_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="?attr/defaultBackground" />
+    <solid android:color="@color/not_quite_black" />
     <corners android:radius="?attr/cardRounding" />
 </shape>


### PR DESCRIPTION
The emerald theme changes the defaultBackground to a drawable (is a color by default). Obviously can't use a drawable as color.

**Changes**
- Hardcode the not_quite_black color in audio_now_playing_album_background instead of using the defaultBackground attribute

**Issues**

Fixes #4266