### PR TITLE
Fix logo in next up too large

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
@@ -38,6 +38,7 @@ fun AsyncImage(
 		modifier = modifier,
 		factory = { context ->
 			AsyncImageView(context).also { view ->
+				view.adjustViewBounds = true
 				view.scaleType = scaleType ?: ImageView.ScaleType.FIT_CENTER
 			}
 		},

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -100,7 +100,8 @@ fun NextUpScreen(
 			AsyncImage(
 				modifier = Modifier
 					.align(Alignment.TopStart)
-					.overscan(),
+					.overscan()
+					.height(75.dp),
 				url = logo.url,
 				blurHash = logo.blurHash,
 				aspectRatio = logo.aspectRatio,


### PR DESCRIPTION
Fix regression of #4531

**Changes**
- Make sure logo cannot exceed height of 75dp (same value as screensaver)
- Fix AsyncImage not adjusting view bounds to image aspect ratio

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
