### PR TITLE
Add codec features, color formats and profile levels to device profile report

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/MarkdownBuilder.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/MarkdownBuilder.kt
@@ -58,3 +58,14 @@ fun MarkdownBuilder.appendCodeBlock(language: String, code: String?) {
 fun MarkdownBuilder.appendValue(value: String?) {
 	append("`", value ?: "<null>", "`")
 }
+
+fun MarkdownBuilder.appendDetails(summary: String? = null, content: MarkdownBuilder.() -> Unit) {
+	appendLine()
+	appendLine("<details>")
+	if (summary != null) appendLine("<summary>${summary}</summary>")
+	appendLine()
+	content()
+	appendLine()
+	appendLine("</details>")
+	appendLine()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -19,6 +19,26 @@ private fun formatJson(json: String) = prettyPrintJson.encodeToString(prettyPrin
 
 private fun Range<Int>.prettyFormat() = if (lower == upper) "$lower" else "$lower-$upper"
 
+// Names are copied from MediaCodecInfo.CodecCapabilities.FEATURE_xxx constants as some constants are not available in older API versions
+private val featureNames = setOf(
+	"adaptive-playback",
+	"detached-surface",
+	"dynamic-color-aspects",
+	"dynamic-timestamp",
+	"encoding-statistics",
+	"frame-parsing",
+	"hdr-editing",
+	"hlg-editing",
+	"intra-refresh",
+	"low-latency",
+	"multiple-frames",
+	"partial-frame",
+	"qp-bounds",
+	"region-of-interest",
+	"secure-playback",
+	"tunneled-playback",
+)
+
 fun createDeviceProfileReport(
 	context: Context,
 	userPreferences: UserPreferences,
@@ -105,6 +125,20 @@ fun createDeviceProfileReport(
 					appendLine("    - profileLevels")
 					for (profileLevel in profileLevels) {
 						appendLine("      - ${profileLevel.profile}: ${profileLevel.level}")
+					}
+				}
+
+				// Only show features section if there is at least 1
+				featureNames.mapNotNull { name ->
+					when {
+						capabilities.isFeatureRequired(name) -> "$name (required)"
+						capabilities.isFeatureSupported(name) -> name
+						else -> null
+					}
+				}.takeIf { it.isNotEmpty() }?.let { features ->
+					appendLine("    - features")
+					for (feature in features) {
+						appendLine("      - $feature")
 					}
 				}
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.util.appendCodeBlock
+import org.jellyfin.androidtv.util.appendDetails
 import org.jellyfin.androidtv.util.appendItem
 import org.jellyfin.androidtv.util.appendSection
 import org.jellyfin.androidtv.util.appendValue
@@ -54,7 +55,7 @@ fun createDeviceProfileReport(
 	appendLine()
 
 	// Device profile send to server
-	appendSection("Generated device profile") {
+	appendDetails("Generated device profile") {
 		appendCodeBlock(
 			language = "json",
 			code = createDeviceProfile(userPreferences, disableDirectPlay = false)
@@ -64,14 +65,14 @@ fun createDeviceProfileReport(
 	}
 
 	// Device capabilities used to generate profile
-	appendSection("Device codec decoders") {
-		val isQ = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-		val isS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+	val isQ = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+	val isS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
-		val codecs = MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
-			.filter { !it.isEncoder }
-			.sortedBy { if (isQ) it.canonicalName else it.name }
+	val codecs = MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
+		.filter { !it.isEncoder }
+		.sortedBy { if (isQ) it.canonicalName else it.name }
 
+	appendDetails("Device codec decoders") {
 		for (codec in codecs) {
 			if (isQ) appendLine("- **${codec.canonicalName} (${codec.name})**")
 			else appendLine("- **${codec.name}**")
@@ -145,14 +146,14 @@ fun createDeviceProfileReport(
 
 			appendLine()
 		}
+	}
 
-		appendSection("Known media types", depth = 4) {
-			codecs
-				.flatMap { codec -> codec.supportedTypes.asIterable() }
-				.distinct()
-				.sorted()
-				.forEach { type -> appendLine("- $type") }
-		}
+	appendDetails("Known media types") {
+		codecs
+			.flatMap { codec -> codec.supportedTypes.asIterable() }
+			.distinct()
+			.sorted()
+			.forEach { type -> appendLine("- $type") }
 	}
 
 	appendSection("App information") {


### PR DESCRIPTION
Extends the tool from #4482 with even more data.

**Changes**

- Add color formats
- Add profile levels
- Add device codec features
- Use collapsed detail blocks
- Updated formatting of current values to be easier to read
  - Ranges are now `45-70` instead of `[45,70]`
  - null values now hidden

Updated the gist with new example: https://gist.github.com/nielsvanvelzen/cba33b29c1dfc82350735fd5f0190abd


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
