### PR TITLE
Clear skip overlay before applying media segments

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -480,7 +480,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 if (binding.skipOverlay.getVisible()) {
                     // Hide without doing anything
                     if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_ESCAPE) {
-                        binding.skipOverlay.setTargetPositionMs(null);
+                        clearSkipOverlay();
                         return true;
                     }
 
@@ -488,7 +488,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
                         playbackControllerContainer.getValue().getPlaybackController().seek(binding.skipOverlay.getTargetPositionMs(), true);
                         leanbackOverlayFragment.setShouldShowOverlay(false);
-                        if (binding != null) binding.skipOverlay.setTargetPositionMs(null);
+                        if (binding != null) clearSkipOverlay();
                         return true;
                     }
                 }
@@ -1264,6 +1264,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 prepareChapterAdapter();
             }
         }
+    }
+
+    public void clearSkipOverlay() {
+        binding.skipOverlay.setTargetPositionMs(null);
     }
 
     private void prepareChapterAdapter() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -154,6 +154,7 @@ fun PlaybackController.applyMediaSegments(
 ) {
 	val mediaSegmentRepository by fragment.inject<MediaSegmentRepository>()
 
+	fragment?.clearSkipOverlay()
 	fragment.lifecycleScope.launch {
 		val mediaSegments = runCatching {
 			mediaSegmentRepository.getSegmentsForItem(item)


### PR DESCRIPTION
This PR fixes an issue where the skip overlay persists when switching episodes

**Changes**
- Clear the skip overlay target before applying any segments
- Extract the clear overlay logic to a helper function since it was being used in 3 places 

**Issues**
Fixes #4721 
