### PR TITLE
Fix compose focus deprecations

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/modifier/childFocusRestorer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/modifier/childFocusRestorer.kt
@@ -3,7 +3,6 @@ package org.jellyfin.androidtv.ui.base.modifier
 import androidx.compose.foundation.focusGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -14,12 +13,11 @@ import androidx.compose.ui.focus.focusRequester
  * Any other focus related modifiers should be added after this one.
  */
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 fun Modifier.childFocusRestorer(
 	focusRequester: FocusRequester = remember { FocusRequester() }
 ): Modifier = focusRequester(focusRequester)
 	.focusProperties {
-		exit = { focusRequester.saveFocusedChild(); FocusRequester.Default }
-		enter = { if (focusRequester.restoreFocusedChild()) FocusRequester.Cancel else FocusRequester.Default }
+		onExit = { focusRequester.saveFocusedChild() }
+		onEnter = { if (focusRequester.restoreFocusedChild()) cancelFocusChange() }
 	}
 	.focusGroup()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
@@ -127,7 +126,6 @@ fun NextUpScreen(
 	}
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun NextUpOverlay(
 	modifier: Modifier = Modifier,
@@ -161,7 +159,7 @@ fun NextUpOverlay(
 		modifier = modifier
 			.overscan()
 			.fillMaxWidth()
-			.focusRestorer { focusRequester }
+			.focusRestorer(focusRequester)
 	) {
 		item.thumbnail?.let { thumbnail ->
 			AsyncImage(
@@ -203,7 +201,7 @@ fun NextUpOverlay(
 			Row(
 				modifier = Modifier
 					.focusGroup()
-					.focusRestorer { focusRequester }
+					.focusRestorer(focusRequester)
 			) {
 				Button(onClick = onCancel) {
 					Text(stringResource(R.string.btn_cancel))


### PR DESCRIPTION
I think onExit isn't called when focus changes to a (non-compose) view. Not sure if bug or intended behavior in compose... issue was there before this PR though.

**Changes**
- Fix compose focus deprecations
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
