### PR TITLE
Fix wrong Trickplay thumbnail displayed while seeking

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
@@ -42,6 +42,8 @@ class CustomSeekProvider(
 		val currentRequest = imageRequests[index]
 		if (currentRequest?.isDisposed == false) currentRequest.dispose()
 
+		callback.onThumbnailLoaded(null, index)
+
 		val item = videoPlayerAdapter.currentlyPlayingItem
 		val mediaSource = videoPlayerAdapter.currentMediaSource
 		val mediaSourceId = mediaSource?.id?.toUUIDOrNull()


### PR DESCRIPTION
**Changes**
Clear Trickplay thumbnail in current index while starting the request for a new one.

**Issues**
[I didn't find any issue regarding this one and I also didn't open one myself because it is an unsupported feature]
Instead of seeing the same thumbnail over and over again while seeking, now the old thumbnails are being cleared until the right image is loaded.