### PR TITLE
Use OkHttp for networking in media3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
 
 	// Media players
 	implementation(libs.androidx.media3.exoplayer)
+	implementation(libs.androidx.media3.datasource.okhttp)
 	implementation(libs.androidx.media3.exoplayer.hls)
 	implementation(libs.androidx.media3.ui)
 	implementation(libs.jellyfin.androidx.media3.ffmpeg.decoder)

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -51,6 +51,7 @@ import org.jellyfin.androidtv.util.coil.CoilTimberLogger
 import org.jellyfin.androidtv.util.coil.createCoilConnectivityChecker
 import org.jellyfin.androidtv.util.sdk.SdkPlaybackHelper
 import org.jellyfin.sdk.android.androidDevice
+import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.createJellyfin
 import org.jellyfin.sdk.model.ClientInfo
 import org.koin.android.ext.koin.androidContext
@@ -64,6 +65,7 @@ val defaultDeviceInfo = named("defaultDeviceInfo")
 val appModule = module {
 	// New SDK
 	single(defaultDeviceInfo) { androidDevice(get()) }
+	single { HttpClientOptions() }
 	single {
 		createJellyfin {
 			context = androidContext()
@@ -79,7 +81,7 @@ val appModule = module {
 
 	single {
 		// Create an empty API instance, the actual values are set by the SessionRepository
-		get<JellyfinSdk>().createApi()
+		get<JellyfinSdk>().createApi(httpClientOptions = get<HttpClientOptions>())
 	}
 
 	single { SocketHandler(get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -6,6 +6,9 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationManagerCompat
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import okhttp3.OkHttpClient
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -24,10 +27,12 @@ import org.jellyfin.playback.media3.exoplayer.exoPlayerPlugin
 import org.jellyfin.playback.media3.session.MediaSessionOptions
 import org.jellyfin.playback.media3.session.media3SessionPlugin
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.scope.Scope
 import org.koin.dsl.module
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.toJavaDuration
 import org.jellyfin.androidtv.ui.playback.PlaybackManager as LegacyPlaybackManager
 
 val playbackModule = module {
@@ -41,6 +46,19 @@ val playbackModule = module {
 
 		if (useRewrite) RewritePlaybackLauncher()
 		else GarbagePlaybackLauncher(get())
+	}
+
+	// OkHttp data source using OkHttpFactory from SDK
+	single<HttpDataSource.Factory> {
+		val httpClientOptions = get<HttpClientOptions>()
+
+		OkHttpDataSource.Factory(OkHttpClient.Builder().apply {
+			followRedirects(httpClientOptions.followRedirects)
+			connectTimeout(httpClientOptions.connectTimeout.toJavaDuration())
+			callTimeout(httpClientOptions.requestTimeout.toJavaDuration())
+			readTimeout(httpClientOptions.socketTimeout.toJavaDuration())
+			writeTimeout(httpClientOptions.socketTimeout.toJavaDuration())
+		}.build())
 	}
 
 	single { createPlaybackManager() }
@@ -63,10 +81,9 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 	val userPreferences = get<UserPreferences>()
 	val api = get<ApiClient>()
 	val exoPlayerOptions = ExoPlayerOptions(
-		httpConnectTimeout = api.httpClientOptions.connectTimeout,
-		httpReadTimeout = api.httpClientOptions.requestTimeout,
 		preferFfmpeg = userPreferences[UserPreferences.preferExoPlayerFfmpeg],
 		enableDebugLogging = userPreferences[UserPreferences.debuggingEnabled],
+		baseDataSourceFactory = get<HttpDataSource.Factory>(),
 	)
 	install(exoPlayerPlugin(get(), exoPlayerOptions))
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -28,7 +28,7 @@ import androidx.media3.common.TrackSelectionParameters;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.datasource.DefaultDataSource;
-import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.datasource.HttpDataSource;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
@@ -77,6 +77,7 @@ public class VideoManager {
     public boolean isContracted = false;
 
     private final UserPreferences userPreferences = KoinJavaComponent.get(UserPreferences.class);
+    private final HttpDataSource.Factory exoPlayerHttpDataSourceFactory = KoinJavaComponent.get(HttpDataSource.Factory.class);
 
     public VideoManager(@NonNull Activity activity, @NonNull View view, @NonNull PlaybackOverlayFragmentHelper helper) {
         mActivity = activity;
@@ -201,11 +202,7 @@ public class VideoManager {
         exoPlayerBuilder.setTrackSelector(trackSelector);
 
         DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory().setTsExtractorTimestampSearchBytes(TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES * 3);
-        DefaultHttpDataSource.Factory httpDataSourceFactory = new DefaultHttpDataSource.Factory();
-        // Note: default values from Kotlin SDK 1.5
-        httpDataSourceFactory.setConnectTimeoutMs(6 * 1000);
-        httpDataSourceFactory.setReadTimeoutMs(30 * 1000);
-        DefaultDataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, httpDataSourceFactory);
+        DefaultDataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, exoPlayerHttpDataSourceFactory);
         exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory));
         extractorsFactory.setConstantBitrateSeekingEnabled(true);
         extractorsFactory.setConstantBitrateSeekingAlwaysEnabled(true);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,8 +72,6 @@ androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", 
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
-androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "androidx-media3" }
-androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
@@ -88,9 +86,12 @@ koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", versi
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin" }
 
 # Media players
+androidx-media3-datasource-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "androidx-media3" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "androidx-media3" }
-jellyfin-androidx-media3-ffmpeg-decoder = { group = "org.jellyfin.media3", name = "media3-ffmpeg-decoder", version.ref = "jellyfin-androidx-media" }
+androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "androidx-media3" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
+jellyfin-androidx-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-decoder", version.ref = "jellyfin-androidx-media" }
 
 # Markwon
 markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }

--- a/playback/media3/exoplayer/build.gradle.kts
+++ b/playback/media3/exoplayer/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
 	// media3
 	implementation(libs.androidx.media3.exoplayer)
+	implementation(libs.androidx.media3.datasource.okhttp)
 	implementation(libs.androidx.media3.exoplayer.hls)
 	implementation(libs.jellyfin.androidx.media3.ffmpeg.decoder)
 	implementation(libs.androidx.media3.ui)

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -15,7 +15,6 @@ import androidx.media3.common.VideoSize
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
-import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -78,17 +77,7 @@ class ExoPlayerBackend(
 			.setMediaSourceFactory(DefaultMediaSourceFactory(
 				DefaultDataSource.Factory(
 					context,
-					DefaultHttpDataSource.Factory().apply {
-						exoPlayerOptions.httpConnectTimeout
-							?.inWholeMilliseconds
-							?.toInt()
-							?.let(::setConnectTimeoutMs)
-
-						exoPlayerOptions.httpReadTimeout
-							?.inWholeMilliseconds
-							?.toInt()
-							?.let(::setReadTimeoutMs)
-					}
+					exoPlayerOptions.baseDataSourceFactory,
 				),
 				DefaultExtractorsFactory().apply {
 					val isLowRamDevice = context.getSystemService<ActivityManager>()?.isLowRamDevice == true

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerOptions.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerOptions.kt
@@ -1,10 +1,10 @@
 package org.jellyfin.playback.media3.exoplayer
 
-import kotlin.time.Duration
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultHttpDataSource
 
 data class ExoPlayerOptions(
-	val httpConnectTimeout: Duration? = null,
-	val httpReadTimeout: Duration? = null,
 	val preferFfmpeg: Boolean = false,
 	val enableDebugLogging: Boolean = false,
+	val baseDataSourceFactory: DataSource.Factory = DefaultHttpDataSource.Factory(),
 )


### PR DESCRIPTION
The next version of our SDK will use OkHttp as default networking library and allows us to supply the base OkHttp client. That way the connection pool and cache can be easily shared to slightly speed up networking and allow for easy network configuration (like proxy authentication) in the future.
This PR prepares our media playback to also use OkHttp, with a follow up to share the same base with the SDK/Coil coming once we've updated the SDK.

**Changes**
- Use OkHttp for networking in media3

**Issues**

Part of #1057 
