### PR TITLE
Add missing action for AndroidMediaService to manifest

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -24,7 +24,6 @@ import org.jellyfin.playback.media3.exoplayer.ExoPlayerOptions
 import org.jellyfin.playback.media3.exoplayer.exoPlayerPlugin
 import org.jellyfin.playback.media3.session.MediaSessionOptions
 import org.jellyfin.playback.media3.session.media3SessionPlugin
-import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.scope.Scope
@@ -67,11 +66,11 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 			notificationChannelId,
 			NotificationManager.IMPORTANCE_LOW
 		)
+		channel.setShowBadge(false)
 		NotificationManagerCompat.from(get()).createNotificationChannel(channel)
 	}
 
 	val userPreferences = get<UserPreferences>()
-	val api = get<ApiClient>()
 	val exoPlayerOptions = ExoPlayerOptions(
 		preferFfmpeg = userPreferences[UserPreferences.preferExoPlayerFfmpeg],
 		enableDebugLogging = userPreferences[UserPreferences.debuggingEnabled],

--- a/playback/media3/session/src/main/AndroidManifest.xml
+++ b/playback/media3/session/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application>
         <service
             android:name="org.jellyfin.playback.media3.session.AndroidMediaService"
@@ -9,6 +12,7 @@
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
+                <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
     </application>


### PR DESCRIPTION
**Changes**

- Add missing action for AndroidMediaService
  - This now enables the remote control notification on phones with gplay services when playing music
- Disable channel badge for media notification channel

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
