### PR TITLE
Adds a new "Natural D-pad Controls" setting that changes D-pad left/right behavior from snapping to fixed intervals to smooth relative seeking from the current position

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -89,6 +89,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var cinemaModeEnabled = booleanPreference("pref_enable_cinema_mode", true)
 
 		/**
+		 * Require confirmation before seeking with D-pad
+		 */
+		var requireSeekConfirmation = booleanPreference("require_seek_confirmation", false)
+
+		/**
 		 * Enable still watching
 		 */
 		var stillWatchingBehavior = enumPreference("enable_still_watching", StillWatchingBehavior.DISABLED)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -88,10 +88,7 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var cinemaModeEnabled = booleanPreference("pref_enable_cinema_mode", true)
 
-		/**
-		 * Require confirmation before seeking with D-pad
-		 */
-		var requireSeekConfirmation = booleanPreference("require_seek_confirmation", false)
+
 
 		/**
 		 * Enable still watching

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -254,6 +254,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
   		 * Enable PGS subtitle direct-play.
 		 */
 		var pgsDirectPlay = booleanPreference("pgs_enabled", true)
+
+		/**
+		 * Enable enhanced D-pad seeking with improved responsiveness and bounds checking.
+		 */
+		var enhancedDpadSeekingEnabled = booleanPreference("enhanced_dpad_seeking", false)
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -256,9 +256,9 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var pgsDirectPlay = booleanPreference("pgs_enabled", true)
 
 		/**
-		 * Enable enhanced D-pad seeking with improved responsiveness and bounds checking.
+		 * Enable natural D-pad seeking that moves relative to current position instead of snapping to fixed intervals.
 		 */
-		var enhancedDpadSeekingEnabled = booleanPreference("enhanced_dpad_seeking", false)
+		var naturalDpadSeekingEnabled = booleanPreference("natural_dpad_seeking", false)
 	}
 
 	init {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -636,6 +636,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 }
             }
 
+            boolean naturalDpadSeekingEnabled = userPreferences.getValue().get(UserPreferences.Companion.getNaturalDpadSeekingEnabled());
             if (!naturalDpadSeekingEnabled) {
                 switch (keyCode) {
                     case KeyEvent.KEYCODE_DPAD_LEFT:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -139,6 +139,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
+    private final Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
 
     private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
 
@@ -610,8 +611,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                         }
                     }
 
-                    // D-pad seek logic - when overlay hidden OR when seek bar is focused
-                    if ((!mIsVisible || isSeekBarFocused()) && !playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
+                    // Enhanced D-pad seek logic - when overlay hidden OR when seek bar is focused (if enhanced seeking is enabled)
+                    if (userPreferences.getValue().get(UserPreferences.Companion.getEnhancedDpadSeekingEnabled()) && 
+                        (!mIsVisible || isSeekBarFocused()) && !playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
                         if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                             if (!mIsVisible) {
                                 show();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -455,10 +455,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     playbackController.playPause();
                     return true;
                 } else if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BUTTON_R1 || keyCode == KeyEvent.KEYCODE_BUTTON_R2) {
-                    playbackController.fastForward();
+                    leanbackOverlayFragment.getPlayerAdapter().fastForward();
                     return true;
                 } else if (keyCode == KeyEvent.KEYCODE_MEDIA_REWIND || keyCode == KeyEvent.KEYCODE_BUTTON_L1 || keyCode == KeyEvent.KEYCODE_BUTTON_L2) {
-                    playbackController.rewind();
+                    leanbackOverlayFragment.getPlayerAdapter().rewind();
                     return true;
                 }
             }
@@ -578,7 +578,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     // Control fast forward and rewind if overlay hidden and not showing live TV
                     if (!playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
                         if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BUTTON_R1 || keyCode == KeyEvent.KEYCODE_BUTTON_R2) {
-                            playbackControllerContainer.getValue().getPlaybackController().fastForward();
+                            // Use VideoPlayerAdapter method for consistent behavior with FF button
+                            leanbackOverlayFragment.getPlayerAdapter().fastForward();
                             setFadingEnabled(true);
                             
 
@@ -586,7 +587,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                         }
 
                         if (keyCode == KeyEvent.KEYCODE_MEDIA_REWIND || keyCode == KeyEvent.KEYCODE_BUTTON_L1 || keyCode == KeyEvent.KEYCODE_BUTTON_L2) {
-                            playbackControllerContainer.getValue().getPlaybackController().rewind();
+                            // Use VideoPlayerAdapter method for consistent behavior with RW button
+                            leanbackOverlayFragment.getPlayerAdapter().rewind();
                             setFadingEnabled(true);
                             
 
@@ -615,7 +617,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                                 show();
                             }
 
-                            playbackControllerContainer.getValue().getPlaybackController().fastForward();
+                            // Use VideoPlayerAdapter method for consistent behavior with FF button
+                            leanbackOverlayFragment.getPlayerAdapter().fastForward();
                             setFadingEnabled(true);
                             
                             return true;
@@ -626,7 +629,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                                 show();
                             }
 
-                            playbackControllerContainer.getValue().getPlaybackController().rewind();
+                            // Use VideoPlayerAdapter method for consistent behavior with RW button
+                            leanbackOverlayFragment.getPlayerAdapter().rewind();
                             setFadingEnabled(true);
                             
                             return true;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -86,6 +86,7 @@ import java.util.UUID;
 import kotlin.Lazy;
 import timber.log.Timber;
 import org.jellyfin.androidtv.preference.UserSettingPreferences;
+import org.jellyfin.androidtv.preference.UserPreferences;
 import org.koin.java.KoinJavaComponent;
 
 public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGuide, View.OnKeyListener {
@@ -127,6 +128,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private boolean mIsVisible = false;
     private boolean mPopupPanelVisible = false;
     private boolean navigating = false;
+    
+    // Seek preview state
+    private boolean mIsSeekPreview = false;
+    private long mOriginalPosition = 0;
+    private long mTargetPosition = 0;
 
     protected LeanbackOverlayFragment leanbackOverlayFragment;
 
@@ -138,6 +144,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
+    private final Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
 
     private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
 
@@ -506,39 +513,17 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     return true;
                 }
 
-                if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
-                    if (!playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
-                        if (!mIsVisible) {
-                            show();
-                        }
-
-                        long currentPos = playbackControllerContainer.getValue().getPlaybackController().getCurrentPosition();
-                        UserSettingPreferences prefs = KoinJavaComponent.<UserSettingPreferences>get(UserSettingPreferences.class);
-                        long skipAmount = prefs.get(UserSettingPreferences.Companion.getSkipForwardLength());
-                        long targetPos = Utils.getSafeSeekPosition(currentPos + skipAmount, playbackControllerContainer.getValue().getPlaybackController().getDuration());
-                        playbackControllerContainer.getValue().getPlaybackController().seek(targetPos);
-
-                        return true;
-                    }
-                }
-
-                if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
-                    if (!playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
-                        if (!mIsVisible) {
-                            show();
-                        }
-
-                        long currentPos = playbackControllerContainer.getValue().getPlaybackController().getCurrentPosition();
-                        UserSettingPreferences prefs = KoinJavaComponent.<UserSettingPreferences>get(UserSettingPreferences.class);
-                        long skipAmount = prefs.get(UserSettingPreferences.Companion.getSkipBackLength());
-                        long targetPos = Utils.getSafeSeekPosition(currentPos - skipAmount, playbackControllerContainer.getValue().getPlaybackController().getDuration());
-                        playbackControllerContainer.getValue().getPlaybackController().seek(targetPos);
-
-                        return true;
-                    }
-                }
-
                 if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_ESCAPE) {
+                    // Handle seek preview cancellation first
+                    if (mIsSeekPreview) {
+                        // Cancel preview and return to original position
+                        playbackControllerContainer.getValue().getPlaybackController().seek(mOriginalPosition);
+                        mIsSeekPreview = false;
+                        mOriginalPosition = 0;
+                        mTargetPosition = 0;
+                        return true;
+                    }
+                    
                     if (mPopupPanelVisible) {
                         // back should just hide the popup panel
                         hidePopupPanel();
@@ -621,12 +606,93 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                         }
                     }
 
+                    // Handle seek preview confirmation (works regardless of overlay visibility)
+                    if (mIsSeekPreview && (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)) {
+                        // Confirm the seek by seeking to stored target position
+                        playbackControllerContainer.getValue().getPlaybackController().seek(mTargetPosition);
+                        mIsSeekPreview = false;
+                        mOriginalPosition = 0;
+                        mTargetPosition = 0;
+                        return true;
+                    }
+
                     if (!mIsVisible) {
                         if ((keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)
                                 && playbackControllerContainer.getValue().getPlaybackController().canSeek()) {
                             // if the player is playing and the overlay is hidden, this will pause
                             // if the player is paused and then 'back' is pressed to hide the overlay, this will play
                             playbackControllerContainer.getValue().getPlaybackController().playPause();
+                            return true;
+                        }
+                    }
+
+                    // D-pad seek logic - when overlay hidden OR when seek bar is focused
+                    if ((!mIsVisible || isSeekBarFocused()) && !playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
+                        if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                            if (!mIsVisible) {
+                                show();
+                            }
+
+                            long currentPos = playbackControllerContainer.getValue().getPlaybackController().getCurrentPosition();
+                            UserSettingPreferences prefs = KoinJavaComponent.<UserSettingPreferences>get(UserSettingPreferences.class);
+                            long skipAmount = prefs.get(UserSettingPreferences.Companion.getSkipForwardLength());
+                            long targetPos = Utils.getSafeSeekPosition(currentPos + skipAmount, playbackControllerContainer.getValue().getPlaybackController().getDuration());
+                            
+                            // Check if user wants seek confirmation
+                            boolean requireConfirmation = userPreferences.getValue().get(UserPreferences.Companion.getRequireSeekConfirmation());
+                            
+                            if (requireConfirmation) {
+                                // Preview mode: accumulate multiple clicks and show visual preview
+                                if (!mIsSeekPreview) {
+                                    // First click - start preview mode
+                                    mOriginalPosition = currentPos;
+                                    mTargetPosition = targetPos;
+                                    mIsSeekPreview = true;
+                                } else {
+                                    // Subsequent clicks - accumulate from current target
+                                    mTargetPosition = Utils.getSafeSeekPosition(mTargetPosition + skipAmount, playbackControllerContainer.getValue().getPlaybackController().getDuration());
+                                }
+                                // Show visual preview by seeking to target position
+                                playbackControllerContainer.getValue().getPlaybackController().seek(mTargetPosition);
+                            } else {
+                                // Direct seek mode: immediately seek to target position
+                                playbackControllerContainer.getValue().getPlaybackController().seek(targetPos);
+                            }
+
+                            return true;
+                        }
+
+                        if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+                            if (!mIsVisible) {
+                                show();
+                            }
+
+                            long currentPos = playbackControllerContainer.getValue().getPlaybackController().getCurrentPosition();
+                            UserSettingPreferences prefs = KoinJavaComponent.<UserSettingPreferences>get(UserSettingPreferences.class);
+                            long skipAmount = prefs.get(UserSettingPreferences.Companion.getSkipBackLength());
+                            long targetPos = Utils.getSafeSeekPosition(currentPos - skipAmount, playbackControllerContainer.getValue().getPlaybackController().getDuration());
+                            
+                            // Check if user wants seek confirmation
+                            boolean requireConfirmation = userPreferences.getValue().get(UserPreferences.Companion.getRequireSeekConfirmation());
+                            
+                            if (requireConfirmation) {
+                                // Preview mode: accumulate multiple clicks and show visual preview
+                                if (!mIsSeekPreview) {
+                                    // First click - start preview mode
+                                    mOriginalPosition = currentPos;
+                                    mTargetPosition = targetPos;
+                                    mIsSeekPreview = true;
+                                } else {
+                                    // Subsequent clicks - accumulate from current target
+                                    mTargetPosition = Utils.getSafeSeekPosition(mTargetPosition - skipAmount, playbackControllerContainer.getValue().getPlaybackController().getDuration());
+                                }
+                                // Show visual preview by seeking to target position
+                                playbackControllerContainer.getValue().getPlaybackController().seek(mTargetPosition);
+                            } else {
+                                // Direct seek mode: immediately seek to target position
+                                playbackControllerContainer.getValue().getPlaybackController().seek(targetPos);
+                            }
+
                             return true;
                         }
                     }
@@ -743,6 +809,14 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         if (!mIsVisible) return;
 
         mIsVisible = false;
+        
+        // Reset seek preview state when hiding overlay
+        if (mIsSeekPreview) {
+            mIsSeekPreview = false;
+            mOriginalPosition = 0;
+            mTargetPosition = 0;
+        }
+        
         binding.topPanel.startAnimation(fadeOut);
         binding.skipOverlay.setSkipUiEnabled(!mIsVisible && !mGuideVisible && !mPopupPanelVisible);
     }
@@ -1359,5 +1433,24 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             params.preferredDisplayModeId = 0;
             getActivity().getWindow().setAttributes(params);
         }
+    }
+
+    private boolean isSeekBarFocused() {
+        try {
+            if (leanbackOverlayFragment != null && leanbackOverlayFragment.getView() != null) {
+                View currentFocus = leanbackOverlayFragment.getView().findFocus();
+                // Check if the focused view is related to seeking/transport controls
+                // The seek bar would typically be a SeekBar or similar component
+                return currentFocus != null && (
+                    currentFocus.getClass().getSimpleName().contains("Seek") ||
+                    currentFocus.getClass().getSimpleName().contains("Transport") ||
+                    currentFocus.getClass().getSimpleName().contains("Progress")
+                );
+            }
+        } catch (Exception e) {
+            // Fallback: if we can't determine focus, assume seek bar is focused when overlay is visible
+            return mIsVisible;
+        }
+        return false;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -603,8 +603,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                         }
                     }
 
-                    // Enhanced D-pad seek logic - when overlay hidden OR when seek bar is focused (if enhanced seeking is enabled)
-                    if (userPreferences.getValue().get(UserPreferences.Companion.getEnhancedDpadSeekingEnabled()) && 
+                    boolean naturalDpadSeekingEnabled = userPreferences.getValue().get(UserPreferences.Companion.getNaturalDpadSeekingEnabled());
+                    if (naturalDpadSeekingEnabled && 
                         (!mIsVisible || isSeekBarFocused()) && !playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
                         if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                             if (!mIsVisible) {
@@ -636,8 +636,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 }
             }
 
-            // Original D-pad UI handling when enhanced seeking is disabled
-            if (!userPreferences.getValue().get(UserPreferences.Companion.getEnhancedDpadSeekingEnabled())) {
+            if (!naturalDpadSeekingEnabled) {
                 switch (keyCode) {
                     case KeyEvent.KEYCODE_DPAD_LEFT:
                     case KeyEvent.KEYCODE_DPAD_RIGHT:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -611,7 +611,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                                 show();
                             }
 
-                            // Use VideoPlayerAdapter method for consistent behavior with FF button
+                            // Use VideoPlayerAdapter method for smoother seeking behavior
                             leanbackOverlayFragment.getPlayerAdapter().fastForward();
                             setFadingEnabled(true);
                             
@@ -623,7 +623,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                                 show();
                             }
 
-                            // Use VideoPlayerAdapter method for consistent behavior with RW button
+                            // Use VideoPlayerAdapter method for smoother seeking behavior
                             leanbackOverlayFragment.getPlayerAdapter().rewind();
                             setFadingEnabled(true);
                             
@@ -726,8 +726,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
         if (leanbackOverlayFragment != null)
             leanbackOverlayFragment.setOnKeyInterceptListener(null);
-
-
 
         // end playback from here if this fragment belongs to the current session.
         // if it doesn't, playback has already been stopped elsewhere, and the references to this have been replaced

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -456,10 +456,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     playbackController.playPause();
                     return true;
                 } else if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BUTTON_R1 || keyCode == KeyEvent.KEYCODE_BUTTON_R2) {
-                    leanbackOverlayFragment.getPlayerAdapter().fastForward();
+                    playbackController.fastForward();
                     return true;
                 } else if (keyCode == KeyEvent.KEYCODE_MEDIA_REWIND || keyCode == KeyEvent.KEYCODE_BUTTON_L1 || keyCode == KeyEvent.KEYCODE_BUTTON_L2) {
-                    leanbackOverlayFragment.getPlayerAdapter().rewind();
+                    playbackController.rewind();
                     return true;
                 }
             }
@@ -579,25 +579,17 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     // Control fast forward and rewind if overlay hidden and not showing live TV
                     if (!playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
                         if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BUTTON_R1 || keyCode == KeyEvent.KEYCODE_BUTTON_R2) {
-                            // Use VideoPlayerAdapter method for consistent behavior with FF button
-                            leanbackOverlayFragment.getPlayerAdapter().fastForward();
+                            playbackControllerContainer.getValue().getPlaybackController().fastForward();
                             setFadingEnabled(true);
-                            
-
                             return true;
                         }
 
                         if (keyCode == KeyEvent.KEYCODE_MEDIA_REWIND || keyCode == KeyEvent.KEYCODE_BUTTON_L1 || keyCode == KeyEvent.KEYCODE_BUTTON_L2) {
-                            // Use VideoPlayerAdapter method for consistent behavior with RW button
-                            leanbackOverlayFragment.getPlayerAdapter().rewind();
+                            playbackControllerContainer.getValue().getPlaybackController().rewind();
                             setFadingEnabled(true);
-                            
-
                             return true;
                         }
                     }
-
-
 
                     if (!mIsVisible) {
                         if ((keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)
@@ -641,6 +633,15 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     //and then manage our fade timer
                     if (mFadeEnabled) startFadeTimer();
+                }
+            }
+
+            // Original D-pad UI handling when enhanced seeking is disabled
+            if (!userPreferences.getValue().get(UserPreferences.Companion.getEnhancedDpadSeekingEnabled())) {
+                switch (keyCode) {
+                    case KeyEvent.KEYCODE_DPAD_LEFT:
+                    case KeyEvent.KEYCODE_DPAD_RIGHT:
+                        leanbackOverlayFragment.getPlayerGlue().setInjectedViewsVisibility();
                 }
             }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -113,6 +113,10 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
         playerGlue.recordingStateChanged();
     }
 
+    public VideoPlayerAdapter getPlayerAdapter() {
+        return playerAdapter;
+    }
+
     @Override
     public void onPause() {
         super.onPause();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -88,6 +88,12 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				}
 				bind(userSettingPreferences, UserSettingPreferences.skipForwardLength)
 			}
+			
+			checkbox {
+				setTitle(R.string.pref_seek_confirmation_title)
+				setContent(R.string.pref_seek_confirmation_description)
+				bind(userPreferences, UserPreferences.requireSeekConfirmation)
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -79,7 +79,7 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 			checkbox {
 				setTitle(R.string.lbl_enhanced_dpad_seeking)
 				setContent(R.string.sum_enhanced_dpad_seeking)
-				bind(userPreferences, UserPreferences.enhancedDpadSeekingEnabled)
+				bind(userPreferences, UserPreferences.naturalDpadSeekingEnabled)
 			}
 
 			@Suppress("MagicNumber")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -89,11 +89,7 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				bind(userSettingPreferences, UserSettingPreferences.skipForwardLength)
 			}
 			
-			checkbox {
-				setTitle(R.string.pref_seek_confirmation_title)
-				setContent(R.string.pref_seek_confirmation_description)
-				bind(userPreferences, UserPreferences.requireSeekConfirmation)
-			}
+
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackPreferencesScreen.kt
@@ -76,6 +76,12 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.cinemaModeEnabled)
 			}
 
+			checkbox {
+				setTitle(R.string.lbl_enhanced_dpad_seeking)
+				setContent(R.string.sum_enhanced_dpad_seeking)
+				bind(userPreferences, UserPreferences.enhancedDpadSeekingEnabled)
+			}
+
 			@Suppress("MagicNumber")
 			seekbar {
 				setTitle(R.string.skip_forward_length)

--- a/app/src/main/java/org/jellyfin/androidtv/util/Utils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/Utils.kt
@@ -63,9 +63,11 @@ object Utils : KoinComponent {
 	}
 
 	@JvmStatic
-	fun getSafeSeekPosition(position: Long, duration: Long): Long = when {
-		position >= duration -> (duration - 1000).coerceAtLeast(0)
-		else -> position.coerceAtLeast(0)
+	fun getSafeSeekPosition(position: Long, duration: Long): Long {
+		val minSafePosition = 100L // Use 100ms instead of 0 to avoid ExoPlayer issues with position 0 causing the seek position to reset to source position
+		val maxSafePosition = duration - 1000L
+
+		return position.coerceIn(minSafePosition, maxSafePosition)
 	}
 
 	@JvmStatic

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,6 +534,8 @@
     <string name="segment_type_recap">Recaps</string>
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
+    <string name="pref_seek_confirmation_title">Require seek confirmation</string>
+    <string name="pref_seek_confirmation_description">When enabled, D-pad left/right will preview the skip position and require OK to confirm. When disabled, D-pad left/right will skip immediately.</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
     <string name="pref_subtitles_background_opacity">Subtitle background opacity</string>
     <string name="pref_troubleshooting">Troubleshooting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="lbl_episodes">Episodes</string>
     <string name="lbl_enable_cinema_mode">Cinema mode</string>
     <string name="sum_enable_cinema_mode">Play available intros and previews before starting a movie</string>
+    <string name="lbl_enhanced_dpad_seeking">Natural D-pad controls</string>
+    <string name="sum_enhanced_dpad_seeking">Skip forward/back from current position instead of jumping to preset times</string>
     <string name="lbl_playlists">Playlists</string>
     <string name="msg_items_added">" items added"</string>
     <string name="lbl_add_to_queue">Add to queue</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,8 +534,7 @@
     <string name="segment_type_recap">Recaps</string>
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
-    <string name="pref_seek_confirmation_title">Require seek confirmation</string>
-    <string name="pref_seek_confirmation_description">When enabled, D-pad left/right will preview the skip position and require OK to confirm. When disabled, D-pad left/right will skip immediately.</string>
+    
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
     <string name="pref_subtitles_background_opacity">Subtitle background opacity</string>
     <string name="pref_troubleshooting">Troubleshooting</string>


### PR DESCRIPTION
Add Natural D-pad Controls feature for improved seeking behavior

**Changes**
Adds a new "Natural D-pad Controls" setting that changes D-pad left/right behavior from snapping to fixed intervals to smooth relative seeking from the current position.

- Defaults to false to keep current behavior unchanged unless opted in
- Uses user's configured skip forward/back times relative to the current position, instead of snapping to precalculated position intervals  
- Provides immediate visual feedback and enhanced responsiveness
- Preserves original behavior when disabled
- Includes proper bounds checking to avoid ExoPlayer position 0 issues that could cause seeking to revert to the original position when requesting negative values (a bug that also affected the RW button when pressed rapidly)

**Issues**
https://github.com/jellyfin/jellyfin-androidtv/issues/460
https://github.com/jellyfin/jellyfin-androidtv/issues/2529
https://github.com/jellyfin/jellyfin-androidtv/issues/2592