### PR TITLE
Fix progress bar calculation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
@@ -42,14 +42,14 @@ public class ChannelCardView extends FrameLayout {
                     .append(DateTimeExtensionsKt.getTimeFormatter(getContext()).format(program.getEndDate()))
             );
 
-            if (program.getStartDate().isAfter(LocalDateTime.now()) && program.getEndDate().isBefore(LocalDateTime.now())) {
+            if (program.getStartDate().isBefore(LocalDateTime.now()) && program.getEndDate().isAfter(LocalDateTime.now())) {
                 Duration duration = Duration.between(program.getStartDate(), program.getEndDate());
                 Duration progress = Duration.between(program.getStartDate(), LocalDateTime.now());
-
-                binding.progress.setProgress((int) (progress.getSeconds() / duration.getSeconds() * 100));
+            
+                binding.progress.setProgress((int) ((progress.getSeconds() / (double) duration.getSeconds()) * 100));
             } else {
                 binding.progress.setProgress(0);
-            }
+            }          
         } else {
             binding.time.setText("");
             binding.progress.setProgress(0);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -50,6 +50,8 @@ import java.util.List;
 import kotlin.Lazy;
 import timber.log.Timber;
 
+import java.time.Duration;
+
 public class PlaybackController implements PlaybackControllerNotifiable {
     // Frequency to report playback progress
     private final static long PROGRESS_REPORTING_INTERVAL = TimeUtils.secondsToMillis(3);
@@ -978,7 +980,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 BaseItemDto program = updatedChannel.getCurrentProgram();
                 if (program != null) {
                     mCurrentProgramEnd = program.getEndDate();
-                    mCurrentProgramStart = program.getPremiereDate();
+                    mCurrentProgramStart = program.getStartDate();
                     if (mFragment != null) mFragment.updateDisplay();
                 }
                 return null;
@@ -987,11 +989,10 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     private long getRealTimeProgress() {
-        long progress = Instant.now().toEpochMilli();
         if (mCurrentProgramStart != null) {
-            progress -= mCurrentProgramStart.toInstant(ZoneOffset.UTC).toEpochMilli();
+            return Duration.between(mCurrentProgramStart, LocalDateTime.now()).toMillis();
         }
-        return progress;
+        return 0;
     }
 
     private long getTimeShiftedProgress() {


### PR DESCRIPTION
Hello there! This is my first Jellyfin PR – Feedback Welcome!

**Changes**
- Corrected condition to properly check if the current time is within the program's duration.
- Fixed progress percentage calculation using double division for accuracy.
- Replaced getPremiereDate() with getStartDate() for correct program start time.
- Refactored getRealTimeProgress() to ensure proper duration calculation.

**Issues**
Both Live TV progress bars are not working properly.
Couldn't find a matching issue, but this likely affects many. If one exists, please link it. Thanks!
