### PR TITLE
Replace Icons.Default.Done with ic_check in ConnectHelpAlertFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -87,7 +85,7 @@ private fun ConnectHelpAlert(
 					),
 				) {
 					Icon(
-						imageVector = Icons.Default.Done,
+						painter = painterResource(R.drawable.ic_check),
 						contentDescription = null,
 						modifier = Modifier.size(ButtonDefaults.IconSize),
 					)

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+</vector>


### PR DESCRIPTION
We should avoid using anything in `androidx.compose.material.icons` as that dependency will be dropped once we remove `androidx.tv`.

**Changes**
- Replace Icons.Default.Done with ic_check in ConnectHelpAlertFragment
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
