### PR TITLE
Fix "favorites" playlist not showing when the user has no playlists

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -588,7 +588,7 @@ fun ItemRowAdapter.retrieveItems(
 				},
 			)
 
-			if (response.items.isEmpty()) removeRow()
+			if (itemsLoaded == 0) removeRow()
 		}.fold(
 			onSuccess = { notifyRetrieveFinished() },
 			onFailure = { error -> notifyRetrieveFinished(error as? Exception) }


### PR DESCRIPTION
We add the "favorites playlist" client-side and then load the other playlists to the same row, if we only check the response list it won't know about that and hide the row.. oops

**Changes**
- Fix "favorites" playlist not showing when the user has no playlists


**Issues**
Fix #4587