### PR TITLE
Prefer imageVector painting for icon drawables

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
@@ -26,8 +26,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jellyfin.androidtv.R
@@ -145,12 +146,12 @@ class ServerButtonView @JvmOverloads constructor(
 			icon = {
 				when (state) {
 					State.DEFAULT -> Icon(
-						painter = painterResource(R.drawable.ic_house),
+						imageVector = ImageVector.vectorResource(R.drawable.ic_house),
 						contentDescription = null,
 					)
 
 					State.EDIT -> Icon(
-						painter = painterResource(R.drawable.ic_house_edit),
+						imageVector = ImageVector.vectorResource(R.drawable.ic_house_edit),
 						contentDescription = null,
 					)
 
@@ -159,7 +160,7 @@ class ServerButtonView @JvmOverloads constructor(
 					)
 
 					State.ERROR -> Icon(
-						painter = painterResource(R.drawable.ic_error),
+						imageVector = ImageVector.vectorResource(R.drawable.ic_error),
 						contentDescription = null,
 					)
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -8,11 +8,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
@@ -118,7 +119,7 @@ fun BaseItemInfoRowRuntime(
 	runTime: Duration,
 ) {
 	InfoRowItem(
-		icon = painterResource(id = R.drawable.ic_time),
+		icon = ImageVector.vectorResource(id = R.drawable.ic_time),
 		contentDescription = null,
 	) {
 		Text(TimeUtils.formatMillis(runTime.inWholeMilliseconds))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.browsing.composable.inforow
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -13,11 +12,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
 import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 
 /**
@@ -26,7 +27,8 @@ import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 @Composable
 fun InfoRowItem(
 	// Icon options
-	icon: Painter? = null,
+	icon: ImageVector? = null,
+	iconTint: Color? = null,
 	contentDescription: String?,
 	// Styling
 	colors: Pair<Color, Color> = InfoRowColors.Transparent,
@@ -56,10 +58,11 @@ fun InfoRowItem(
 			modifier = modifier.fillMaxHeight(),
 		) {
 			if (icon != null) {
-				Image(
-					painter = icon,
+				Icon(
+					imageVector = icon,
 					contentDescription = contentDescription,
 					modifier = Modifier.size(if (backgroundColor.alpha > 0f) 16.dp else 18.dp),
+					tint = iconTint ?: LocalTextStyle.current.color,
 				)
 			}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/rating.kt
@@ -1,8 +1,10 @@
 package org.jellyfin.androidtv.ui.browsing.composable.inforow
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
 import java.text.NumberFormat
@@ -15,7 +17,8 @@ import java.text.NumberFormat
 @Composable
 fun InfoRowCommunityRating(communityRating: Float) {
 	InfoRowItem(
-		icon = painterResource(R.drawable.ic_star),
+		icon = ImageVector.vectorResource(R.drawable.ic_star),
+		iconTint = Color(0xFFEECE55),
 		contentDescription = stringResource(R.string.lbl_community_rating),
 	) {
 		Text(String.format("%.1f", communityRating * 10f))
@@ -33,9 +36,10 @@ private const val CRITIC_RATING_FRESH = 0.6f
 fun InfoRowCriticRating(criticRating: Float) {
 	InfoRowItem(
 		icon = when {
-			criticRating >= CRITIC_RATING_FRESH -> painterResource(R.drawable.ic_rt_fresh)
-			else -> painterResource(R.drawable.ic_rt_rotten)
+			criticRating >= CRITIC_RATING_FRESH -> ImageVector.vectorResource(R.drawable.ic_rt_fresh)
+			else -> ImageVector.vectorResource(R.drawable.ic_rt_rotten)
 		},
+		iconTint = Color.Unspecified,
 		contentDescription = stringResource(R.string.lbl_critic_rating),
 	) {
 		Text(NumberFormat.getPercentInstance().format(criticRating))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
@@ -6,7 +6,6 @@ import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -36,10 +35,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.LocalTextStyle
 import org.jellyfin.androidtv.ui.base.ProvideTextStyle
@@ -161,8 +162,8 @@ class UserCardView @JvmOverloads constructor(
 					)
 				} else {
 					Box(modifier = Modifier.fillMaxSize()) {
-						Image(
-							painter = painterResource(R.drawable.ic_user),
+						Icon(
+							imageVector = ImageVector.vectorResource(R.drawable.ic_user),
 							contentDescription = name,
 							modifier = Modifier
 								.size(48.dp)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -16,8 +16,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jellyfin.androidtv.R
@@ -77,7 +78,7 @@ fun initializePreviewView(
 				}
 			} else if (lyrics == null) {
 				// "placeholder" image
-				Icon(painterResource(R.drawable.ic_album), contentDescription = null, tint = Color.White.copy(alpha = 0.4f))
+				Icon(ImageVector.vectorResource(R.drawable.ic_album), contentDescription = null, tint = Color.White.copy(alpha = 0.4f))
 			}
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -5,7 +5,6 @@ import android.util.AttributeSet
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,15 +20,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import kotlin.time.Duration
@@ -53,8 +54,8 @@ fun SkipOverlayComposable(
 				horizontalArrangement = Arrangement.spacedBy(8.dp),
 				verticalAlignment = Alignment.CenterVertically,
 			) {
-				Image(
-					painter = painterResource(R.drawable.ic_control_select),
+				Icon(
+					imageVector = ImageVector.vectorResource(R.drawable.ic_control_select),
 					contentDescription = null,
 				)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/composable/SearchTextInput.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/composable/SearchTextInput.kt
@@ -17,7 +17,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -73,7 +74,7 @@ fun SearchTextInput(
 						.border(2.dp, color.first, RoundedCornerShape(percent = 30))
 						.padding(12.dp)
 				) {
-					Icon(painterResource(R.drawable.ic_search), contentDescription = null)
+					Icon(ImageVector.vectorResource(R.drawable.ic_search), contentDescription = null)
 					Spacer(Modifier.width(12.dp))
 					innerTextField()
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/composable/SearchVoiceInput.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/composable/SearchVoiceInput.kt
@@ -17,8 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Icon
@@ -108,7 +109,7 @@ fun SearchVoiceInput(
 			}
 		) {
 			Icon(
-				painter = painterResource(R.drawable.ic_microphone),
+				imageVector = ImageVector.vectorResource(R.drawable.ic_microphone),
 				contentDescription = null,
 				modifier = Modifier.size(28.dp)
 			)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImagePainter
@@ -108,7 +110,7 @@ private fun MainToolbar(
 					contentPadding = if (userImageVisible) PaddingValues(3.dp) else IconButtonDefaults.ContentPadding,
 				) {
 					Image(
-						painter = if (userImageVisible) userImagePainter else painterResource(R.drawable.ic_user),
+						painter = if (userImageVisible) userImagePainter else rememberVectorPainter(ImageVector.vectorResource(R.drawable.ic_user)),
 						contentDescription = stringResource(R.string.lbl_switch_user),
 						contentScale = ContentScale.Crop,
 						modifier = Modifier
@@ -160,7 +162,7 @@ private fun MainToolbar(
 					},
 				) {
 					Icon(
-						painter = painterResource(R.drawable.ic_settings),
+						imageVector = ImageVector.vectorResource(R.drawable.ic_settings),
 						contentDescription = stringResource(R.string.lbl_settings),
 					)
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/StartupToolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/StartupToolbar.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Icon
@@ -21,14 +22,14 @@ fun StartupToolbar(
 			ToolbarButtons {
 				IconButton(onClick = openHelp) {
 					Icon(
-						painter = painterResource(R.drawable.ic_help),
+						imageVector = ImageVector.vectorResource(R.drawable.ic_help),
 						contentDescription = stringResource(R.string.help),
 					)
 				}
 
 				IconButton(onClick = openSettings) {
 					Icon(
-						painter = painterResource(R.drawable.ic_settings),
+						imageVector = ImageVector.vectorResource(R.drawable.ic_settings),
 						contentDescription = stringResource(R.string.lbl_settings),
 					)
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
@@ -22,9 +22,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
@@ -76,7 +78,7 @@ private fun ConnectHelpAlert(
 						onClick = onClose,
 					) {
 						Icon(
-							painter = painterResource(R.drawable.ic_check),
+							imageVector = ImageVector.vectorResource(R.drawable.ic_check),
 							contentDescription = null,
 							modifier = Modifier.size(20.dp),
 						)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Use Icon composable instead of Image composable where possible
- Use vectorResource instead of painterResource where possible
- Change InfoRowItem to allow for tinting (or disabling tinting using Color.Unspecified)
  - Update community rating / critic rating to use their colors as tint

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
