### PR TITLE
Centralize requested item fields

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/ItemRepository.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.androidtv.data.repository
+
+import org.jellyfin.sdk.model.api.ItemFields
+
+object ItemRepository {
+	val itemFields = setOf(
+		ItemFields.CAN_DELETE,
+		ItemFields.CHANNEL_INFO,
+		ItemFields.CHAPTERS,
+		ItemFields.CHILD_COUNT,
+		ItemFields.CUMULATIVE_RUN_TIME_TICKS,
+		ItemFields.DATE_CREATED,
+		ItemFields.DISPLAY_PREFERENCES_ID,
+		ItemFields.GENRES,
+		ItemFields.ITEM_COUNTS,
+		ItemFields.MEDIA_SOURCE_COUNT,
+		ItemFields.MEDIA_SOURCES,
+		ItemFields.MEDIA_STREAMS,
+		ItemFields.OVERVIEW,
+		ItemFields.PATH,
+		ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
+		ItemFields.SERIES_PRIMARY_IMAGE,
+		ItemFields.TAGLINES,
+		ItemFields.TRICKPLAY,
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -41,7 +42,6 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.extensions.ticks
 import org.koin.core.component.KoinComponent
@@ -270,7 +270,7 @@ class LeanbackChannelWorker(
 		withContext(Dispatchers.IO) {
 			val resume = async {
 				api.itemsApi.getResumeItems(
-					fields = listOf(ItemFields.DATE_CREATED),
+					fields = ItemRepository.itemFields,
 					imageTypeLimit = 1,
 					limit = 10,
 					mediaTypes = listOf(MediaType.VIDEO),
@@ -284,7 +284,7 @@ class LeanbackChannelWorker(
 					imageTypeLimit = 1,
 					limit = 10,
 					enableResumable = false,
-					fields = listOf(ItemFields.DATE_CREATED),
+					fields = ItemRepository.itemFields,
 				).content.items
 			}
 
@@ -296,9 +296,7 @@ class LeanbackChannelWorker(
 		withContext(Dispatchers.IO) {
 			val latestEpisodes = async {
 				api.userLibraryApi.getLatestMedia(
-					fields = listOf(
-						ItemFields.OVERVIEW,
-					),
+					fields = ItemRepository.itemFields,
 					limit = 50,
 					includeItemTypes = listOf(BaseItemKind.EPISODE),
 					isPlayed = false
@@ -307,9 +305,7 @@ class LeanbackChannelWorker(
 
 			val latestMovies = async {
 				api.userLibraryApi.getLatestMedia(
-					fields = listOf(
-						ItemFields.OVERVIEW,
-					),
+					fields = ItemRepository.itemFields,
 					limit = 50,
 					includeItemTypes = listOf(BaseItemKind.MOVIE),
 					isPlayed = false
@@ -318,9 +314,7 @@ class LeanbackChannelWorker(
 
 			val latestMedia = async {
 				api.userLibraryApi.getLatestMedia(
-					fields = listOf(
-						ItemFields.OVERVIEW,
-					),
+					fields = ItemRepository.itemFields,
 					limit = 50,
 					includeItemTypes = listOf(BaseItemKind.MOVIE, BaseItemKind.SERIES),
 					isPlayed = false

--- a/app/src/main/java/org/jellyfin/androidtv/integration/MediaContentProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/MediaContentProvider.kt
@@ -12,6 +12,7 @@ import android.provider.BaseColumns
 import kotlinx.coroutines.runBlocking
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.util.ImageHelper
 import org.jellyfin.androidtv.util.sdk.isUsable
@@ -21,7 +22,6 @@ import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.ImageType
-import org.jellyfin.sdk.model.api.ItemFields
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
@@ -75,7 +75,7 @@ class MediaContentProvider : ContentProvider(), KoinComponent {
 			searchTerm = query,
 			recursive = true,
 			limit = limit,
-			fields = setOf(ItemFields.TAGLINES)
+			fields = ItemRepository.itemFields
 		)
 
 		items

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemListViewHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemListViewHelper.kt
@@ -3,9 +3,9 @@ package org.jellyfin.androidtv.ui
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
-import org.jellyfin.sdk.model.api.ItemFields
 import org.koin.java.KoinJavaComponent
 
 fun ItemListView.refresh() {
@@ -14,14 +14,7 @@ fun ItemListView.refresh() {
 	findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
 		val response by api.itemsApi.getItems(
 			ids = mItemIds,
-			fields = setOf(
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.OVERVIEW,
-				ItemFields.ITEM_COUNTS,
-				ItemFields.DISPLAY_PREFERENCES_ID,
-				ItemFields.CHILD_COUNT,
-				ItemFields.MEDIA_SOURCES,
-			)
+			fields = ItemRepository.itemFields
 		)
 
 		response.items?.forEachIndexed { index, item ->

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragmentHelper.kt
@@ -2,12 +2,12 @@ package org.jellyfin.androidtv.ui.browsing
 
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.LocationType
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.TimerInfoDto
@@ -24,11 +24,7 @@ fun EnhancedBrowseFragment.getLiveTvRecordingsAndTimers(
 	lifecycleScope.launch {
 		runCatching {
 			val recordings by api.liveTvApi.getRecordings(
-				fields = setOf(
-					ItemFields.OVERVIEW,
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.CHILD_COUNT,
-				),
+				fields = ItemRepository.itemFields,
 				enableImages = true,
 				limit = 40,
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
@@ -3,13 +3,13 @@ package org.jellyfin.androidtv.ui.browsing
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.CollectionType
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
@@ -59,22 +59,13 @@ object BrowsingUtils {
 		limit = 50,
 		parentId = parentId,
 		imageTypeLimit = 1,
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.CHILD_COUNT,
-			ItemFields.MEDIA_SOURCES,
-			ItemFields.MEDIA_STREAMS,
-		)
+		fields = ItemRepository.itemFields
 	)
 
 	@JvmStatic
 	fun createSeriesGetNextUpRequest(parentId: UUID) = GetNextUpRequest(
 		seriesId = parentId,
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		)
+		fields = ItemRepository.itemFields
 	)
 
 	@JvmStatic
@@ -84,13 +75,7 @@ object BrowsingUtils {
 		itemType: BaseItemKind? = null,
 		groupItems: Boolean? = null
 	) = GetLatestMediaRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.CHILD_COUNT,
-			ItemFields.MEDIA_SOURCES,
-			ItemFields.MEDIA_STREAMS,
-		),
+		fields = ItemRepository.itemFields,
 		parentId = parentId,
 		limit = 50,
 		imageTypeLimit = 1,
@@ -101,42 +86,26 @@ object BrowsingUtils {
 	@JvmStatic
 	fun createSeasonsRequest(seriesId: UUID) = GetSeasonsRequest(
 		seriesId = seriesId,
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 	)
 
 	@JvmStatic
 	fun createUpcomingEpisodesRequest(parentId: UUID) = GetUpcomingEpisodesRequest(
 		parentId = parentId,
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 	)
 
 	@JvmStatic
 	fun createSimilarItemsRequest(itemId: UUID) = GetSimilarItemsRequest(
 		itemId = itemId,
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		limit = 20,
 	)
 
 	@JvmStatic
 	fun createLiveTVOnNowRequest() = GetRecommendedProgramsRequest(
 		isAiring = true,
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHANNEL_INFO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		imageTypeLimit = 1,
 		enableTotalRecordCount = false,
 		limit = 150,
@@ -146,12 +115,7 @@ object BrowsingUtils {
 	fun createLiveTVUpcomingRequest() = GetRecommendedProgramsRequest(
 		isAiring = false,
 		hasAired = false,
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHANNEL_INFO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		imageTypeLimit = 1,
 		enableTotalRecordCount = false,
 		limit = 150,
@@ -160,22 +124,14 @@ object BrowsingUtils {
 	@JvmStatic
 	@JvmOverloads
 	fun createLiveTVRecordingsRequest(limit: Int? = null) = GetRecordingsRequest(
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		enableImages = true,
 		limit = limit,
 	)
 
 	@JvmStatic
 	fun createLiveTVMovieRecordingsRequest() = GetRecordingsRequest(
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		enableImages = true,
 		limit = 60,
 		isMovie = true,
@@ -183,11 +139,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createLiveTVSeriesRecordingsRequest() = GetRecordingsRequest(
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		enableImages = true,
 		limit = 60,
 		isSeries = true,
@@ -195,11 +147,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createLiveTVSportsRecordingsRequest() = GetRecordingsRequest(
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		enableImages = true,
 		limit = 60,
 		isSports = true,
@@ -207,11 +155,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createLiveTVKidsRecordingsRequest() = GetRecordingsRequest(
-		fields = setOf(
-			ItemFields.OVERVIEW,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		enableImages = true,
 		limit = 60,
 		isKids = true,
@@ -224,31 +168,19 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createAlbumArtistsRequest(parentId: UUID) = GetAlbumArtistsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		parentId = parentId,
 	)
 
 	@JvmStatic
 	fun createArtistsRequest(parentId: UUID) = GetArtistsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		parentId = parentId,
 	)
 
 	@JvmStatic
 	fun createPersonItemsRequest(personId: UUID, itemType: BaseItemKind) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		personIds = setOf(personId),
 		recursive = true,
 		includeItemTypes = setOf(itemType),
@@ -257,11 +189,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createArtistItemsRequest(artistId: UUID, itemType: BaseItemKind) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		artistIds = setOf(artistId),
 		recursive = true,
 		includeItemTypes = setOf(itemType),
@@ -270,13 +198,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createNextEpisodesRequest(seasonId: UUID, indexNumber: Int) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		parentId = seasonId,
 		includeItemTypes = setOf(BaseItemKind.EPISODE),
 		startIndex = indexNumber,
@@ -285,15 +207,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createResumeItemsRequest(parentId: UUID, itemType: BaseItemKind) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-			ItemFields.MEDIA_STREAMS,
-			ItemFields.MEDIA_SOURCES,
-		),
+		fields = ItemRepository.itemFields,
 		includeItemTypes = setOf(itemType),
 		recursive = true,
 		parentId = parentId,
@@ -308,15 +222,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createFavoriteItemsRequest(parentId: UUID, itemType: BaseItemKind) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-			ItemFields.MEDIA_STREAMS,
-			ItemFields.MEDIA_SOURCES,
-		),
+		fields = ItemRepository.itemFields,
 		includeItemTypes = setOf(itemType),
 		recursive = true,
 		parentId = parentId,
@@ -327,7 +233,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createCollectionsRequest(parentId: UUID) = GetItemsRequest(
-		fields = setOf(ItemFields.CHILD_COUNT),
+		fields = ItemRepository.itemFields,
 		includeItemTypes = setOf(BaseItemKind.BOX_SET),
 		recursive = true,
 		imageTypeLimit = 1,
@@ -337,12 +243,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createPremieresRequest(parentId: UUID) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.DATE_CREATED,
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		includeItemTypes = setOf(BaseItemKind.EPISODE),
 		parentId = parentId,
 		indexNumber = 1,
@@ -358,13 +259,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createLastPlayedRequest(parentId: UUID) = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		includeItemTypes = setOf(BaseItemKind.AUDIO),
 		recursive = true,
 		parentId = parentId,
@@ -378,11 +273,7 @@ object BrowsingUtils {
 
 	@JvmStatic
 	fun createPlaylistsRequest() = GetItemsRequest(
-		fields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.CUMULATIVE_RUN_TIME_TICKS,
-			ItemFields.CHILD_COUNT,
-		),
+		fields = ItemRepository.itemFields,
 		includeItemTypes = setOf(BaseItemKind.PLAYLIST),
 		imageTypeLimit = 1,
 		recursive = true,
@@ -393,13 +284,7 @@ object BrowsingUtils {
 	@JvmStatic
 	fun createBrowseGridItemsRequest(parent: BaseItemDto): GetItemsRequest {
 		val baseRequest = GetItemsRequest(
-			fields = setOf(
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.CHILD_COUNT,
-				ItemFields.MEDIA_SOURCES,
-				ItemFields.MEDIA_STREAMS,
-				ItemFields.DISPLAY_PREFERENCES_ID,
-			),
+			fields = ItemRepository.itemFields,
 			parentId = parent.id,
 		)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByGenreFragment.kt
@@ -1,9 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.genresApi
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
 import org.koin.android.ext.android.inject
@@ -28,13 +28,7 @@ class ByGenreFragment : BrowseFolderFragment() {
 				includeItemTypes = includeType?.let(BaseItemKind::fromNameOrNull)?.let(::setOf),
 				genres = setOf(genre.name.orEmpty()),
 				recursive = true,
-				fields = setOf(
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.OVERVIEW,
-					ItemFields.ITEM_COUNTS,
-					ItemFields.DISPLAY_PREFERENCES_ID,
-					ItemFields.CHILD_COUNT,
-				),
+				fields = ItemRepository.itemFields,
 			)
 			rows.add(BrowseRowDef(genre.name, itemsRequest, 40))
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/ByLetterFragment.kt
@@ -1,8 +1,8 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
 
@@ -20,13 +20,7 @@ class ByLetterFragment : BrowseFolderFragment() {
 			includeItemTypes = includeType?.let(BaseItemKind::fromNameOrNull)?.let(::setOf),
 			nameLessThan = letters.substring(0, 1),
 			recursive = true,
-			fields = setOf(
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.OVERVIEW,
-				ItemFields.ITEM_COUNTS,
-				ItemFields.DISPLAY_PREFERENCES_ID,
-				ItemFields.CHILD_COUNT,
-			),
+			fields = ItemRepository.itemFields,
 		)
 
 		rows.add(BrowseRowDef("#", numbersItemsRequest, 40))
@@ -39,13 +33,7 @@ class ByLetterFragment : BrowseFolderFragment() {
 				includeItemTypes = includeType?.let(BaseItemKind::fromNameOrNull)?.let(::setOf),
 				nameStartsWith = letter.toString(),
 				recursive = true,
-				fields = setOf(
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.OVERVIEW,
-					ItemFields.ITEM_COUNTS,
-					ItemFields.DISPLAY_PREFERENCES_ID,
-					ItemFields.CHILD_COUNT,
-				),
+				fields = ItemRepository.itemFields,
 			)
 
 			rows.add(BrowseRowDef(letter.toString(), letterItemsRequest, 40))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/CollectionFragment.kt
@@ -1,40 +1,28 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
 
 class CollectionFragment : EnhancedBrowseFragment() {
-	companion object {
-		private val itemFields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
-			ItemFields.MEDIA_STREAMS,
-			ItemFields.MEDIA_SOURCES,
-		)
-	}
-
 	override fun setupQueries(rowLoader: RowLoader) {
 		val movies = GetItemsRequest(
-			fields = itemFields,
+			fields = ItemRepository.itemFields,
 			parentId = mFolder.id,
 			includeItemTypes = setOf(BaseItemKind.MOVIE),
 		)
 		mRows.add(BrowseRowDef(getString(R.string.lbl_movies), movies, 100))
 
 		val series = GetItemsRequest(
-			fields = itemFields,
+			fields = ItemRepository.itemFields,
 			parentId = mFolder.id,
 			includeItemTypes = setOf(BaseItemKind.SERIES),
 		)
 		mRows.add(BrowseRowDef(getString(R.string.lbl_tv_series), series, 100))
 
 		val others = GetItemsRequest(
-			fields = itemFields,
+			fields = ItemRepository.itemFields,
 			parentId = mFolder.id,
 			excludeItemTypes = setOf(BaseItemKind.MOVIE, BaseItemKind.SERIES),
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.kt
@@ -2,8 +2,8 @@ package org.jellyfin.androidtv.ui.browsing
 
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.querying.GetSpecialsRequest
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
@@ -16,14 +16,6 @@ class GenericFolderFragment : EnhancedBrowseFragment() {
 			BaseItemKind.FOLDER,
 			BaseItemKind.USER_VIEW,
 			BaseItemKind.CHANNEL_FOLDER_ITEM,
-		)
-
-		private val itemFields = setOf(
-			ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-			ItemFields.OVERVIEW,
-			ItemFields.ITEM_COUNTS,
-			ItemFields.DISPLAY_PREFERENCES_ID,
-			ItemFields.CHILD_COUNT,
 		)
 	}
 
@@ -39,7 +31,7 @@ class GenericFolderFragment : EnhancedBrowseFragment() {
 		if (showSpecialViewTypes.contains(mFolder.type)) {
 			if (mFolder.type != BaseItemKind.CHANNEL_FOLDER_ITEM) {
 				val resume = GetItemsRequest(
-					fields = itemFields,
+					fields = ItemRepository.itemFields,
 					parentId = mFolder.id,
 					limit = 50,
 					filters = setOf(ItemFilter.IS_RESUMABLE),
@@ -50,7 +42,7 @@ class GenericFolderFragment : EnhancedBrowseFragment() {
 			}
 
 			val latest = GetItemsRequest(
-				fields = itemFields,
+				fields = ItemRepository.itemFields,
 				parentId = mFolder.id,
 				limit = 50,
 				filters = setOf(ItemFilter.IS_UNPLAYED),
@@ -61,7 +53,7 @@ class GenericFolderFragment : EnhancedBrowseFragment() {
 		}
 
 		val byName = GetItemsRequest(
-			fields = itemFields,
+			fields = ItemRepository.itemFields,
 			parentId = mFolder.id,
 		)
 		val header = when (mFolder.type) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.QueryType
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.request.GetSimilarItemsRequest
@@ -34,13 +34,7 @@ class SuggestedMoviesFragment : EnhancedBrowseFragment() {
 			for (item in response.items) {
 				val similar = GetSimilarItemsRequest(
 					itemId = item.id,
-					fields = setOf(
-						ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-						ItemFields.OVERVIEW,
-						ItemFields.CHILD_COUNT,
-						ItemFields.MEDIA_STREAMS,
-						ItemFields.MEDIA_SOURCES
-					),
+					fields = ItemRepository.itemFields,
 					limit = 7,
 				)
 				mRows.add(BrowseRowDef(getString(R.string.because_you_watched, item.name), similar, QueryType.SimilarMovies))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -4,16 +4,15 @@ import android.content.Context
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.constant.ChangeTriggerType
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.request.GetNextUpRequest
 import org.jellyfin.sdk.model.api.request.GetRecommendedProgramsRequest
 import org.jellyfin.sdk.model.api.request.GetRecordingsRequest
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
-import org.jellyfin.sdk.model.api.ItemFields as SdkItemFields
 
 class HomeFragmentHelper(
 	private val context: Context,
@@ -26,13 +25,7 @@ class HomeFragmentHelper(
 	fun loadResume(title: String, includeMediaTypes: Collection<MediaType>): HomeFragmentRow {
 		val query = GetResumeItemsRequest(
 			limit = ITEM_LIMIT_RESUME,
-			fields = listOf(
-				SdkItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				SdkItemFields.OVERVIEW,
-				SdkItemFields.ITEM_COUNTS,
-				SdkItemFields.DISPLAY_PREFERENCES_ID,
-				SdkItemFields.CHILD_COUNT,
-			),
+			fields = ItemRepository.itemFields,
 			imageTypeLimit = 1,
 			enableTotalRecordCount = false,
 			mediaTypes = includeMediaTypes,
@@ -52,11 +45,7 @@ class HomeFragmentHelper(
 
 	fun loadLatestLiveTvRecordings(): HomeFragmentRow {
 		val query = GetRecordingsRequest(
-			fields = setOf(
-				ItemFields.OVERVIEW,
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.CHILD_COUNT
-			),
+			fields = ItemRepository.itemFields,
 			enableImages = true,
 			limit = ITEM_LIMIT_RECORDINGS
 		)
@@ -69,11 +58,7 @@ class HomeFragmentHelper(
 			imageTypeLimit = 1,
 			limit = ITEM_LIMIT_NEXT_UP,
 			enableResumable = false,
-			fields = setOf(
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.OVERVIEW,
-				ItemFields.CHILD_COUNT,
-			)
+			fields = ItemRepository.itemFields
 		)
 
 		return HomeFragmentBrowseRowDefRow(BrowseRowDef(context.getString(R.string.lbl_next_up), query, arrayOf(ChangeTriggerType.TvPlayback)))
@@ -82,12 +67,7 @@ class HomeFragmentHelper(
 	fun loadOnNow(): HomeFragmentRow {
 		val query = GetRecommendedProgramsRequest(
 			isAiring = true,
-			fields = setOf(
-				ItemFields.OVERVIEW,
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.CHANNEL_INFO,
-				ItemFields.CHILD_COUNT,
-			),
+			fields = ItemRepository.itemFields,
 			imageTypeLimit = 1,
 			enableTotalRecordCount = false,
 			limit = ITEM_LIMIT_ON_NOW

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.kt
@@ -5,12 +5,12 @@ import androidx.leanback.widget.Row
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.constant.ChangeTriggerType
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.CollectionType
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.request.GetLatestMediaRequest
 
 class HomeFragmentLatestRow(
@@ -28,12 +28,7 @@ class HomeFragmentLatestRow(
 			.map { item ->
 				// Create query and add it to a new row
 				val request = GetLatestMediaRequest(
-					fields = setOf(
-						ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-						ItemFields.OVERVIEW,
-						ItemFields.CHILD_COUNT,
-						ItemFields.SERIES_PRIMARY_IMAGE,
-					),
+					fields = ItemRepository.itemFields,
 					imageTypeLimit = 1,
 					parentId = item.id,
 					groupItems = true,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.androidtv.data.repository.ItemMutationRepository
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.util.apiclient.getSeriesOverview
@@ -28,7 +29,6 @@ import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaType
@@ -242,12 +242,7 @@ fun FullDetailsFragment.resumePlayback() {
 				includeItemTypes = setOf(BaseItemKind.EPISODE),
 				recursive = true,
 				filters = setOf(ItemFilter.IS_UNPLAYED),
-				fields = setOf(
-					ItemFields.MEDIA_SOURCES,
-					ItemFields.MEDIA_STREAMS,
-					ItemFields.CHAPTERS,
-					ItemFields.TRICKPLAY,
-				),
+				fields = ItemRepository.itemFields,
 				sortBy = setOf(
 					ItemSortBy.PARENT_INDEX_NUMBER,
 					ItemSortBy.INDEX_NUMBER,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragmentHelper.kt
@@ -4,26 +4,16 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.data.repository.ItemMutationRepository
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.playlistsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.koin.android.ext.android.inject
 import java.util.UUID
-
-private val itemFields = setOf(
-	ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-	ItemFields.OVERVIEW,
-	ItemFields.ITEM_COUNTS,
-	ItemFields.DISPLAY_PREFERENCES_ID,
-	ItemFields.CHILD_COUNT,
-	ItemFields.GENRES,
-	ItemFields.CHAPTERS,
-)
 
 fun ItemListFragment.loadItem(itemId: UUID) {
 	val api by inject<ApiClient>()
@@ -48,7 +38,7 @@ fun MusicFavoritesListFragment.getFavoritePlaylist(
 			filters = setOf(org.jellyfin.sdk.model.api.ItemFilter.IS_FAVORITE_OR_LIKES),
 			sortBy = setOf(ItemSortBy.RANDOM),
 			limit = 100,
-			fields = itemFields,
+			fields = ItemRepository.itemFields,
 		)
 
 		callback(result.items)
@@ -66,7 +56,7 @@ fun ItemListFragment.getPlaylist(
 			item.type == BaseItemKind.PLAYLIST -> api.playlistsApi.getPlaylistItems(
 				playlistId = item.id,
 				limit = 150,
-				fields = itemFields,
+				fields = ItemRepository.itemFields,
 			)
 
 			else -> api.itemsApi.getItems(
@@ -75,7 +65,7 @@ fun ItemListFragment.getPlaylist(
 				recursive = true,
 				sortBy = setOf(ItemSortBy.SORT_NAME),
 				limit = 200,
-				fields = itemFields,
+				fields = ItemRepository.itemFields,
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
 import java.util.UUID
@@ -35,7 +35,7 @@ class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
 		val albumResponse by api.itemsApi.getItems(
 			parentId = itemResponse.parentId,
 			includeItemTypes = setOf(BaseItemKind.PHOTO),
-			fields = setOf(ItemFields.PRIMARY_IMAGE_ASPECT_RATIO),
+			fields = ItemRepository.itemFields,
 			sortBy = sortBy,
 			sortOrder = listOf(sortOrder),
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchRepository.kt
@@ -1,11 +1,11 @@
 package org.jellyfin.androidtv.ui.search
 
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
 import timber.log.Timber
@@ -33,11 +33,7 @@ class SearchRepositoryImpl(
 			limit = QUERY_LIMIT,
 			imageTypeLimit = 1,
 			includeItemTypes = itemTypes,
-			fields = listOf(
-				ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-				ItemFields.CAN_DELETE,
-				ItemFields.MEDIA_SOURCE_COUNT
-			),
+			fields = ItemRepository.itemFields,
 			recursive = true,
 			enableTotalRecordCount = false,
 		)

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.playback.MediaManager
@@ -24,7 +25,6 @@ import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.extensions.inWholeTicks
@@ -83,16 +83,7 @@ class SdkPlaybackHelper(
 					startItemId = mainItem.id,
 					isMissing = false,
 					limit = ITEM_QUERY_LIMIT,
-					fields = setOf(
-						ItemFields.MEDIA_SOURCES,
-						ItemFields.MEDIA_STREAMS,
-						ItemFields.CHAPTERS,
-						ItemFields.PATH,
-						ItemFields.OVERVIEW,
-						ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-						ItemFields.CHILD_COUNT,
-						ItemFields.TRICKPLAY,
-					)
+					fields = ItemRepository.itemFields
 				)
 
 				response.items
@@ -113,16 +104,7 @@ class SdkPlaybackHelper(
 				sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(ItemSortBy.SORT_NAME),
 				recursive = true,
 				limit = ITEM_QUERY_LIMIT,
-				fields = setOf(
-					ItemFields.MEDIA_SOURCES,
-					ItemFields.MEDIA_STREAMS,
-					ItemFields.CHAPTERS,
-					ItemFields.PATH,
-					ItemFields.OVERVIEW,
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.CHILD_COUNT,
-					ItemFields.TRICKPLAY,
-				)
+				fields = ItemRepository.itemFields
 			)
 
 			response.items
@@ -138,11 +120,7 @@ class SdkPlaybackHelper(
 				),
 				recursive = true,
 				limit = ITEM_QUERY_LIMIT,
-				fields = setOf(
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.GENRES,
-					ItemFields.CHILD_COUNT
-				),
+				fields = ItemRepository.itemFields,
 				albumIds = listOf(mainItem.id)
 			)
 
@@ -156,11 +134,7 @@ class SdkPlaybackHelper(
 				sortBy = listOf(ItemSortBy.SORT_NAME),
 				recursive = true,
 				limit = ITEM_QUERY_LIMIT,
-				fields = setOf(
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.GENRES,
-					ItemFields.CHILD_COUNT
-				),
+				fields = ItemRepository.itemFields,
 				artistIds = listOf(mainItem.id)
 			)
 
@@ -174,14 +148,7 @@ class SdkPlaybackHelper(
 				sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else null,
 				recursive = true,
 				limit = ITEM_QUERY_LIMIT,
-				fields = setOf(
-					ItemFields.MEDIA_SOURCES,
-					ItemFields.MEDIA_STREAMS,
-					ItemFields.CHAPTERS,
-					ItemFields.PATH,
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.CHILD_COUNT
-				)
+				fields = ItemRepository.itemFields
 			)
 
 			response.items
@@ -278,11 +245,7 @@ class SdkPlaybackHelper(
 		getScope(context).launch {
 			val response by api.instantMixApi.getInstantMixFromItem(
 				itemId = item.id,
-				fields = setOf(
-					ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
-					ItemFields.GENRES,
-					ItemFields.CHILD_COUNT
-				)
+				fields = ItemRepository.itemFields
 			)
 
 			val items = response.items


### PR DESCRIPTION
We currently have API requests all over the app but they all request a different set of item fields. This can cause issues if baseitemdto's are passed between various parts of the app. 

**Changes**
- Add ItemRepository, which for now holds a set of fields used by the app only
- Update all API calls that currently request fields to use the new ItemRepository.itemFields

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
