### PR TITLE
Add option to always burn in subtitles when transcoding

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/VideoOptions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/VideoOptions.kt
@@ -3,4 +3,5 @@ package org.jellyfin.androidtv.data.compat
 class VideoOptions : AudioOptions() {
 	var audioStreamIndex: Int? = null
 	var subtitleStreamIndex: Int? = null
+	var alwaysBurnInSubtitleWhenTranscoding: Boolean = false
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -245,6 +245,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var assDirectPlay = booleanPreference("libass_enabled", false)
 
 		/**
+		 * Always burn in subtitles when transcoding.
+		 */
+		var subtitlesBurnDuringTranscode = booleanPreference("subtitles_burn_during_transcode", false)
+
+		/**
 		 * Enable PGS subtitle direct-play.
 		 */
 		var pgsDirectPlay = booleanPreference("pgs_enabled", true)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -85,6 +85,23 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     protected VideoOptions mCurrentOptions;
     private int mDefaultAudioIndex = -1;
     protected boolean burningSubs = false;
+
+    // The server does not update the subtitle delivery method when alwaysBurnInSubtitleWhenTranscoding
+    // is set, so we need to assume subs are burned in when transcoding with the option enabled.
+    protected boolean shouldBurnInSubtitles(PlayMethod playMethod) {
+        return userPreferences.getValue().get(UserPreferences.Companion.getSubtitlesBurnDuringTranscode())
+                && playMethod == PlayMethod.TRANSCODE;
+    }
+
+    private void updateBurningSubs(StreamInfo response) {
+        if (response.getSubtitleDeliveryMethod() == SubtitleDeliveryMethod.DROP) {
+            burningSubs = false;
+            return;
+        }
+
+        burningSubs = response.getSubtitleDeliveryMethod() == SubtitleDeliveryMethod.ENCODE
+                || shouldBurnInSubtitles(response.getPlayMethod());
+    }
     private float mRequestedPlaybackSpeed = -1.0f;
 
     private Runnable mReportLoop;
@@ -502,6 +519,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         VideoOptions internalOptions = new VideoOptions();
         internalOptions.setItemId(item.getId());
         internalOptions.setMediaSources(item.getMediaSources());
+        internalOptions.setAlwaysBurnInSubtitleWhenTranscoding(userPreferences.getValue().get(UserPreferences.Companion.getSubtitlesBurnDuringTranscode()));
         if (playbackRetries > 0 || (isLiveTv && !directStreamLiveTv)) internalOptions.setEnableDirectPlay(false);
         if (playbackRetries > 1) internalOptions.setEnableDirectStream(false);
         if (mCurrentOptions != null) {
@@ -564,7 +582,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     if (mVideoManager == null)
                         return;
                     mCurrentOptions = internalOptions;
-                    if (internalOptions.getSubtitleStreamIndex() == null) burningSubs = internalResponse.getSubtitleDeliveryMethod() == SubtitleDeliveryMethod.ENCODE;
+                    updateBurningSubs(internalResponse);
                     startItem(item, position, internalResponse);
                 }
 
@@ -995,6 +1013,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 public void onResponse(StreamInfo response) {
                     if (!isActive()) return;
                     mCurrentStreamInfo = response;
+
+                    updateBurningSubs(response);
+
                     if (mVideoManager != null) {
                         mVideoManager.setMediaStreamInfo(api.getValue(), response);
                         mVideoManager.start();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -99,15 +99,8 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 			return setSubtitleIndex(-1)
 		}
 
-		// The server does not update the subtitle delivery method when alwaysBurnInSubtitleWhenTranscoding
-		// is set, so we treat all subtitles as burned in when transcoding with the option enabled.
-		val deliveryMethod = when {
-			shouldBurnInSubtitles(currentStreamInfo.playMethod) -> SubtitleDeliveryMethod.ENCODE
-			else -> stream.deliveryMethod
-		}
-
-		when (deliveryMethod) {
-			SubtitleDeliveryMethod.ENCODE -> {
+		when {
+			stream.deliveryMethod == SubtitleDeliveryMethod.ENCODE || shouldBurnInSubtitles(currentStreamInfo.playMethod) -> {
 				Timber.i("Restarting playback for subtitle baking")
 
 				stop()
@@ -116,9 +109,9 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 				play(mCurrentPosition, index)
 			}
 
-			SubtitleDeliveryMethod.EXTERNAL,
-			SubtitleDeliveryMethod.EMBED,
-			SubtitleDeliveryMethod.HLS -> {
+			stream.deliveryMethod == SubtitleDeliveryMethod.EXTERNAL ||
+				stream.deliveryMethod == SubtitleDeliveryMethod.EMBED ||
+				stream.deliveryMethod == SubtitleDeliveryMethod.HLS -> {
 				// External subtitles need to be resolved differently
 				val group = if (stream.deliveryMethod == SubtitleDeliveryMethod.EXTERNAL) {
 					mVideoManager.mExoPlayer.currentTracks.groups.firstOrNull { group ->
@@ -162,7 +155,7 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 				}
 			}
 
-			SubtitleDeliveryMethod.DROP, null -> {
+			stream.deliveryMethod == SubtitleDeliveryMethod.DROP || stream.deliveryMethod == null -> {
 				Timber.i("Dropping subtitles")
 				setSubtitleIndex(-1)
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -99,7 +99,14 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 			return setSubtitleIndex(-1)
 		}
 
-		when (stream.deliveryMethod) {
+		// The server does not update the subtitle delivery method when alwaysBurnInSubtitleWhenTranscoding
+		// is set, so we treat all subtitles as burned in when transcoding with the option enabled.
+		val deliveryMethod = when {
+			shouldBurnInSubtitles(currentStreamInfo.playMethod) -> SubtitleDeliveryMethod.ENCODE
+			else -> stream.deliveryMethod
+		}
+
+		when (deliveryMethod) {
 			SubtitleDeliveryMethod.ENCODE -> {
 				Timber.i("Restarting playback for subtitle baking")
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.kt
@@ -111,6 +111,7 @@ class PlaybackManager(
 					allowVideoStreamCopy = true,
 					allowAudioStreamCopy = true,
 					autoOpenLiveStream = true,
+					alwaysBurnInSubtitleWhenTranscoding = options.alwaysBurnInSubtitleWhenTranscoding,
 				)
 			).content
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -195,6 +195,17 @@ fun SettingsPlaybackAdvancedScreen() {
 			)
 		}
 
+		item {
+			var subtitlesBurnDuringTranscode by rememberPreference(userPreferences, UserPreferences.subtitlesBurnDuringTranscode)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_burn_subtitles_when_transcoding)) },
+				captionContent = { Text(stringResource(R.string.pref_burn_subtitles_when_transcoding_description)) },
+				trailingContent = { Checkbox(checked = subtitlesBurnDuringTranscode) },
+				onClick = { subtitlesBurnDuringTranscode = !subtitlesBurnDuringTranscode }
+			)
+		}
+
 		item { ListSection(headingContent = { Text(stringResource(R.string.pref_live_tv_cat)) }) }
 
 		item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,6 +542,8 @@
     <string name="rewind">Rewind</string>
     <string name="preference_enable_libass">Enable Advanced SubStation Alpha subtitle client rendering</string>
     <string name="preference_enable_pgs">Direct play PGS subtitles</string>
+    <string name="pref_burn_subtitles_when_transcoding">Burn in subtitles when transcoding</string>
+    <string name="pref_burn_subtitles_when_transcoding_description">Always burn subtitles into the video during transcoding. This can fix subtitle sync issues but disables subtitle customization.</string>
     <string name="speech_error_no_permission">No permission to use the microphone. Please enable it in system settings.</string>
     <string name="speech_error_unavailable">Speech recognition is unavailable on your device.</string>
     <string name="speech_error_unknown">An unexpected error occurred during speech recognition.</string>


### PR DESCRIPTION
**Changes**
Adds support for toggling the `alwaysBurnInSubtitleWhenTranscoding` option that was introduced to Jellyfin in 10.10.

**Issues**
Fixes #4399

**Notes**
This is a first draft, partly to check whether or not you're amenable to adding this feature at all and partly to check if it's going in the right direction.

Things I know may need work:

- I have to double-check the whole `burningSubs` logic (PlaybackController and PlaybackControllerHelper) for different scenarios
- I was wondering if you could tell me whether or not the new playback code is far enough along for me to try adding it there as well of if it's something best left for later (or never).