### PR TITLE
Enable logging for Coil

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -8,6 +8,7 @@ import coil3.gif.GifDecoder
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.serviceLoaderEnabled
 import coil3.svg.SvgDecoder
+import coil3.util.Logger
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
@@ -45,6 +46,7 @@ import org.jellyfin.androidtv.util.KeyProcessor
 import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.androidtv.util.PlaybackHelper
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper
+import org.jellyfin.androidtv.util.coil.CoilTimberLogger
 import org.jellyfin.androidtv.util.sdk.SdkPlaybackHelper
 import org.jellyfin.sdk.android.androidDevice
 import org.jellyfin.sdk.createJellyfin
@@ -84,6 +86,7 @@ val appModule = module {
 	single {
 		ImageLoader.Builder(androidContext()).apply {
 			serviceLoaderEnabled(false)
+			logger(CoilTimberLogger(if (BuildConfig.DEBUG) Logger.Level.Warn else Logger.Level.Error))
 			components {
 				add(OkHttpNetworkFetcherFactory())
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) add(AnimatedImageDecoder.Factory())

--- a/app/src/main/java/org/jellyfin/androidtv/util/coil/CoilTimberLogger.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/coil/CoilTimberLogger.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.androidtv.util.coil
+
+import android.util.Log
+import coil3.util.Logger
+import timber.log.Timber
+
+class CoilTimberLogger(
+	override var minLevel: Logger.Level = Logger.Level.Debug,
+) : Logger {
+	override fun log(tag: String, level: Logger.Level, message: String?, throwable: Throwable?) {
+		val priority = when (level) {
+			Logger.Level.Verbose -> Log.VERBOSE
+			Logger.Level.Debug -> Log.DEBUG
+			Logger.Level.Info -> Log.INFO
+			Logger.Level.Warn -> Log.WARN
+			Logger.Level.Error -> Log.ERROR
+		}
+
+		Timber.tag("CoilTimberLogger.$tag").log(priority, throwable, message)
+	}
+}


### PR DESCRIPTION
Turns out Coil was really quiet because we didn't configure logging.

**Changes**

Add new logger implementation for Coil using Timber. It will always prefix the Coil tag with "CoilTimberLogger." so it's easy to filter with logcat. It will log both warnings and errors in debug builds, and only errors on release builds. The level can be changed to verbose/debug/info in AppModule if needed for testing.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
