### PR TITLE
Use media3 MimeTypes in deviceProfile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.androidtv.util.profile
 
-import android.media.MediaFormat
+import androidx.media3.common.MimeTypes
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.sdk.model.api.CodecType
 import org.jellyfin.sdk.model.api.DlnaProfileType
@@ -62,9 +62,9 @@ fun createDeviceProfile(
 	val avcHigh10Level = mediaTest.getAVCHigh10Level()
 	val supportsAV1 = mediaTest.supportsAV1()
 	val supportsAV1Main10 = mediaTest.supportsAV1Main10()
-	val maxResolutionAVC = mediaTest.getMaxResolution(MediaFormat.MIMETYPE_VIDEO_AVC)
-	val maxResolutionHevc = mediaTest.getMaxResolution(MediaFormat.MIMETYPE_VIDEO_HEVC)
-	val maxResolutionAV1 = mediaTest.getMaxResolution(MediaFormat.MIMETYPE_VIDEO_AV1)
+	val maxResolutionAVC = mediaTest.getMaxResolution(MimeTypes.VIDEO_H264)
+	val maxResolutionHevc = mediaTest.getMaxResolution(MimeTypes.VIDEO_H265)
+	val maxResolutionAV1 = mediaTest.getMaxResolution(MimeTypes.VIDEO_AV1)
 
 	name = "AndroidTV-Default"
 


### PR DESCRIPTION
The AV1 constant in MediaFormat is not available in older API levels, use the media3 constants instead

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Use media3 MimeTypes in deviceProfile
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
