### PR TITLE
Use audio API for audio playback

### DIFF
--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
@@ -7,6 +7,7 @@ import org.jellyfin.playback.core.queue.QueueEntry
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.mediaSourceId
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.audioApi
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -30,11 +31,23 @@ class JellyfinMediaStreamResolver(
 		val mediaInfo = getPlaybackInfo(baseItem, queueEntry.mediaSourceId)
 
 		return when {
-			// Direct play
-			mediaInfo.mediaSource.supportsDirectPlay -> mediaInfo.toStream(
+			// Direct play video
+			mediaInfo.mediaSource.supportsDirectPlay && baseItem.mediaType == MediaType.VIDEO -> mediaInfo.toStream(
 				queueEntry = queueEntry,
 				conversionMethod = MediaConversionMethod.None,
 				url = api.videosApi.getVideoStreamUrl(
+					itemId = baseItem.id,
+					mediaSourceId = mediaInfo.mediaSource.id,
+					static = true,
+					tag = mediaInfo.mediaSource.eTag,
+				)
+			)
+
+			// Direct play audio
+			mediaInfo.mediaSource.supportsDirectPlay && baseItem.mediaType == MediaType.AUDIO -> mediaInfo.toStream(
+				queueEntry = queueEntry,
+				conversionMethod = MediaConversionMethod.None,
+				url = api.audioApi.getAudioStreamUrl(
 					itemId = baseItem.id,
 					mediaSourceId = mediaInfo.mediaSource.id,
 					static = true,

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -222,15 +222,13 @@ class ExoPlayerBackend(
 
 		currentStream = stream
 
-		var streamIsPrepared = false
-		repeat(exoPlayer.mediaItemCount) { index ->
-			streamIsPrepared =
-				streamIsPrepared || exoPlayer.getMediaItemAt(index).mediaId == stream.hashCode()
-					.toString()
+		val streamIsPrepared = (0 until exoPlayer.mediaItemCount).any { index ->
+			exoPlayer.getMediaItemAt(index).mediaId == stream.hashCode().toString()
 		}
 
 		if (!streamIsPrepared) prepareItem(item)
 
+		Timber.i("Playing ${item.mediaStream?.url}")
 		exoPlayer.seekToNextMediaItem()
 		exoPlayer.play()
 	}


### PR DESCRIPTION
While answering some playback-API related questions in our dev room yesterday I was verifying my answers with the server/ATV client code as reference. I noticed the app uses the video API for audio playback which looked off.
Well turns out, in the server both API's have 99% the same behavior, with a few differences in default values. Both use the same code (although copy-pasted into 2 places). Still opted to use the audio API in case we ever make changes.

**Changes**

- Use the AudioApi for audio items and VideoApi for video items
- Slightly optimize streamIsPrepared implementation in ExoPlayerBackend
- Log the URL of the played item in ExoPlayerBackend

**Issues**

Part of #1057 
