### PR TITLE
Always call notifyInteraction on navigation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -111,6 +111,8 @@ class MainActivity : FragmentActivity() {
 	}
 
 	private fun handleNavigationAction(action: NavigationAction) {
+		screensaverViewModel.notifyInteraction(true)
+
 		when (action) {
 			// DestinationFragmentView actions
 			is NavigationAction.NavigateFragment -> binding.contentView.navigate(action)


### PR DESCRIPTION
Navigating does not cancel the screensaver when using remote control. This is not the intended behavior, it should always cancel the screensaver.

**Changes**
- Always call notifyInteraction on navigation
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Fixes #4262