### PR TITLE
Enable audio focus for music playback

### DIFF
--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.annotation.OptIn
 import androidx.core.content.getSystemService
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
@@ -101,6 +102,9 @@ class ExoPlayerBackend(
 					setConstantBitrateSeekingAlwaysEnabled(true)
 				}
 			))
+			.setAudioAttributes(AudioAttributes.Builder().apply {
+				setUsage(C.USAGE_MEDIA)
+			}.build(), true)
 			.setPauseAtEndOfMediaItems(true)
 			.build()
 			.also { player ->


### PR DESCRIPTION
In Android multiple apps can be playing media at once, even with multiple media sessions. To avoid  this an app should claim "audio focus". This way only the last app requesting audio focus can actually play audio. This helps when a user switches between media apps and is a best practice according to [Android documentation](https://developer.android.com/media/optimize/audio-focus).

**Changes**
- Enable audio focus and set usage audio attribute

**Issues**

Part of #1057 
