### PR TITLE
Remove logo from screensaver

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -3,69 +3,42 @@ package org.jellyfin.androidtv.integration.dream.composable
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.composable.rememberCurrentTime
 
 @Composable
 fun DreamHeader(
-	showLogo: Boolean,
 	showClock: Boolean,
+) = Box(
+	modifier = Modifier
+		.fillMaxWidth()
+		.overscan(),
 ) {
-	Row(
-		horizontalArrangement = Arrangement.SpaceBetween,
+	// Clock
+	AnimatedVisibility(
+		visible = showClock,
+		enter = fadeIn(),
+		exit = fadeOut(),
 		modifier = Modifier
-			.fillMaxWidth()
-			.overscan(),
+			.align(Alignment.TopEnd),
 	) {
-		// Logo
-		AnimatedVisibility(
-			visible = showLogo,
-			enter = fadeIn(),
-			exit = fadeOut(),
-			modifier = Modifier.height(41.dp),
-		) {
-			Image(
-				painter = painterResource(R.drawable.app_logo),
-				contentDescription = stringResource(R.string.app_name),
-			)
-		}
-
-		Spacer(
-			modifier = Modifier
-				.fillMaxWidth(0f)
+		val currentTime by rememberCurrentTime()
+		Text(
+			text = currentTime,
+			style = TextStyle(
+				color = Color.White,
+				fontSize = 20.sp
+			),
 		)
-
-		// Clock
-		AnimatedVisibility(
-			visible = showClock,
-			enter = fadeIn(),
-			exit = fadeOut(),
-		) {
-			val currentTime by rememberCurrentTime()
-			Text(
-				text = currentTime,
-				style = TextStyle(
-					color = Color.White,
-					fontSize = 20.sp
-				),
-			)
-		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamView.kt
@@ -36,7 +36,6 @@ fun DreamView(
 
 	// Header overlay
 	DreamHeader(
-		showLogo = content != DreamContent.Logo,
 		showClock = showClock,
 	)
 }


### PR DESCRIPTION
Remove Jellyfin branding just like in the new toolbar. The logo still shows for 2 seconds when the screensaver initializes but it will no longer show on the now playing / library showcase elements.

**Changes**

- Remove logo from screensaver library showcase

**Screenshots**

<img width="962" height="541" alt="image" src="https://github.com/user-attachments/assets/17bc7e37-e359-4df0-934e-d7a38a25b58c" />


**Issues**
Supersedes #4763
Closes #1888