### PR TITLE
Fix external subtitles not added to external player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java
@@ -392,9 +392,7 @@ public class ExternalPlayerActivity extends FragmentActivity {
      * @param playerIntent    Put player API params of sub urls.
      */
     private void adaptExternalSubtitles(StreamInfo mediaStreamInfo, Intent playerIntent) {
-
-        List<SubtitleStreamInfo> externalSubs = mediaStreamInfo.getSubtitleProfiles(false,
-                        apiClient.getValue().getBaseUrl(), apiClient.getValue().getAccessToken()).stream()
+        List<SubtitleStreamInfo> externalSubs = mediaStreamInfo.getSubtitleProfiles(apiClient.getValue()).stream()
                 .filter(stream -> stream.getDeliveryMethod() == SubtitleDeliveryMethod.External && stream.getUrl() != null)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
The delivery URL was not copied over (using API URL builder) to the stream info anymore, so it would later be filtered out because we can't link without an URL.

**Changes**
- Fix external subtitles not added to external player
- Simplify getSubtitleProfiles function a bit (remove unused code)

**Issues**
Fixes #4310