### PR TITLE
Fix UI audio queue order when shuffling

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -31,7 +31,6 @@ import org.jellyfin.playback.jellyfin.queue.createBaseItemQueueEntry
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MediaType
-import kotlin.math.max
 
 @Suppress("TooManyFunctions")
 class RewriteMediaManager(
@@ -136,25 +135,23 @@ class RewriteMediaManager(
 		}.launchIn(this)
 
 		playbackManager.queue.entry.onEach { updateAdapter() }.launchIn(this)
+		playbackManager.state.playbackOrder.onEach { updateAdapter() }.launchIn(this)
 	}
 
 	private fun updateAdapter() {
-		// Get all items as BaseRowItem
-		val items = queueSupplier
-			.items
-			// Map to audio queue items
-			.mapIndexed { index, item ->
-				AudioQueueBaseRowItem(item).apply {
-					playing = playbackManager.queue.entryIndex.value == index
-				}
-			}
-			// Remove items before currently playing item
-			.drop(max(0, playbackManager.queue.entryIndex.value))
+		val currentItem = playbackManager.queue.entry.value?.baseItem?.let(::AudioQueueBaseRowItem)?.apply {
+			playing = true
+		}
+		// It's safe to run this blocking as all items are prefetched via the [BaseItemQueueSupplier]
+		val upcomingItems = runBlocking { playbackManager.queue.peekNext(100) }
+			.mapIndexedNotNull { index, item -> item.baseItem?.let(::AudioQueueBaseRowItem) }
+
+		val items = listOfNotNull(currentItem) + upcomingItems
 
 		// Update item row
 		currentAudioQueue.replaceAll(
 			items,
-			areItemsTheSame = { old, new -> (old as? AudioQueueBaseRowItem)?.baseItem == (new as? AudioQueueBaseRowItem)?.baseItem },
+			areItemsTheSame = { old, new -> (old as? AudioQueueBaseRowItem)?.baseItem?.id == (new as? AudioQueueBaseRowItem)?.baseItem?.id },
 			// The equals functions for BaseRowItem only compare by id
 			areContentsTheSame = { _, _ -> false },
 		)


### PR DESCRIPTION
When shuffling the queue stays the same data structure and the playback order is used to return items based on the shuffled indices. The updateAdapter function used the internal list of the queue supplier so playback ordering was never used, causing the wrong items to display during shuffle.

**Changes**
- Use the actual queue to provide items instead, limited to the next 100 items (including current)
- Refresh adapter when playback order changes
- Compare items by id (performance gain)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
