### PR TITLE
Fix ItemRowAdapter failures never logged

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -719,6 +719,8 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     }
 
     protected void notifyRetrieveFinished(@Nullable Exception exception) {
+        if (exception != null) Timber.w(exception, "Failed to retrieve items");
+
         setCurrentlyRetrieving(false);
         if (mRetrieveFinishedListener != null) {
             if (exception == null) mRetrieveFinishedListener.onResponse();


### PR DESCRIPTION
The ItemRowAdapter is used in a lot of old UI (home/browsing/search). It didn't log any API errors, making debugging very hard, the exceptions were just swallowed in most cases.

**Changes**
- Fix ItemRowAdapter failures never logged

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
