### PR TITLE
Fix missing coroutines dependency in playback:jellyfin module

### DIFF
--- a/playback/jellyfin/build.gradle.kts
+++ b/playback/jellyfin/build.gradle.kts
@@ -26,6 +26,9 @@ android {
 }
 
 dependencies {
+	// Kotlin
+	implementation(libs.kotlinx.coroutines)
+
 	// Jellyfin
 	implementation(projects.playback.core)
 	implementation(libs.jellyfin.sdk) {


### PR DESCRIPTION
Honestly no idea how compilation was working without this.

**Changes**
- Fix missing coroutines dependency in playback:jellyfin module

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
