### PR TITLE
Fix DestinationFragmentView not replacing existing fragment on resume

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/DestinationFragmentView.kt
@@ -152,7 +152,7 @@ class DestinationFragmentView @JvmOverloads constructor(
 
 			// Attach or add next fragment
 			if (fragment.isDetached) attach(fragment)
-			else add(container.id, fragment, FRAGMENT_TAG_CONTENT)
+			else replace(container.id, fragment, FRAGMENT_TAG_CONTENT)
 		}
 
 		if (fragmentManager.isDestroyed) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

- Always use `replace` in `HistoryEntry.activateHistoryEntry` so calls from the `onRestoreInstanceState` function will properly remove any existing fragment in the view.

**Issues**

Fixes #4703