### PR TITLE
Moving logo randomly in the screensaver to prevent burn-ins

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [MajMongoose](https://github.com/majmongoose)
  - [Olaren15](https://github.com/Olaren15)
  - [dtrexler](https://github.com/dtrexler)
+ - [patricks1](https://github.com/patricks1)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -1,8 +1,11 @@
 package org.jellyfin.androidtv.integration.dream.composable
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -11,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -22,50 +26,86 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.composable.rememberCurrentTime
+import kotlin.random.Random
 
+/**
+ *A header composable for the screensaver view that displays the Jellyfin logo
+ * and current time.
+ *
+ * The logo is horizontally offset by a random amount that changes each time
+ * the screensaver changes the title being displayed.
+ *
+ * @param showLogo Whether to display the Jellyfin logo.
+ * @param showClock Whether to display the current time.
+ * @param contentKey A stable key (usually the current DreamContent or its ID)
+ *                   that changes when
+ *                   the screensaver switches content. Used to re-randomize the
+ *                   logo position.
+ * @param fadeMillis Duration of the fade-in/out animation in milliseconds.
+ */
 @Composable
 fun DreamHeader(
 	showLogo: Boolean,
 	showClock: Boolean,
+	contentKey: Any?,
+	fadeMillis: Int,
 ) {
-	Row(
-		horizontalArrangement = Arrangement.SpaceBetween,
-		modifier = Modifier
-			.fillMaxWidth()
-			.overscan(),
-	) {
-		// Logo
-		AnimatedVisibility(
-			visible = showLogo,
-			enter = fadeIn(),
-			exit = fadeOut(),
-			modifier = Modifier.height(41.dp),
-		) {
-			Image(
-				painter = painterResource(R.drawable.app_logo),
-				contentDescription = stringResource(R.string.app_name),
-			)
-		}
+	AnimatedContent(
+		// Jellyfin logo will change positions when content changes
+		targetState = contentKey,
+		transitionSpec = {
+			// use the same timing both ways
+			fadeIn(tween(fadeMillis)) togetherWith fadeOut(tween(fadeMillis))
+		},
+		label = "Header cross-fade",
+	) { currentKey ->
+		// A random position between 0% and 70% of the
+		// screen width.
+		val randomPad = remember(currentKey) { Random.nextFloat() * 0.7f }
 
-		Spacer(
+		Row(
+			horizontalArrangement = Arrangement.SpaceBetween,
 			modifier = Modifier
-				.fillMaxWidth(0f)
-		)
-
-		// Clock
-		AnimatedVisibility(
-			visible = showClock,
-			enter = fadeIn(),
-			exit = fadeOut(),
+				.fillMaxWidth()
+				.overscan(),
 		) {
-			val currentTime by rememberCurrentTime()
-			Text(
-				text = currentTime,
-				style = TextStyle(
-					color = Color.White,
-					fontSize = 20.sp
-				),
+			// Place the logo at the randomly selected horizontal
+			// position.
+			Spacer(Modifier.fillMaxWidth(randomPad))
+
+			// Logo
+			AnimatedVisibility(
+				visible = showLogo,
+				enter = fadeIn(),
+				exit = fadeOut(),
+				modifier = Modifier.height(41.dp),
+			) {
+				Image(
+					painter = painterResource(R.drawable.app_logo),
+					contentDescription = stringResource(R.string.app_name),
+				)
+			}
+
+			Spacer(
+				modifier = Modifier
+					.fillMaxWidth(0f)
 			)
+
+			// Clock
+			AnimatedVisibility(
+				visible = showClock,
+				enter = fadeIn(),
+				exit = fadeOut(),
+			) {
+				val currentTime by rememberCurrentTime()
+				Text(
+					text = currentTime,
+					style = TextStyle(
+						color = Color.White,
+						fontSize = 20.sp
+					),
+				)
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
@@ -20,10 +20,12 @@ fun DreamView(
 	modifier = Modifier
 		.fillMaxSize()
 ) {
+	val fadeMillis = 1_000
+
 	AnimatedContent(
 		targetState = content,
 		transitionSpec = {
-			fadeIn(tween(durationMillis = 1_000)) togetherWith fadeOut(snap(delayMillis = 1_000))
+			fadeIn(tween(durationMillis = fadeMillis)) togetherWith fadeOut(snap(delayMillis = fadeMillis))
 		},
 		label = "DreamContentTransition"
 	) { content ->
@@ -38,5 +40,7 @@ fun DreamView(
 	DreamHeader(
 		showLogo = content != DreamContent.Logo,
 		showClock = showClock,
+		contentKey = content, // logo changes position on new content
+		fadeMillis = fadeMillis,
 	)
 }


### PR DESCRIPTION
Adds a feature that randomly moves the Jellyfin logo in the screensaver so it does not burn in on plasma and OLED TVs.
- Modifies `DreamHeader` so that it takes a `contentKey` and randomly moves the Jellyfin logo's horizontal position when that `contentKey` changes. 
- Where `DreamView` calls `DreamHeader`, it provides the `content` of the title poster being displayed as the argument for `contentKey`. This makes it so when the app shows a new poster, the logo position changes. 
- `DreamHeader` takes a `fadeMillis` argument and is now an `AnimatedContent` so it can fade out and in smoothly at the same rate as the title poster.

**Relevant Issue**
Fixes #1888. In the interest of making the simplest possible change, I did not modify the clock. The user can turn off the clock to prevent it from burning in.