### PR TITLE
Handle multiple srt cues at the same timestamp

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomSubtitleHelper.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomSubtitleHelper.java
@@ -1,0 +1,149 @@
+package org.jellyfin.androidtv.ui.playback;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.media3.common.text.Cue;
+import androidx.media3.common.text.CueGroup;
+import androidx.media3.ui.CaptionStyleCompat;
+
+import org.jellyfin.androidtv.preference.UserPreferences;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import timber.log.Timber;
+
+/**
+ * Helper class to manage custom subtitle rendering with proper stacking of multiple cues.
+ */
+public class CustomSubtitleHelper {
+    private final Context context;
+    private final LinearLayout subtitleContainer;
+    private final List<TextView> subtitleViews = new ArrayList<>();
+    private CaptionStyleCompat captionStyle;
+    private float textSize = 18f;
+
+    public CustomSubtitleHelper(@NonNull Context context, @NonNull LinearLayout subtitleContainer, @NonNull UserPreferences userPreferences) {
+        this.context = context;
+        this.subtitleContainer = subtitleContainer;
+
+        // Configure the subtitle style based on user preferences
+        int strokeColor = userPreferences.get(UserPreferences.Companion.getSubtitleTextStrokeColor()).intValue();
+        captionStyle = new CaptionStyleCompat(
+                userPreferences.get(UserPreferences.Companion.getSubtitlesTextColor()).intValue(),
+                userPreferences.get(UserPreferences.Companion.getSubtitlesBackgroundColor()).intValue(),
+                Color.TRANSPARENT,
+                Color.alpha(strokeColor) == 0 ? CaptionStyleCompat.EDGE_TYPE_NONE : CaptionStyleCompat.EDGE_TYPE_OUTLINE,
+                strokeColor,
+                null
+        );
+
+        // Set text size based on user preferences, with a multiplier to make it larger
+        float userSizePreference = userPreferences.get(UserPreferences.Companion.getSubtitlesTextSize());
+        textSize = 0.0533f * userSizePreference * 500;
+
+        Timber.d("Setting subtitle text size to %f (user preference: %f)", textSize, userSizePreference);
+    }
+
+    /**
+     * Process and display subtitle cues.
+     * @param cueGroup The cue group containing subtitle cues
+     */
+    public void onCues(CueGroup cueGroup) {
+        List<Cue> cues = cueGroup != null ? cueGroup.cues : null;
+
+        if (cues == null || cues.isEmpty()) {
+            subtitleContainer.setVisibility(ViewGroup.GONE);
+            return;
+        }
+
+        // Make sure the container is visible
+        subtitleContainer.setVisibility(ViewGroup.VISIBLE);
+
+        // Clear previous subtitles
+        subtitleContainer.removeAllViews();
+
+        Timber.d("Displaying %d subtitle cues", cues.size());
+
+        // Ensure we have enough TextView instances
+        while (subtitleViews.size() < cues.size()) {
+            TextView textView = new TextView(context);
+            textView.setLayoutParams(new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT));
+            subtitleViews.add(textView);
+        }
+
+        // Add and configure each cue
+        for (int i = 0; i < cues.size(); i++) {
+            Cue cue = cues.get(i);
+            TextView cueView = subtitleViews.get(i);
+
+            // Set the text from the cue
+            if (cue.text != null) {
+                cueView.setText(cue.text);
+
+                // Apply styling
+                applyTextStyle(cueView);
+
+                // Add to the container
+                subtitleContainer.addView(cueView);
+            }
+        }
+    }
+
+    /**
+     * Apply text styling to a subtitle TextView.
+     * @param textView The TextView to style
+     */
+    private void applyTextStyle(TextView textView) {
+        // Use a different unit for better TV display
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize);
+        textView.setTextColor(captionStyle.foregroundColor);
+
+        // Make text bold for better visibility on TV
+        textView.setTypeface(textView.getTypeface(), android.graphics.Typeface.BOLD);
+
+        // Apply edge type (outline, drop shadow, etc.)
+        switch (captionStyle.edgeType) {
+            case CaptionStyleCompat.EDGE_TYPE_OUTLINE:
+                // Increase outline thickness for better visibility
+                textView.setShadowLayer(4, 0, 0, captionStyle.edgeColor);
+                break;
+            case CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW:
+                // Increase shadow size for better visibility
+                textView.setShadowLayer(4, 2, 2, captionStyle.edgeColor);
+                break;
+            case CaptionStyleCompat.EDGE_TYPE_NONE:
+            default:
+                textView.setShadowLayer(0, 0, 0, 0);
+                break;
+        }
+
+        // Center the text
+        textView.setTextAlignment(TextView.TEXT_ALIGNMENT_CENTER);
+        textView.setGravity(Gravity.CENTER);
+
+        // Set the background color
+        textView.setBackgroundColor(captionStyle.backgroundColor);
+
+        // Add some padding
+        int padding = (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                4,
+                context.getResources().getDisplayMetrics());
+        textView.setPadding(padding, padding, padding, padding);
+
+        // Add some margin between subtitle lines
+        LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) textView.getLayoutParams();
+        params.setMargins(0, 0, 0, padding / 2);
+        textView.setLayoutParams(params);
+    }
+}

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -30,6 +30,19 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:use_controller="false" />
+            
+        <!-- Custom subtitle container for stacked subtitles -->
+        <LinearLayout
+            android:id="@+id/custom_subtitle_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="50dp"
+            android:layout_marginLeft="50dp"
+            android:layout_marginRight="50dp"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:visibility="gone" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/leanback_fragment"


### PR DESCRIPTION
Currently, there is a problem in the android-tv client where if multiple cues in an .srt subtitle file occur at the same timestamp, the android-tv client stacks them on top of each other, rendering them completely illegible.

See example, the line is "Maybe the people on this world are cave dwellers.":

<img width="966" alt="Screenshot 2025-03-14 at 2 52 21 AM" src="https://github.com/user-attachments/assets/179976b0-4955-4353-8fc4-60743244fc03" />

You can see in the screenshot that the text is jumbled. It appears to read "Maybeare cave dwellerss world.".

In the jellyfin-web client, this is handled well enough by stacking the cues on top of each other. You can see that cue is broken into two lines "Maybe the people on this world" and "are cave dwellers."

<img width="1589" alt="Screenshot 2025-03-14 at 2 46 52 AM" src="https://github.com/user-attachments/assets/e08c2166-ed04-4a18-9660-997a50663e3c" />

The jellyfin-web client has these out of order, so it reads "are cave dwellers. Maybe the people on this world". It's not exactly right, but at least the text is legible.

This PR implements a custom subtitle handler that maintains the existing behavior except in the case where multiple srt cues exist at the same timestamp.

<img width="1044" alt="Screenshot 2025-03-14 at 11 03 20 PM" src="https://github.com/user-attachments/assets/cc6e3b0e-59c6-4744-a297-ec8e73b33684" />

The result is a fully correct and legible subtitle render that reads  "Maybe the people on this world are cave dwellers."

