### PR TITLE
Add custom connectivity checker for Coil that always claims to be connected

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.di
 import android.content.Context
 import android.os.Build
 import coil3.ImageLoader
+import coil3.annotation.ExperimentalCoilApi
 import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
@@ -47,6 +48,7 @@ import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.androidtv.util.PlaybackHelper
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper
 import org.jellyfin.androidtv.util.coil.CoilTimberLogger
+import org.jellyfin.androidtv.util.coil.createCoilConnectivityChecker
 import org.jellyfin.androidtv.util.sdk.SdkPlaybackHelper
 import org.jellyfin.sdk.android.androidDevice
 import org.jellyfin.sdk.createJellyfin
@@ -87,8 +89,11 @@ val appModule = module {
 		ImageLoader.Builder(androidContext()).apply {
 			serviceLoaderEnabled(false)
 			logger(CoilTimberLogger(if (BuildConfig.DEBUG) Logger.Level.Warn else Logger.Level.Error))
+
 			components {
-				add(OkHttpNetworkFetcherFactory())
+				@OptIn(ExperimentalCoilApi::class)
+				add(OkHttpNetworkFetcherFactory(connectivityChecker = ::createCoilConnectivityChecker))
+
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) add(AnimatedImageDecoder.Factory())
 				else add(GifDecoder.Factory())
 				add(SvgDecoder.Factory())

--- a/app/src/main/java/org/jellyfin/androidtv/util/coil/coilConnectivityChecker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/coil/coilConnectivityChecker.kt
@@ -1,0 +1,14 @@
+package org.jellyfin.androidtv.util.coil
+
+import android.content.Context
+import coil3.annotation.ExperimentalCoilApi
+import coil3.network.ConnectivityChecker
+
+/**
+ * Coil uses a "connectivity checker" to skip the network if it thinks there is no available connection. In Android this is sometimes
+ * detected by pinging a known host (e.g. google.com) which might fail for users that blackhole these hosts or only use the app on their
+ * local network. This implementation of the connectivity checker will always return `true` to force a network request to be made.
+ */
+@Suppress("UNUSED_PARAMETER")
+@ExperimentalCoilApi
+fun createCoilConnectivityChecker(context: Context) = ConnectivityChecker { true }


### PR DESCRIPTION
Coil uses a "connectivity checker" to skip the network if it thinks there is no available connection. In Android this is sometimes detected by pinging a known host (e.g. google.com) which might fail for users that blackhole these hosts or only use the app on their local network.

**Changes**

Add custom connectivity checker that will always return `true` to force a network request to be made.

**Issues**

Fixes #4379
