### PR TITLE
Move activity opening out of navigation code

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -9,14 +9,12 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import okhttp3.OkHttpClient
-import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.jellyfin.androidtv.ui.browsing.MainActivity
-import org.jellyfin.androidtv.ui.playback.GarbagePlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.MediaManager
-import org.jellyfin.androidtv.ui.playback.RewritePlaybackLauncher
+import org.jellyfin.androidtv.ui.playback.PlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
 import org.jellyfin.androidtv.util.profile.createDeviceProfile
@@ -40,13 +38,7 @@ val playbackModule = module {
 	single { VideoQueueManager() }
 	single<MediaManager> { RewriteMediaManager(get(), get(), get(), get()) }
 
-	factory {
-		val preferences = get<UserPreferences>()
-		val useRewrite = preferences[UserPreferences.playbackRewriteVideoEnabled] && BuildConfig.DEVELOPMENT
-
-		if (useRewrite) RewritePlaybackLauncher()
-		else GarbagePlaybackLauncher(get())
-	}
+	single { PlaybackLauncher(get(), get(), get()) }
 
 	// OkHttp data source using OkHttpFactory from SDK
 	single<HttpDataSource.Factory> {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -50,7 +50,7 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapterHelperKt;
-import org.jellyfin.androidtv.ui.navigation.Destinations;
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.HorizontalGridPresenter;
@@ -814,7 +814,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
             @Override
             public void onClick(View v) {
                 boolean allowViewSelection = userViewsRepository.getValue().allowViewSelection(mFolder.getCollectionType());
-                navigationRepository.getValue().navigate(Destinations.INSTANCE.displayPreferences(mFolder.getDisplayPreferencesId(), allowViewSelection));
+                startActivity(ActivityDestinations.INSTANCE.displayPreferences(getContext(), mFolder.getDisplayPreferencesId(), allowViewSelection));
             }
         });
         mSettingsButton.setContentDescription(getString(R.string.lbl_settings));

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -121,18 +121,8 @@ class MainActivity : FragmentActivity() {
 		screensaverViewModel.notifyInteraction(true)
 
 		when (action) {
-			// DestinationFragmentView actions
 			is NavigationAction.NavigateFragment -> binding.contentView.navigate(action)
 			NavigationAction.GoBack -> binding.contentView.goBack()
-
-			// Others
-			is NavigationAction.NavigateActivity -> {
-				val destination = action.destination
-				val intent = Intent(this@MainActivity, destination.activity.java)
-				intent.putExtras(destination.extras)
-				startActivity(intent)
-				action.onOpened()
-			}
 
 			NavigationAction.Nothing -> Unit
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -21,6 +22,7 @@ import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.databinding.FragmentHomeBinding
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.playback.MediaManager
@@ -49,9 +51,10 @@ class HomeFragment : Fragment() {
 			val currentUser by remember { userRepository.currentUser.filterNotNull() }.collectAsState(null)
 			val userImage = remember(currentUser) { currentUser?.let(imageHelper::getPrimaryImageUrl) }
 
+			val context = LocalContext.current
 			HomeToolbar(
 				openSearch = { navigationRepository.navigate(Destinations.search()) },
-				openSettings = { navigationRepository.navigate(Destinations.userPreferences) },
+				openSettings = { startActivity(ActivityDestinations.userPreferences(context)) },
 				switchUsers = { switchUser() },
 				userImage = userImage,
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -57,7 +57,6 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
-import org.jellyfin.androidtv.ui.navigation.Destination;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
@@ -1205,9 +1204,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 if (item.getType() == BaseItemKind.MUSIC_ARTIST) {
                     mediaManager.getValue().playNow(requireContext(), response, 0, shuffle);
                 } else {
-                    videoQueueManager.getValue().setCurrentVideoQueue(response);
-                    Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(item.getType(), pos);
-                    navigationRepository.getValue().navigate(destination);
+                    KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).launch(getContext(), response, pos);
                 }
             }
         });
@@ -1216,8 +1213,6 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     void play(final List<BaseItemDto> items, final int pos, final boolean shuffle) {
         if (items.isEmpty()) return;
         if (shuffle) Collections.shuffle(items);
-        videoQueueManager.getValue().setCurrentVideoQueue(items);
-        Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(items.get(0).getType(), pos);
-        navigationRepository.getValue().navigate(destination);
+        KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).launch(getContext(), items, pos);
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/ItemListFragment.java
@@ -35,7 +35,6 @@ import org.jellyfin.androidtv.ui.ItemRowView;
 import org.jellyfin.androidtv.ui.TextUnderButton;
 import org.jellyfin.androidtv.ui.itemhandling.BaseItemDtoBaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
-import org.jellyfin.androidtv.ui.navigation.Destination;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.AudioEventListener;
@@ -367,10 +366,7 @@ public class ItemListFragment extends Fragment implements View.OnKeyListener {
             if (item != null && item.getUserData() != null) {
                 pos = Math.toIntExact(item.getUserData().getPlaybackPositionTicks() / 10000);
             }
-            videoQueueManager.getValue().setCurrentVideoQueue(items);
-            videoQueueManager.getValue().setCurrentMediaPosition(ndx);
-            Destination destination = KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).getPlaybackDestination(mBaseItem.getType(), pos);
-            navigationRepository.getValue().navigate(destination);
+            KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).launch(getContext(), items, pos, false, ndx);
         } else {
             mediaManager.getValue().playNow(requireContext(), items, ndx, shuffle);
         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -14,7 +14,6 @@ import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
-import org.jellyfin.androidtv.ui.playback.VideoQueueManager;
 import org.jellyfin.androidtv.util.PlaybackHelper;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.Response;
@@ -35,7 +34,6 @@ public class ItemLauncher {
     private final Lazy<NavigationRepository> navigationRepository = KoinJavaComponent.<NavigationRepository>inject(NavigationRepository.class);
     private final Lazy<PreferencesRepository> preferencesRepository = KoinJavaComponent.<PreferencesRepository>inject(org.jellyfin.androidtv.preference.PreferencesRepository .class);
     private final Lazy<MediaManager> mediaManager = KoinJavaComponent.<MediaManager>inject(MediaManager.class);
-    private final Lazy<VideoQueueManager> videoQueueManager = KoinJavaComponent.<VideoQueueManager>inject(VideoQueueManager.class);
     private final Lazy<PlaybackLauncher> playbackLauncher = KoinJavaComponent.<PlaybackLauncher>inject(PlaybackLauncher.class);
     private final Lazy<PlaybackHelper> playbackHelper = KoinJavaComponent.<PlaybackHelper>inject(PlaybackHelper.class);
 
@@ -154,13 +152,10 @@ public class ItemLauncher {
                             break;
                         case Play:
                             //Just play it directly
-                            final BaseItemKind itemType = baseItem.getType();
                             playbackHelper.getValue().getItemsToPlay(context, baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
                                 @Override
                                 public void onResponse(List<BaseItemDto> response) {
-                                    videoQueueManager.getValue().setCurrentVideoQueue(response);
-                                    Destination destination = playbackLauncher.getValue().getPlaybackDestination(itemType, 0);
-                                    navigationRepository.getValue().navigate(destination);
+                                    playbackLauncher.getValue().launch(context, response);
                                 }
                             });
                             break;
@@ -177,12 +172,10 @@ public class ItemLauncher {
                 ItemLauncherHelper.getItem(rowItem.getItemId(), new Response<BaseItemDto>() {
                     @Override
                     public void onResponse(BaseItemDto response) {
-                        List<BaseItemDto> items = new ArrayList<>();
+                        List<BaseItemDto> items = new ArrayList<>(1);
                         items.add(response);
-                        videoQueueManager.getValue().setCurrentVideoQueue(items);
                         Long start = chapter.getStartPositionTicks() / 10000;
-                        Destination destination = playbackLauncher.getValue().getPlaybackDestination(response.getType(), start.intValue());
-                        navigationRepository.getValue().navigate(destination);
+                        playbackLauncher.getValue().launch(context, items, start.intValue());
                     }
                 });
 
@@ -200,11 +193,9 @@ public class ItemLauncher {
                         ItemLauncherHelper.getItem(program.getChannelId(), new Response<BaseItemDto>() {
                             @Override
                             public void onResponse(BaseItemDto response) {
-                                List<BaseItemDto> items = new ArrayList<>();
+                                List<BaseItemDto> items = new ArrayList<>(1);
                                 items.add(response);
-                                videoQueueManager.getValue().setCurrentVideoQueue(items);
-                                Destination destination = playbackLauncher.getValue().getPlaybackDestination(response.getType(), 0);
-                                navigationRepository.getValue().navigate(destination);
+                                playbackLauncher.getValue().launch(context, items);
 
                             }
                         });
@@ -220,9 +211,7 @@ public class ItemLauncher {
                         playbackHelper.getValue().getItemsToPlay(context, response, false, false, new Response<List<BaseItemDto>>() {
                             @Override
                             public void onResponse(List<BaseItemDto> response) {
-                                videoQueueManager.getValue().setCurrentVideoQueue(response);
-                                Destination destination = playbackLauncher.getValue().getPlaybackDestination(channel.getType(), 0);
-                                navigationRepository.getValue().navigate(destination);
+                                playbackLauncher.getValue().launch(context, response);
                             }
                         });
                     }
@@ -240,11 +229,9 @@ public class ItemLauncher {
                         ItemLauncherHelper.getItem(rowItem.getBaseItem().getId(), new Response<BaseItemDto>() {
                             @Override
                             public void onResponse(BaseItemDto response) {
-                                List<BaseItemDto> items = new ArrayList<>();
+                                List<BaseItemDto> items = new ArrayList<>(1);
                                 items.add(response);
-                                videoQueueManager.getValue().setCurrentVideoQueue(items);
-                                Destination destination = playbackLauncher.getValue().getPlaybackDestination(rowItem.getBaseItem().getType(), 0);
-                                navigationRepository.getValue().navigate(destination);
+                                playbackLauncher.getValue().launch(context, items);
                             }
                         });
                         break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -39,7 +39,7 @@ import org.jellyfin.androidtv.ui.ObservableHorizontalScrollView;
 import org.jellyfin.androidtv.ui.ObservableScrollView;
 import org.jellyfin.androidtv.ui.ProgramGridCell;
 import org.jellyfin.androidtv.ui.ScrollViewListener;
-import org.jellyfin.androidtv.ui.navigation.Destinations;
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.DateTimeExtensionsKt;
@@ -439,12 +439,12 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
     }
 
     public void showFilterOptions() {
-        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvGuideFilterPreferences());
+        startActivity(ActivityDestinations.INSTANCE.liveTvGuideFilterPreferences(getContext()));
         TvManager.forceReload();
     }
 
     public void showOptions() {
-        navigationRepository.getValue().navigate(Destinations.INSTANCE.getLiveTvGuideOptionPreferences());
+        startActivity(ActivityDestinations.INSTANCE.liveTvGuideOptionPreferences(getContext()));
         TvManager.forceReload();
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
@@ -1,0 +1,46 @@
+package org.jellyfin.androidtv.ui.navigation
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.os.bundleOf
+import org.jellyfin.androidtv.ui.browsing.DisplayPreferencesScreen
+import org.jellyfin.androidtv.ui.livetv.GuideFiltersScreen
+import org.jellyfin.androidtv.ui.livetv.GuideOptionsScreen
+import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
+import org.jellyfin.androidtv.ui.preference.PreferencesActivity
+import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
+import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
+import kotlin.time.Duration
+
+object ActivityDestinations {
+	private inline fun <reified T : OptionsFragment> preferenceIntent(
+		context: Context,
+		vararg screenArguments: Pair<String, Any?>
+	) = Intent(context, PreferencesActivity::class.java).apply {
+		putExtras(
+			bundleOf(
+				PreferencesActivity.EXTRA_SCREEN to T::class.qualifiedName,
+				PreferencesActivity.EXTRA_SCREEN_ARGS to bundleOf(*screenArguments),
+			)
+		)
+	}
+
+	fun userPreferences(context: Context) = preferenceIntent<UserPreferencesScreen>(context)
+	fun displayPreferences(context: Context, displayPreferencesId: String, allowViewSelection: Boolean) =
+		preferenceIntent<DisplayPreferencesScreen>(
+			context,
+			DisplayPreferencesScreen.ARG_PREFERENCES_ID to displayPreferencesId,
+			DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to allowViewSelection,
+		)
+
+	fun liveTvGuideFilterPreferences(context: Context) = preferenceIntent<GuideFiltersScreen>(context)
+	fun liveTvGuideOptionPreferences(context: Context) = preferenceIntent<GuideOptionsScreen>(context)
+
+	fun externalPlayer(context: Context, position: Duration = Duration.ZERO) = Intent(context, ExternalPlayerActivity::class.java).apply {
+		putExtras(
+			bundleOf(
+				ExternalPlayerActivity.EXTRA_POSITION to position.inWholeMilliseconds
+			)
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destination.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destination.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.navigation
 
-import android.app.Activity
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -11,11 +10,6 @@ sealed interface Destination {
 		val fragment: KClass<out androidx.fragment.app.Fragment>,
 		val arguments: Bundle = bundleOf(),
 	) : Destination
-
-	data class Activity(
-		val activity: KClass<out android.app.Activity>,
-		val extras: Bundle = bundleOf(),
-	) : Destination
 }
 
 inline fun <reified T : Fragment> fragmentDestination(
@@ -23,11 +17,4 @@ inline fun <reified T : Fragment> fragmentDestination(
 ) = Destination.Fragment(
 	fragment = T::class,
 	arguments = bundleOf(*arguments),
-)
-
-inline fun <reified T : Activity> activityDestination(
-	vararg extras: Pair<String, Any?>,
-) = Destination.Activity(
-	activity = T::class,
-	extras = bundleOf(*extras),
 )

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -1,7 +1,5 @@
 package org.jellyfin.androidtv.ui.navigation
 
-import androidx.core.os.bundleOf
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.constant.Extras
 import org.jellyfin.androidtv.ui.browsing.BrowseGridFragment
@@ -11,49 +9,32 @@ import org.jellyfin.androidtv.ui.browsing.BrowseViewFragment
 import org.jellyfin.androidtv.ui.browsing.ByGenreFragment
 import org.jellyfin.androidtv.ui.browsing.ByLetterFragment
 import org.jellyfin.androidtv.ui.browsing.CollectionFragment
-import org.jellyfin.androidtv.ui.browsing.DisplayPreferencesScreen
 import org.jellyfin.androidtv.ui.browsing.GenericFolderFragment
 import org.jellyfin.androidtv.ui.browsing.SuggestedMoviesFragment
 import org.jellyfin.androidtv.ui.home.HomeFragment
 import org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragment
 import org.jellyfin.androidtv.ui.itemdetail.ItemListFragment
 import org.jellyfin.androidtv.ui.itemdetail.MusicFavoritesListFragment
-import org.jellyfin.androidtv.ui.livetv.GuideFiltersScreen
-import org.jellyfin.androidtv.ui.livetv.GuideOptionsScreen
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideFragment
 import org.jellyfin.androidtv.ui.picture.PictureViewerFragment
 import org.jellyfin.androidtv.ui.playback.AudioNowPlayingFragment
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment
-import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpFragment
 import org.jellyfin.androidtv.ui.playback.rewrite.PlaybackRewriteFragment
-import org.jellyfin.androidtv.ui.preference.PreferencesActivity
-import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
-import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
 import org.jellyfin.androidtv.ui.search.SearchFragment
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SeriesTimerInfoDto
 import org.jellyfin.sdk.model.api.SortOrder
 import java.util.UUID
-import kotlin.time.Duration
 
 @Suppress("TooManyFunctions")
 object Destinations {
-	// Helpers
-	private inline fun <reified T : OptionsFragment> preferenceDestination(
-		vararg screenArguments: Pair<String, Any?>
-	) = activityDestination<PreferencesActivity>(
-		PreferencesActivity.EXTRA_SCREEN to T::class.qualifiedName,
-		PreferencesActivity.EXTRA_SCREEN_ARGS to bundleOf(*screenArguments),
-	)
-
 	// General
 	val home = fragmentDestination<HomeFragment>()
 	fun search(query: String? = null) = fragmentDestination<SearchFragment>(
 		SearchFragment.EXTRA_QUERY to query,
 	)
-	val userPreferences = preferenceDestination<UserPreferencesScreen>()
 
 	// Browsing
 	// TODO only pass item id instead of complete JSON to browsing destinations
@@ -103,12 +84,6 @@ object Destinations {
 			Extras.Folder to Json.Default.encodeToString(item),
 		)
 
-	fun displayPreferences(displayPreferencesId: String, allowViewSelection: Boolean) =
-		preferenceDestination<DisplayPreferencesScreen>(
-			DisplayPreferencesScreen.ARG_PREFERENCES_ID to displayPreferencesId,
-			DisplayPreferencesScreen.ARG_ALLOW_VIEW_SELECTION to allowViewSelection,
-		)
-
 	// Item details
 	fun itemDetails(item: UUID) = fragmentDestination<FullDetailsFragment>(
 		"ItemId" to item.toString(),
@@ -142,8 +117,6 @@ object Destinations {
 	val liveTvSchedule = fragmentDestination<BrowseScheduleFragment>()
 	val liveTvRecordings = fragmentDestination<BrowseRecordingsFragment>()
 	val liveTvSeriesRecordings = fragmentDestination<BrowseViewFragment>(Extras.IsLiveTvSeriesRecordings to true)
-	val liveTvGuideFilterPreferences = preferenceDestination<GuideFiltersScreen>()
-	val liveTvGuideOptionPreferences = preferenceDestination<GuideOptionsScreen>()
 
 	// Playback
 	val nowPlaying = fragmentDestination<AudioNowPlayingFragment>()
@@ -155,10 +128,6 @@ object Destinations {
 			PictureViewerFragment.ARGUMENT_ALBUM_SORT_ORDER to albumSortOrder?.serialName,
 			PictureViewerFragment.ARGUMENT_AUTO_PLAY to autoPlay,
 		)
-
-	fun externalPlayer(position: Duration = Duration.ZERO) = activityDestination<ExternalPlayerActivity>(
-		ExternalPlayerActivity.EXTRA_POSITION to position.inWholeMilliseconds
-	)
 
 	fun videoPlayer(position: Int?) = fragmentDestination<CustomPlaybackOverlayFragment>(
 		"Position" to (position ?: 0)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationAction.kt
@@ -15,14 +15,6 @@ sealed interface NavigationAction {
 	) : NavigationAction
 
 	/**
-	 * Open the activity in [destination] and immediately call [onOpened] to clear the emitted state.
-	 */
-	data class NavigateActivity(
-		val destination: Destination.Activity,
-		val onOpened: () -> Unit,
-	) : NavigationAction
-
-	/**
 	 * Go back to the previous fragment manager state.
 	 */
 	data object GoBack : NavigationAction

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
@@ -71,10 +71,6 @@ class NavigationRepositoryImpl(
 		Timber.d("Navigating to $destination (via navigate function)")
 		val action = when (destination) {
 			is Destination.Fragment -> NavigationAction.NavigateFragment(destination, true, replace, false)
-			is Destination.Activity -> NavigationAction.NavigateActivity(destination) {
-				Timber.d("Navigating to nothing")
-				_currentAction.tryEmit(NavigationAction.Nothing)
-			}
 		}
 		if (destination is Destination.Fragment) {
 			if (replace && fragmentHistory.isNotEmpty()) fragmentHistory[fragmentHistory.lastIndex] = destination

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -4,7 +4,6 @@ import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.navigation.Destination
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.sdk.model.api.BaseItemKind
-import kotlin.time.Duration.Companion.milliseconds
 
 interface PlaybackLauncher {
 	fun useExternalPlayer(itemType: BaseItemKind?): Boolean
@@ -23,15 +22,13 @@ class GarbagePlaybackLauncher(
 		BaseItemKind.RECORDING,
 		BaseItemKind.TV_CHANNEL,
 		BaseItemKind.PROGRAM,
-		-> userPreferences[UserPreferences.useExternalPlayer]
+			-> userPreferences[UserPreferences.useExternalPlayer]
 
 		else -> false
 	}
 
-	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = when {
-		useExternalPlayer(itemType) -> Destinations.externalPlayer(position.milliseconds)
-		else -> Destinations.videoPlayer(position)
-	}
+	// TODO: Launch external :-)
+	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = Destinations.videoPlayer(position)
 }
 
 class RewritePlaybackLauncher : PlaybackLauncher {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -1,37 +1,53 @@
 package org.jellyfin.androidtv.ui.playback
 
+import android.content.Context
 import org.jellyfin.androidtv.preference.UserPreferences
-import org.jellyfin.androidtv.ui.navigation.Destination
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
 import org.jellyfin.androidtv.ui.navigation.Destinations
+import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
-interface PlaybackLauncher {
-	fun useExternalPlayer(itemType: BaseItemKind?): Boolean
-	fun getPlaybackDestination(itemType: BaseItemKind?, position: Int): Destination
-}
+/**
+ * Utility class to launch the playback UI for an item.
+ */
+class PlaybackLauncher(
+	private val videoQueueManager: VideoQueueManager,
+	private val navigationRepository: NavigationRepository,
+	private val userPreferences: UserPreferences,
+) {
+	private val BaseItemDto.supportsExternalPlayer
+		get() = when (type) {
+			BaseItemKind.MOVIE,
+			BaseItemKind.EPISODE,
+			BaseItemKind.VIDEO,
+			BaseItemKind.SERIES,
+			BaseItemKind.SEASON,
+			BaseItemKind.RECORDING,
+			BaseItemKind.TV_CHANNEL,
+			BaseItemKind.PROGRAM,
+				-> true
 
-class GarbagePlaybackLauncher(
-	private val userPreferences: UserPreferences
-) : PlaybackLauncher {
-	override fun useExternalPlayer(itemType: BaseItemKind?) = when (itemType) {
-		BaseItemKind.MOVIE,
-		BaseItemKind.EPISODE,
-		BaseItemKind.VIDEO,
-		BaseItemKind.SERIES,
-		BaseItemKind.SEASON,
-		BaseItemKind.RECORDING,
-		BaseItemKind.TV_CHANNEL,
-		BaseItemKind.PROGRAM,
-			-> userPreferences[UserPreferences.useExternalPlayer]
+			else -> false
+		}
 
-		else -> false
+	@JvmOverloads
+	fun launch(context: Context, items: Collection<BaseItemDto>, position: Int? = null, replace: Boolean = false, itemsPosition: Int = 0) {
+		videoQueueManager.setCurrentVideoQueue(items.toList())
+		videoQueueManager.setCurrentMediaPosition(itemsPosition)
+
+		if (items.isEmpty()) return
+
+		if (userPreferences[UserPreferences.useExternalPlayer] && items.all { it.supportsExternalPlayer }) {
+			context.startActivity(ActivityDestinations.externalPlayer(context, position?.milliseconds ?: Duration.ZERO))
+		} else if (userPreferences[UserPreferences.playbackRewriteVideoEnabled]) {
+			val destination = Destinations.playbackRewritePlayer(position)
+			navigationRepository.navigate(destination, replace)
+		} else {
+			val destination = Destinations.videoPlayer(position)
+			navigationRepository.navigate(destination, replace)
+		}
 	}
-
-	// TODO: Launch external :-)
-	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = Destinations.videoPlayer(position)
-}
-
-class RewritePlaybackLauncher : PlaybackLauncher {
-	override fun useExternalPlayer(itemType: BaseItemKind?) = false
-	override fun getPlaybackDestination(itemType: BaseItemKind?, position: Int) = Destinations.playbackRewritePlayer(position)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -235,12 +235,10 @@ class SdkPlaybackHelper(
 			} else if (item.type == BaseItemKind.AUDIO && items.isNotEmpty()) {
 				mediaManager.playNow(context, listOf(items.first()), 0, false)
 			} else {
-				videoQueueManager.setCurrentVideoQueue(items)
-				navigationRepository.navigate(
-					playbackLauncher.getPlaybackDestination(
-						item.type,
-						pos.inWholeTicks.toInt()
-					),
+				playbackLauncher.launch(
+					context,
+					items,
+					pos.inWholeTicks.toInt(),
 					playbackControllerContainer.playbackController?.hasFragment() == true
 				)
 			}


### PR DESCRIPTION
Thee are the initial changes to improvements on our navigation code to fix some long standing fragment transaction issues on resume and to better support compose (without fragments wrapping the screen composable).

**Changes**
- Remove activityDestination
- Add ActivityDestinations object to create intents for launching our previous activity destinations: preferences & external player
- Rewrite PlaybackLauncher to actually launch (set media queue & navigate) instead of just returning a destination

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
