### PR TITLE
Make playbackController reference optional in ReportingHelper

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/ReportingHelper.kt
@@ -25,7 +25,7 @@ class ReportingHelper(
 ) {
 	fun reportStart(
 		lifecycleOwner: LifecycleOwner,
-		playbackController: PlaybackController,
+		playbackController: PlaybackController?,
 		item: BaseItemDto,
 		streamInfo: StreamInfo,
 		position: Long,
@@ -43,8 +43,8 @@ class ReportingHelper(
 				PlayMethod.DirectStream -> org.jellyfin.sdk.model.api.PlayMethod.DIRECT_STREAM
 				PlayMethod.DirectPlay -> org.jellyfin.sdk.model.api.PlayMethod.DIRECT_PLAY
 			},
-			audioStreamIndex = playbackController.audioStreamIndex,
-			subtitleStreamIndex = playbackController.subtitleStreamIndex,
+			audioStreamIndex = playbackController?.audioStreamIndex,
+			subtitleStreamIndex = playbackController?.subtitleStreamIndex,
 			isMuted = false,
 			repeatMode = RepeatMode.REPEAT_NONE,
 			playbackOrder = PlaybackOrder.DEFAULT,
@@ -61,7 +61,7 @@ class ReportingHelper(
 
 	fun reportProgress(
 		lifecycleOwner: LifecycleOwner,
-		playbackController: PlaybackController,
+		playbackController: PlaybackController?,
 		item: BaseItemDto,
 		streamInfo: StreamInfo,
 		position: Long,
@@ -79,8 +79,8 @@ class ReportingHelper(
 				PlayMethod.DirectStream -> org.jellyfin.sdk.model.api.PlayMethod.DIRECT_STREAM
 				PlayMethod.DirectPlay -> org.jellyfin.sdk.model.api.PlayMethod.DIRECT_PLAY
 			},
-			audioStreamIndex = playbackController.audioStreamIndex,
-			subtitleStreamIndex = playbackController.subtitleStreamIndex,
+			audioStreamIndex = playbackController?.audioStreamIndex,
+			subtitleStreamIndex = playbackController?.subtitleStreamIndex,
 			isMuted = false,
 			repeatMode = RepeatMode.REPEAT_NONE,
 			playbackOrder = PlaybackOrder.DEFAULT,


### PR DESCRIPTION
Going over the very few changes made that could affect the external video player my best guess right now is that the `playbackControllerContainer` is empty (null) causing an NPE when the app tries to start a video. Untested.

**Changes**
- Make playbackController reference optional in ReportingHelper
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Maybe fixes #4274 