### PR TITLE
Run Detekt from root module only

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,20 +16,25 @@ java {
 	}
 }
 
-subprojects {
-	// Configure linting
-	apply<io.gitlab.arturbosch.detekt.DetektPlugin>()
-	detekt {
-		buildUponDefaultConfig = true
-		ignoreFailures = true
-		config = files("$rootDir/detekt.yaml")
-		basePath = rootDir.absolutePath
+detekt {
+	buildUponDefaultConfig = true
+	ignoreFailures = true
+	config.setFrom(files("$rootDir/detekt.yaml"))
+	basePath = rootDir.absolutePath
+	parallel = true
 
-		reports {
-			sarif.enabled = true
-		}
+	source.setFrom(fileTree(projectDir) {
+		include("**/*.kt", "**/*.kts")
+	})
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
+	reports {
+		sarif.required.set(true)
 	}
+}
 
+subprojects {
 	// Configure default Kotlin compiler options
 	tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile> {
 		compilerOptions {


### PR DESCRIPTION
Unfortunately GitHub made a breaking change in how they process SARIF files without properly communicating it (I follow the release blog RSS feed and I didn't know about this until they made the actual change). This PR updates the way we lint using Detekt so all results are in a single run so GitHub is happy again.

This change must be backported if we do another 0.18 release.

**Changes**

- Run Detekt from root module only

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
