### PR TITLE
Infer subtitle codec from delivery URL if unknown

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -44,7 +44,6 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.data.compat.StreamInfo;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.ZoomMode;
-import org.jellyfin.playback.media3.exoplayer.mapping.SubtitleKt;
 import org.jellyfin.sdk.api.client.ApiClient;
 import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
@@ -346,7 +345,7 @@ public class VideoManager {
                     Uri subtitleUri = Uri.parse(api.createUrl(mediaStream.getDeliveryUrl(), Collections.emptyMap(), Collections.emptyMap(), true));
                     MediaItem.SubtitleConfiguration subtitleConfiguration = new MediaItem.SubtitleConfiguration.Builder(subtitleUri)
                             .setId("JF_EXTERNAL:" + String.valueOf(mediaStream.getIndex()))
-                            .setMimeType(SubtitleKt.getFfmpegSubtitleMimeType(mediaStream.getCodec()))
+                            .setMimeType(VideoManagerHelperKt.getSubtitleMediaStreamCodec(mediaStream))
                             .setLanguage(mediaStream.getLanguage())
                             .setLabel(mediaStream.getDisplayTitle())
                             .setSelectionFlags(getSubtitleSelectionFlags(mediaStream))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.androidtv.ui.playback
+
+import androidx.core.net.toUri
+import org.jellyfin.playback.media3.exoplayer.mapping.getFfmpegSubtitleMimeType
+import org.jellyfin.sdk.model.api.MediaStream
+
+/**
+ * Return the media type for the codec found in this media stream. First tries to infer the media type from the streams delivery URL and
+ * falls back to the original stream codec.
+ */
+fun getSubtitleMediaStreamCodec(stream: MediaStream): String {
+	val codec = requireNotNull(stream.codec)
+	val codecMediaType = getFfmpegSubtitleMimeType(codec, "").ifBlank { null }
+
+	val urlSubtitleExtension = stream.deliveryUrl?.toUri()?.lastPathSegment?.split('.')?.last()
+	val urlExtensionMediaType = urlSubtitleExtension?.let { getFfmpegSubtitleMimeType(it, "") }?.ifBlank { null }
+
+	return urlExtensionMediaType ?: codecMediaType ?: urlSubtitleExtension ?: codec
+}

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/audio.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/audio.kt
@@ -5,10 +5,10 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegAudioMimeType(codec: String) = codec.lowercase().let { codec ->
+fun getFfmpegAudioMimeType(codec: String, fallback: String = codec) = codec.lowercase().let { codec ->
 	ffmpegAudioMimeTypes[codec]
 		?: MimeTypes.getAudioMediaMimeType(codec)
-		?: codec
+		?: fallback
 }
 
 val ffmpegAudioMimeTypes = mapOf(

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/container.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/container.kt
@@ -5,12 +5,12 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegContainerMimeType(codec: String) = codec.lowercase().let { codec ->
+fun getFfmpegContainerMimeType(codec: String, fallback: String = codec) = codec.lowercase().let { codec ->
 	ffmpegContainerMimeTypes[codec]
 		?: ffmpegVideoMimeTypes[codec]
 		?: ffmpegAudioMimeTypes[codec]
 		?: MimeTypes.getMediaMimeType(codec)
-		?: codec
+		?: fallback
 }
 
 @OptIn(UnstableApi::class)

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/subtitle.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/subtitle.kt
@@ -5,10 +5,10 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegSubtitleMimeType(codec: String): String = codec.lowercase().let { codec ->
+fun getFfmpegSubtitleMimeType(codec: String, fallback: String = codec): String = codec.lowercase().let { codec ->
 	ffmpegSubtitleMimeTypes[codec]
 		?: MimeTypes.getTextMediaMimeType(codec)
-		?: codec
+		?: fallback
 }
 
 @OptIn(UnstableApi::class)

--- a/playback/media3/exoplayer/src/main/kotlin/mapping/video.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/mapping/video.kt
@@ -5,10 +5,10 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
-fun getFfmpegVideoMimeType(codec: String) = codec.lowercase().let { codec ->
+fun getFfmpegVideoMimeType(codec: String, fallback: String = codec) = codec.lowercase().let { codec ->
 	ffmpegVideoMimeTypes[codec]
 		?: MimeTypes.getVideoMediaMimeType(codec)
-		?: codec
+		?: fallback
 }
 
 @OptIn(UnstableApi::class)


### PR DESCRIPTION
This fix is a bit of a hack because I'm parsing the URL client side which I shouldn't need to do.

**Changes**
- Try to infer external subtitle media type from URL first before falling back to using the original codec type (which is the previous behavior)

**Issues**

Fixes #4326