### PR TITLE
Fix crash when trying to report playback progress when there is no current stream

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1000,6 +1000,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     private void startReportLoop() {
+        if (mCurrentStreamInfo == null) return;
+
         stopReportLoop();
         reportingHelper.getValue().reportProgress(mFragment, this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 10000, false);
         mReportLoop = new Runnable() {


### PR DESCRIPTION
When the stream needs to be recreated to change audio streams (e.g. transcoding/external stream etc.) the app sets the current stream to null and once the new stream info is ready it will be set again. It does stop all progress reporting for that (normally short) duration.

However, if you try to seek during that time period it will try to report progress which will fail and crash the app.

**Changes**

- Add a check for null before trying to start a report loop

**Issues**

Should fix #4254