### PR TITLE
Allow Exoplayer to invalidate the track selection on capabilities change

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -217,6 +217,7 @@ public class VideoManager {
                         .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
                         .build()
                 )
+                .setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true)
                 .build()
         );
         exoPlayerBuilder.setTrackSelector(trackSelector);

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -104,6 +104,7 @@ class ExoPlayerBackend(
 							setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
 						}.build()
 					)
+					setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true)
 				})
 			})
 			.setMediaSourceFactory(mediaSourceFactory)


### PR DESCRIPTION
**Changes**
If the capabilities of a device change, Exoplayer can invalidate the current selection to adhere to the new list of capabilities.

This helps the Nvidia Shield and its content matching refresh rate option because, during the refresh rate switching period, the reported capabilities change. Without this flag, the device could reproduce audio as PCM instead of the expected passthrough.

**Issues**
Addresses https://github.com/jellyfin/jellyfin-androidtv/issues/4067, additional context https://github.com/androidx/media/issues/2258

I'm using "addresses" because I don't want to automatically close https://github.com/jellyfin/jellyfin-androidtv/issues/4067. To fully fix it, we also need to bump media3 to the upcoming release (1.6.1+) because we need https://github.com/androidx/media/commit/f825ad7e476c7190f21ff0bddb8e02ddf9a5a856 and https://github.com/androidx/media/commit/93cf82df151b16b4220d0c9f646abd45a3d1aed5. On that matter, we probably just need to wait for them to tag a new release (bumping media3 is not a blocker for this PR).
