### PR TITLE
Fix filtering not working in collections view (v2)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
@@ -300,12 +300,6 @@ object BrowsingUtils {
 					recursive = true,
 				)
 
-				CollectionType.BOXSETS -> baseRequest.copy(
-					includeItemTypes = setOf(BaseItemKind.BOX_SET),
-					parentId = null,
-					recursive = true,
-				)
-
 				CollectionType.MUSIC -> baseRequest.copy(
 					includeItemTypes = setOf(BaseItemKind.MUSIC_ALBUM),
 					recursive = true,


### PR DESCRIPTION
Alternative to #4496. That one would accidentally make libraries into folder views, which was not the intended behavior.

**Changes**

- Remove special case when retrieving box sets (collections) from the server. The server does not support filters on these. The query is now more similar to jellyfin-web.

**Issues**

Fixes #4475