### PR TITLE
Fix playing next audio item while shuffling

### DIFF
--- a/playback/core/src/main/kotlin/queue/order/RandomOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/RandomOrderIndexProvider.kt
@@ -23,6 +23,6 @@ internal class RandomOrderIndexProvider : OrderIndexProvider {
 	}
 
 	override fun useNextIndex() {
-		nextIndices.remove(0)
+		nextIndices.removeAt(0)
 	}
 }

--- a/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
+++ b/playback/core/src/main/kotlin/queue/order/ShuffleOrderIndexProvider.kt
@@ -34,6 +34,6 @@ internal class ShuffleOrderIndexProvider : OrderIndexProvider {
 	}
 
 	override fun useNextIndex() {
-		nextIndices.remove(0)
+		nextIndices.removeAt(0)
 	}
 }


### PR DESCRIPTION
oops

**Changes**
- Fix useNextIndex never removing first element in ShuffleOrderIndexProvider and RandomOrderIndexProvider
- Fix QueueService.next not respecting usePlaybackOrder and useRepeatMode properly

**Issues**

Regression from #4144
