### PR TITLE
Change subtitle positioning and sizing on wide aspect ratio video

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -155,9 +155,9 @@ public class VideoManager {
                 // We're changing wide aspect ratio video subtitle to match others, so return if lower AR
                 if (aspectRatio<1.78f)
                     return;
-                // In case movie is 4k, transform videoHeight in its 1080p equivalent
+                // In case movie is not 1080p, transform videoHeight in its 1080p equivalent
                 // because display dimensions are 1080p conformant
-                if (videoHeight > mExoPlayerView.getHeight())
+                if (videoHeight != mExoPlayerView.getHeight())
                     videoHeight = (int) (mExoPlayerView.getWidth() / aspectRatio);
                 FrameLayout.LayoutParams subslp = (FrameLayout.LayoutParams) subtitleView.getLayoutParams();
                 int verticalMargins = mExoPlayerView.getHeight() - videoHeight;


### PR DESCRIPTION
Change subtitle positioning and sizing on wide aspect ratio video

**Changes**
Improved subtitle positioning and sizing on wide aspect ratio video so it matches the parameters of the others. All videos should display the subtitles in a similar fashion with this change.

**Issues**
Solves #4234, #4314 and #4544
