### PR TITLE
feat: Add ability to use latest audio and subtitles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -2,6 +2,8 @@ package org.jellyfin.androidtv.ui.playback;
 
 import static org.koin.java.KoinJavaComponent.inject;
 
+import static java.util.Objects.requireNonNull;
+
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -23,6 +25,7 @@ import org.jellyfin.androidtv.preference.constant.NextUpBehavior;
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior;
 import org.jellyfin.androidtv.preference.constant.ZoomMode;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
+import org.jellyfin.androidtv.util.PlaybackHelper;
 import org.jellyfin.androidtv.util.TimeUtils;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
@@ -41,15 +44,15 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod;
 import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
 import org.koin.java.KoinJavaComponent;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import kotlin.Lazy;
 import timber.log.Timber;
-
-import java.time.Duration;
 
 public class PlaybackController implements PlaybackControllerNotifiable {
     // Frequency to report playback progress
@@ -63,6 +66,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
     private Lazy<ReportingHelper> reportingHelper = inject(ReportingHelper.class);
+    final Lazy<PlaybackHelper> playbackHelper = inject(PlaybackHelper.class);
 
     List<BaseItemDto> mItems;
     VideoManager mVideoManager;
@@ -76,7 +80,11 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private CustomPlaybackOverlayFragment mFragment;
     private Boolean spinnerOff = false;
 
-    protected VideoOptions mCurrentOptions;
+    protected VideoOptions mCurrentOptions = new VideoOptions();
+    private MediaStream mPreviousSubtitle;
+    private MediaStream mPreviousAudio;
+    private Integer inferredAudioIndex;
+    private Integer inferredSubtitleIndex;
     private int mDefaultAudioIndex = -1;
     protected boolean burningSubs = false;
     private float mRequestedPlaybackSpeed = -1.0f;
@@ -114,7 +122,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         }
         mFragment = fragment;
         mHandler = new Handler();
-
 
         refreshRateSwitchingBehavior = userPreferences.getValue().get(UserPreferences.Companion.getRefreshRateSwitchingBehavior());
         if (refreshRateSwitchingBehavior != RefreshRateSwitchingBehavior.DISABLED)
@@ -536,25 +543,80 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 }
             });
         } else {
-            playbackManager.getValue().getVideoStreamInfo(mFragment, internalOptions, position * 10000, new Response<StreamInfo>() {
-                @Override
-                public void onResponse(StreamInfo internalResponse) {
-                    Timber.i("Internal player would %s", internalResponse.getPlayMethod().equals(PlayMethod.TRANSCODE) ? "transcode" : "direct stream");
-                    if (mVideoManager == null)
-                        return;
-                    mCurrentOptions = internalOptions;
-                    if (internalOptions.getSubtitleStreamIndex() == null) burningSubs = internalResponse.getSubtitleDeliveryMethod() == SubtitleDeliveryMethod.ENCODE;
-                    startItem(item, position, internalResponse);
-                }
-
-                @Override
-                public void onError(Exception exception) {
-                    Timber.e(exception, "Unable to get stream info for internal player");
-                    if (mVideoManager == null)
-                        return;
-                }
-            });
+            buildPreviousOptionsAndStartItem(item, position, internalOptions);
         }
+    }
+
+    private void buildPreviousOptionsAndStartItem(BaseItemDto item, Long position, VideoOptions internalOptions) {
+        playbackHelper.getValue().getLastPlayedItem(mFragment.getContext(), getCurrentlyPlayingItem(), new Response<BaseItemDto>() {
+            @Override
+            public void onResponse(BaseItemDto lastPlayedItem) {
+
+                final VideoOptions lastPlayedVideoOptions = new VideoOptions();
+                lastPlayedVideoOptions.setItemId(lastPlayedItem.getId());
+
+                playbackManager.getValue().getVideoStreamInfo(mFragment, lastPlayedVideoOptions, 0, new Response<StreamInfo>() {
+                    @Override
+                    public void onResponse(StreamInfo lastPlayedStreamInfo) {
+                        final MediaSourceInfo lastPlayedMediaSource = lastPlayedStreamInfo.getMediaSource();
+
+                        if (requireNonNull(requireNonNull(lastPlayedMediaSource).getDefaultAudioStreamIndex()) != -1)
+                            mPreviousAudio = requireNonNull(lastPlayedMediaSource.getMediaStreams()).get(lastPlayedMediaSource.getDefaultAudioStreamIndex());
+                        if (requireNonNull(requireNonNull(lastPlayedMediaSource).getDefaultSubtitleStreamIndex()) != -1)
+                            mPreviousSubtitle = requireNonNull(lastPlayedMediaSource.getMediaStreams()).get(lastPlayedMediaSource.getDefaultSubtitleStreamIndex());
+
+                        if (item.getMediaStreams() != null && mPreviousAudio != null)
+                            inferredAudioIndex = inferMediaStreamIndex(item, mPreviousAudio);
+                        if (item.getMediaStreams() != null && mPreviousSubtitle != null)
+                            inferredSubtitleIndex = inferMediaStreamIndex(item, mPreviousSubtitle);
+
+                        getVideoStreamInfoAndStartItem(internalOptions, position, item);
+                    }
+                });
+            }
+        });
+    }
+
+    private Integer inferMediaStreamIndex(final BaseItemDto item, final MediaStream previousMediaStream) {
+        assert item.getMediaStreams() != null;
+        Integer newMediaStream;
+        List<MediaStream> matchingMediaStreamList = item.getMediaStreams()
+                .stream()
+                .filter(mediaStream ->
+                        previousMediaStream.getType().equals(mediaStream.getType()) &&
+                                previousMediaStream.getLanguage().equals(mediaStream.getLanguage()))
+                .collect(Collectors.toList());
+
+        if (matchingMediaStreamList.size() == 1) {
+            newMediaStream = item.getMediaStreams().indexOf(matchingMediaStreamList.get(0));
+        } else {
+            newMediaStream = matchingMediaStreamList
+                    .stream()
+                    .filter(mediaStream -> previousMediaStream.getTitle().equals(mediaStream.getTitle()))
+                    .findFirst()
+                    .map(mediaStream -> item.getMediaStreams().indexOf(mediaStream))
+                    .orElseGet(() -> null);
+        }
+        return newMediaStream;
+    }
+
+    private void getVideoStreamInfoAndStartItem(VideoOptions internalOptions, Long position, BaseItemDto item) {
+        playbackManager.getValue().getVideoStreamInfo(mFragment, internalOptions, position * 10000, new Response<StreamInfo>() {
+            @Override
+            public void onResponse(StreamInfo internalResponse) {
+                Timber.i("Internal player would %s", internalResponse.getPlayMethod().equals(PlayMethod.TRANSCODE) ? "transcode" : "direct stream");
+                if (mVideoManager == null)
+                    return;
+                if (inferredSubtitleIndex == null)
+                    burningSubs = internalResponse.getSubtitleDeliveryMethod() == SubtitleDeliveryMethod.ENCODE;
+                startItem(item, position, internalResponse);
+            }
+
+            @Override
+            public void onError(Exception exception) {
+                Timber.e(exception, "Unable to get stream info for internal player");
+            }
+        });
     }
 
     private void handlePlaybackInfoError(Exception exception) {
@@ -602,7 +664,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         }
 
         // get subtitle info
-        mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex() != null ? response.getMediaSource().getDefaultSubtitleStreamIndex() : null);
+        mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex());
         setDefaultAudioIndex(response);
         Timber.d("default audio index set to %s remote default %s", mDefaultAudioIndex, response.getMediaSource().getDefaultAudioStreamIndex());
         Timber.d("default sub index set to %s remote default %s", mCurrentOptions.getSubtitleStreamIndex(), response.getMediaSource().getDefaultSubtitleStreamIndex());
@@ -696,8 +758,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         Integer remoteDefault = info.getMediaSource().getDefaultAudioStreamIndex();
         Integer bestGuess = bestGuessAudioTrack(info.getMediaSource());
-
-        if (remoteDefault != null)
+        if (inferredAudioIndex != null)
+            mDefaultAudioIndex = inferredAudioIndex;
+        else if (remoteDefault != null)
             mDefaultAudioIndex = remoteDefault;
         else if (bestGuess != null)
             mDefaultAudioIndex = bestGuess;
@@ -705,6 +768,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     public void switchAudioStream(int index) {
+        mVideoManager.setExoPlayerTrack(index, MediaStreamType.AUDIO, getCurrentlyPlayingItem().getMediaStreams());
         if (!(isPlaying() || isPaused()) || index < 0)
             return;
 
@@ -1124,23 +1188,34 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         } else {
             if (!burningSubs) {
                 // Make sure the requested subtitles are enabled when external/embedded
-                Integer currentSubtitleIndex = mCurrentOptions.getSubtitleStreamIndex();
-                if (currentSubtitleIndex == null) currentSubtitleIndex = -1;
-                PlaybackControllerHelperKt.setSubtitleIndex(this, currentSubtitleIndex, true);
+                Integer subtitleIndex = inferredSubtitleIndex;
+
+                if (subtitleIndex == null) subtitleIndex = -1;
+                PlaybackControllerHelperKt.setSubtitleIndex(this, subtitleIndex, true);
             }
 
             // select an audio track
-            int eligibleAudioTrack = mDefaultAudioIndex;
-
-            // if track switching is done without rebuilding the stream, mCurrentOptions is updated
-            // otherwise, use the server default
-            if (mCurrentOptions.getAudioStreamIndex() != null) {
-                eligibleAudioTrack = mCurrentOptions.getAudioStreamIndex();
-            } else if (getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
-                eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex();
-            }
+            final int eligibleAudioTrack = getEligibleAudioTrack();
             switchAudioStream(eligibleAudioTrack);
         }
+    }
+
+    private int getEligibleAudioTrack() {
+        Integer currentAudioIndex = mCurrentOptions.getAudioStreamIndex();
+        final int eligibleAudioTrack;
+
+        // if track switching is done without rebuilding the stream, mCurrentOptions is updated
+        // otherwise, use the server default
+        if (inferredAudioIndex != null)
+            eligibleAudioTrack = inferredAudioIndex;
+        else if (currentAudioIndex != null) {
+            eligibleAudioTrack = currentAudioIndex;
+        } else if (getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
+            eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex();
+        } else {
+            eligibleAudioTrack = mDefaultAudioIndex;
+        }
+        return eligibleAudioTrack;
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/util/PlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/PlaybackHelper.kt
@@ -20,4 +20,6 @@ interface PlaybackHelper {
 		retrieveAndPlay(id, shuffle, null, context)
 
 	fun playInstantMix(context: Context, item: BaseItemDto)
+
+	fun getLastPlayedItem(context: Context, mainItem: BaseItemDto, callback: Response<BaseItemDto?>)
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Add ability to remember audio and subtitle languages from last played episode. By enabling correspondent option in settings section, every new episode played will take into account last played episode to select audio and/or subtitles track.
