### PR TITLE
Add intermediate model for image information

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -119,7 +119,7 @@ val appModule = module {
 	viewModel { StartupViewModel(get(), get(), get(), get()) }
 	viewModel { UserLoginViewModel(get(), get(), get(), get(defaultDeviceInfo)) }
 	viewModel { ServerAddViewModel(get()) }
-	viewModel { NextUpViewModel(get(), get(), get(), get()) }
+	viewModel { NextUpViewModel(get(), get(), get()) }
 	viewModel { PictureViewerViewModel(get()) }
 	viewModel { ScreensaverViewModel(get()) }
 	viewModel { SearchViewModel(get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -27,20 +27,21 @@ import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.ImageHelper
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.androidtv.util.apiclient.itemImages
+import org.jellyfin.androidtv.util.apiclient.parentImages
 import org.jellyfin.androidtv.util.dp
 import org.jellyfin.androidtv.util.sdk.isUsable
 import org.jellyfin.androidtv.util.stripHtml
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.exception.TimeoutException
-import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.extensions.ticks
@@ -51,7 +52,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.time.Duration
-
 
 /**
  * Manages channels on the android tv home screen.
@@ -100,39 +100,39 @@ class LeanbackChannelWorker(
 			// Get channel URIs
 			val latestMediaChannel = getChannelUri(
 				"latest_media", Channel.Builder()
-				.setType(TvContractCompat.Channels.TYPE_PREVIEW)
-				.setDisplayName(context.getString(R.string.home_section_latest_media))
-				.setAppLinkIntent(Intent(context, StartupActivity::class.java))
-				.build(),
+					.setType(TvContractCompat.Channels.TYPE_PREVIEW)
+					.setDisplayName(context.getString(R.string.home_section_latest_media))
+					.setAppLinkIntent(Intent(context, StartupActivity::class.java))
+					.build(),
 				default = true
 			)
 			val myMediaChannel = getChannelUri(
 				"my_media", Channel.Builder()
-				.setType(TvContractCompat.Channels.TYPE_PREVIEW)
-				.setDisplayName(context.getString(R.string.lbl_my_media))
-				.setAppLinkIntent(Intent(context, StartupActivity::class.java))
-				.build()
+					.setType(TvContractCompat.Channels.TYPE_PREVIEW)
+					.setDisplayName(context.getString(R.string.lbl_my_media))
+					.setAppLinkIntent(Intent(context, StartupActivity::class.java))
+					.build()
 			)
 			val nextUpChannel = getChannelUri(
 				"next_up", Channel.Builder()
-				.setType(TvContractCompat.Channels.TYPE_PREVIEW)
-				.setDisplayName(context.getString(R.string.lbl_next_up))
-				.setAppLinkIntent(Intent(context, StartupActivity::class.java))
-				.build()
+					.setType(TvContractCompat.Channels.TYPE_PREVIEW)
+					.setDisplayName(context.getString(R.string.lbl_next_up))
+					.setAppLinkIntent(Intent(context, StartupActivity::class.java))
+					.build()
 			)
 			val latestMoviesChannel = getChannelUri(
 				"latest_movies", Channel.Builder()
-				.setType(TvContractCompat.Channels.TYPE_PREVIEW)
-				.setDisplayName(context.getString(R.string.lbl_movies))
-				.setAppLinkIntent(Intent(context, StartupActivity::class.java))
-				.build()
+					.setType(TvContractCompat.Channels.TYPE_PREVIEW)
+					.setDisplayName(context.getString(R.string.lbl_movies))
+					.setAppLinkIntent(Intent(context, StartupActivity::class.java))
+					.build()
 			)
 			val latestEpisodesChannel = getChannelUri(
 				"latest_episodes", Channel.Builder()
-				.setType(TvContractCompat.Channels.TYPE_PREVIEW)
-				.setDisplayName(context.getString(R.string.lbl_new_episodes))
-				.setAppLinkIntent(Intent(context, StartupActivity::class.java))
-				.build()
+					.setType(TvContractCompat.Channels.TYPE_PREVIEW)
+					.setDisplayName(context.getString(R.string.lbl_new_episodes))
+					.setAppLinkIntent(Intent(context, StartupActivity::class.java))
+					.build()
 			)
 			val preferParentThumb = userPreferences[UserPreferences.seriesThumbnailsEnabled]
 
@@ -231,35 +231,12 @@ class LeanbackChannelWorker(
 	private fun BaseItemDto.getPosterArtImageUrl(
 		preferParentThumb: Boolean
 	): Uri = when {
-		type == BaseItemKind.MOVIE || type == BaseItemKind.SERIES -> api.imageApi.getItemImageUrl(
-			itemId = id,
-			imageType = ImageType.PRIMARY,
-			format = ImageFormat.WEBP,
-			width = 106.dp(context),
-			height = 153.dp(context),
-			tag = imageTags?.get(ImageType.PRIMARY),
-		)
-
-		(preferParentThumb || imageTags?.contains(ImageType.PRIMARY) != true) && parentThumbItemId != null -> api.imageApi.getItemImageUrl(
-			itemId = parentThumbItemId!!,
-			imageType = ImageType.THUMB,
-			format = ImageFormat.WEBP,
-			width = 272.dp(context),
-			height = 153.dp(context),
-			tag = imageTags?.get(ImageType.THUMB),
-		)
-
-		imageTags?.containsKey(ImageType.PRIMARY) == true -> api.imageApi.getItemImageUrl(
-			itemId = id,
-			imageType = ImageType.PRIMARY,
-			format = ImageFormat.WEBP,
-			width = 272.dp(context),
-			height = 153.dp(context),
-			tag = imageTags?.get(ImageType.PRIMARY),
-		)
-
-		else -> imageHelper.getResourceUrl(context, R.drawable.tile_land_tv)
-	}.let(ImageProvider::getImageUri)
+		type == BaseItemKind.MOVIE || type == BaseItemKind.SERIES -> itemImages[ImageType.PRIMARY]
+		(preferParentThumb || imageTags?.contains(ImageType.PRIMARY) != true) && parentThumbItemId != null -> parentImages[ImageType.THUMB]
+		else -> itemImages[ImageType.PRIMARY]
+	}.let { image ->
+		ImageProvider.getImageUri(image?.getUrl(api) ?: imageHelper.getResourceUrl(context, R.drawable.tile_land_tv))
+	}
 
 	/**
 	 * Gets the resume and next up episodes. The returned pair contains two lists:
@@ -405,10 +382,10 @@ class LeanbackChannelWorker(
 
 		// Create all programs in nextUpItems but not in watch next
 		val programsToAdd = nextUpItems
-			.filter { next -> currentWatchNextPrograms.none{ it.internalProviderId == next.id.toString() }}
+			.filter { next -> currentWatchNextPrograms.none { it.internalProviderId == next.id.toString() } }
 		context.contentResolver.bulkInsert(
 			WatchNextPrograms.CONTENT_URI,
-			programsToAdd.map{item -> getBaseItemAsWatchNextProgram(item).toContentValues() }
+			programsToAdd.map { item -> getBaseItemAsWatchNextProgram(item).toContentValues() }
 				.toTypedArray())
 	}
 
@@ -423,8 +400,9 @@ class LeanbackChannelWorker(
 
 		// Find all stale programs to delete
 		val deletedByUser = currentWatchNextPrograms.filter { !it.isBrowsable }
-		val noLongerInWatchNext = currentWatchNextPrograms.filter { (nextUpItems).none { next -> it.internalProviderId == next.id.toString() } }
-		val continueWatching = currentWatchNextPrograms.filter { it.watchNextType == WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE}
+		val noLongerInWatchNext =
+			currentWatchNextPrograms.filter { (nextUpItems).none { next -> it.internalProviderId == next.id.toString() } }
+		val continueWatching = currentWatchNextPrograms.filter { it.watchNextType == WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE }
 
 		// Delete the programs
 		(deletedByUser + noLongerInWatchNext + continueWatching)
@@ -490,14 +468,18 @@ class LeanbackChannelWorker(
 					setLastPlaybackPositionMillis(item.userData!!.playbackPositionTicks.ticks.inWholeMilliseconds.toInt())
 					// Use last played date to prioritize
 
-					setLastEngagementTimeUtcMillis(item.userData?.lastPlayedDate?.atZone(ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
-						?: Instant.now().toEpochMilli())
+					setLastEngagementTimeUtcMillis(
+						item.userData?.lastPlayedDate?.atZone(ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
+							?: Instant.now().toEpochMilli()
+					)
 				}
 				// First episode of the season
 				item.indexNumber == 1 -> {
 					setWatchNextType(WatchNextPrograms.WATCH_NEXT_TYPE_NEW)
-					setLastEngagementTimeUtcMillis(item.dateCreated?.atZone(ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
-						?: Instant.now().toEpochMilli())
+					setLastEngagementTimeUtcMillis(
+						item.dateCreated?.atZone(ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
+							?: Instant.now().toEpochMilli()
+					)
 				}
 				// Default
 				else -> {

--- a/app/src/main/java/org/jellyfin/androidtv/integration/MediaContentProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/MediaContentProvider.kt
@@ -17,10 +17,11 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.util.ImageHelper
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.androidtv.util.apiclient.itemImages
 import org.jellyfin.androidtv.util.sdk.isUsable
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
-import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.ImageType
@@ -107,10 +108,10 @@ class MediaContentProvider : ContentProvider(), KoinComponent {
 
 		MatrixCursor(columns).also { cursor ->
 			searchResult?.items?.forEach { item ->
-				val imageUri = if (item.imageTags?.contains(ImageType.PRIMARY) == true)
-					ImageProvider.getImageUri(api.imageApi.getItemImageUrl(item.id, ImageType.PRIMARY))
-				else
-					imageHelper.getResourceUrl(context!!, R.drawable.tile_land_tv)
+				val imageUri = ImageProvider.getImageUri(
+					item.itemImages[ImageType.PRIMARY]?.getUrl(api)
+						?: imageHelper.getResourceUrl(context!!, R.drawable.tile_land_tv)
+				)
 
 				cursor.newRow().apply {
 					add(BaseColumns._ID, item.id)

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/DreamViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/DreamViewModel.kt
@@ -21,15 +21,16 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
 import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.androidtv.util.apiclient.itemBackdropImages
+import org.jellyfin.androidtv.util.apiclient.itemImages
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
-import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemSortBy
 import timber.log.Timber
@@ -100,24 +101,8 @@ class DreamViewModel(
 
 			Timber.i("Loading random library showcase item ${item.id}")
 
-			val backdropTag = item.backdropImageTags!!.randomOrNull()
-				?: item.imageTags?.get(ImageType.BACKDROP)
-
-			val logoTag = item.imageTags?.get(ImageType.LOGO)
-
-			val backdropUrl = api.imageApi.getItemImageUrl(
-				itemId = item.id,
-				imageType = ImageType.BACKDROP,
-				tag = backdropTag,
-				format = ImageFormat.WEBP,
-			)
-
-			val logoUrl = api.imageApi.getItemImageUrl(
-				itemId = item.id,
-				imageType = ImageType.LOGO,
-				tag = logoTag,
-				format = ImageFormat.WEBP,
-			)
+			val backdropUrl = item.itemBackdropImages.randomOrNull()?.getUrl(api)
+			val logoUrl = item.itemImages[ImageType.LOGO]?.getUrl(api)
 
 			val (logo, backdrop) = withContext(Dispatchers.IO) {
 				val logoDeferred = async {

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -34,13 +34,14 @@ import org.jellyfin.androidtv.ui.composable.blurHashPainter
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
+import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.androidtv.util.apiclient.itemImages
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.jellyfin.lyrics
 import org.jellyfin.playback.jellyfin.lyricsFlow
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.imageApi
-import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
 import org.koin.compose.koinInject
 
@@ -55,20 +56,12 @@ fun DreamContentNowPlaying(
 	val lyrics = content.entry.run { lyricsFlow.collectAsState(lyrics) }.value
 	val progress = rememberPlayerProgress(playbackManager)
 
-	val primaryImageTag = content.item.imageTags?.get(ImageType.PRIMARY)
-	val (imageItemId, imageTag) = when {
-		primaryImageTag != null -> content.item.id to primaryImageTag
-		(content.item.albumId != null && content.item.albumPrimaryImageTag != null) -> content.item.albumId to content.item.albumPrimaryImageTag
-		else -> null to null
-	}
+	val primaryImage = content.item.itemImages[ImageType.PRIMARY] ?: content.item.albumPrimaryImage
 
 	// Background
-	val imageBlurHash = imageTag?.let { tag ->
-		content.item.imageBlurHashes?.get(ImageType.PRIMARY)?.get(tag)
-	}
-	if (imageBlurHash != null) {
+	if (primaryImage?.blurHash != null) {
 		Image(
-			painter = blurHashPainter(imageBlurHash, IntSize(32, 32)),
+			painter = blurHashPainter(primaryImage.blurHash, IntSize(32, 32)),
 			contentDescription = null,
 			alignment = Alignment.Center,
 			contentScale = ContentScale.Crop,
@@ -103,15 +96,10 @@ fun DreamContentNowPlaying(
 			.align(Alignment.BottomStart)
 			.overscan(),
 	) {
-		if (imageItemId != null) {
+		if (primaryImage != null) {
 			AsyncImage(
-				url = api.imageApi.getItemImageUrl(
-					itemId = imageItemId,
-					imageType = ImageType.PRIMARY,
-					tag = imageTag,
-					format = ImageFormat.WEBP,
-				),
-				blurHash = imageBlurHash,
+				url = primaryImage.getUrl(api),
+				blurHash = primaryImage.blurHash,
 				scaleType = ImageView.ScaleType.CENTER_CROP,
 				modifier = Modifier
 					.size(128.dp)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/AsyncImage.kt
@@ -27,7 +27,7 @@ fun AsyncImage(
 	url: String? = null,
 	blurHash: String? = null,
 	placeholder: Drawable? = null,
-	aspectRatio: Double = 1.0,
+	aspectRatio: Float = 1f,
 	blurHashResolution: Int = 32,
 	scaleType: ImageView.ScaleType? = null,
 ) {
@@ -51,7 +51,7 @@ fun AsyncImage(
 					url = compositionState.url,
 					blurHash = compositionState.blurHash,
 					placeholder = placeholder,
-					aspectRatio = aspectRatio,
+					aspectRatio = aspectRatio.toDouble(),
 					blurHashResolution = blurHashResolution,
 				)
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -53,6 +53,8 @@ import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -62,6 +64,7 @@ import java.util.UUID
 fun NextUpScreen(
 	itemId: UUID,
 ) {
+	val api = koinInject<ApiClient>()
 	val navigationRepository = koinInject<NavigationRepository>()
 	val backgroundService = koinInject<BackgroundService>()
 	val viewModel = koinViewModel<NextUpViewModel>()
@@ -102,9 +105,9 @@ fun NextUpScreen(
 					.align(Alignment.TopStart)
 					.overscan()
 					.height(75.dp),
-				url = logo.url,
+				url = logo.getUrl(api),
 				blurHash = logo.blurHash,
-				aspectRatio = logo.aspectRatio,
+				aspectRatio = logo.aspectRatio ?: 1f,
 			)
 		}
 
@@ -132,6 +135,7 @@ fun NextUpOverlay(
 	onConfirm: () -> Unit,
 	onCancel: () -> Unit,
 ) = ProvideTextStyle(JellyfinTheme.typography.default.copy(color = Color.White)) {
+	val api = koinInject<ApiClient>()
 	val userPreferences = koinInject<UserPreferences>()
 	val confirmTimer = remember { Animatable(0f) }
 	LaunchedEffect(item) {
@@ -164,11 +168,11 @@ fun NextUpOverlay(
 				modifier = Modifier
 					.align(Alignment.CenterVertically)
 					.height(145.dp)
-					.aspectRatio(thumbnail.aspectRatio.toFloat())
+					.aspectRatio(thumbnail.aspectRatio ?: 1f)
 					.clip(JellyfinTheme.shapes.extraSmall),
-				url = thumbnail.url,
+				url = thumbnail.getUrl(api),
 				blurHash = thumbnail.blurHash,
-				aspectRatio = thumbnail.aspectRatio,
+				aspectRatio = thumbnail.aspectRatio ?: 1f,
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpItemData.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpItemData.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.ui.playback.nextup
 
+import org.jellyfin.androidtv.util.apiclient.JellyfinImage
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 
@@ -7,8 +8,6 @@ data class NextUpItemData(
 	val baseItem: BaseItemDto,
 	val id: UUID,
 	val title: String,
-	val thumbnail: Image?,
-	val logo: Image?,
-) {
-	data class Image(val url: String, val blurHash: String?, val aspectRatio: Double)
-}
+	val thumbnail: JellyfinImage?,
+	val logo: JellyfinImage?,
+)

--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/JellyfinImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/JellyfinImage.kt
@@ -1,0 +1,209 @@
+package org.jellyfin.androidtv.util.apiclient
+
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemPerson
+import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.UserDto
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import java.util.UUID
+
+/**
+ * Utility class used to collect information about images in Jellyfin API responses to easily pass around the app.
+ */
+data class JellyfinImage(
+	val item: UUID,
+	val source: JellyfinImageSource,
+	val type: ImageType,
+	val tag: String,
+	val blurHash: String?,
+	val aspectRatio: Float?,
+	val index: Int?,
+)
+
+fun JellyfinImage.getUrl(
+	api: ApiClient,
+	maxWidth: Int? = null,
+	maxHeight: Int? = null,
+	fillWidth: Int? = null,
+	fillHeight: Int? = null,
+): String = api.imageApi.getItemImageUrl(
+	itemId = item,
+	imageType = type,
+	tag = tag,
+	imageIndex = index,
+	maxWidth = maxWidth,
+	maxHeight = maxHeight,
+	fillWidth = fillWidth,
+	fillHeight = fillHeight,
+)
+
+enum class JellyfinImageSource {
+	ITEM,
+	PARENT,
+	ALBUM,
+	SERIES,
+	CHANNEL,
+}
+
+// UserDto
+val UserDto.primaryImage
+	get() = primaryImageTag?.let { primaryImageTag ->
+		JellyfinImage(
+			item = id,
+			source = JellyfinImageSource.ITEM,
+			type = ImageType.PRIMARY,
+			tag = primaryImageTag,
+			blurHash = null,
+			aspectRatio = primaryImageAspectRatio?.toFloat(),
+			index = null,
+		)
+	}
+
+// BaseItemDto
+
+val BaseItemDto.itemImages
+	get() = imageTags?.mapValues { (type, tag) ->
+		JellyfinImage(
+			item = id,
+			source = JellyfinImageSource.ITEM,
+			type = type,
+			tag = tag,
+			blurHash = imageBlurHashes?.get(type)?.get(tag),
+			aspectRatio = if (type == ImageType.PRIMARY) primaryImageAspectRatio?.toFloat() else null,
+			index = null,
+		)
+	}.orEmpty()
+
+val BaseItemDto.itemBackdropImages
+	get() = backdropImageTags?.mapIndexed { index, tag ->
+		JellyfinImage(
+			item = id,
+			source = JellyfinImageSource.ITEM,
+			type = ImageType.BACKDROP,
+			tag = tag,
+			blurHash = imageBlurHashes?.get(ImageType.BACKDROP)?.get(tag),
+			aspectRatio = null,
+			index = index,
+		)
+	}.orEmpty()
+
+val BaseItemDto.parentImages
+	get() = mapOf(
+		ImageType.PRIMARY to (parentPrimaryImageItemId?.toUUIDOrNull() to parentPrimaryImageTag),
+		ImageType.LOGO to (parentLogoItemId to parentLogoImageTag),
+		ImageType.ART to (parentArtItemId to parentArtImageTag),
+		ImageType.THUMB to (parentThumbItemId to parentThumbImageTag),
+	).mapNotNull { (type, itemAndTag) ->
+		itemAndTag.first?.let { item ->
+			itemAndTag.second?.let { tag ->
+				JellyfinImage(
+					item = item,
+					source = JellyfinImageSource.PARENT,
+					type = type,
+					tag = tag,
+					blurHash = imageBlurHashes?.get(type)?.get(tag),
+					aspectRatio = null,
+					index = null,
+				)
+			}
+		}
+	}.associateBy { it.type }
+
+val BaseItemDto.parentBackdropImages
+	get() = parentBackdropImageTags?.mapIndexed { index, tag ->
+		JellyfinImage(
+			item = requireNotNull(parentBackdropItemId),
+			source = JellyfinImageSource.PARENT,
+			type = ImageType.BACKDROP,
+			tag = tag,
+			blurHash = imageBlurHashes?.get(ImageType.BACKDROP)?.get(tag),
+			aspectRatio = null,
+			index = index,
+		)
+	}.orEmpty()
+
+val BaseItemDto.albumPrimaryImage
+	get() = albumPrimaryImageTag?.let { albumPrimaryImageTag ->
+		JellyfinImage(
+			item = requireNotNull(albumId),
+			source = JellyfinImageSource.ALBUM,
+			type = ImageType.PRIMARY,
+			tag = albumPrimaryImageTag,
+			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(albumPrimaryImageTag),
+			aspectRatio = null,
+			index = null,
+		)
+	}
+
+val BaseItemDto.channelPrimaryImage
+	get() = channelPrimaryImageTag?.let { channelPrimaryImageTag ->
+		JellyfinImage(
+			item = requireNotNull(channelId),
+			source = JellyfinImageSource.CHANNEL,
+			type = ImageType.PRIMARY,
+			tag = channelPrimaryImageTag,
+			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(channelPrimaryImageTag),
+			aspectRatio = null,
+			index = null,
+		)
+	}
+
+val BaseItemDto.seriesPrimaryImage
+	get() = seriesPrimaryImageTag?.let { seriesPrimaryImageTag ->
+		JellyfinImage(
+			item = requireNotNull(seriesId),
+			source = JellyfinImageSource.SERIES,
+			type = ImageType.PRIMARY,
+			tag = seriesPrimaryImageTag,
+			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(seriesPrimaryImageTag),
+			aspectRatio = null,
+			index = null,
+		)
+	}
+
+val BaseItemDto.seriesThumbImage
+	get() = seriesThumbImageTag?.let { seriesThumbImageTag ->
+		JellyfinImage(
+			item = requireNotNull(seriesId),
+			source = JellyfinImageSource.SERIES,
+			type = ImageType.THUMB,
+			tag = seriesThumbImageTag,
+			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(seriesThumbImageTag),
+			aspectRatio = null,
+			index = null,
+		)
+	}
+
+val BaseItemDto.images
+	get() = listOfNotNull(
+		itemImages.values,
+		itemBackdropImages,
+		parentImages.values,
+		parentBackdropImages,
+		listOfNotNull(albumPrimaryImage),
+		listOfNotNull(channelPrimaryImage),
+		listOfNotNull(seriesPrimaryImage),
+		listOfNotNull(seriesThumbImage),
+	).flatten()
+
+// BaseItemPerson
+
+val BaseItemPerson.primaryImage
+	get() = primaryImageTag?.let { primaryImageTag ->
+		JellyfinImage(
+			item = id,
+			source = JellyfinImageSource.ITEM,
+			type = ImageType.PRIMARY,
+			tag = primaryImageTag,
+			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(primaryImageTag),
+			aspectRatio = null,
+			index = null,
+		)
+	}
+
+val BaseItemPerson.images
+	get() = listOfNotNull(primaryImage)
+
+// TODO Add SeriesTimerInfoDto once API types are fixed (correct nullability, UUID types) and blurhashes are added


### PR DESCRIPTION
Add a new "JellyfinImage" model that contains all image information retrievable from API responses. This is accessible via the next ".images" extension getters like `BaseItemDto.itemImages`, `BaseItemDto.parentBackgroundImages` etc.

The goal is to make it much easier to use images from the API by grouping information like the item id, blurhash, tag etc in a single model. That model can then be passed through the application and resolved to a URL easily.

Current implementation does not use it everywhere yet but it does in the background/screensaver/nowplaying code and fixes at least one bug that has been here for a long time and we only recently became aware of 👀.

**Changes**
- Add intermediate model for image information
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #4628
