### PR TITLE
Reduce Quality Option clutter by allowing the user to limit the Options under a given threshold

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [MajMongoose](https://github.com/majmongoose)
  - [Olaren15](https://github.com/Olaren15)
  - [dtrexler](https://github.com/dtrexler)
+ - [InTrustABC](https://github.com/InTrustABC)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/constant/QualityProfiles.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/QualityProfiles.kt
@@ -13,9 +13,10 @@ private val qualityOptions = setOf(
 
 @Suppress("MagicNumber")
 fun getQualityProfiles(
-	context: Context
-): Map<String, String> = qualityOptions.associate {
-	val value = when {
+	context: Context,
+	threshold : Double = 200.0
+): Map<String, String> = filteredQualityOptions(threshold).associate {
+val value = when {
 		it >= 1.0 -> context.getString(R.string.bitrate_mbit, it)
 		else -> context.getString(R.string.bitrate_kbit, it * 1000.0)
 	}
@@ -23,3 +24,4 @@ fun getQualityProfiles(
 	it.toString().removeSuffix(".0") to value
 }
 
+private fun filteredQualityOptions(threshold: Double) = qualityOptions.filter { it <= threshold }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -230,6 +230,13 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Enable TrickPlay in legacy player user interface while seeking.
 		 */
 		var trickPlayEnabled = booleanPreference("trick_play_enabled", false)
+
+
+		/**
+		 * The threshold under which no quality option will be available/shown
+		 */
+		var qualityOptionThreshold = intPreference("quality_option_threshold", 200)
+
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectQualityAction.kt
@@ -19,7 +19,7 @@ class SelectQualityAction(
 ) : CustomAction(context, customPlaybackTransportControlGlue) {
 	private val previousQualitySelection = userPreferences[UserPreferences.maxBitrate]
 	private val qualityController = VideoQualityController(previousQualitySelection, userPreferences)
-	private val qualityProfiles = getQualityProfiles(context)
+	private val qualityProfiles = getQualityProfiles(context, userPreferences[UserPreferences.qualityOptionThreshold].toDouble())
 	private var popup: PopupMenu? = null
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -6,10 +6,12 @@ import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.SystemPreferences
 import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.action
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
+import org.jellyfin.androidtv.ui.preference.dsl.seekbar
 import org.jellyfin.androidtv.util.isTvDevice
 import org.koin.android.ext.android.inject
 
@@ -72,6 +74,19 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 					rebuild()
 				}
 			}
+
+			seekbar {
+				setTitle(R.string.quality_option_threshold)
+				setContent(R.string.quality_option_threshold_content)
+				min = 1
+				max = 200
+				increment = 1
+				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
+					override fun display(value: Int) = "${value}Mbit/s"
+				}
+				bind(userPreferences, UserPreferences.qualityOptionThreshold)
+			}
+
 		}
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -514,6 +514,8 @@
     <string name="prefer_exoplayer_ffmpeg">Prefer FFmpeg for audio playback</string>
     <string name="prefer_exoplayer_ffmpeg_content">Use FFmpeg to decode audio, even if platform codecs are available.</string>
     <string name="default_video_zoom">Default zoom mode</string>
+    <string name="quality_option_threshold">Only show Quality Options under threshold.</string>
+    <string name="quality_option_threshold_content">Limit the number of shown Quality Options to those under 50 Mbit/s. If your Server only has 50 Mbit Upload this reduces clutter.</string>
     <string name="video_start_delay">Video start delay</string>
     <string name="pref_mediasegment_actions">Media segment actions</string>
     <string name="segment_action_ask_to_skip">Ask to skip</string>


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added a slider/seekbar to the developer options in the client.
Quality Options <= the set value of this seekbar are not shown in the Quality selection anymore.
This reduces clutter when watching from a server whos upload is under the threshold of this option.

**Issues**
#4632 [Discussion](https://github.com/jellyfin/jellyfin-androidtv/discussions/4632)
#4633 

