### PR TITLE
Added popup for External Player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -788,6 +788,14 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 }
             });
 
+            playButton.setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View view) {
+                    FullDetailsFragmentHelperKt.externalPlayerPopup(FullDetailsFragment.this, view, mBaseItem);
+                    return true;
+                }
+            });
+
             mDetailsOverviewRow.addAction(playButton);
 
             if (resumeButtonVisible) {
@@ -1194,6 +1202,10 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     }
 
     void play(final BaseItemDto item, final int pos, final boolean shuffle) {
+        play(item, pos, shuffle, false);
+    }
+
+    void play(final BaseItemDto item, final int pos, final boolean shuffle, final boolean forceExternalPlayer) {
         playbackHelper.getValue().getItemsToPlay(getContext(), item, pos == 0 && item.getType() == BaseItemKind.MOVIE, shuffle, new Response<List<BaseItemDto>>() {
             @Override
             public void onResponse(List<BaseItemDto> response) {
@@ -1206,7 +1218,9 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     mediaManager.getValue().playNow(requireContext(), response, 0, shuffle);
                 } else {
                     videoQueueManager.getValue().setCurrentVideoQueue(response);
-                    Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(item.getType(), pos);
+                    Destination destination = forceExternalPlayer
+                            ? KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getExternalPlayer(item.getType(), pos)
+                            : KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(item.getType(), pos);
                     navigationRepository.getValue().navigate(destination);
                 }
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -42,6 +42,13 @@ import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
+fun FullDetailsFragment.externalPlayerPopup(view: View, mBaseItem: BaseItemDto,
+) = popupMenu(requireContext(), view) {
+	item(getString(R.string.pref_external_player)) {
+		play(mBaseItem, 0, false, true)
+	}
+}.show()
+
 fun FullDetailsFragment.deleteItem(
 	api: ApiClient,
 	item: BaseItemDto,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -9,6 +9,7 @@ import kotlin.time.Duration.Companion.milliseconds
 interface PlaybackLauncher {
 	fun useExternalPlayer(itemType: BaseItemKind?): Boolean
 	fun getPlaybackDestination(itemType: BaseItemKind?, position: Int): Destination
+	fun getExternalPlayer(itemType: BaseItemKind?, position: Int): Destination
 }
 
 class GarbagePlaybackLauncher(
@@ -28,6 +29,9 @@ class GarbagePlaybackLauncher(
 		else -> false
 	}
 
+	override fun getExternalPlayer(itemType: BaseItemKind?, position: Int): Destination =
+		Destinations.externalPlayer(position.milliseconds)
+
 	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = when {
 		useExternalPlayer(itemType) -> Destinations.externalPlayer(position.milliseconds)
 		else -> Destinations.videoPlayer(position)
@@ -37,4 +41,5 @@ class GarbagePlaybackLauncher(
 class RewritePlaybackLauncher : PlaybackLauncher {
 	override fun useExternalPlayer(itemType: BaseItemKind?) = false
 	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = Destinations.playbackRewritePlayer(position)
+	override fun getExternalPlayer(itemType: BaseItemKind?, position: Int) = Destinations.playbackRewritePlayer(position)
 }


### PR DESCRIPTION
**Feature:** Add Long-Click Popup for External Player Selection

**Description:**

This pull request addresses issue #4487 by introducing a long-click popup on the play button. This popup provides users with the option to launch the current media using an external player of their choice, enhancing flexibility and user control.

Issues

Fixes #4465
Related #4261


