### PR TITLE
Fix music play action not working after queue has ended

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -266,7 +266,7 @@ class RewriteMediaManager(
 
 	override fun togglePlayPause() {
 		val playState = playbackManager.state.playState.value
-		if (playState == PlayState.PAUSED) playbackManager.state.unpause()
+		if (playState == PlayState.PAUSED || playState == PlayState.STOPPED) playbackManager.state.unpause()
 		else if (playState == PlayState.PLAYING) playbackManager.state.pause()
 	}
 

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -209,6 +209,8 @@ class ExoPlayerBackend(
 	}
 
 	override fun play() {
+		// If the item has ended, revert first so the item will start over again
+		if (exoPlayer.playbackState == Player.STATE_ENDED) exoPlayer.seekTo(0)
 		exoPlayer.play()
 	}
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Fix music play action not working after queue has ended
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes secondary issue of #4328