### PR TITLE
Clicking Next play up results in a java.lang.NullPointerException in …

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -270,10 +270,7 @@ fun FullDetailsFragment.resumePlayback(v: View) {
 				getString(R.string.msg_video_playback_error),
 				Toast.LENGTH_LONG
 			).show()
-			return@launch
-		}
-
-		if (nextUpEpisode.userData?.playbackPositionTicks == 0L) {
+		} else if (nextUpEpisode.userData?.playbackPositionTicks == 0L) {
 			play(nextUpEpisode, 0, false)
 		} else {
 			showResumeMenu(v, nextUpEpisode)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -270,12 +270,13 @@ fun FullDetailsFragment.resumePlayback(v: View) {
 				getString(R.string.msg_video_playback_error),
 				Toast.LENGTH_LONG
 			).show()
+			return@launch
 		}
 
-		if (nextUpEpisode?.userData?.playbackPositionTicks == 0L) {
+		if (nextUpEpisode.userData?.playbackPositionTicks == 0L) {
 			play(nextUpEpisode, 0, false)
 		} else {
-			showResumeMenu(v, nextUpEpisode!!)
+			showResumeMenu(v, nextUpEpisode)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

Sorry that my English is not very good. I use Google Translate

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
 - I found on my TV that clicking Next play up on some episodes would result in a java.lang.NullPointerException

***Stack Trace***: 
```log
java.lang.NullPointerException
	at org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragmentHelperKt$resumePlayback$1.invokeSuspend(FullDetailsFragmentHelper.kt:278)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at android.os.Handler.handleCallback(Handler.java:883)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loop(Looper.java:214)
	at android.app.ActivityThread.main(ActivityThread.java:7356)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@e3f3558, Dispatchers.Main.immediate]

```
  
***Issues***
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
 - The code ```if (nextUpEpisode == null)``` only pops up a Toast reminder, but does not return, causing ```showResumeMenu(v, nextUpEpisode!!)``` to be executed and trigger a ```java.lang.NullPointerException```, which I think is the main reason for the crash

 ```fun FullDetailsFragment.resumePlayback(v: View) {
	if (mBaseItem.type != BaseItemKind.SERIES) {
		val pos = (mBaseItem.userData?.playbackPositionTicks?.ticks
			?: Duration.ZERO) - resumePreroll.milliseconds
		play(mBaseItem, pos.inWholeMilliseconds.toInt(), false)
		return
	}

	lifecycleScope.launch {
		val nextUpEpisode = getNextUpEpisode()
		if (nextUpEpisode == null) {
			Toast.makeText(
				requireContext(),
				getString(R.string.msg_video_playback_error),
				Toast.LENGTH_LONG
			).show()
		}

		if (nextUpEpisode?.userData?.playbackPositionTicks == 0L) {
			play(nextUpEpisode, 0, false)
		} else {
			showResumeMenu(v, nextUpEpisode!!)
		}
	}
}```