### PR TITLE
Fix retrieveAndPlay incorrectly using ticks instead of milliseconds as start position

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -26,7 +26,6 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaType
-import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.extensions.ticks
 import java.util.UUID
 import kotlin.time.Duration
@@ -268,7 +267,7 @@ class SdkPlaybackHelper(
 			playbackLauncher.launch(
 				context,
 				items,
-				pos.inWholeTicks.toInt(),
+				pos.inWholeMilliseconds.toInt(),
 				playbackControllerContainer.playbackController?.hasFragment() == true,
 				0,
 				shuffle,


### PR DESCRIPTION
Basically made the value overflow all the time causing the value to be reset 0 and play videos from the start instead of resuming.

**Changes**
- Fix retrieveAndPlay incorrectly using ticks instead of milliseconds as start position
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #4405
