### PR TITLE
Always create boxset queues with default sorting instead of using sort names of individual items

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -95,7 +95,7 @@ class SdkPlaybackHelper(
 				}
 			}
 
-			BaseItemKind.SERIES, BaseItemKind.SEASON, BaseItemKind.BOX_SET, BaseItemKind.FOLDER -> {
+			BaseItemKind.SERIES, BaseItemKind.SEASON, BaseItemKind.FOLDER -> {
 				val response by api.itemsApi.getItems(
 					parentId = mainItem.id,
 					isMissing = false,
@@ -105,6 +105,24 @@ class SdkPlaybackHelper(
 						BaseItemKind.VIDEO
 					),
 					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(ItemSortBy.SORT_NAME),
+					recursive = true,
+					limit = ITEM_QUERY_LIMIT,
+					fields = ItemRepository.itemFields
+				)
+
+				response.items
+			}
+
+			BaseItemKind.BOX_SET -> {
+				val response by api.itemsApi.getItems(
+					parentId = mainItem.id,
+					isMissing = false,
+					includeItemTypes = listOf(
+						BaseItemKind.EPISODE,
+						BaseItemKind.MOVIE,
+						BaseItemKind.VIDEO
+					),
+					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else null,
 					recursive = true,
 					limit = ITEM_QUERY_LIMIT,
 					fields = ItemRepository.itemFields


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

A boxset (collection) has its own sorting that should be preferred over individual sorting names of its contents. Those sorting names are meant for the parent (e.g. episode sorting name for ordering in a season) not for in a collection.

**Issues**

Fixes #4649
