### PR TITLE
Do not set audio session to pipeline on create

### DIFF
--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -98,7 +98,6 @@ class ExoPlayerBackend(
 			.build()
 			.also { player ->
 				player.addListener(PlayerListener())
-				audioPipeline.setAudioSessionId(player.audioSessionId)
 
 				if (exoPlayerOptions.enableDebugLogging) {
 					player.addAnalyticsListener(EventLogger())


### PR DESCRIPTION
Similar to #4582 but this one didn't cause a crash

**Changes**
- Do not set audio session to pipeline on create as it will always be `0` (global)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
