### PR TITLE
Differentiate client name for debug version in API authorization

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -75,7 +75,11 @@ val appModule = module {
 			context = androidContext()
 
 			// Add client info
-			clientInfo = ClientInfo("Jellyfin Android TV", BuildConfig.VERSION_NAME)
+			val clientName = buildString {
+				append("Jellyfin Android TV")
+				if (BuildConfig.DEBUG) append(" (debug)")
+			}
+			clientInfo = ClientInfo(clientName, BuildConfig.VERSION_NAME)
 			deviceInfo = get(defaultDeviceInfo)
 
 			// Change server version


### PR DESCRIPTION
Still doesn't fix the issue I'm encountering but this makes for a nice feature to see whether the debug version of the app is used or not from the jellyfin dashboard.

**Changes**
- Differentiate client name for debug version in API authorization

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
