### PR TITLE
Fix QueueService.getNextIndices returning one item too many when using REPEAT_ENTRY_ONCE

### DIFF
--- a/playback/core/src/main/kotlin/queue/QueueService.kt
+++ b/playback/core/src/main/kotlin/queue/QueueService.kt
@@ -115,9 +115,9 @@ class QueueService internal constructor() : PlayerService(), Queue {
 		return when (repeatMode) {
 			RepeatMode.NONE -> provider.provideIndices(amount, estimatedSize, currentQueueIndicesPlayed, entryIndex.value)
 
-			RepeatMode.REPEAT_ENTRY_ONCE -> buildList {
+			RepeatMode.REPEAT_ENTRY_ONCE -> buildList(amount) {
 				add(entryIndex.value)
-				addAll(provider.provideIndices(amount, estimatedSize, currentQueueIndicesPlayed, entryIndex.value))
+				addAll(provider.provideIndices(amount - 1, estimatedSize, currentQueueIndicesPlayed, entryIndex.value))
 			}.take(amount)
 
 			RepeatMode.REPEAT_ENTRY_INFINITE -> List(amount) { entryIndex.value }


### PR DESCRIPTION
I don't think we even use this repeat mode anywhere yet.

**Changes**
- Fix QueueService.getNextIndices returning one item too many when using REPEAT_ENTRY_ONCE

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
