### PR TITLE
Add hearing impaired indicator for subtitles (SDH)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -150,24 +150,25 @@ private fun List<MediaStream>.getDefault(type: MediaStreamType, defaultIndex: In
 fun InfoRowMediaDetails(mediaSource: MediaSourceInfo) {
 	val videoStream = mediaSource.mediaStreams?.getDefault(MediaStreamType.VIDEO)
 	val audioStream = mediaSource.mediaStreams?.getDefault(MediaStreamType.AUDIO, mediaSource.defaultAudioStreamIndex)
-	val subtitleStream = mediaSource.mediaStreams?.getDefault(MediaStreamType.SUBTITLE, mediaSource.defaultSubtitleStreamIndex)
+	val hasSdhSubtitleStream = mediaSource.mediaStreams?.any { it.type == MediaStreamType.SUBTITLE && it.isHearingImpaired } == true
+	val hasCcSubtitleStream = mediaSource.mediaStreams?.any { it.type == MediaStreamType.SUBTITLE && !it.isHearingImpaired } == true
 
 	// Subtitles
-	if (subtitleStream != null) {
-		if (subtitleStream.isHearingImpaired) {
-			InfoRowItem(
-				contentDescription = null,
-				colors = InfoRowColors.Default,
-			) {
-				Text(stringResource(R.string.indicator_subtitles_hearing_impaired))
-			}
-		} else {
-			InfoRowItem(
-				contentDescription = null,
-				colors = InfoRowColors.Default,
-			) {
-				Text(stringResource(R.string.indicator_subtitles))
-			}
+	if (hasSdhSubtitleStream) {
+		InfoRowItem(
+			contentDescription = null,
+			colors = InfoRowColors.Default,
+		) {
+			Text(stringResource(R.string.indicator_subtitles_hearing_impaired))
+		}
+	}
+
+	if (hasCcSubtitleStream) {
+		InfoRowItem(
+			contentDescription = null,
+			colors = InfoRowColors.Default,
+		) {
+			Text(stringResource(R.string.indicator_subtitles))
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -154,11 +154,20 @@ fun InfoRowMediaDetails(mediaSource: MediaSourceInfo) {
 
 	// Subtitles
 	if (subtitleStream != null) {
-		InfoRowItem(
-			contentDescription = null,
-			colors = InfoRowColors.Default,
-		) {
-			Text(stringResource(R.string.indicator_subtitles))
+		if (subtitleStream.isHearingImpaired) {
+			InfoRowItem(
+				contentDescription = null,
+				colors = InfoRowColors.Default,
+			) {
+				Text(stringResource(R.string.indicator_subtitles_hearing_impaired))
+			}
+		} else {
+			InfoRowItem(
+				contentDescription = null,
+				colors = InfoRowColors.Default,
+			) {
+				Text(stringResource(R.string.indicator_subtitles))
+			}
 		}
 	}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,6 +486,7 @@
     <string name="person_birthday_and_age">Born %1$s (%2$d)</string>
     <string name="dolby_vision">Dolby Vision</string>
     <string name="indicator_subtitles">CC</string>
+    <string name="indicator_subtitles_hearing_impaired">SDH</string>
     <string name="dolby_atmos">Dolby Atmos</string>
     <string name="dts_x">DTS:X</string>
     <string name="dts_hd">DTS:HD</string>


### PR DESCRIPTION
Would it be better to show CC when there is _any_ non-sdh subtitle stream and SDH when there is _any_ SDH stream? Let me know in the comments (don't forget to like and subscribe).

**Changes**
- Add "SDH" instead of "CC" as indicator to the info row when subtitles are marked as hearing impaired

![image](https://github.com/user-attachments/assets/81a1b7be-75a7-4d61-9215-284945b75900)


**Issues**

Fixes #3463