### PR TITLE
Fix ItemRowAdapterHelper.refreshItem using wrong thread when invoking callback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -694,6 +694,8 @@ fun ItemRowAdapter.refreshItem(
 			}
 		)
 
-		callback()
+		withContext(Dispatchers.Main) {
+			callback()
+		}
 	}
 }


### PR DESCRIPTION
UI must always use main thread

**Changes**
- Fix ItemRowAdapterHelper.refreshItem using wrong thread when invoking callback

**Issues**

Fixes #4273