### PR TITLE
Display cover art of currently playing music via compose

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -37,6 +37,7 @@ import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
 import org.jellyfin.androidtv.util.apiclient.getUrl
 import org.jellyfin.androidtv.util.apiclient.itemImages
+import org.jellyfin.androidtv.util.apiclient.parentImages
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.jellyfin.lyrics
@@ -56,7 +57,7 @@ fun DreamContentNowPlaying(
 	val lyrics = content.entry.run { lyricsFlow.collectAsState(lyrics) }.value
 	val progress = rememberPlayerProgress(playbackManager)
 
-	val primaryImage = content.item.itemImages[ImageType.PRIMARY] ?: content.item.albumPrimaryImage
+	val primaryImage = content.item.itemImages[ImageType.PRIMARY] ?: content.item.albumPrimaryImage ?: content.item.parentImages[ImageType.PRIMARY]
 
 	// Background
 	if (primaryImage?.blurHash != null) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -16,7 +16,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -32,16 +31,13 @@ import androidx.lifecycle.Lifecycle;
 import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.databinding.FragmentAudioNowPlayingBinding;
-import org.jellyfin.androidtv.ui.AsyncImageView;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
-import org.jellyfin.androidtv.util.ImageHelper;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.TimeUtils;
-import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.playback.core.PlaybackManager;
 
 import java.util.List;
@@ -69,7 +65,6 @@ public class AudioNowPlayingFragment extends Fragment {
     private TextView mSongTitle;
     private TextView mAlbumTitle;
     private TextView mCurrentNdx;
-    private AsyncImageView mPoster;
     private ProgressBar mCurrentProgress;
     private TextView mCurrentPos;
     private TextView mRemainingTime;
@@ -88,7 +83,6 @@ public class AudioNowPlayingFragment extends Fragment {
     private final Lazy<PlaybackManager> playbackManager = inject(PlaybackManager.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
-    private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
 
     private PopupMenu popupMenu;
 
@@ -100,8 +94,6 @@ public class AudioNowPlayingFragment extends Fragment {
         homeButton = binding.clock.getHomeButton();
         homeButton.setOnFocusChangeListener(mainAreaFocusListener);
 
-        mPoster = binding.poster;
-        mPoster.setClipToOutline(true);
         mArtistName = binding.artistTitle;
         mGenreRow = binding.genreRow;
         mSongTitle = binding.song;
@@ -109,7 +101,8 @@ public class AudioNowPlayingFragment extends Fragment {
         mCurrentNdx = binding.track;
         mScrollView = binding.mainScroller;
         mCounter = binding.counter;
-        AudioNowPlayingFragmentHelperKt.initializeLyricsView(binding.poster, binding.lyrics, playbackManager.getValue());
+
+        AudioNowPlayingFragmentHelperKt.initializePreviewView(binding.preview, playbackManager.getValue());
 
         ImageButton rewindButton = binding.rewindBtn;
         rewindButton.setContentDescription(getString(R.string.rewind));
@@ -309,21 +302,10 @@ public class AudioNowPlayingFragment extends Fragment {
         }
     };
 
-    private void updatePoster() {
-        // Figure image size
-        Double aspect = imageHelper.getValue().getImageAspectRatio(mBaseItem, false);
-        int posterHeight = aspect > 1 ? Utils.convertDpToPixel(requireContext(), 150) : Utils.convertDpToPixel(requireActivity(), 250);
-
-        String primaryImageUrl = imageHelper.getValue().getPrimaryImageUrl(mBaseItem, false, null, posterHeight);
-        Timber.d("Audio Poster url: %s", primaryImageUrl);
-        mPoster.load(primaryImageUrl, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_album), aspect, 0);
-    }
-
     private void loadItem() {
         dismissPopup();
         mBaseItem = mediaManager.getValue().getCurrentAudioItem();
         if (mBaseItem != null) {
-            updatePoster();
             updateInfo(mBaseItem);
         } else {
             if (navigationRepository.getValue().getCanGoBack()) navigationRepository.getValue().goBack();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -1,42 +1,85 @@
 package org.jellyfin.androidtv.ui.playback
 
+import android.widget.ImageView
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.jellyfin.androidtv.ui.AsyncImageView
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.androidtv.ui.composable.rememberQueueEntry
+import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.androidtv.util.apiclient.itemImages
+import org.jellyfin.androidtv.util.apiclient.parentImages
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.jellyfin.lyrics
 import org.jellyfin.playback.jellyfin.lyricsFlow
+import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.playback.jellyfin.queue.baseItemFlow
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.model.api.ImageType
+import org.koin.compose.koinInject
 
-fun initializeLyricsView(
-	coverView: AsyncImageView,
+fun initializePreviewView(
 	lyricsView: ComposeView,
 	playbackManager: PlaybackManager,
 ) {
 	lyricsView.setContent {
+		val api = koinInject<ApiClient>()
 		val entry by rememberQueueEntry(playbackManager)
+		val baseItem = entry?.run { baseItemFlow.collectAsState(baseItem).value }
 		val lyrics = entry?.run { lyricsFlow.collectAsState(lyrics) }?.value
+		val cover = baseItem?.itemImages[ImageType.PRIMARY] ?: baseItem?.albumPrimaryImage ?: baseItem?.parentImages[ImageType.PRIMARY]
 
-		// Animate cover view alpha
+		// Show track/album art when available and fade it out when lyrics are displayed on top
 		val coverViewAlpha by animateFloatAsState(
-			label = "CoverViewAlpha",
+			label = "coverViewAlpha",
 			targetValue = if (lyrics == null) 1f else 0.2f,
 		)
-		LaunchedEffect(coverViewAlpha) { coverView.alpha = coverViewAlpha }
+
+		AnimatedContent(cover) { cover ->
+			if (cover != null) {
+				Box(
+					modifier = Modifier
+						.wrapContentSize()
+						.clip(RoundedCornerShape(4.dp))
+						.background(Color.Black)
+				) {
+					AsyncImage(
+						url = cover.getUrl(api),
+						blurHash = cover.blurHash,
+						aspectRatio = cover.aspectRatio?.toFloat() ?: 1f,
+						scaleType = ImageView.ScaleType.CENTER_INSIDE,
+						modifier = Modifier
+							.alpha(coverViewAlpha)
+					)
+				}
+			} else if (lyrics == null) {
+				// "placeholder" image
+				Icon(painterResource(R.drawable.ic_album), contentDescription = null, tint = Color.White.copy(alpha = 0.4f))
+			}
+		}
 
 		// Display lyrics overlay
 		if (lyrics != null) {

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -52,7 +52,7 @@
                 android:id="@+id/detailArea"
                 android:layout_width="match_parent"
                 android:layout_height="250dp"
-                android:layout_toStartOf="@id/poster">
+                android:layout_toStartOf="@id/preview">
 
                 <LinearLayout
                     android:id="@+id/information"
@@ -220,30 +220,12 @@
                 </LinearLayout>
             </RelativeLayout>
 
-            <FrameLayout
-                android:layout_width="250dp"
-                android:layout_height="250dp"
-                android:layout_alignParentEnd="true"
-                android:layout_marginEnd="60dp"
-                android:background="@drawable/audio_now_playing_album_background" />
-
-            <org.jellyfin.androidtv.ui.AsyncImageView
-                android:id="@+id/poster"
-                android:layout_width="250dp"
-                android:layout_height="250dp"
-                android:layout_alignParentEnd="true"
-                android:layout_marginEnd="60dp"
-                android:background="@drawable/shape_card" />
-
             <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/lyrics"
+                android:id="@+id/preview"
                 android:layout_width="250dp"
                 android:layout_height="250dp"
                 android:layout_alignParentEnd="true"
-                android:layout_marginEnd="60dp"
-                android:background="@drawable/shape_card"
-                android:descendantFocusability="blocksDescendants"
-                android:focusable="false" />
+                android:layout_marginEnd="60dp" />
 
             <FrameLayout
                 android:id="@+id/rowsFragment"


### PR DESCRIPTION
Was planning to add some additional feature but ended up being dumb

**Changes**

- Display cover art of currently playing music via compose
  - Now animates when the image changes
  - Has a nicer rounding

- Used image is now consistent across the 3 "now playing" views (screensaver, browsing widget, this screen)
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved fallback logic for displaying the primary image in the "Now Playing" UI, ensuring a suitable image is shown even if the item's own or album image is unavailable.

- **Refactor**
  - Replaced the legacy poster image view in the audio playback screen with a modern Compose-based preview, offering smoother transitions and improved image handling.
  - Updated the layout to remove the old poster image and streamline the UI structure.

- **Style**
  - Enhanced visual presentation of cover art and placeholder icons in the audio playback interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->