### PR TITLE
Display lyrics as captions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -29,12 +29,14 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
 import org.jellyfin.androidtv.ui.composable.AsyncImage
+import org.jellyfin.androidtv.ui.composable.CaptionsDtoBox
 import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.blurHashPainter
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.LyricsMode
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.jellyfin.lyrics
 import org.jellyfin.playback.jellyfin.lyricsFlow
@@ -81,18 +83,37 @@ fun DreamContentNowPlaying(
 	// Lyrics overlay (on top of background)
 	if (lyrics != null) {
 		val playState by playbackManager.state.playState.collectAsState()
-		LyricsDtoBox(
-			lyricDto = lyrics,
-			currentTimestamp = playbackManager.state.positionInfo.active,
-			duration = playbackManager.state.positionInfo.duration,
-			paused = playState != PlayState.PLAYING,
-			fontSize = 22.sp,
-			color = Color.White,
-			modifier = Modifier
-				.fillMaxSize()
-				.fadingEdges(vertical = 250.dp)
-				.padding(horizontal = 50.dp),
-		)
+		val lyricsMode by playbackManager.state.lyricsMode.collectAsState()
+
+		when (lyricsMode) {
+			LyricsMode.SCROLLING ->
+				LyricsDtoBox(
+					lyricDto = lyrics,
+					currentTimestamp = playbackManager.state.positionInfo.active,
+					duration = playbackManager.state.positionInfo.duration,
+					paused = playState != PlayState.PLAYING,
+					fontSize = 22.sp,
+					color = Color.White,
+					modifier = Modifier
+						.fillMaxSize()
+						.fadingEdges(vertical = 250.dp)
+						.padding(horizontal = 50.dp),
+				)
+
+			LyricsMode.CAPTIONS ->
+				CaptionsDtoBox(
+					lyricDto = lyrics,
+					currentTimestamp = playbackManager.state.positionInfo.active,
+					fontSize = 22.sp,
+					color = Color.White,
+					modifier = Modifier
+						.fillMaxSize()
+						.fadingEdges(vertical = 250.dp)
+						.padding(horizontal = 50.dp),
+				)
+
+			LyricsMode.OFF -> {}
+		}
 	}
 
 	// Metadata overlay (includes title / progress)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -50,7 +51,6 @@ private fun LyricsLine(
 	text: String,
 	fontSize: TextUnit,
 	color: Color,
-	backgroundColor: Color = Color.Transparent,
 	active: Boolean = false,
 	gap: Dp = 15.dp,
 ) {
@@ -58,12 +58,6 @@ private fun LyricsLine(
 		targetValue = if (active) color else color.copy(alpha = 0.5f),
 		animationSpec = tween(),
 		label = "LyricsLineColor",
-	)
-
-	val backgroundColor by animateColorAsState(
-		targetValue = backgroundColor,
-		animationSpec = tween(),
-		label = "LyricsLineBackgroundColor",
 	)
 
 	val scale by animateFloatAsState(
@@ -80,7 +74,6 @@ private fun LyricsLine(
 		modifier = Modifier
 			.padding(bottom = gap)
 			.scale(scale)
-			.background(backgroundColor)
 	)
 }
 
@@ -226,6 +219,26 @@ fun LyricsDtoBox(
 
 
 @Composable
+private fun CaptionsLine(
+	text: String,
+	fontSize: TextUnit,
+	color: Color,
+	active: Boolean = false,
+	backgroundColor: Color = Color.Black
+) {
+	Text(
+		text = text,
+		textAlign = TextAlign.Center,
+		fontSize = fontSize,
+		color = color,
+		modifier = Modifier
+			.alpha(if (active) 1f else 0f)
+			.background(backgroundColor)
+	)
+}
+
+
+@Composable
 private fun <T> CaptionsBoxContent(
 	items: Collection<T>,
 	modifier: Modifier = Modifier,
@@ -256,7 +269,7 @@ fun CaptionsBox(
 		items = lines,
 		modifier = Modifier.fillMaxSize()
 	) { line, index ->
-		LyricsLine(
+		CaptionsLine(
 			text = line.text,
 			active = index == activeLine,
 			fontSize = fontSize,
@@ -271,8 +284,6 @@ fun CaptionsDtoBox(
 	lyricDto: LyricDto,
 	modifier: Modifier = Modifier,
 	currentTimestamp: Duration = Duration.ZERO,
-	duration: Duration = Duration.ZERO,
-	paused: Boolean = false,
 	fontSize: TextUnit = LocalTextStyle.current.fontSize,
 	color: Color = LocalTextStyle.current.color,
 	backgroundColor: Color = Color.Black
@@ -287,6 +298,7 @@ fun CaptionsDtoBox(
 			currentTimestamp = currentTimestamp,
 			fontSize = fontSize,
 			color = color,
+			backgroundColor = backgroundColor
 		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -112,6 +112,7 @@ public class AudioNowPlayingFragment extends Fragment {
         mScrollView = binding.mainScroller;
         mCounter = binding.counter;
         AudioNowPlayingFragmentHelperKt.initializeLyricsView(binding.poster, binding.lyrics, playbackManager.getValue());
+        AudioNowPlayingFragmentHelperKt.initializeCaptionsView(binding.captions, playbackManager.getValue());
 
         mPlayPauseButton = binding.playPauseBtn;
         mPlayPauseButton.setContentDescription(getString(R.string.lbl_pause));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -43,6 +43,7 @@ import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.playback.core.PlaybackManager;
+import org.jellyfin.playback.core.model.LyricsMode;
 
 import java.util.List;
 
@@ -59,6 +60,7 @@ public class AudioNowPlayingFragment extends Fragment {
     private ImageButton mRepeatButton;
     private ImageButton mShuffleButton;
     private ImageButton mAlbumButton;
+    private ImageButton mLyricsButton;
     private ImageButton mArtistButton;
     private TextView mCounter;
     private ScrollView mScrollView;
@@ -172,6 +174,17 @@ public class AudioNowPlayingFragment extends Fragment {
             }
         });
         mAlbumButton.setOnFocusChangeListener(mainAreaFocusListener);
+
+        mLyricsButton = binding.lyricsBtn;
+        mLyricsButton.setContentDescription(getString(R.string.lbl_lyrics));
+        mLyricsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                playbackManager.getValue().getState().cycleLyricsMode();
+                updateButtons();
+            }
+        });
+        mLyricsButton.setOnFocusChangeListener(mainAreaFocusListener);
 
         mArtistButton = binding.artistBtn;
         mArtistButton.setContentDescription(getString(R.string.lbl_open_artist));
@@ -312,6 +325,7 @@ public class AudioNowPlayingFragment extends Fragment {
     private void updateButtons() {
         Timber.d("Updating buttons");
         boolean playing = mediaManager.getValue().isPlayingAudio();
+        LyricsMode lyricsMode = playbackManager.getValue().getState().getLyricsMode().getValue();
         requireActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -332,6 +346,21 @@ public class AudioNowPlayingFragment extends Fragment {
                 if (mBaseItem != null) {
                     mAlbumButton.setEnabled(mBaseItem.getAlbumId() != null);
                     mArtistButton.setEnabled(mBaseItem.getAlbumArtists() != null && !mBaseItem.getAlbumArtists().isEmpty());
+                }
+
+                switch(lyricsMode) {
+                    case OFF:
+                        mLyricsButton.setImageResource(R.drawable.ic_lyrics);
+                        mLyricsButton.setContentDescription(getString(R.string.lbl_lyrics));
+                        break;
+                    case SCROLLING:
+                        mLyricsButton.setImageResource(R.drawable.ic_closed_caption_off);
+                        mLyricsButton.setContentDescription(getString(R.string.lbl_show_captions));
+                        break;
+                    case CAPTIONS:
+                        mLyricsButton.setImageResource(R.drawable.ic_closed_caption);
+                        mLyricsButton.setContentDescription(getString(R.string.lbl_hide_captions));
+                        break;
                 }
             }
         });

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
@@ -56,6 +57,7 @@ fun initializeLyricsView(
 				fontSize = 12.sp,
 				color = Color.White,
 				modifier = Modifier
+					.alpha(if (lyricsMode == LyricsMode.SCROLLING) 1f else 0f)
 					.fillMaxSize()
 					.fadingEdges(vertical = 50.dp)
 					.padding(horizontal = 15.dp),

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jellyfin.androidtv.ui.AsyncImageView
+import org.jellyfin.androidtv.ui.composable.CaptionsDtoBox
 import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
@@ -63,5 +64,37 @@ fun initializeLyricsView(
 					.padding(horizontal = 15.dp),
 			)
 		}
+	}
+}
+
+
+fun initializeCaptionsView(
+	captionsView: ComposeView,
+	playbackManager: PlaybackManager
+) {
+	captionsView.setContent {
+		val entry by rememberQueueEntry(playbackManager)
+		val lyrics = entry?.run { lyricsFlow.collectAsState(lyrics) }?.value
+		val lyricsMode = entry?.run { playbackManager.state.lyricsMode.collectAsState() }?.value
+		val playState by remember { playbackManager.state.playState }.collectAsState()
+
+		// Using the progress animation causes the layout to recompose, which we need for synced lyrics to work
+		// we don't actually use the animation value here
+		rememberPlayerProgress(playbackManager)
+
+		if (lyrics != null) {
+			CaptionsDtoBox(
+				lyricDto = lyrics,
+				currentTimestamp = playbackManager.state.positionInfo.active,
+				duration = playbackManager.state.positionInfo.duration,
+				paused = playState != PlayState.PLAYING,
+				fontSize = 14.sp,
+				color = Color.White,
+				backgroundColor = Color.Black,
+				modifier = Modifier
+					.alpha(if (lyricsMode == LyricsMode.CAPTIONS) 1f else 0f),
+			)
+		}
+
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -18,6 +18,7 @@ import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.androidtv.ui.composable.rememberQueueEntry
 import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.LyricsMode
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.jellyfin.lyrics
 import org.jellyfin.playback.jellyfin.lyricsFlow
@@ -30,16 +31,17 @@ fun initializeLyricsView(
 	lyricsView.setContent {
 		val entry by rememberQueueEntry(playbackManager)
 		val lyrics = entry?.run { lyricsFlow.collectAsState(lyrics) }?.value
+		val lyricsMode = entry?.run { playbackManager.state.lyricsMode.collectAsState() }?.value
 
 		// Animate cover view alpha
 		val coverViewAlpha by animateFloatAsState(
 			label = "CoverViewAlpha",
-			targetValue = if (lyrics == null) 1f else 0.2f,
+			targetValue = if (lyrics == null || lyricsMode == null || lyricsMode != LyricsMode.SCROLLING) 1f else 0.2f,
 		)
 		LaunchedEffect(coverViewAlpha) { coverView.alpha = coverViewAlpha }
 
 		// Display lyrics overlay
-		if (lyrics != null) {
+		if (lyrics != null && lyricsMode != null) {
 			val playState by remember { playbackManager.state.playState }.collectAsState()
 
 			// Using the progress animation causes the layout to recompose, which we need for synced lyrics to work

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -86,9 +86,7 @@ fun initializeCaptionsView(
 			CaptionsDtoBox(
 				lyricDto = lyrics,
 				currentTimestamp = playbackManager.state.positionInfo.active,
-				duration = playbackManager.state.positionInfo.duration,
-				paused = playState != PlayState.PLAYING,
-				fontSize = 14.sp,
+				fontSize = 16.sp,
 				color = Color.White,
 				backgroundColor = Color.Black,
 				modifier = Modifier

--- a/app/src/main/res/drawable/ic_closed_caption.xml
+++ b/app/src/main/res/drawable/ic_closed_caption.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.9,-2 -2,-2zM11,11L9.5,11v-0.5h-2v3h2L9.5,13L11,13v1c0,0.55 -0.45,1 -1,1L7,15c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h3c0.55,0 1,0.45 1,1v1zM18,11h-1.5v-0.5h-2v3h2L16.5,13L18,13v1c0,0.55 -0.45,1 -1,1h-3c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h3c0.55,0 1,0.45 1,1v1z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_closed_caption_off.xml
+++ b/app/src/main/res/drawable/ic_closed_caption_off.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M19.5,5.5v13h-15v-13h15zM19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.9,-2 -2,-2zM11,11L9.5,11v-0.5h-2v3h2L9.5,13L11,13v1c0,0.55 -0.45,1 -1,1L7,15c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h3c0.55,0 1,0.45 1,1v1zM18,11h-1.5v-0.5h-2v3h2L16.5,13L18,13v1c0,0.55 -0.45,1 -1,1h-3c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h3c0.55,0 1,0.45 1,1v1z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lyrics.xml
+++ b/app/src/main/res/drawable/ic_lyrics.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M14,9c0,-2.04 1.24,-3.79 3,-4.57V4c0,-1.1 -0.9,-2 -2,-2H4C2.9,2 2.01,2.9 2.01,4L2,22l4,-4h9c1.1,0 2,-0.9 2,-2v-2.42C15.24,12.8 14,11.05 14,9zM10,14H6v-2h4V14zM13,11H6V9h7V11zM13,8H6V6h7V8z"/>
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M20,6.18C19.69,6.07 19.35,6 19,6c-1.66,0 -3,1.34 -3,3c0,1.66 1.34,3 3,3s3,-1.34 3,-3V3h2V1h-4V6.18z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -190,6 +190,13 @@
                         android:src="@drawable/ic_shuffle" />
 
                     <ImageButton
+                        android:id="@+id/lyricsBtn"
+                        style="@style/Button.Icon"
+                        android:layout_width="28sp"
+                        android:layout_height="28sp"
+                        android:src="@drawable/ic_lyrics" />
+
+                    <ImageButton
                         android:id="@+id/albumBtn"
                         style="@style/Button.Icon"
                         android:layout_width="28sp"
@@ -238,6 +245,14 @@
                 android:layout_below="@+id/detailArea"
                 android:layout_alignParentBottom="false"
                 android:layout_marginTop="30dp" />
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/captions"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_below="@+id/detailArea"
+                android:descendantFocusability="afterDescendants"
+                android:focusable="false" />
 
             <TextView
                 android:id="@+id/counter"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -532,6 +532,9 @@
     <string name="pref_report_device_profile_summary">Upload a troubleshooting document to the Jellyfin server with information about playback capabilities</string>
     <string name="pref_report_device_profile_success">Document submitted as %1$s</string>
     <string name="pref_report_device_profile_failure">Failed to submit document. Your Jellyfin server may prohibit client logs.</string>
+    <string name="lbl_lyrics">Show lyrics</string>
+    <string name="lbl_show_captions">Show captions</string>
+    <string name="lbl_hide_captions">Hide captions</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>

--- a/playback/core/src/main/kotlin/model/LyricsMode.kt
+++ b/playback/core/src/main/kotlin/model/LyricsMode.kt
@@ -1,0 +1,7 @@
+package org.jellyfin.playback.core.model
+
+enum class LyricsMode {
+	OFF,
+	SCROLLING,
+	CAPTIONS
+}


### PR DESCRIPTION
**Changes**
Lyrics on audio media are not displayed by default.  Added a button to the audio player which cycles through showing no lyrics, showing scrolling lyrics (per existing functionality) or showing lyrics as closed captions.   This implements: https://features.jellyfin.org/posts/3124/lyrics-as-closed-captions-on-androidvtv
