### PR TITLE
Update app build script for Gradle 9 compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,6 @@ android {
 		applicationId = namespace
 		versionName = project.getVersionName()
 		versionCode = getVersionCode(versionName!!)
-		setProperty("archivesBaseName", "jellyfin-androidtv-v$versionName")
 	}
 
 	buildFeatures {
@@ -32,7 +31,7 @@ android {
 	}
 
 	buildTypes {
-		val release by getting {
+		release {
 			isMinifyEnabled = false
 
 			// Set package names used in various XML files
@@ -46,7 +45,7 @@ android {
 			buildConfigField("boolean", "DEVELOPMENT", "false")
 		}
 
-		val debug by getting {
+		debug {
 			// Use different application id to run release and debug at the same time
 			applicationIdSuffix = ".debug"
 
@@ -74,7 +73,9 @@ android {
 	}
 }
 
-val versionTxt by tasks.registering {
+base.archivesName.set("jellyfin-androidtv-v${project.getVersionName()}")
+
+tasks.register("versionTxt") {
 	val path = layout.buildDirectory.asFile.get().resolve("version.txt")
 
 	doLast {


### PR DESCRIPTION
**Changes**
- Set archive name using the project.base extension instead of the setProperty function
- Update versionTxt task creation syntax
- Select Android build flavors using existing extensions

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
