### PR TITLE
Remove testStream parameter from MediaStreamResolver.getStream

### DIFF
--- a/playback/core/src/main/kotlin/mediastream/MediaStreamResolver.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStreamResolver.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.playback.core.mediastream
 
 import org.jellyfin.playback.core.queue.QueueEntry
-import org.jellyfin.playback.core.support.PlaySupportReport
 
 /**
  * Determine the media stream for a given queue item.
@@ -12,6 +11,5 @@ interface MediaStreamResolver {
 	 */
 	suspend fun getStream(
 		queueEntry: QueueEntry,
-		testStream: (stream: MediaStream) -> PlaySupportReport,
 	): PlayableMediaStream?
 }

--- a/playback/core/src/main/kotlin/mediastream/MediaStreamService.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStreamService.kt
@@ -21,7 +21,7 @@ internal class MediaStreamService(
 			if (entry == null) {
 				backend.setCurrent(null)
 			} else {
-				val hasMediaStream = entry.ensureMediaStream(backend)
+				val hasMediaStream = entry.ensureMediaStream()
 
 				if (hasMediaStream) {
 					backend.setCurrent(entry)
@@ -40,12 +40,10 @@ internal class MediaStreamService(
 		// TODO Register some kind of event when $current item is at -30 seconds to setNext()
 	}
 
-	private suspend fun QueueEntry.ensureMediaStream(
-		backend: PlayerBackend,
-	): Boolean {
+	private suspend fun QueueEntry.ensureMediaStream(): Boolean {
 		mediaStream = mediaStream ?: mediaStreamResolvers.firstNotNullOfOrNull { resolver ->
 			runCatching {
-				resolver.getStream(this, backend::supportsStream)
+				resolver.getStream(this)
 			}.onFailure {
 				Timber.e(it, "Media stream resolver failed for $this")
 			}.getOrNull()

--- a/playback/core/src/main/kotlin/mediastream/MediaStreamService.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStreamService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import org.jellyfin.playback.core.backend.PlayerBackend
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.queue.QueueEntry
@@ -43,7 +44,9 @@ internal class MediaStreamService(
 	private suspend fun QueueEntry.ensureMediaStream(): Boolean {
 		mediaStream = mediaStream ?: mediaStreamResolvers.firstNotNullOfOrNull { resolver ->
 			runCatching {
-				resolver.getStream(this)
+				withContext(Dispatchers.IO) {
+					resolver.getStream(this@ensureMediaStream)
+				}
 			}.onFailure {
 				Timber.e(it, "Media stream resolver failed for $this")
 			}.getOrNull()

--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
@@ -1,11 +1,9 @@
 package org.jellyfin.playback.jellyfin.mediastream
 
 import org.jellyfin.playback.core.mediastream.MediaConversionMethod
-import org.jellyfin.playback.core.mediastream.MediaStream
 import org.jellyfin.playback.core.mediastream.MediaStreamResolver
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.queue.QueueEntry
-import org.jellyfin.playback.core.support.PlaySupportReport
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.mediaSourceId
 import org.jellyfin.sdk.api.client.ApiClient
@@ -25,7 +23,7 @@ class JellyfinMediaStreamResolver(
 		private val supportedMediaTypes = arrayOf(MediaType.VIDEO, MediaType.AUDIO)
 	}
 
-	override suspend fun getStream(queueEntry: QueueEntry, testStream: (stream: MediaStream) -> PlaySupportReport): PlayableMediaStream? {
+	override suspend fun getStream(queueEntry: QueueEntry): PlayableMediaStream? {
 		val baseItem = queueEntry.baseItem
 		if (baseItem == null || !supportedMediaTypes.contains(baseItem.mediaType)) return null
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Remove testStream parameter from MediaStreamResolver.getStream
  - It is currently unused and wasn't a nice design either way
- Always run MediaStreamResolver on IO thread
  - Prevents media codec lookup (for device profile generation) from blocking main thread

**Issues**

Part of #1057 
