### PR TITLE
Fix URL generation for user profile pictures

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/JellyfinImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/JellyfinImage.kt
@@ -28,16 +28,28 @@ fun JellyfinImage.getUrl(
 	maxHeight: Int? = null,
 	fillWidth: Int? = null,
 	fillHeight: Int? = null,
-): String = api.imageApi.getItemImageUrl(
-	itemId = item,
-	imageType = type,
-	tag = tag,
-	imageIndex = index,
-	maxWidth = maxWidth,
-	maxHeight = maxHeight,
-	fillWidth = fillWidth,
-	fillHeight = fillHeight,
-)
+): String = when (source) {
+	JellyfinImageSource.USER -> api.imageApi.getUserImageUrl(
+		userId = item,
+		tag = tag,
+		imageIndex = index,
+		maxWidth = maxWidth,
+		maxHeight = maxHeight,
+		fillWidth = fillWidth,
+		fillHeight = fillHeight,
+	)
+
+	else -> api.imageApi.getItemImageUrl(
+		itemId = item,
+		imageType = type,
+		tag = tag,
+		imageIndex = index,
+		maxWidth = maxWidth,
+		maxHeight = maxHeight,
+		fillWidth = fillWidth,
+		fillHeight = fillHeight,
+	)
+}
 
 enum class JellyfinImageSource {
 	ITEM,
@@ -45,6 +57,7 @@ enum class JellyfinImageSource {
 	ALBUM,
 	SERIES,
 	CHANNEL,
+	USER,
 }
 
 // UserDto
@@ -52,7 +65,7 @@ val UserDto.primaryImage
 	get() = primaryImageTag?.let { primaryImageTag ->
 		JellyfinImage(
 			item = id,
-			source = JellyfinImageSource.ITEM,
+			source = JellyfinImageSource.USER,
 			type = ImageType.PRIMARY,
 			tag = primaryImageTag,
 			blurHash = null,


### PR DESCRIPTION
You can't get the profile picture with the item image API, weird isn't it?

**Changes**
- Fix URL generation for user profile pictures

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of user profile images, ensuring user images are displayed more accurately throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->