### PR TITLE
Respect server-side user preference for live TV default view

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -132,4 +132,7 @@ val appModule = module {
 	single<PlaybackHelper> { SdkPlaybackHelper(get(), get(), get(), get(), get(), get(), get()) }
 
 	factory { (context: Context) -> SearchFragmentDelegate(context, get(), get()) }
+
+	// Add coroutine scope for async operations
+	single { kotlinx.coroutines.MainScope() }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/KoinInitializer.kt
@@ -18,9 +18,9 @@ class KoinInitializer : Initializer<KoinApplication> {
 			playbackModule,
 			preferenceModule,
 			utilsModule,
+			liveTvModule,
 		)
 	}
 
 	override fun dependencies() = listOf(LogInitializer::class.java)
 }
-

--- a/app/src/main/java/org/jellyfin/androidtv/di/LiveTvModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/LiveTvModule.kt
@@ -1,0 +1,16 @@
+package org.jellyfin.androidtv.di
+
+import org.jellyfin.androidtv.ui.home.HomeFragmentLiveTVRowWithUserPreferenceCheck
+import org.koin.dsl.module
+
+val liveTvModule = module {
+    factory { (activity: android.app.Activity) ->
+        HomeFragmentLiveTVRowWithUserPreferenceCheck(
+            activity = activity,
+            userRepository = get(),
+            navigationRepository = get(),
+            api = get(),
+            coroutineScope = get()
+        )
+    }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -6,6 +6,9 @@ import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.constant.ChangeTriggerType
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.koin.core.parameter.parametersOf
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaType
@@ -17,7 +20,7 @@ import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
 class HomeFragmentHelper(
 	private val context: Context,
 	private val userRepository: UserRepository,
-) {
+) : KoinComponent {
 	fun loadRecentlyAdded(userViews: Collection<BaseItemDto>): HomeFragmentRow {
 		return HomeFragmentLatestRow(userRepository, userViews)
 	}
@@ -74,6 +77,10 @@ class HomeFragmentHelper(
 		)
 
 		return HomeFragmentBrowseRowDefRow(BrowseRowDef(context.getString(R.string.lbl_on_now), query))
+	}
+
+	fun loadLiveTv(): HomeFragmentRow {
+		return get<HomeFragmentLiveTVRowWithUserPreferenceCheck> { parametersOf(context as android.app.Activity) }
 	}
 
 	companion object {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRowWithUserPreferenceCheck.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLiveTVRowWithUserPreferenceCheck.kt
@@ -1,0 +1,133 @@
+package org.jellyfin.androidtv.ui.home
+
+import android.app.Activity
+import android.content.Context
+import androidx.leanback.widget.ArrayObjectAdapter
+import androidx.leanback.widget.HeaderItem
+import androidx.leanback.widget.ListRow
+import androidx.leanback.widget.OnItemViewClickedListener
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.Row
+import androidx.leanback.widget.RowPresenter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.repository.UserRepository
+import org.jellyfin.androidtv.constant.LiveTvOption
+import org.jellyfin.androidtv.ui.GridButton
+import org.jellyfin.androidtv.ui.navigation.Destinations
+import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.androidtv.ui.presentation.CardPresenter
+import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter
+import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
+import org.jellyfin.androidtv.util.LiveTvDefaultViewHelper
+import org.jellyfin.androidtv.util.Utils
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.userViewsApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.CollectionType
+import timber.log.Timber
+
+/**
+ * Enhanced version of HomeFragmentLiveTVRow that respects the user's default Live TV view preference
+ */
+class HomeFragmentLiveTVRowWithUserPreferenceCheck(
+    private val activity: Activity,
+    private val userRepository: UserRepository,
+    private val navigationRepository: NavigationRepository,
+    private val api: ApiClient,
+    private val coroutineScope: CoroutineScope
+) : HomeFragmentRow, OnItemViewClickedListener {
+    override fun addToRowsAdapter(context: Context, cardPresenter: CardPresenter, rowsAdapter: MutableObjectAdapter<Row>) {
+        val header = HeaderItem(rowsAdapter.size().toLong(), activity.getString(R.string.pref_live_tv_cat))
+        val adapter = ArrayObjectAdapter(GridButtonPresenter())
+
+        // Live TV Guide button
+        adapter.add(GridButton(LiveTvOption.LIVE_TV_GUIDE_OPTION_ID, activity.getString(R.string.lbl_live_tv_guide)))
+        // Live TV Recordings button
+        adapter.add(GridButton(LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID, activity.getString(R.string.lbl_recorded_tv)))
+        if (Utils.canManageRecordings(userRepository.currentUser.value)) {
+            // Recording Schedule button
+            adapter.add(GridButton(LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID, activity.getString(R.string.lbl_schedule)))
+            // Recording Series button
+            adapter.add(GridButton(LiveTvOption.LIVE_TV_SERIES_OPTION_ID, activity.getString(R.string.lbl_series)))
+        }
+
+        rowsAdapter.add(ListRow(header, adapter))
+    }
+
+    override fun onItemClicked(itemViewHolder: Presenter.ViewHolder?, item: Any?, rowViewHolder: RowPresenter.ViewHolder?, row: Row?) {
+        if (item !is GridButton) return
+
+        when (item.id) {
+            LiveTvOption.LIVE_TV_GUIDE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvGuide)
+            LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSchedule)
+            LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvRecordings)
+            LiveTvOption.LIVE_TV_SERIES_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSeriesRecordings)
+        }
+    }
+
+    /**
+     * Handle click on the Live TV card from the home screen
+     * Checks user preferences and navigates directly to the preferred view if set
+     */
+    fun onLiveTvCardClicked() {
+        coroutineScope.launch {
+            try {
+                // First, get the Live TV library item
+                val liveTvItem = getLiveTvLibraryItem()
+
+                // Then check for default view preference
+                val defaultViewId = withContext(Dispatchers.IO) {
+                    LiveTvDefaultViewHelper.getDefaultLiveTvView(api)
+                }
+
+                withContext(Dispatchers.Main) {
+                    if (defaultViewId != null) {
+                        // Navigate directly to the preferred view
+                        when (defaultViewId) {
+                            LiveTvOption.LIVE_TV_GUIDE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvGuide)
+                            LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSchedule)
+                            LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvRecordings)
+                            LiveTvOption.LIVE_TV_SERIES_OPTION_ID -> navigationRepository.navigate(Destinations.liveTvSeriesRecordings)
+                            else -> {
+                                // Fallback to the standard Live TV selection screen
+                                if (liveTvItem != null) {
+                                    navigationRepository.navigate(Destinations.librarySmartScreen(liveTvItem))
+                                } else {
+                                    // If we couldn't get the Live TV item, navigate to the guide as a fallback
+                                    navigationRepository.navigate(Destinations.liveTvGuide)
+                                }
+                            }
+                        }
+                    } else {
+                        // No preference set, show the standard Live TV selection screen
+                        if (liveTvItem != null) {
+                            navigationRepository.navigate(Destinations.librarySmartScreen(liveTvItem))
+                        } else {
+                            // If we couldn't get the Live TV item, navigate to the guide as a fallback
+                            navigationRepository.navigate(Destinations.liveTvGuide)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // Fallback to the Live TV guide on error
+                navigationRepository.navigate(Destinations.liveTvGuide)
+            }
+        }
+    }
+
+    /**
+     * Gets the Live TV library item from the user's views
+     */
+    private suspend fun getLiveTvLibraryItem(): BaseItemDto? {
+        return try {
+            val userViews = api.userViewsApi.getUserViews().content?.items ?: emptyList()
+            userViews.find { it.collectionType == CollectionType.LIVETV }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -42,9 +42,49 @@ public class ItemLauncher {
     public void launchUserView(@Nullable final BaseItemDto baseItem) {
         Timber.d("**** Collection type: %s", baseItem.getCollectionType());
 
-        Destination destination = getUserViewDestination(baseItem);
+        // Special handling for Live TV to check for default view preference
+        if (baseItem != null && baseItem.getCollectionType() == CollectionType.LIVETV) {
+            launchLiveTvWithUserPreferenceCheck(baseItem);
+            return;
+        }
 
+        Destination destination = getUserViewDestination(baseItem);
         navigationRepository.getValue().navigate(destination);
+    }
+
+    private void launchLiveTvWithUserPreferenceCheck(@Nullable final BaseItemDto baseItem) {
+        try {
+            org.jellyfin.sdk.api.client.ApiClient api = org.koin.java.KoinJavaComponent.get(org.jellyfin.sdk.api.client.ApiClient.class);
+            Integer defaultViewId = org.jellyfin.androidtv.util.LiveTvDefaultViewHelper.getDefaultLiveTvViewBlocking(api);
+
+            if (defaultViewId != null) {
+                // Navigate directly to the preferred view
+                switch (defaultViewId) {
+                    case LiveTvOption.LIVE_TV_GUIDE_OPTION_ID:
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvGuide());
+                        break;
+                    case LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID:
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvSchedule());
+                        break;
+                    case LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID:
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvRecordings());
+                        break;
+                    case LiveTvOption.LIVE_TV_SERIES_OPTION_ID:
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvSeriesRecordings());
+                        break;
+                    default:
+                        // Fallback to the standard Live TV selection screen
+                        navigationRepository.getValue().navigate(Destinations.INSTANCE.librarySmartScreen(baseItem));
+                        break;
+                }
+            } else {
+                // No preference set, show the standard Live TV selection screen
+                navigationRepository.getValue().navigate(Destinations.INSTANCE.librarySmartScreen(baseItem));
+            }
+        } catch (Exception e) {
+            // Fallback to the standard Live TV selection screen on error
+            navigationRepository.getValue().navigate(Destinations.INSTANCE.librarySmartScreen(baseItem));
+        }
     }
 
     public Destination.Fragment getUserViewDestination(@Nullable final BaseItemDto baseItem) {

--- a/app/src/main/java/org/jellyfin/androidtv/util/LiveTvDefaultViewHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/LiveTvDefaultViewHelper.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.util
+
+import org.jellyfin.androidtv.auth.repository.UserRepository
+import org.jellyfin.androidtv.constant.LiveTvOption
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.displayPreferencesApi
+import org.koin.java.KoinJavaComponent
+import timber.log.Timber
+import java.util.UUID
+
+/**
+ * Helper class to handle Live TV default view preferences
+ */
+object LiveTvDefaultViewHelper {
+    /**
+     * Gets the user's preferred default Live TV screen from server settings
+     *
+     * @param api The API client to use for the request
+     * @return The LiveTvOption ID to navigate to, or null if we should show the default selection screen
+     */
+    suspend fun getDefaultLiveTvView(api: ApiClient): Int? {
+        try {
+            // Get the current user ID from the UserRepository
+            val userRepository = KoinJavaComponent.get<UserRepository>(UserRepository::class.java)
+            val userId = userRepository.currentUser.value?.id
+
+            if (userId == null) {
+                return null
+            }
+
+            var displayPreferences = api.displayPreferencesApi.getDisplayPreferences(
+                displayPreferencesId = "usersettings",
+                userId = userId,
+                client = "emby"
+            ).content
+
+            // Check for the "landing-livetv" preference
+            var defaultView = displayPreferences?.customPrefs?.get("landing-livetv")
+
+            // Map the server preference to our LiveTvOption constants
+            val result = when (defaultView?.lowercase()) {
+                "guide" -> LiveTvOption.LIVE_TV_GUIDE_OPTION_ID
+                "recordings" -> LiveTvOption.LIVE_TV_RECORDINGS_OPTION_ID
+                "schedule" -> LiveTvOption.LIVE_TV_SCHEDULE_OPTION_ID
+                "seriestimers" -> LiveTvOption.LIVE_TV_SERIES_OPTION_ID
+                else -> null
+            }
+
+            return result
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    /**
+     * Java-friendly wrapper for getDefaultLiveTvView
+     * This method blocks the current thread until the result is available
+     */
+    @JvmStatic
+    fun getDefaultLiveTvViewBlocking(api: ApiClient): Int? {
+        return kotlinx.coroutines.runBlocking {
+            getDefaultLiveTvView(api)
+        }
+    }
+}


### PR DESCRIPTION
**Changes**

This PR respects the server-side user preference for the "Default view" for the Live TV category. 

This is configurable on the web client in your `User Preferences -> Home -> Live TV -> Default Screen`. See

<img width="843" alt="Screenshot 2025-03-22 at 4 12 53 PM" src="https://github.com/user-attachments/assets/99f0f4d7-5b09-4982-abe4-1d8383dc7c44" />

For example, my preference is the TV Guide, so it skips directly to the TV Guide view:

https://github.com/user-attachments/assets/05da4bc3-3b0d-4417-af94-3e6a04559581

Worth noting not every view has an equivalent on android tv, so if it's an unsupported selection, it will show the same default screen that appears today.

If we like this idea of having the client respect the server preferences, I can do the same for other categories as well (like movies / shows / music / etc) but it's much cleaner to do one thing at a time.

Let me know what else you'd like me to include to get this over the finish line! Tbh for Live TV, none of the views other than Guide are useful for me at all, so this would save a lot of clicks!

**Issues**

* Resolves https://github.com/jellyfin/jellyfin-androidtv/issues/1113
* Resolves https://features.jellyfin.org/posts/1831/straight-to-live-tv-guide