### PR TITLE
Fix crash when starting progress report loop without active stream in video player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1023,7 +1023,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     private void startPauseReportLoop() {
         stopReportLoop();
-        reportingHelper.getValue().reportProgress(mFragment, this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), mCurrentPosition * 10000, true);
+        if (mCurrentStreamInfo == null) return;
+        reportingHelper.getValue().reportProgress(mFragment, this, getCurrentlyPlayingItem(), mCurrentStreamInfo, mCurrentPosition * 10000, true);
         mReportLoop = new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION


**Changes**
- Fix crash when starting progress report loop without active stream in video player
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Fixes #4331
