### PR TITLE
Fix focus issues on older Android versions

### DIFF
--- a/app/src/main/res/layout/fragment_select_server.xml
+++ b/app/src/main/res/layout/fragment_select_server.xml
@@ -70,7 +70,9 @@
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/notifications"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:descendantFocusability="blocksDescendants"
+            android:focusable="false" />
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Mixing compose with legacy views keeps challenging us :-)

**Changes**

- Fix focusing the "home" button in the toolbar in the item details screen
  - Caused by the "now playing" music composable
- Fix focusing the "get help" button in the toolbar in the server selection screen
  - Caused by the "notifications" composable

**Issues**

Fixes #4363