### PR TITLE
Refetch server information on authenticate when cached server version is unsupported

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
@@ -126,7 +126,7 @@ class SessionRepositoryImpl(
 			authenticationPreferences[AuthenticationPreferences.lastUserId] = session.userId.toString()
 
 			// Check if server version is supported
-			val server = serverRepository.getServer(session.serverId)
+			val server = serverRepository.getServer(session.serverId, true)
 			if (server == null || !server.versionSupported) return false
 		}
 


### PR DESCRIPTION
This is mostly useful for users upgrading their server and then re-opening the app when it was active on their previous server version less than 10 minutes ago. Now, the app will recheck the server version before showing the "server version not supported" warning which should result in a smoother upgrade.

**Changes**
- Refetch server information on authenticate when cached server version is unsupported

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
