### PR TITLE
Replace androidx.tv with own theme implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,7 +123,6 @@ dependencies {
 	implementation(libs.androidx.cardview)
 	implementation(libs.androidx.startup)
 	implementation(libs.bundles.androidx.compose)
-	implementation(libs.androidx.tv.material)
 
 	// Dependency Injection
 	implementation(libs.bundles.koin)

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.tv.material3.Text
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.ZoomBox
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.tv.material3.Text
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.blurHashPainter

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.composable.rememberCurrentTime
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Icon.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Icon.kt
@@ -1,0 +1,82 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toolingGraphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Icon(
+	imageVector: ImageVector,
+	contentDescription: String?,
+	modifier: Modifier = Modifier,
+	tint: Color = LocalTextStyle.current.color,
+) = Icon(
+	painter = rememberVectorPainter(imageVector),
+	contentDescription = contentDescription,
+	modifier = modifier,
+	tint = tint,
+)
+
+@Composable
+fun Icon(
+	bitmap: ImageBitmap,
+	contentDescription: String?,
+	modifier: Modifier = Modifier,
+	tint: Color = LocalTextStyle.current.color,
+) = Icon(
+	painter = remember(bitmap) { BitmapPainter(bitmap) },
+	contentDescription = contentDescription,
+	modifier = modifier,
+	tint = tint,
+)
+
+@Composable
+fun Icon(
+	painter: Painter,
+	contentDescription: String?,
+	modifier: Modifier = Modifier,
+	tint: Color = LocalTextStyle.current.color,
+) {
+	val colorFilter = remember(tint) { tint.takeUnless { it == Color.Unspecified }?.let(ColorFilter::tint) }
+	val semantics = if (contentDescription != null) Modifier.semantics {
+		this.contentDescription = contentDescription
+		this.role = Role.Image
+	} else Modifier
+
+	Box(
+		modifier
+			.toolingGraphicsLayer()
+			.defaultSizeFor(painter)
+			.paint(painter, colorFilter = colorFilter, contentScale = ContentScale.Fit)
+			.then(semantics)
+	)
+}
+
+private fun Modifier.defaultSizeFor(painter: Painter) = then(
+	if (painter.intrinsicSize == Size.Unspecified || painter.intrinsicSize.isInfinite()) {
+		Modifier.size(20.dp)
+	} else {
+		Modifier
+	}
+)
+
+private fun Size.isInfinite() = width.isInfinite() && height.isInfinite()
+

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/JellyfinTheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/JellyfinTheme.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+
+object JellyfinTheme {
+	val typography: Typography
+		@Composable @ReadOnlyComposable get() = LocalTypography.current
+
+	val shapes: Shapes
+		@Composable @ReadOnlyComposable get() = LocalShapes.current
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Text.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Text.kt
@@ -1,0 +1,122 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+
+@Composable
+fun Text(
+	text: String,
+	modifier: Modifier = Modifier,
+	color: Color = Color.Unspecified,
+	fontSize: TextUnit = TextUnit.Unspecified,
+	fontStyle: FontStyle? = null,
+	fontWeight: FontWeight? = null,
+	fontFamily: FontFamily? = null,
+	letterSpacing: TextUnit = TextUnit.Unspecified,
+	textDecoration: TextDecoration? = null,
+	textAlign: TextAlign? = null,
+	lineHeight: TextUnit = TextUnit.Unspecified,
+	overflow: TextOverflow = TextOverflow.Clip,
+	softWrap: Boolean = true,
+	maxLines: Int = Int.MAX_VALUE,
+	minLines: Int = 1,
+	onTextLayout: (TextLayoutResult) -> Unit = {},
+	style: TextStyle = LocalTextStyle.current
+) {
+	val textColor = color.takeOrElse { style.color.takeOrElse { Color.Black } }
+
+	BasicText(
+		text = text,
+		modifier = modifier.graphicsLayer { this.compositingStrategy = CompositingStrategy.Offscreen },
+		style = style.merge(
+			color = textColor,
+			fontSize = fontSize,
+			fontWeight = fontWeight,
+			textAlign = textAlign ?: TextAlign.Unspecified,
+			lineHeight = lineHeight,
+			fontFamily = fontFamily,
+			textDecoration = textDecoration,
+			fontStyle = fontStyle,
+			letterSpacing = letterSpacing
+		),
+		onTextLayout = onTextLayout,
+		overflow = overflow,
+		softWrap = softWrap,
+		maxLines = maxLines,
+		minLines = minLines
+	)
+}
+
+@Composable
+fun Text(
+	text: AnnotatedString,
+	modifier: Modifier = Modifier,
+	color: Color = Color.Unspecified,
+	fontSize: TextUnit = TextUnit.Unspecified,
+	fontStyle: FontStyle? = null,
+	fontWeight: FontWeight? = null,
+	fontFamily: FontFamily? = null,
+	letterSpacing: TextUnit = TextUnit.Unspecified,
+	textDecoration: TextDecoration? = null,
+	textAlign: TextAlign? = null,
+	lineHeight: TextUnit = TextUnit.Unspecified,
+	overflow: TextOverflow = TextOverflow.Clip,
+	softWrap: Boolean = true,
+	maxLines: Int = Int.MAX_VALUE,
+	minLines: Int = 1,
+	inlineContent: Map<String, InlineTextContent> = mapOf(),
+	onTextLayout: (TextLayoutResult) -> Unit = {},
+	style: TextStyle = LocalTextStyle.current
+) {
+	val textColor = color.takeOrElse { style.color.takeOrElse { Color.Black } }
+
+	BasicText(
+		text = text,
+		modifier = modifier.graphicsLayer { this.compositingStrategy = CompositingStrategy.Offscreen },
+		style =
+			style.merge(
+				color = textColor,
+				fontSize = fontSize,
+				fontWeight = fontWeight,
+				textAlign = textAlign ?: TextAlign.Unspecified,
+				lineHeight = lineHeight,
+				fontFamily = fontFamily,
+				textDecoration = textDecoration,
+				fontStyle = fontStyle,
+				letterSpacing = letterSpacing
+			),
+		onTextLayout = onTextLayout,
+		overflow = overflow,
+		softWrap = softWrap,
+		maxLines = maxLines,
+		minLines = minLines,
+		inlineContent = inlineContent
+	)
+}
+
+val LocalTextStyle = compositionLocalOf(structuralEqualityPolicy()) { TypographyDefaults.Default }
+
+@Composable
+fun ProvideTextStyle(value: TextStyle, content: @Composable () -> Unit) {
+	val mergedStyle = LocalTextStyle.current.merge(value)
+	CompositionLocalProvider(LocalTextStyle provides mergedStyle, content = content)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ButtonBase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ButtonBase.kt
@@ -1,0 +1,94 @@
+package org.jellyfin.androidtv.ui.base.button
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ButtonBase(
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+	onLongClick: (() -> Unit)? = null,
+	enabled: Boolean = true,
+	shape: Shape = CircleShape,
+	contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
+	interactionSource: MutableInteractionSource? = null,
+	content: @Composable RowScope.() -> Unit
+) {
+	@Suppress("NAME_SHADOWING")
+	val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+	val focused by interactionSource.collectIsFocusedAsState()
+	val pressed by interactionSource.collectIsPressedAsState()
+
+	val containerColor = colorResource(R.color.button_default_normal_background)
+	val contentColor = colorResource(R.color.button_default_normal_text)
+	val focusedContainerColor = colorResource(R.color.button_default_highlight_background)
+	val focusedContentColor = colorResource(R.color.button_default_highlight_text)
+	val disabledContainerColor = colorResource(R.color.button_default_disabled_background)
+	val disabledContentColor = colorResource(R.color.button_default_disabled_text)
+
+	val colors = when {
+		!enabled -> disabledContainerColor to disabledContentColor
+		pressed -> focusedContainerColor to focusedContentColor
+		focused -> focusedContainerColor to focusedContentColor
+		else -> containerColor to contentColor
+	}
+
+	Box(
+		modifier = modifier
+			.combinedClickable(
+				interactionSource = interactionSource,
+				indication = LocalIndication.current,
+				enabled = enabled,
+				role = Role.Button,
+				onClick = onClick,
+				onLongClick = onLongClick,
+			)
+			.background(colors.first, shape)
+			.graphicsLayer {
+				this.shape = shape
+				this.clip = true
+			}
+	) {
+		ProvideTextStyle(value = JellyfinTheme.typography.default.copy(fontSize = 14.sp, color = colors.second)) {
+			Row(
+				modifier = Modifier
+					.defaultMinSize(
+						minWidth = 58.dp,
+						minHeight = 40.dp
+					)
+					.padding(contentPadding),
+				horizontalArrangement = Arrangement.Center,
+				verticalAlignment = Alignment.CenterVertically,
+				content = content
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/shapes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/shapes.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.dp
+
+object ShapeDefaults {
+	val ExtraSmall: CornerBasedShape = RoundedCornerShape(4.0.dp)
+	val Small: CornerBasedShape = RoundedCornerShape(8.0.dp)
+	val Medium: CornerBasedShape = RoundedCornerShape(12.0.dp)
+	val Large: CornerBasedShape = RoundedCornerShape(16.0.dp)
+	val ExtraLarge: CornerBasedShape = RoundedCornerShape(28.0.dp)
+}
+
+@Immutable
+data class Shapes(
+	val extraSmall: CornerBasedShape = ShapeDefaults.ExtraSmall,
+	val small: CornerBasedShape = ShapeDefaults.Small,
+	val medium: CornerBasedShape = ShapeDefaults.Medium,
+	val large: CornerBasedShape = ShapeDefaults.Large,
+	val extraLarge: CornerBasedShape = ShapeDefaults.ExtraLarge,
+)
+
+val LocalShapes = staticCompositionLocalOf { Shapes() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/typography.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/typography.kt
@@ -1,0 +1,16 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+
+object TypographyDefaults {
+	val Default: TextStyle = TextStyle.Default
+}
+
+@Immutable
+data class Typography(
+	val default: TextStyle = TypographyDefaults.Default,
+)
+
+val LocalTypography = staticCompositionLocalOf { Typography() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -14,11 +14,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.Text
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.RatingType
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.getResolutionName
 import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.androidtv.util.sdk.getProgramSubText

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.tv.material3.ProvideTextStyle
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 
 /**
  * A single item in the [BaseItemInfoRow].

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
@@ -3,8 +3,8 @@ package org.jellyfin.androidtv.ui.browsing.composable.inforow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Text
 import java.text.NumberFormat
 
 /**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.LocalTextStyle
-import androidx.tv.material3.Text
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.sdk.model.api.LyricDto
 import org.jellyfin.sdk.model.extensions.ticks
 import kotlin.time.Duration

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.tv.material3.Text
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
@@ -20,9 +20,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.leanback.widget.Presenter
-import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.GridButton
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.itemhandling.GridButtonBaseRowItem
 
 class GridButtonPresenter @JvmOverloads constructor(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,16 +26,15 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
-import androidx.tv.material3.Button
-import androidx.tv.material3.ButtonDefaults
-import androidx.tv.material3.Icon
-import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Surface
-import androidx.tv.material3.SurfaceDefaults
-import androidx.tv.material3.Text
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.button.ButtonBase
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 
 @Composable
@@ -42,68 +43,59 @@ private fun ConnectHelpAlert(
 ) {
 	val focusRequester = remember { FocusRequester() }
 
-	Surface(
-		colors = SurfaceDefaults.colors(
-			containerColor = colorResource(R.color.not_quite_black),
-			contentColor = colorResource(R.color.white),
-		)
+	Box(
+		modifier = Modifier.background(colorResource(R.color.not_quite_black))
 	) {
-		Row(
-			modifier = Modifier
-				.fillMaxWidth()
-				.fillMaxHeight()
-				.overscan(),
-			horizontalArrangement = Arrangement.SpaceEvenly,
-		) {
-			Column(
+		ProvideTextStyle(LocalTextStyle.current.copy(color = colorResource(R.color.white))) {
+			Row(
 				modifier = Modifier
-					.width(400.dp)
-					.align(Alignment.CenterVertically),
+					.fillMaxWidth()
+					.fillMaxHeight()
+					.overscan(),
+				horizontalArrangement = Arrangement.SpaceEvenly,
 			) {
-				Text(
-					text = stringResource(R.string.login_help_title),
-					style = MaterialTheme.typography.displayMedium,
-				)
-				Text(
-					modifier = Modifier.padding(top = 16.dp),
-					text = stringResource(R.string.login_help_description),
-					style = MaterialTheme.typography.bodyLarge,
-				)
-				Button(
+				Column(
 					modifier = Modifier
-						.padding(top = 24.dp)
-						.align(Alignment.Start)
-						.focusRequester(focusRequester),
-					onClick = onClose,
-					colors = ButtonDefaults.colors(
-						containerColor = colorResource(R.color.button_default_normal_background),
-						contentColor = colorResource(R.color.button_default_normal_text),
-						focusedContainerColor = colorResource(R.color.button_default_highlight_background),
-						focusedContentColor = colorResource(R.color.button_default_highlight_text),
-						disabledContainerColor = colorResource(R.color.button_default_disabled_background),
-						disabledContentColor = colorResource(R.color.button_default_disabled_text),
-					),
+						.width(400.dp)
+						.align(Alignment.CenterVertically),
 				) {
-					Icon(
-						painter = painterResource(R.drawable.ic_check),
-						contentDescription = null,
-						modifier = Modifier.size(ButtonDefaults.IconSize),
-					)
-					Spacer(Modifier.size(ButtonDefaults.IconSpacing))
 					Text(
-						text = stringResource(id = R.string.btn_got_it),
-						style = MaterialTheme.typography.bodyLarge,
+						text = stringResource(R.string.login_help_title),
+						style = LocalTextStyle.current.copy(fontSize = 45.sp),
 					)
+					Text(
+						modifier = Modifier.padding(top = 16.dp),
+						text = stringResource(R.string.login_help_description),
+						style = LocalTextStyle.current.copy(fontSize = 16.sp),
+					)
+					ButtonBase(
+						modifier = Modifier
+							.padding(top = 24.dp)
+							.align(Alignment.Start)
+							.focusRequester(focusRequester),
+						onClick = onClose,
+					) {
+						Icon(
+							painter = painterResource(R.drawable.ic_check),
+							contentDescription = null,
+							modifier = Modifier.size(20.dp),
+						)
+						Spacer(Modifier.size(8.dp))
+						Text(
+							text = stringResource(id = R.string.btn_got_it),
+							style = LocalTextStyle.current.copy(fontSize = 16.sp),
+						)
+					}
 				}
-			}
 
-			Image(
-				painter = painterResource(R.drawable.qr_jellyfin_docs),
-				contentDescription = stringResource(R.string.app_name),
-				modifier = Modifier
-					.width(200.dp)
-					.align(Alignment.CenterVertically),
-			)
+				Image(
+					painter = painterResource(R.drawable.qr_jellyfin_docs),
+					contentDescription = stringResource(R.string.app_name),
+					modifier = Modifier
+						.width(200.dp)
+						.align(Alignment.CenterVertically),
+				)
+			}
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SelectServerFragment.kt
@@ -27,8 +27,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
-import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Text
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -43,6 +41,8 @@ import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.databinding.FragmentSelectServerBinding
 import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.SpacingItemDecoration
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.util.ListAdapter
 import org.jellyfin.androidtv.util.MenuBuilder
@@ -173,13 +173,13 @@ class SelectServerFragment : Fragment() {
 					Box(
 						modifier = Modifier
 							.fillMaxWidth()
-							.clip(MaterialTheme.shapes.medium)
+							.clip(JellyfinTheme.shapes.medium)
 							.background(colorResource(id = R.color.lb_basic_card_info_bg_color)),
 					) {
 						Text(
 							text = notification.message,
 							modifier = Modifier.padding(10.dp),
-							color = colorResource(id = R.color.white)
+							color = colorResource(id = R.color.white),
 						)
 					}
 				}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ androidx-media3 = "1.5.1"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.4.0"
 androidx-startup = "1.2.0"
-androidx-tv = "1.0.0"
 androidx-tvprovider = "1.1.0-alpha01"
 androidx-window = "1.3.0"
 androidx-work = "2.10.0"
@@ -78,7 +77,6 @@ androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "andr
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
-androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "androidx-tv" }
 androidx-tvprovider = { module = "androidx.tvprovider:tvprovider", version.ref = "androidx-tvprovider" }
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
@@ -131,7 +129,6 @@ acra = [
 androidx-compose = [
     "androidx-compose-foundation",
     "androidx-compose-ui-tooling",
-    "androidx-tv-material"
 ]
 androidx-lifecycle = [
     "androidx-lifecycle-process",


### PR DESCRIPTION
Jetpack Compose (library used for new UI) is build in layers. The top layer is the "theme" package, of which we currently use `androidx.tv`. Unfortunately this library is lacking and IMO not suited for a lot of our uses (like not supporting touch), in addition to already being somewhat unmaintained by Google similar to how they did with the `androidx.leanback` library.

This PR marks the start of our own "Jellyfin" theme. Eventually it will adhere to our design guidelines made by @erikbucik. Right now most of it is close to the previous (material based) theme, as our Figma does not have foundations like typography or shapes ready yet.

The new design composables will eventually be moved to their own Gradle module and be used in both our mobile and TV apps where possible. Some composables will obviously be platform specific due to the different input methods (dpad remote vs touch). 

The API is mostly similar to what the official compose themes do to make it easy to work with for new contributors.

**Changes**

- Add "org.jellyfin.androidtv.ui.base" (will probably be moved later)
  - Add "Text" composable (yes this is a theme thing for some reason)
  - Add "Icon" composable
  - Add `JellyfinTheme" used to access current typograpy/shapes
  - Add Typography tokens (currently only Default which uses platform defaults)
  - Add shape tokens (currently the same values as `androidx.tv`, rounded corner shapes)
- Remove "androidx.tv" dependency
- Add "ButtonBase" composable which is the basis of a button
- Use the new composables
  - ConnectHelpAlert somewhat refactored
  - NowPlayingComposable now uses ButtonBase

Note: ButtonBase will behave a lot better with the next Compose version, which implements better key (dpad) support.

**Screenshots**

Notable differences are found in the ConnectHelpAlert in which letter spacing is now different. Other UI changes are not/barely noticeable.

**Before**
![9950000556](https://github.com/user-attachments/assets/8d6ce042-28a8-4579-8495-b77e2057fea5)

**After**
![9770000553](https://github.com/user-attachments/assets/dc441bf3-f48d-4567-9338-da22fc5fd76d)


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
