### PR TITLE
Change screensaver to cycle through random selection and avoid repeats

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/DreamViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/DreamViewModel.kt
@@ -61,18 +61,21 @@ class DreamViewModel(
 		emit(null)
 		delay(2.seconds)
 
-		var randomItems = getRandomLibraryItems();
-		while (randomItems == null)
-			delay(3.seconds)
-			randomItems = getRandomLibraryItems();
-
-		val isCompleteList = randomItems.totalRecordCount == randomItems.items.size
-		var itemsWithBackdrops = randomItems.items.filter { item ->
-				!item.backdropImageTags.isNullOrEmpty()
-		}
-
+		var isCompletList = false
+		var randomItems = null
 		while (true) {
-			for (item in itemsWithBackdrops) {
+			if (!isCompleteList) {
+				randomItems = getRandomLibraryItems();
+				while (randomItems == null)
+					delay(3.seconds)
+					randomItems = getRandomLibraryItems();
+				isCompleteList = randomItems.totalRecordCount == randomItems.items.size
+			}
+
+			for (item in randomItems.items) {
+				if (item.backdropImageTags.isNullOrEmpty()) {
+					continue
+				}
 				val next = withContext(Dispatchers.IO) { libraryShowcase(item) }
 				if (next != null) {
 					emit(next)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
I was watching my Jellyfin screensaver and noticed that there were some media that were displayed repeatedly, and found that this was because the screensaver has no memory of the media it recently cycled through. This is a rough draft of an alternative model; instead of requesting a new random library item to display each time, request many distinct random library items from the outset, and then play them in (the provided random) order. This ensures better coverage of the media library and reduces repetition.