### PR TITLE
Add ButtonColors and colorScheme

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/JellyfinTheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/JellyfinTheme.kt
@@ -1,9 +1,29 @@
 package org.jellyfin.androidtv.ui.base
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 
+@Composable
+fun JellyfinTheme(
+	colorScheme: ColorScheme = JellyfinTheme.colorScheme,
+	shapes: Shapes = JellyfinTheme.shapes,
+	typography: Typography = JellyfinTheme.typography,
+	content: @Composable () -> Unit
+) {
+	CompositionLocalProvider(
+		LocalColorScheme provides colorScheme,
+		LocalShapes provides shapes,
+		LocalTypography provides typography
+	) {
+		ProvideTextStyle(value = typography.default, content = content)
+	}
+}
+
 object JellyfinTheme {
+	val colorScheme: ColorScheme
+		@Composable @ReadOnlyComposable get() = LocalColorScheme.current
+
 	val typography: Typography
 		@Composable @ReadOnlyComposable get() = LocalTypography.current
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/button/Button.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/button/Button.kt
@@ -9,14 +9,35 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 
 object ButtonDefaults {
 	val Shape: Shape = CircleShape
 	val ContentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
+
+	@ReadOnlyComposable
+	@Composable
+	fun colors(
+		containerColor: Color = JellyfinTheme.colorScheme.button,
+		contentColor: Color = JellyfinTheme.colorScheme.onButton,
+		focusedContainerColor: Color = JellyfinTheme.colorScheme.buttonFocused,
+		focusedContentColor: Color = JellyfinTheme.colorScheme.onButtonFocused,
+		disabledContainerColor: Color = JellyfinTheme.colorScheme.buttonDisabled,
+		disabledContentColor: Color = JellyfinTheme.colorScheme.onButtonDisabled,
+	) = ButtonColors(
+		containerColor = containerColor,
+		contentColor = contentColor,
+		focusedContainerColor = focusedContainerColor,
+		focusedContentColor = focusedContentColor,
+		disabledContainerColor = disabledContainerColor,
+		disabledContentColor = disabledContentColor,
+	)
 }
 
 @Composable
@@ -26,6 +47,7 @@ fun Button(
 	onLongClick: (() -> Unit)? = null,
 	enabled: Boolean = true,
 	shape: Shape = ButtonDefaults.Shape,
+	colors: ButtonColors = ButtonDefaults.colors(),
 	contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
 	interactionSource: MutableInteractionSource? = null,
 	content: @Composable RowScope.() -> Unit
@@ -36,6 +58,7 @@ fun Button(
 		onLongClick = onLongClick,
 		enabled = enabled,
 		shape = shape,
+		colors = colors,
 		interactionSource = interactionSource,
 	) {
 		ButtonRow(
@@ -53,6 +76,7 @@ fun ProgressButton(
 	onLongClick: (() -> Unit)? = null,
 	enabled: Boolean = true,
 	shape: Shape = ButtonDefaults.Shape,
+	colors: ButtonColors = ButtonDefaults.colors(),
 	contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
 	interactionSource: MutableInteractionSource? = null,
 	content: @Composable RowScope.() -> Unit
@@ -64,6 +88,7 @@ fun ProgressButton(
 		onLongClick = onLongClick,
 		enabled = enabled,
 		shape = shape,
+		colors = colors,
 		interactionSource = interactionSource,
 	) {
 		ButtonRow(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ButtonBase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ButtonBase.kt
@@ -14,10 +14,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.sp
-import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 
@@ -29,6 +27,7 @@ fun ButtonBase(
 	onLongClick: (() -> Unit)? = null,
 	enabled: Boolean = true,
 	shape: Shape = ButtonDefaults.Shape,
+	colors: ButtonColors = ButtonDefaults.colors(),
 	interactionSource: MutableInteractionSource? = null,
 	content: @Composable BoxScope.() -> Unit
 ) {
@@ -37,18 +36,11 @@ fun ButtonBase(
 	val focused by interactionSource.collectIsFocusedAsState()
 	val pressed by interactionSource.collectIsPressedAsState()
 
-	val containerColor = colorResource(R.color.button_default_normal_background)
-	val contentColor = colorResource(R.color.button_default_normal_text)
-	val focusedContainerColor = colorResource(R.color.button_default_highlight_background)
-	val focusedContentColor = colorResource(R.color.button_default_highlight_text)
-	val disabledContainerColor = colorResource(R.color.button_default_disabled_background)
-	val disabledContentColor = colorResource(R.color.button_default_disabled_text)
-
 	val colors = when {
-		!enabled -> disabledContainerColor to disabledContentColor
-		pressed -> focusedContainerColor to focusedContentColor
-		focused -> focusedContainerColor to focusedContentColor
-		else -> containerColor to contentColor
+		!enabled -> colors.disabledContainerColor to colors.disabledContentColor
+		pressed -> colors.focusedContainerColor to colors.focusedContentColor
+		focused -> colors.focusedContainerColor to colors.focusedContentColor
+		else -> colors.containerColor to colors.contentColor
 	}
 
 	ProvideTextStyle(value = JellyfinTheme.typography.default.copy(fontSize = 14.sp, color = colors.second)) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ButtonColors.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ButtonColors.kt
@@ -1,0 +1,14 @@
+package org.jellyfin.androidtv.ui.base.button
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class ButtonColors(
+	val containerColor: Color,
+	val contentColor: Color,
+	val focusedContainerColor: Color,
+	val focusedContentColor: Color,
+	val disabledContainerColor: Color,
+	val disabledContentColor: Color,
+)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/button/IconButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/button/IconButton.kt
@@ -5,15 +5,35 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 
 object IconButtonDefaults {
-	val Shape: Shape = CircleShape
+	val Shape: Shape = ButtonDefaults.Shape
 	val ContentPadding: PaddingValues = PaddingValues(horizontal = 10.dp, vertical = 10.dp)
+
+	@ReadOnlyComposable
+	@Composable
+	fun colors(
+		containerColor: Color = JellyfinTheme.colorScheme.button,
+		contentColor: Color = JellyfinTheme.colorScheme.onButton,
+		focusedContainerColor: Color = JellyfinTheme.colorScheme.buttonFocused,
+		focusedContentColor: Color = JellyfinTheme.colorScheme.onButtonFocused,
+		disabledContainerColor: Color = JellyfinTheme.colorScheme.buttonDisabled,
+		disabledContentColor: Color = JellyfinTheme.colorScheme.onButtonDisabled,
+	) = ButtonDefaults.colors(
+		containerColor = containerColor,
+		contentColor = contentColor,
+		focusedContainerColor = focusedContainerColor,
+		focusedContentColor = focusedContentColor,
+		disabledContainerColor = disabledContainerColor,
+		disabledContentColor = disabledContentColor,
+	)
 }
 
 @Composable
@@ -23,6 +43,7 @@ fun IconButton(
 	onLongClick: (() -> Unit)? = null,
 	enabled: Boolean = true,
 	shape: Shape = IconButtonDefaults.Shape,
+	colors: ButtonColors = ButtonDefaults.colors(),
 	contentPadding: PaddingValues = IconButtonDefaults.ContentPadding,
 	interactionSource: MutableInteractionSource? = null,
 	content: @Composable BoxScope.() -> Unit
@@ -33,6 +54,7 @@ fun IconButton(
 		onLongClick = onLongClick,
 		enabled = enabled,
 		shape = shape,
+		colors = colors,
 		interactionSource = interactionSource,
 	) {
 		Box(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ProgressButtonBase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/button/ProgressButtonBase.kt
@@ -20,6 +20,7 @@ fun ProgressButtonBase(
 	onLongClick: (() -> Unit)? = null,
 	enabled: Boolean = true,
 	shape: Shape = ButtonDefaults.Shape,
+	colors: ButtonColors = ButtonDefaults.colors(),
 	interactionSource: MutableInteractionSource? = null,
 	content: @Composable BoxScope.() -> Unit
 ) {
@@ -31,6 +32,7 @@ fun ProgressButtonBase(
 		onLongClick = onLongClick,
 		enabled = enabled,
 		shape = shape,
+		colors = colors,
 		interactionSource = interactionSource,
 	) {
 		Box(Modifier.matchParentSize()) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
@@ -1,0 +1,31 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+fun colorScheme(): ColorScheme = ColorScheme(
+	background = Color(0xFF101010),
+	onBackground = Color(0xFFFFFFFF),
+	button = Color(0xB3747474),
+	onButton = Color(0xFFDDDDDD),
+	buttonFocused = Color(0xE6CCCCCC),
+	onButtonFocused = Color(0xFF444444),
+	buttonDisabled = Color(0x33747474),
+	onButtonDisabled = Color(0xFF686868),
+)
+
+@Immutable
+data class ColorScheme(
+	val background: Color,
+	val onBackground: Color,
+
+	val button: Color,
+	val onButton: Color,
+	val buttonFocused: Color,
+	val onButtonFocused: Color,
+	val buttonDisabled: Color,
+	val onButtonDisabled: Color,
+)
+
+val LocalColorScheme = staticCompositionLocalOf { colorScheme() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/HomeToolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/HomeToolbar.kt
@@ -47,12 +47,19 @@ fun HomeToolbar(
 				onClick = switchUsers,
 				contentPadding = if (userImageVisible) PaddingValues(3.dp) else IconButtonDefaults.ContentPadding,
 			) {
-				Image(
-					painter = if (userImageVisible) userImagePainter else painterResource(R.drawable.ic_switch_users),
-					contentDescription = stringResource(R.string.lbl_switch_user),
-					modifier = Modifier
-						.clip(IconButtonDefaults.Shape)
-				)
+				if (userImageVisible) {
+					Image(
+						painter = userImagePainter,
+						contentDescription = stringResource(R.string.lbl_switch_user),
+						modifier = Modifier
+							.clip(IconButtonDefaults.Shape)
+					)
+				} else {
+					Icon(
+						painter = painterResource(R.drawable.ic_switch_users),
+						contentDescription = stringResource(R.string.lbl_switch_user),
+					)
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/Toolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/Toolbar.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.modifier.childFocusRestorer
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
@@ -87,7 +88,13 @@ fun BoxScope.ToolbarButtons(
 			.align(Alignment.CenterEnd),
 		horizontalArrangement = Arrangement.spacedBy(8.dp),
 	) {
-		content()
+		JellyfinTheme(
+			colorScheme = JellyfinTheme.colorScheme.copy(
+				button = Color.Transparent
+			)
+		) {
+			content()
+		}
 	}
 }
 


### PR DESCRIPTION
Make the background of icon buttons in the toolbar (see #4562) transparent again. But in the most complicated way.

**Changes**
- Add JellyfinTheme fun to easily set theme properties
- Add colorScheme
- Add ButtonColors & ButtonDefaults.colors
- Set transparent button color in ToolbarButtons

**Screenshots**

![sample text](https://github.com/user-attachments/assets/761c1d13-3c00-4263-848a-dc50ce4eb2fd)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
