### PR TITLE
Add support for empty and logo screensaver modes to reduce (OLED) screen burn-in

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import org.jellyfin.androidtv.integration.dream.DreamViewModel
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
+import org.jellyfin.androidtv.preference.constant.ScreenSaverType
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -20,6 +21,11 @@ fun DreamHost() {
 		showClock = when (userPreferences[UserPreferences.clockBehavior]) {
 			ClockBehavior.ALWAYS, ClockBehavior.IN_MENUS -> true
 			else -> false
-		}
+		},
+		showLogoSetting = userPreferences[UserPreferences.screensaverShowLogo],
+		showBlank = when (userPreferences[UserPreferences.screensaverType]) {
+			ScreenSaverType.EMPTY_SCREEN -> true
+			else -> false
+		},
 	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
@@ -16,27 +16,33 @@ import org.jellyfin.androidtv.integration.dream.model.DreamContent
 fun DreamView(
 	content: DreamContent,
 	showClock: Boolean,
-) = Box(
-	modifier = Modifier
-		.fillMaxSize()
-) {
-	AnimatedContent(
-		targetState = content,
-		transitionSpec = {
-			fadeIn(tween(durationMillis = 1_000)) togetherWith fadeOut(snap(delayMillis = 1_000))
-		},
-		label = "DreamContentTransition"
-	) { content ->
-		when (content) {
-			DreamContent.Logo -> DreamContentLogo()
-			is DreamContent.LibraryShowcase -> DreamContentLibraryShowcase(content)
-			is DreamContent.NowPlaying -> DreamContentNowPlaying(content)
+	showLogoSetting: Boolean,
+	showBlank: Boolean,
+) = if (showBlank) {
+	Box(modifier = Modifier.fillMaxSize()) {}
+} else {
+	Box(
+		modifier = Modifier
+			.fillMaxSize()
+	) {
+		AnimatedContent(
+			targetState = content,
+			transitionSpec = {
+				fadeIn(tween(durationMillis = 1_000)) togetherWith fadeOut(snap(delayMillis = 1_000))
+			},
+			label = "DreamContentTransition"
+		) { content ->
+			when (content) {
+				DreamContent.Logo -> DreamContentLogo()
+				is DreamContent.LibraryShowcase -> DreamContentLibraryShowcase(content)
+				is DreamContent.NowPlaying -> DreamContentNowPlaying(content)
+			}
 		}
-	}
 
-	// Header overlay
-	DreamHeader(
-		showLogo = content != DreamContent.Logo,
-		showClock = showClock,
-	)
+		// Header overlay
+		DreamHeader(
+			showLogo = content != DreamContent.Logo && showLogoSetting,
+			showClock = showClock,
+		)
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -9,6 +9,7 @@ import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.RatingType
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
+import org.jellyfin.androidtv.preference.constant.ScreenSaverType
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.preference.constant.ZoomMode
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
@@ -189,6 +190,17 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Show screensaver in app
 		 */
 		var screensaverInAppEnabled = booleanPreference("screensaver_inapp_enabled", true)
+
+		/**
+		 * Screensaver Type in app
+		 */
+		var screensaverType = enumPreference("screensaver_inapp_type", ScreenSaverType.NORMAL)
+
+		/**
+		 * Show Logo in screensaver
+		 */
+		var screensaverShowLogo = booleanPreference("screensaver_inapp_showlogo", true)
+
 
 		/**
 		 * Timeout before showing the screensaver in app, depends on [screensaverInAppEnabled].

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/ScreenSaverType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/ScreenSaverType.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.androidtv.preference.constant
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.preference.PreferenceEnum
+
+enum class ScreenSaverType(
+	override val nameRes: Int,
+) : PreferenceEnum {
+	/**
+	 * Sets the screensaver to normal slideshow behavior
+	 */
+	NORMAL(R.string.lbl_fit),
+
+	/**
+	 * Sets the screensaver to black screen
+	 */
+	EMPTY_SCREEN(R.string.lbl_empty_screen),
+}
+

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -5,6 +5,7 @@ import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AppTheme
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.RatingType
+import org.jellyfin.androidtv.preference.constant.ScreenSaverType
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
@@ -120,6 +121,24 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 				}
 
 				depends { userPreferences[UserPreferences.screensaverInAppEnabled] }
+			}
+
+			enum<ScreenSaverType> {
+				setTitle(R.string.pref_screensaver_inapp_type)
+				bind(userPreferences, UserPreferences.screensaverType)
+				depends { userPreferences[UserPreferences.screensaverInAppEnabled] }
+			}
+			checkbox {
+				setTitle(R.string.pref_screensaver_showlogo)
+				setContent(
+					R.string.pref_screensaver_showlogo_enabled,
+					R.string.pref_screensaver_showlogo_disabled,
+				)
+				depends {
+                    userPreferences[UserPreferences.screensaverType] == ScreenSaverType.NORMAL
+                }
+
+				bind(userPreferences, UserPreferences.screensaverShowLogo)
 			}
 
 			checkbox {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="msg_cannot_play">This item cannot be played</string>
     <string name="lbl_no_items">No items</string>
     <string name="lbl_empty">Empty</string>
+    <string name="lbl_empty_screen">Empty Screen</string>
     <string name="lbl_tv_queuing">Play next episode automatically</string>
     <string name="lbl_search_hint">Search text (select for keyboard)</string>
     <string name="lbl_play_first_unwatched">Play first unwatched</string>
@@ -476,6 +477,7 @@
     <string name="pref_screensaver_inapp_enabled">Use in-app screensaver</string>
     <string name="pref_screensaver_inapp_enabled_description">Show the Jellyfin screensaver while the app is open</string>
     <string name="pref_screensaver_inapp_timeout">Start screensaver after</string>
+    <string name="pref_screensaver_inapp_type">Screensaver type</string>
     <string name="enable_reactive_homepage">Enable reactive homepage</string>
     <string name="not_set">Not set</string>
     <string name="lbl_album_artists">Album artists</string>
@@ -497,6 +499,9 @@
     <string name="random">Random</string>
     <string name="unreleased">Not yet released</string>
     <string name="pref_playback_advanced">Advanced playback preferences</string>
+    <string name="pref_screensaver_showlogo">Show Logo in Screensaver</string>
+    <string name="pref_screensaver_showlogo_enabled">Show Logo in Screensaver</string>
+    <string name="pref_screensaver_showlogo_disabled">Do not show Logo in Screensaver</string>
     <string name="pref_screensaver_ageratingmax">Maximum age rating</string>
     <string name="pref_screensaver_ageratingmax_zero">All ages</string>
     <string name="pref_screensaver_ageratingmax_entry">Up to age %1$d</string>


### PR DESCRIPTION
Add support for empty and logo screensaver modes to reduce (OLED) screen burn-in

- Introduces `ScreenSaverType` enum with `NORMAL` (slideshow) and `EMPTY_SCREEN` (black screen) options.
- Adds `screensaverType` user preference to control the screensaver type.
- Adds `screensaverShowLogo` user preference to show or not the logo on the screensaver.
- Implements the empty screen logic in `DreamView`.
- Update DreamHost logic for the new settings.
- Add the new settings on the Customization screen.

**Issues**
Fixes #3256 #3269 #1888

@nielsvanvelzen For some reasons the default screensaver from the Chromecast with Android doesn't work, hence these screensaver changes. Met vriendelijke groet!
