### PR TITLE
Fix filtering not working in collections view

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
@@ -288,7 +288,7 @@ object BrowsingUtils {
 			parentId = parent.id,
 		)
 
-		if (parent.type == BaseItemKind.USER_VIEW || parent.type == BaseItemKind.COLLECTION_FOLDER) {
+		if (parent.type == BaseItemKind.USER_VIEW) {
 			return when (parent.collectionType) {
 				CollectionType.MOVIES -> baseRequest.copy(
 					includeItemTypes = setOf(BaseItemKind.MOVIE),


### PR DESCRIPTION
Bit of old code that was migrated to the SDK with exact same behavior. We shouldn't need to apply additional constrictions when requesting collections, API request now matches more similarly with jellyfin-web.

**Changes**
- Fix filtering not working in collections view
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
Fixes #4475