### PR TITLE
Add rating option to only display ratings on media info screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/RatingType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/RatingType.kt
@@ -20,4 +20,9 @@ enum class RatingType(
 	 * Sets the default rating type to hidden.
 	 */
 	RATING_HIDDEN(R.string.lbl_hidden),
+
+	/**
+	 * Sets the default rating type to only display ratings in the media info screen.
+	 */
+	RATING_ONLY_IN_MEDIA_INFO(R.string.lbl_only_in_media_info),
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -251,7 +251,7 @@ fun BaseItemInfoRow(
 		horizontalArrangement = Arrangement.spacedBy(8.dp),
 		verticalAlignment = Alignment.CenterVertically,
 	) {
-		if (ratingType != RatingType.RATING_HIDDEN) {
+		if (ratingType == RatingType.RATING_ONLY_IN_MEDIA_INFO || ratingType != RatingType.RATING_HIDDEN ) {
 			item.communityRating?.let { InfoRowCommunityRating(it / 10f) }
 			item.criticRating?.let { InfoRowCriticRating(it / 100f) }
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,7 @@
     <string name="pref_developer_link">Developer options</string>
     <string name="pref_developer_link_description">Advanced and experimental features</string>
     <string name="lbl_hidden">Hidden</string>
+    <string name="lbl_only_in_media_info">Only in media info</string>
     <string name="discovered_servers_title">Discovered servers</string>
     <string name="discovered_servers_empty">No servers found on local network.</string>
     <string name="connect_manually_by_address">Enter server address</string>


### PR DESCRIPTION
Currently ratings can be '_displayed_' or '_hidden_', this new additional option "Only in media info" allows ratings to be hidden on the home screen items while still appearing in the media info.

Selection:
<img width="423" alt="Screenshot 2025-04-23 at 5 19 19 pm" src="https://github.com/user-attachments/assets/2c01eba0-32f8-450b-b86d-ed80a3af1904" />

