### PR TITLE
Fix a lot of networking on main thread issues

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/SessionInitializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/SessionInitializer.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.startup.AppInitializer
 import androidx.startup.Initializer
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.di.KoinInitializer
@@ -17,7 +18,7 @@ class SessionInitializer : Initializer<Unit> {
 			.koin
 
 		// Restore system session
-		ProcessLifecycleOwner.get().lifecycleScope.launch {
+		ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.IO) {
 			koin.get<SessionRepository>().restoreSession(destroyOnly = false)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/ItemMutationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/ItemMutationRepository.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.data.repository
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
@@ -19,8 +21,8 @@ class ItemMutationRepositoryImpl(
 ) : ItemMutationRepository {
 	override suspend fun setFavorite(item: UUID, favorite: Boolean): UserItemDataDto {
 		val response by when {
-			favorite -> api.userLibraryApi.markFavoriteItem(itemId = item)
-			else -> api.userLibraryApi.unmarkFavoriteItem(itemId = item)
+			favorite -> withContext(Dispatchers.IO) { api.userLibraryApi.markFavoriteItem(itemId = item) }
+			else -> withContext(Dispatchers.IO) { api.userLibraryApi.unmarkFavoriteItem(itemId = item) }
 		}
 
 		dataRefreshService.lastFavoriteUpdate = Instant.now()
@@ -29,8 +31,8 @@ class ItemMutationRepositoryImpl(
 
 	override suspend fun setPlayed(item: UUID, played: Boolean): UserItemDataDto {
 		val response by when {
-			played -> api.playStateApi.markPlayedItem(itemId = item)
-			else -> api.playStateApi.markUnplayedItem(itemId = item)
+			played -> withContext(Dispatchers.IO) { api.playStateApi.markPlayedItem(itemId = item) }
+			else -> withContext(Dispatchers.IO) { api.playStateApi.markUnplayedItem(itemId = item) }
 		}
 
 		return response

--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -64,7 +64,7 @@ class AsyncImageView @JvmOverloads constructor(
 		aspectRatio: Double = 1.0,
 		blurHashResolution: Int = 32,
 	) = doOnAttach {
-		lifeCycleOwner?.lifecycleScope?.launch {
+		lifeCycleOwner?.lifecycleScope?.launch(Dispatchers.IO) {
 			var placeholderOrBlurHash = placeholder
 
 			// Only show blurhash if an image is going to be loaded from the network

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ItemListViewHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ItemListViewHelper.kt
@@ -2,7 +2,9 @@ package org.jellyfin.androidtv.ui
 
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
@@ -12,10 +14,12 @@ fun ItemListView.refresh() {
 	val api by KoinJavaComponent.inject<ApiClient>(ApiClient::class.java)
 
 	findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-		val response by api.itemsApi.getItems(
-			ids = mItemIds,
-			fields = ItemRepository.itemFields
-		)
+		val response = withContext(Dispatchers.IO) {
+			api.itemsApi.getItems(
+				ids = mItemIds,
+				fields = ItemRepository.itemFields
+			).content
+		}
 
 		response.items?.forEachIndexed { index, item ->
 			val view = mList.getChildAt(index)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopupHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopupHelper.kt
@@ -1,7 +1,9 @@
 package org.jellyfin.androidtv.ui
 
 import androidx.lifecycle.coroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.repository.ItemMutationRepository
 import org.jellyfin.androidtv.util.getActivity
 import org.jellyfin.sdk.api.client.ApiClient
@@ -32,7 +34,9 @@ fun LiveProgramDetailPopup.cancelTimer(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			api.liveTvApi.cancelTimer(timerId)
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.cancelTimer(timerId)
+			}
 		}.onSuccess {
 			callback()
 		}
@@ -47,7 +51,9 @@ fun LiveProgramDetailPopup.cancelSeriesTimer(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			api.liveTvApi.cancelSeriesTimer(seriesTimerId)
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.cancelSeriesTimer(seriesTimerId)
+			}
 		}.onSuccess {
 			callback()
 		}
@@ -88,10 +94,12 @@ fun LiveProgramDetailPopup.recordProgram(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			val seriesTimer by api.liveTvApi.getDefaultTimer(programId.toString())
-			val timer = seriesTimer.asTimerInfoDto()
-			api.liveTvApi.createTimer(timer)
-			api.liveTvApi.getProgram(programId.toString()).content
+			withContext(Dispatchers.IO) {
+				val seriesTimer by api.liveTvApi.getDefaultTimer(programId.toString())
+				val timer = seriesTimer.asTimerInfoDto()
+				api.liveTvApi.createTimer(timer)
+				api.liveTvApi.getProgram(programId.toString()).content
+			}
 		}.onSuccess { program ->
 			callback(program)
 		}
@@ -106,9 +114,11 @@ fun LiveProgramDetailPopup.recordSeries(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			val timer by api.liveTvApi.getDefaultTimer(programId.toString())
-			api.liveTvApi.createSeriesTimer(timer)
-			api.liveTvApi.getProgram(programId.toString()).content
+			withContext(Dispatchers.IO) {
+				val timer by api.liveTvApi.getDefaultTimer(programId.toString())
+				api.liveTvApi.createSeriesTimer(timer)
+				api.liveTvApi.getProgram(programId.toString()).content
+			}
 		}.onSuccess { program ->
 			callback(program)
 		}
@@ -123,7 +133,9 @@ fun LiveProgramDetailPopup.getSeriesTimer(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			api.liveTvApi.getSeriesTimer(seriesTimerId).content
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getSeriesTimer(seriesTimerId).content
+			}
 		}.onSuccess { seriesTimer ->
 			callback(seriesTimer)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopupHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/RecordPopupHelper.kt
@@ -1,7 +1,9 @@
 package org.jellyfin.androidtv.ui
 
 import androidx.lifecycle.coroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.util.getActivity
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
@@ -41,9 +43,11 @@ fun RecordPopup.updateSeriesTimer(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			val id = seriesTimer.id
-			if (id == null) api.liveTvApi.createSeriesTimer(seriesTimer)
-			else api.liveTvApi.updateSeriesTimer(id, seriesTimer)
+			withContext(Dispatchers.IO) {
+				val id = seriesTimer.id
+				if (id == null) api.liveTvApi.createSeriesTimer(seriesTimer)
+				else api.liveTvApi.updateSeriesTimer(id, seriesTimer)
+			}
 		}.onSuccess {
 			callback()
 		}
@@ -58,9 +62,11 @@ fun RecordPopup.updateTimer(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			val id = timer.id
-			if (id == null) api.liveTvApi.createTimer(timer)
-			else api.liveTvApi.updateTimer(id, timer)
+			withContext(Dispatchers.IO) {
+				val id = timer.id
+				if (id == null) api.liveTvApi.createTimer(timer)
+				else api.liveTvApi.updateTimer(id, timer)
+			}
 		}.onSuccess {
 			callback()
 		}
@@ -86,7 +92,9 @@ fun RecordPopup.getLiveTvProgram(
 
 	lifecycle.coroutineScope.launch {
 		runCatching {
-			api.liveTvApi.getProgram(id.toString()).content
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getProgram(id.toString()).content
+			}
 		}.onSuccess { program ->
 			callback(program)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragmentHelper.kt
@@ -1,7 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
@@ -23,11 +25,13 @@ fun EnhancedBrowseFragment.getLiveTvRecordingsAndTimers(
 
 	lifecycleScope.launch {
 		runCatching {
-			val recordings by api.liveTvApi.getRecordings(
-				fields = ItemRepository.itemFields,
-				enableImages = true,
-				limit = 40,
-			)
+			val recordings = withContext(Dispatchers.IO) {
+				api.liveTvApi.getRecordings(
+					fields = ItemRepository.itemFields,
+					enableImages = true,
+					limit = 40,
+				).content
+			}
 
 			val timers by api.liveTvApi.getTimers()
 
@@ -47,7 +51,9 @@ fun EnhancedBrowseFragment.getLiveTvTimers(
 
 	lifecycleScope.launch {
 		runCatching {
-			 api.liveTvApi.getTimers().content
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getTimers().content
+			}
 		}.fold(
 			onSuccess = { timers -> callback(timers) },
 			onFailure = { exception -> errorCallback(exception) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
@@ -2,7 +2,9 @@ package org.jellyfin.androidtv.ui.browsing
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
@@ -36,7 +38,7 @@ object BrowsingUtils {
 		type: BaseItemKind,
 		callback: (item: BaseItemDto?) -> Unit
 	) {
-		lifecycle.lifecycleScope.launch {
+		lifecycle.lifecycleScope.launch(Dispatchers.IO) {
 			try {
 				val result by api.itemsApi.getItems(
 					parentId = library.id,
@@ -46,10 +48,15 @@ object BrowsingUtils {
 					limit = 1,
 				)
 
-				callback(result.items?.firstOrNull())
+				withContext(Dispatchers.Main) {
+					callback(result.items.firstOrNull())
+				}
 			} catch (error: ApiClientException) {
 				Timber.w(error, "Failed to retrieve random item")
-				callback(null)
+
+				withContext(Dispatchers.Main) {
+					callback(null)
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -110,7 +111,7 @@ class MainActivity : FragmentActivity() {
 
 		workManager.enqueue(OneTimeWorkRequestBuilder<LeanbackChannelWorker>().build())
 
-		lifecycleScope.launch {
+		lifecycleScope.launch(Dispatchers.IO) {
 			Timber.d("MainActivity stopped")
 			sessionRepository.restoreSession(destroyOnly = true)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/SuggestedMoviesFragment.kt
@@ -1,7 +1,9 @@
 package org.jellyfin.androidtv.ui.browsing
 
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.QueryType
 import org.jellyfin.androidtv.data.repository.ItemRepository
@@ -22,14 +24,16 @@ class SuggestedMoviesFragment : EnhancedBrowseFragment() {
 
 	override fun setupQueries(rowLoader: RowLoader) {
 		lifecycleScope.launch {
-			val response by api.itemsApi.getItems(
-				parentId = mFolder.id,
-				includeItemTypes = setOf(BaseItemKind.MOVIE),
-				sortOrder = setOf(SortOrder.DESCENDING),
-				sortBy = setOf(ItemSortBy.DATE_PLAYED),
-				limit = 8,
-				recursive = true,
-			)
+			val response = withContext(Dispatchers.IO) {
+				api.itemsApi.getItems(
+					parentId = mFolder.id,
+					includeItemTypes = setOf(BaseItemKind.MOVIE),
+					sortOrder = setOf(SortOrder.DESCENDING),
+					sortBy = setOf(ItemSortBy.DATE_PLAYED),
+					limit = 8,
+					recursive = true,
+				).content
+			}
 
 			for (item in response.items) {
 				val similar = GetSimilarItemsRequest(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncherHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncherHelper.kt
@@ -2,7 +2,9 @@ package org.jellyfin.androidtv.ui.itemhandling
 
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.util.apiclient.Response
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
@@ -18,7 +20,9 @@ object ItemLauncherHelper {
 			val api by KoinJavaComponent.inject<ApiClient>(ApiClient::class.java)
 
 			try {
-				val response by api.userLibraryApi.getItem(itemId = itemId)
+				val response = withContext(Dispatchers.IO) {
+					api.userLibraryApi.getItem(itemId = itemId).content
+				}
 				callback.onResponse(response)
 			} catch (error: ApiClientException) {
 				callback.onError(error)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -643,7 +643,7 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
                 break;
             case Resume:
                 ItemRowAdapterHelperKt.retrieveResumeItems(this, api.getValue(), resumeQuery);
-            break;
+                break;
         }
     }
 
@@ -719,6 +719,8 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     }
 
     protected void notifyRetrieveFinished(@Nullable Exception exception) {
+        if (exception != null) Timber.w(exception, "Failed to retrieve items");
+
         setCurrentlyRetrieving(false);
         if (mRetrieveFinishedListener != null) {
             if (exception == null) mRetrieveFinishedListener.onResponse();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -74,7 +74,9 @@ fun <T : Any> ItemRowAdapter.setItems(
 fun ItemRowAdapter.retrieveResumeItems(api: ApiClient, query: GetResumeItemsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.itemsApi.getResumeItems(query)
+			val response = withContext(Dispatchers.IO) {
+				api.itemsApi.getResumeItems(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -98,7 +100,9 @@ fun ItemRowAdapter.retrieveResumeItems(api: ApiClient, query: GetResumeItemsRequ
 fun ItemRowAdapter.retrieveNextUpItems(api: ApiClient, query: GetNextUpRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.tvShowsApi.getNextUp(query)
+			val response = withContext(Dispatchers.IO) {
+				api.tvShowsApi.getNextUp(query).content
+			}
 
 			// Some special flavor for series, used in FullDetailsFragment
 			val firstNextUp = response.items.firstOrNull()
@@ -106,10 +110,12 @@ fun ItemRowAdapter.retrieveNextUpItems(api: ApiClient, query: GetNextUpRequest) 
 				// If we have exactly 1 episode returned, the series is currently partially watched
 				// we want to query the server for all episodes in the same season starting from
 				// this one to create a list of all unwatched episodes
-				val episodesResponse by api.itemsApi.getItems(
-					parentId = firstNextUp.seasonId,
-					startIndex = firstNextUp.indexNumber,
-				)
+				val episodesResponse = withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						parentId = firstNextUp.seasonId,
+						startIndex = firstNextUp.indexNumber,
+					).content
+				}
 
 				// Combine the next up episode with the additionally retrieved episodes
 				val items = buildList {
@@ -153,7 +159,9 @@ fun ItemRowAdapter.retrieveNextUpItems(api: ApiClient, query: GetNextUpRequest) 
 fun ItemRowAdapter.retrieveLatestMedia(api: ApiClient, query: GetLatestMediaRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.userLibraryApi.getLatestMedia(query)
+			val response = withContext(Dispatchers.IO) {
+				api.userLibraryApi.getLatestMedia(query).content
+			}
 
 			setItems(
 				items = response,
@@ -179,7 +187,9 @@ fun ItemRowAdapter.retrieveLatestMedia(api: ApiClient, query: GetLatestMediaRequ
 fun ItemRowAdapter.retrieveSpecialFeatures(api: ApiClient, query: GetSpecialsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.userLibraryApi.getSpecialFeatures(query.itemId)
+			val response = withContext(Dispatchers.IO) {
+				api.userLibraryApi.getSpecialFeatures(query.itemId).content
+			}
 
 			setItems(
 				items = response,
@@ -199,7 +209,9 @@ fun ItemRowAdapter.retrieveSpecialFeatures(api: ApiClient, query: GetSpecialsReq
 fun ItemRowAdapter.retrieveAdditionalParts(api: ApiClient, query: GetAdditionalPartsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.videosApi.getAdditionalPart(query.itemId)
+			val response = withContext(Dispatchers.IO) {
+				api.videosApi.getAdditionalPart(query.itemId).content
+			}
 
 			setItems(
 				items = response.items,
@@ -217,7 +229,9 @@ fun ItemRowAdapter.retrieveAdditionalParts(api: ApiClient, query: GetAdditionalP
 fun ItemRowAdapter.retrieveUserViews(api: ApiClient, userViewsRepository: UserViewsRepository) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.userViewsApi.getUserViews()
+			val response = withContext(Dispatchers.IO) {
+				api.userViewsApi.getUserViews().content
+			}
 
 			val filteredItems = response.items
 				.filter { userViewsRepository.isSupported(it.collectionType) }
@@ -239,7 +253,9 @@ fun ItemRowAdapter.retrieveUserViews(api: ApiClient, userViewsRepository: UserVi
 fun ItemRowAdapter.retrieveSeasons(api: ApiClient, query: GetSeasonsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.tvShowsApi.getSeasons(query)
+			val response = withContext(Dispatchers.IO) {
+				api.tvShowsApi.getSeasons(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -257,7 +273,9 @@ fun ItemRowAdapter.retrieveSeasons(api: ApiClient, query: GetSeasonsRequest) {
 fun ItemRowAdapter.retrieveUpcomingEpisodes(api: ApiClient, query: GetUpcomingEpisodesRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.tvShowsApi.getUpcomingEpisodes(query)
+			val response = withContext(Dispatchers.IO) {
+				api.tvShowsApi.getUpcomingEpisodes(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -275,7 +293,9 @@ fun ItemRowAdapter.retrieveUpcomingEpisodes(api: ApiClient, query: GetUpcomingEp
 fun ItemRowAdapter.retrieveSimilarItems(api: ApiClient, query: GetSimilarItemsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.libraryApi.getSimilarItems(query)
+			val response = withContext(Dispatchers.IO) {
+				api.libraryApi.getSimilarItems(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -293,7 +313,9 @@ fun ItemRowAdapter.retrieveSimilarItems(api: ApiClient, query: GetSimilarItemsRe
 fun ItemRowAdapter.retrieveTrailers(api: ApiClient, query: GetTrailersRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.userLibraryApi.getLocalTrailers(itemId = query.itemId)
+			val response = withContext(Dispatchers.IO) {
+				api.userLibraryApi.getLocalTrailers(itemId = query.itemId)
+			}.content
 
 			setItems(
 				items = response,
@@ -322,7 +344,9 @@ fun ItemRowAdapter.retrieveLiveTvRecommendedPrograms(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.liveTvApi.getRecommendedPrograms(query)
+			val response = withContext(Dispatchers.IO) {
+				api.liveTvApi.getRecommendedPrograms(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -346,7 +370,9 @@ fun ItemRowAdapter.retrieveLiveTvRecommendedPrograms(
 fun ItemRowAdapter.retrieveLiveTvRecordings(api: ApiClient, query: GetRecordingsRequest) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.liveTvApi.getRecordings(query)
+			val response = withContext(Dispatchers.IO) {
+				api.liveTvApi.getRecordings(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -374,7 +400,9 @@ fun ItemRowAdapter.retrieveLiveTvSeriesTimers(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.liveTvApi.getSeriesTimers()
+			val response = withContext(Dispatchers.IO) {
+				api.liveTvApi.getSeriesTimers().content
+			}
 
 			setItems(
 				items = buildList {
@@ -428,12 +456,14 @@ fun ItemRowAdapter.retrieveLiveTvChannels(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.liveTvApi.getLiveTvChannels(
-				query.copy(
-					startIndex = startIndex,
-					limit = batchSize,
-				)
-			)
+			val response = withContext(Dispatchers.IO) {
+				api.liveTvApi.getLiveTvChannels(
+					query.copy(
+						startIndex = startIndex,
+						limit = batchSize,
+					)
+				).content
+			}
 
 			totalItems = response.totalRecordCount
 			setItems(
@@ -463,12 +493,14 @@ fun ItemRowAdapter.retrieveAlbumArtists(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.artistsApi.getAlbumArtists(
-				query.copy(
-					startIndex = startIndex,
-					limit = batchSize,
-				)
-			)
+			val response = withContext(Dispatchers.IO) {
+				api.artistsApi.getAlbumArtists(
+					query.copy(
+						startIndex = startIndex,
+						limit = batchSize,
+					)
+				).content
+			}
 
 			totalItems = response.totalRecordCount
 			setItems(
@@ -498,12 +530,14 @@ fun ItemRowAdapter.retrieveArtists(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.artistsApi.getArtists(
-				query.copy(
-					startIndex = startIndex,
-					limit = batchSize,
-				)
-			)
+			val response = withContext(Dispatchers.IO) {
+				api.artistsApi.getArtists(
+					query.copy(
+						startIndex = startIndex,
+						limit = batchSize,
+					)
+				).content
+			}
 
 			totalItems = response.totalRecordCount
 			setItems(
@@ -533,12 +567,14 @@ fun ItemRowAdapter.retrieveItems(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.itemsApi.getItems(
-				query.copy(
-					startIndex = startIndex,
-					limit = batchSize,
-				)
-			)
+			val response = withContext(Dispatchers.IO) {
+				api.itemsApi.getItems(
+					query.copy(
+						startIndex = startIndex,
+						limit = batchSize,
+					)
+				).content
+			}
 
 			totalItems = response.totalRecordCount
 			setItems(
@@ -566,7 +602,9 @@ fun ItemRowAdapter.retrievePremieres(
 ) {
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response by api.itemsApi.getItems(query)
+			val response = withContext(Dispatchers.IO) {
+				api.itemsApi.getItems(query).content
+			}
 
 			setItems(
 				items = response.items,
@@ -665,37 +703,34 @@ fun ItemRowAdapter.refreshItem(
 	if (currentBaseRowItem !is BaseItemDtoBaseRowItem || currentBaseRowItem is AudioQueueBaseRowItem) return
 	val currentBaseItem = currentBaseRowItem.baseItem ?: return
 
-	lifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+	lifecycleOwner.lifecycleScope.launch {
 		runCatching {
-			api.userLibraryApi.getItem(itemId = currentBaseItem.id).content
+			withContext(Dispatchers.IO) {
+				api.userLibraryApi.getItem(itemId = currentBaseItem.id).content
+			}
 		}.fold(
 			onSuccess = { refreshedBaseItem ->
-				withContext(Dispatchers.Main) {
-					val index = indexOf(currentBaseRowItem)
-					// Item could be removed while API was loading, check if the index is valid first
-					if (index == -1) return@withContext
+				val index = indexOf(currentBaseRowItem)
+				// Item could be removed while API was loading, check if the index is valid first
+				if (index == -1) return@fold
 
-					set(
-						index = index,
-						element = BaseItemDtoBaseRowItem(
-							item = refreshedBaseItem,
-							preferParentThumb = currentBaseRowItem.preferParentThumb,
-							staticHeight = currentBaseRowItem.staticHeight,
-							selectAction = currentBaseRowItem.selectAction,
-							preferSeriesPoster = currentBaseRowItem.preferSeriesPoster
-						)
+				set(
+					index = index,
+					element = BaseItemDtoBaseRowItem(
+						item = refreshedBaseItem,
+						preferParentThumb = currentBaseRowItem.preferParentThumb,
+						staticHeight = currentBaseRowItem.staticHeight,
+						selectAction = currentBaseRowItem.selectAction,
+						preferSeriesPoster = currentBaseRowItem.preferSeriesPoster
 					)
-				}
+				)
 			},
 			onFailure = { err ->
-				if (err is InvalidStatusException && err.status == 404) withContext(Dispatchers.Main) {
-					remove(currentBaseRowItem)
-				} else Timber.e(err, "Failed to refresh item")
+				if (err is InvalidStatusException && err.status == 404) remove(currentBaseRowItem)
+				else Timber.e(err, "Failed to refresh item")
 			}
 		)
 
-		withContext(Dispatchers.Main) {
-			callback()
-		}
+		callback()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragmentHelper.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.androidtv.data.repository.ItemMutationRepository
@@ -61,7 +63,9 @@ fun LiveTvGuideFragment.refreshSelectedProgram() {
 
 	lifecycleScope.launch {
 		runCatching {
-			val item by api.userLibraryApi.getItem(mSelectedProgram.id)
+			val item = withContext(Dispatchers.IO) {
+				api.userLibraryApi.getItem(mSelectedProgram.id).content
+			}
 			mSelectedProgram = item
 		}.onFailure { error ->
 			Timber.e(error, "Unable to get program details")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManagerHelper.kt
@@ -2,7 +2,9 @@ package org.jellyfin.androidtv.ui.livetv
 
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.preference.LiveTvPreferences
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
@@ -35,12 +37,14 @@ fun loadLiveTvChannels(fragment: Fragment, callback: (channels: Collection<BaseI
 			liveTvPreferences[LiveTvPreferences.channelOrder] == ItemSortBy.DATE_PLAYED.serialName
 
 		runCatching {
-			api.liveTvApi.getLiveTvChannels(
-				addCurrentProgram = true,
-				enableFavoriteSorting = liveTvPreferences[LiveTvPreferences.favsAtTop],
-				sortBy = if (sortDatePlayed) setOf(ItemSortBy.DATE_PLAYED) else setOf(ItemSortBy.SORT_NAME),
-				sortOrder = if (sortDatePlayed) SortOrder.DESCENDING else SortOrder.ASCENDING,
-			).content.items
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getLiveTvChannels(
+					addCurrentProgram = true,
+					enableFavoriteSorting = liveTvPreferences[LiveTvPreferences.favsAtTop],
+					sortBy = if (sortDatePlayed) setOf(ItemSortBy.DATE_PLAYED) else setOf(ItemSortBy.SORT_NAME),
+					sortOrder = if (sortDatePlayed) SortOrder.DESCENDING else SortOrder.ASCENDING,
+				).content.items
+			}
 		}.fold(
 			onSuccess = { channels -> callback(channels) },
 			onFailure = { callback(null) },
@@ -59,13 +63,15 @@ fun getPrograms(
 
 	fragment.lifecycleScope.launch {
 		runCatching {
-			api.liveTvApi.getLiveTvPrograms(
-				channelIds = channelIds.toList(),
-				enableImages = false,
-				sortBy = setOf(ItemSortBy.START_DATE),
-				maxStartDate = endTime,
-				minEndDate = startTime,
-			).content.items
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getLiveTvPrograms(
+					channelIds = channelIds.toList(),
+					enableImages = false,
+					sortBy = setOf(ItemSortBy.START_DATE),
+					maxStartDate = endTime,
+					minEndDate = startTime,
+				).content.items
+			}
 		}.fold(
 			onSuccess = { programs -> callback(programs) },
 			onFailure = { callback(null) },
@@ -82,9 +88,11 @@ fun getScheduleRows(
 
 	fragment.lifecycleScope.launch {
 		runCatching {
-			api.liveTvApi.getTimers(
-				seriesTimerId = seriesTimerId,
-			).content.items
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getTimers(
+					seriesTimerId = seriesTimerId,
+				).content.items
+			}
 		}.fold(
 			onSuccess = { timers ->
 				val groupedTimers = timers

--- a/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/picture/PictureViewerViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
@@ -29,16 +30,20 @@ class PictureViewerViewModel(private val api: ApiClient) : ViewModel() {
 
 	suspend fun loadItem(id: UUID, sortBy: Collection<ItemSortBy>, sortOrder: SortOrder) {
 		// Load requested item
-		val itemResponse by api.userLibraryApi.getItem(itemId = id)
+		val itemResponse =withContext(Dispatchers.IO) {
+			api.userLibraryApi.getItem(itemId = id).content
+		}
 		_currentItem.value = itemResponse
 
-		val albumResponse by api.itemsApi.getItems(
-			parentId = itemResponse.parentId,
-			includeItemTypes = setOf(BaseItemKind.PHOTO),
-			fields = ItemRepository.itemFields,
-			sortBy = sortBy,
-			sortOrder = listOf(sortOrder),
-		)
+		val albumResponse =withContext(Dispatchers.IO) {
+			api.itemsApi.getItems(
+				parentId = itemResponse.parentId,
+				includeItemTypes = setOf(BaseItemKind.PHOTO),
+				fields = ItemRepository.itemFields,
+				sortBy = sortBy,
+				sortOrder = listOf(sortOrder),
+			).content
+		}
 		album = albumResponse.items
 		albumIndex = album.indexOfFirst { it.id == id }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -8,7 +8,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.androidtv.util.sdk.getDisplayName
@@ -190,14 +192,16 @@ class ExternalPlayerActivity : FragmentActivity() {
 
 		lifecycleScope.launch {
 			runCatching {
-				api.playStateApi.reportPlaybackStopped(
-					PlaybackStopInfo(
-						itemId = item.id,
-						mediaSourceId = mediaSource.id,
-						positionTicks = endPosition?.inWholeTicks,
-						failed = false,
+				withContext(Dispatchers.IO) {
+					api.playStateApi.reportPlaybackStopped(
+						PlaybackStopInfo(
+							itemId = item.id,
+							mediaSourceId = mediaSource.id,
+							positionTicks = endPosition?.inWholeTicks,
+							failed = false,
+						)
 					)
-				)
+				}
 			}.onFailure { error ->
 				Timber.w(error, "Failed to report playback stop event")
 				Toast.makeText(this@ExternalPlayerActivity, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.util.sdk.end
@@ -29,7 +30,9 @@ fun PlaybackController.getLiveTvChannel(
 
 	fragment.lifecycleScope.launch {
 		runCatching {
-			api.liveTvApi.getChannel(id).content
+			withContext(Dispatchers.IO) {
+				api.liveTvApi.getChannel(id).content
+			}
 		}.onSuccess { channel ->
 			callback(channel)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segment/MediaSegmentRepository.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.ui.playback.segment
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.util.sdk.duration
 import org.jellyfin.sdk.api.client.ApiClient
@@ -102,9 +104,11 @@ class MediaSegmentRepositoryImpl(
 	}
 
 	override suspend fun getSegmentsForItem(item: BaseItemDto): List<MediaSegmentDto> = runCatching {
-		api.mediaSegmentsApi.getItemSegments(
-			itemId = item.id,
-			includeSegmentTypes = MediaSegmentRepository.SupportedTypes,
-		).content.items
+		withContext(Dispatchers.IO) {
+			api.mediaSegmentsApi.getItemSegments(
+				itemId = item.id,
+				includeSegmentTypes = MediaSegmentRepository.SupportedTypes,
+			).content.items
+		}
 	}.getOrDefault(emptyList())
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -3,7 +3,9 @@ package org.jellyfin.androidtv.ui.preference.screen
 import android.os.Build
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.getQualityProfiles
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -141,7 +143,9 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 
 					lifecycleScope.launch {
 						runCatching {
-							api.clientLogApi.logFile(createDeviceProfileReport(context, userPreferences)).content
+							withContext(Dispatchers.IO) {
+								api.clientLogApi.logFile(createDeviceProfileReport(context, userPreferences)).content
+							}
 						}.fold(
 							onSuccess = { result ->
 								Toast.makeText(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchRepository.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.ui.search
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
@@ -47,11 +49,13 @@ class SearchRepositoryImpl(
 			)
 		}
 
-		val result by apiClient.itemsApi.getItems(request)
+		val result = withContext(Dispatchers.IO) {
+			apiClient.itemsApi.getItems(request).content
+		}
 
 		Result.success(result.items)
 	} catch (e: ApiClientException) {
-		Timber.e("Failed to search for items", e)
+		Timber.e(e, "Failed to search for items")
 		Result.failure(e)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -5,7 +5,9 @@ import android.widget.Toast
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -74,128 +76,130 @@ class SdkPlaybackHelper(
 		mainItem: BaseItemDto,
 		allowIntros: Boolean,
 		shuffle: Boolean,
-	): List<BaseItemDto> = when (mainItem.type) {
-		BaseItemKind.EPISODE -> {
-			val seriesId = mainItem.seriesId
-			if (userPreferences[UserPreferences.mediaQueuingEnabled] && seriesId != null) {
-				val response by api.tvShowsApi.getEpisodes(
-					seriesId = seriesId,
-					startItemId = mainItem.id,
+	): List<BaseItemDto> = withContext(Dispatchers.IO) {
+		when (mainItem.type) {
+			BaseItemKind.EPISODE -> {
+				val seriesId = mainItem.seriesId
+				if (userPreferences[UserPreferences.mediaQueuingEnabled] && seriesId != null) {
+					val response by api.tvShowsApi.getEpisodes(
+						seriesId = seriesId,
+						startItemId = mainItem.id,
+						isMissing = false,
+						limit = ITEM_QUERY_LIMIT,
+						fields = ItemRepository.itemFields
+					)
+
+					response.items
+				} else {
+					listOf(mainItem)
+				}
+			}
+
+			BaseItemKind.SERIES, BaseItemKind.SEASON, BaseItemKind.BOX_SET, BaseItemKind.FOLDER -> {
+				val response by api.itemsApi.getItems(
+					parentId = mainItem.id,
 					isMissing = false,
+					includeItemTypes = listOf(
+						BaseItemKind.EPISODE,
+						BaseItemKind.MOVIE,
+						BaseItemKind.VIDEO
+					),
+					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(ItemSortBy.SORT_NAME),
+					recursive = true,
 					limit = ITEM_QUERY_LIMIT,
 					fields = ItemRepository.itemFields
 				)
 
 				response.items
-			} else {
-				listOf(mainItem)
 			}
-		}
 
-		BaseItemKind.SERIES, BaseItemKind.SEASON, BaseItemKind.BOX_SET, BaseItemKind.FOLDER -> {
-			val response by api.itemsApi.getItems(
-				parentId = mainItem.id,
-				isMissing = false,
-				includeItemTypes = listOf(
-					BaseItemKind.EPISODE,
-					BaseItemKind.MOVIE,
-					BaseItemKind.VIDEO
-				),
-				sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(ItemSortBy.SORT_NAME),
-				recursive = true,
-				limit = ITEM_QUERY_LIMIT,
-				fields = ItemRepository.itemFields
-			)
-
-			response.items
-		}
-
-		BaseItemKind.MUSIC_ALBUM -> {
-			val response by api.itemsApi.getItems(
-				isMissing = false,
-				mediaTypes = listOf(MediaType.AUDIO),
-				sortBy = listOf(
-					ItemSortBy.ALBUM_ARTIST,
-					ItemSortBy.SORT_NAME
-				),
-				recursive = true,
-				limit = ITEM_QUERY_LIMIT,
-				fields = ItemRepository.itemFields,
-				albumIds = listOf(mainItem.id)
-			)
-
-			response.items
-		}
-
-		BaseItemKind.MUSIC_ARTIST -> {
-			val response by api.itemsApi.getItems(
-				isMissing = false,
-				mediaTypes = listOf(MediaType.AUDIO),
-				sortBy = listOf(ItemSortBy.SORT_NAME),
-				recursive = true,
-				limit = ITEM_QUERY_LIMIT,
-				fields = ItemRepository.itemFields,
-				artistIds = listOf(mainItem.id)
-			)
-
-			response.items
-		}
-
-		BaseItemKind.PLAYLIST -> {
-			val response by api.itemsApi.getItems(
-				parentId = mainItem.id,
-				isMissing = false,
-				sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else null,
-				recursive = true,
-				limit = ITEM_QUERY_LIMIT,
-				fields = ItemRepository.itemFields
-			)
-
-			response.items
-		}
-
-		BaseItemKind.PROGRAM -> {
-			val parentId = requireNotNull(mainItem.parentId)
-			val channel by api.userLibraryApi.getItem(parentId)
-			val channelWithProgramMetadata = channel.copy(
-				premiereDate = mainItem.premiereDate,
-				endDate = mainItem.endDate,
-				officialRating = mainItem.officialRating,
-				runTimeTicks = mainItem.runTimeTicks,
-			)
-
-			listOf(channelWithProgramMetadata)
-		}
-
-		BaseItemKind.TV_CHANNEL -> {
-			val channel by api.liveTvApi.getChannel(mainItem.id)
-			val currentProgram = channel.currentProgram
-			if (currentProgram != null) {
-				val channelWithCurrentProgramMetadata = channel.copy(
-					premiereDate = currentProgram.premiereDate,
-					endDate = currentProgram.endDate,
-					officialRating = currentProgram.officialRating,
-					runTimeTicks = currentProgram.runTimeTicks,
+			BaseItemKind.MUSIC_ALBUM -> {
+				val response by api.itemsApi.getItems(
+					isMissing = false,
+					mediaTypes = listOf(MediaType.AUDIO),
+					sortBy = listOf(
+						ItemSortBy.ALBUM_ARTIST,
+						ItemSortBy.SORT_NAME
+					),
+					recursive = true,
+					limit = ITEM_QUERY_LIMIT,
+					fields = ItemRepository.itemFields,
+					albumIds = listOf(mainItem.id)
 				)
-				listOf(channelWithCurrentProgramMetadata)
-			} else {
-				listOf(channel)
+
+				response.items
 			}
-		}
 
-		else -> {
-			val parts = getParts(mainItem)
-			val addIntros = allowIntros && userPreferences[UserPreferences.cinemaModeEnabled]
+			BaseItemKind.MUSIC_ARTIST -> {
+				val response by api.itemsApi.getItems(
+					isMissing = false,
+					mediaTypes = listOf(MediaType.AUDIO),
+					sortBy = listOf(ItemSortBy.SORT_NAME),
+					recursive = true,
+					limit = ITEM_QUERY_LIMIT,
+					fields = ItemRepository.itemFields,
+					artistIds = listOf(mainItem.id)
+				)
 
-			if (addIntros) {
-				val intros = runCatching { api.userLibraryApi.getIntros(mainItem.id).content.items }.getOrNull()
-					.orEmpty()
-					// Force the type to be trailer as the legacy playback UI uses it to determine if it should show the next up screen
-					.map { it.copy(type = BaseItemKind.TRAILER) }
+				response.items
+			}
 
-				intros + parts
-			} else {
-				parts
+			BaseItemKind.PLAYLIST -> {
+				val response by api.itemsApi.getItems(
+					parentId = mainItem.id,
+					isMissing = false,
+					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else null,
+					recursive = true,
+					limit = ITEM_QUERY_LIMIT,
+					fields = ItemRepository.itemFields
+				)
+
+				response.items
+			}
+
+			BaseItemKind.PROGRAM -> {
+				val parentId = requireNotNull(mainItem.parentId)
+				val channel by api.userLibraryApi.getItem(parentId)
+				val channelWithProgramMetadata = channel.copy(
+					premiereDate = mainItem.premiereDate,
+					endDate = mainItem.endDate,
+					officialRating = mainItem.officialRating,
+					runTimeTicks = mainItem.runTimeTicks,
+				)
+
+				listOf(channelWithProgramMetadata)
+			}
+
+			BaseItemKind.TV_CHANNEL -> {
+				val channel by api.liveTvApi.getChannel(mainItem.id)
+				val currentProgram = channel.currentProgram
+				if (currentProgram != null) {
+					val channelWithCurrentProgramMetadata = channel.copy(
+						premiereDate = currentProgram.premiereDate,
+						endDate = currentProgram.endDate,
+						officialRating = currentProgram.officialRating,
+						runTimeTicks = currentProgram.runTimeTicks,
+					)
+					listOf(channelWithCurrentProgramMetadata)
+				} else {
+					listOf(channel)
+				}
+			}
+
+			else -> {
+				val parts = getParts(mainItem)
+				val addIntros = allowIntros && userPreferences[UserPreferences.cinemaModeEnabled]
+
+				if (addIntros) {
+					val intros = runCatching { api.userLibraryApi.getIntros(mainItem.id).content.items }.getOrNull()
+						.orEmpty()
+						// Force the type to be trailer as the legacy playback UI uses it to determine if it should show the next up screen
+						.map { it.copy(type = BaseItemKind.TRAILER) }
+
+					intros + parts
+				} else {
+					parts
+				}
 			}
 		}
 	}
@@ -243,10 +247,12 @@ class SdkPlaybackHelper(
 
 	override fun playInstantMix(context: Context, item: BaseItemDto) {
 		getScope(context).launch {
-			val response by api.instantMixApi.getInstantMixFromItem(
-				itemId = item.id,
-				fields = ItemRepository.itemFields
-			)
+			val response =withContext(Dispatchers.IO) {
+				api.instantMixApi.getInstantMixFromItem(
+					itemId = item.id,
+					fields = ItemRepository.itemFields
+				).content
+			}
 
 			val items = response.items
 			if (items.isNotEmpty()) {


### PR DESCRIPTION
Right now our Kotlin SDK uses Ktor for networking. Ktor will automatically switch coroutine contexts whenever we call the API. The next version of the SDK will use OkHttp and the SDK will stop switching contexts by itself, instead it relies on the library user to switch contexts.

Before this PR the app barely worked because my quick SDK migrations didn't switch contexts and thus networking would run on the main thread with the OkHttp implementation... oops.

Review best enjoyed with whitespace changes disabled.

**Changes**
- Switch contexts when calling API
- Switch contexts in some other places that make sense
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
