### PR TITLE
Update reported client name

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -72,7 +72,7 @@ val appModule = module {
 			context = androidContext()
 
 			// Add client info
-			clientInfo = ClientInfo("Android TV", BuildConfig.VERSION_NAME)
+			clientInfo = ClientInfo("Jellyfin Android TV", BuildConfig.VERSION_NAME)
 			deviceInfo = get(defaultDeviceInfo)
 
 			// Change server version
@@ -90,7 +90,7 @@ val appModule = module {
 	// Old apiclient
 	single {
 		JellyfinApiClient {
-			appInfo = AppInfo("Android TV", BuildConfig.VERSION_NAME)
+			appInfo = AppInfo("Jellyfin Android TV", BuildConfig.VERSION_NAME)
 			logger = AndroidLogger()
 			android(androidApplication())
 		}


### PR DESCRIPTION
All of our official clients I checked start their client name with Jellyfin, e.g. `Jellyfin Android` or `Jellyfin Web`. ATV was the only one that did not. So I fixed it.

**Changes**
- Update reported client name
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
