### PR TITLE
Query based on seriesId in FullDetailsFragmentHelper.getNextUpEpisode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -242,7 +242,7 @@ suspend fun FullDetailsFragment.getNextUpEpisode(): BaseItemDto? {
 	try {
 		val episodes = withContext(Dispatchers.IO) {
 			api.tvShowsApi.getNextUp(
-				parentId = mBaseItem.id,
+				seriesId = mBaseItem.seriesId ?: mBaseItem.id,
 				fields = ItemRepository.itemFields,
 				limit = 1,
 			).content


### PR DESCRIPTION
Fixes a crash that sometimes occurs with 10.11 on unwatched multi-season series.

**Changes**
- Query based on seriesId in FullDetailsFragmentHelper.getNextUpEpisode

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
