### PR TITLE
Prevent AudioNowPlayingFragment from showing without active queue

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -256,14 +256,9 @@ public class AudioNowPlayingFragment extends Fragment {
         @Override
         public void onQueueStatusChanged(boolean hasQueue) {
             Timber.d("Queue status changed (hasQueue=%s)", hasQueue);
-            if (hasQueue) {
-                loadItem();
-                if (mediaManager.getValue().isAudioPlayerInitialized()) {
-                    updateButtons();
-                }
-            } else {
-                if (navigationRepository.getValue().getCanGoBack()) navigationRepository.getValue().goBack();
-                else navigationRepository.getValue().reset(Destinations.INSTANCE.getHome());
+            loadItem();
+            if (mediaManager.getValue().isAudioPlayerInitialized()) {
+                updateButtons();
             }
         }
 
@@ -308,6 +303,9 @@ public class AudioNowPlayingFragment extends Fragment {
         if (mBaseItem != null) {
             updatePoster();
             updateInfo(mBaseItem);
+        } else {
+            if (navigationRepository.getValue().getCanGoBack()) navigationRepository.getValue().goBack();
+            else navigationRepository.getValue().navigate(Destinations.INSTANCE.getHome());
         }
     }
 


### PR DESCRIPTION
The fragment already closed itself when a queue ended. However, it is possible to start the fragment after a queue has ended by switching between apps or having the system screensaver active during playback and then closing it after playback ended.

**Changes**
- Move check to self-close `AudioNowPlayingFragment` to `loadItem()` to prevent `AudioNowPlayingFragment` from showing without active queue

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
