### PR TITLE
Remove WebSocket subscriptions when process is inactive

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.di
 
 import android.content.Context
 import android.os.Build
+import androidx.lifecycle.ProcessLifecycleOwner
 import coil3.ImageLoader
 import coil3.annotation.ExperimentalCoilApi
 import coil3.gif.AnimatedImageDecoder
@@ -96,7 +97,7 @@ val appModule = module {
 		get<JellyfinSdk>().createApi(httpClientOptions = get<HttpClientOptions>())
 	}
 
-	single { SocketHandler(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+	single { SocketHandler(get(), get(), get(), get(), get(), get(), get(), get(), get(), ProcessLifecycleOwner.get().lifecycle) }
 
 	// Coil (images)
 	single {

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -6,9 +6,9 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
-import okhttp3.OkHttpClient
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
@@ -83,7 +83,7 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 	install(media3SessionPlugin(get(), mediaSessionOptions))
 
 	val deviceProfileBuilder = { createDeviceProfile(userPreferences, false) }
-	install(jellyfinPlugin(get(), deviceProfileBuilder))
+	install(jellyfinPlugin(get(), deviceProfileBuilder, ProcessLifecycleOwner.get().lifecycle))
 
 	// Options
 	val userSettingPreferences = get<UserSettingPreferences>()

--- a/playback/jellyfin/build.gradle.kts
+++ b/playback/jellyfin/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
 	// Kotlin
 	implementation(libs.kotlinx.coroutines)
 
+	// Android(x)
+	implementation(libs.androidx.lifecycle.runtime)
+
 	// Jellyfin
 	implementation(projects.playback.core)
 	implementation(libs.jellyfin.sdk) {

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.playback.jellyfin
 
+import androidx.lifecycle.Lifecycle
 import org.jellyfin.playback.core.plugin.playbackPlugin
 import org.jellyfin.playback.jellyfin.mediastream.JellyfinMediaStreamResolver
 import org.jellyfin.playback.jellyfin.playsession.PlaySessionService
@@ -10,12 +11,13 @@ import org.jellyfin.sdk.model.api.DeviceProfile
 fun jellyfinPlugin(
 	api: ApiClient,
 	deviceProfileBuilder: () -> DeviceProfile,
+	lifecycle: Lifecycle? = null,
 ) = playbackPlugin {
 	provide(JellyfinMediaStreamResolver(api, deviceProfileBuilder))
 
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)
-	provide(PlaySessionSocketService(api, playSessionService))
+	provide(PlaySessionSocketService(api, playSessionService, lifecycle))
 
 	provide(LyricsPlayerService(api))
 }


### PR DESCRIPTION
We have two classes ("services") that listen for WebSocket events in the background; the SocketHandler (app) and PlaySessionSocketService (new playback module). Until now those would subscribe when initialized and simply never unsubscribe.
This is not the desired behavior. Instead, we want them to unsubscribe when the app is inactive. With this PR we now use the ProcessLifecycle to gracefully unsubscribe when the app is closed (no more visible activities).

**Changes**
- Remove WebSocket subscriptions when process is inactive
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
