### PR TITLE
Add scrubbing API to PlayerState

### DIFF
--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -21,6 +21,7 @@ interface PlayerState {
 	val videoSize: StateFlow<VideoSize>
 	val playbackOrder: StateFlow<PlaybackOrder>
 	val repeatMode: StateFlow<RepeatMode>
+	val scrubbing: StateFlow<Boolean>
 
 	/**
 	 * The position information for the currently playing item or [PositionInfo.EMPTY]. This
@@ -43,6 +44,7 @@ interface PlayerState {
 	fun seek(to: Duration)
 	fun fastForward(amount: Duration? = null)
 	fun rewind(amount: Duration? = null)
+	fun setScrubbing(scrubbing: Boolean)
 
 	// Playback properties
 
@@ -74,6 +76,9 @@ class MutablePlayerState(
 
 	private val _repeatMode = MutableStateFlow(RepeatMode.NONE)
 	override val repeatMode: StateFlow<RepeatMode> get() = _repeatMode.asStateFlow()
+
+	private val _scrubbing = MutableStateFlow(false)
+	override val scrubbing: StateFlow<Boolean> get() = _scrubbing.asStateFlow()
 
 	override val positionInfo: PositionInfo
 		get() = backendService.backend?.getPositionInfo() ?: PositionInfo.EMPTY
@@ -133,6 +138,11 @@ class MutablePlayerState(
 
 	override fun rewind(amount: Duration?) {
 		seekRelative(-(amount ?: options.defaultRewindAmount()))
+	}
+
+	override fun setScrubbing(scrubbing: Boolean) {
+		_scrubbing.value = scrubbing
+		backendService.backend?.setScrubbing(scrubbing)
 	}
 
 	override fun setSpeed(speed: Float) {

--- a/playback/core/src/main/kotlin/backend/PlayerBackend.kt
+++ b/playback/core/src/main/kotlin/backend/PlayerBackend.kt
@@ -35,6 +35,7 @@ interface PlayerBackend {
 	fun stop()
 
 	fun seekTo(position: Duration)
+	fun setScrubbing(scrubbing: Boolean)
 
 	fun setSpeed(speed: Float)
 }

--- a/playback/core/src/main/kotlin/model/VideoSize.kt
+++ b/playback/core/src/main/kotlin/model/VideoSize.kt
@@ -4,7 +4,7 @@ data class VideoSize(
 	val width: Int,
 	val height: Int,
 ) {
-	val aspectRatio: Float get() = width.toFloat() / height.toFloat()
+	val aspectRatio: Float get() = (width.toFloat() / height.toFloat()).takeIf { !it.isNaN() } ?: 0f
 
 	companion object {
 		val EMPTY = VideoSize(0, 0)

--- a/playback/core/src/main/kotlin/ui/PlayerSurfaceView.kt
+++ b/playback/core/src/main/kotlin/ui/PlayerSurfaceView.kt
@@ -3,7 +3,6 @@ package org.jellyfin.playback.core.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.view.SurfaceView
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import org.jellyfin.playback.core.PlaybackManager
 
@@ -20,7 +19,7 @@ class PlayerSurfaceView @JvmOverloads constructor(
 	lateinit var playbackManager: PlaybackManager
 
 	val surface = SurfaceView(context, attrs).apply {
-		addView(this, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+		addView(this, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
 	}
 
 	override fun onAttachedToWindow() {

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
@@ -93,7 +93,7 @@ class PlaySessionService(
 					}
 				)
 			)
-		}.onFailure { error -> Timber.w("Failed to send playback start event", error) }
+		}.onFailure { error -> Timber.w(error, "Failed to send playback start event") }
 	}
 
 	private suspend fun sendStreamUpdate() {

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -148,7 +148,9 @@ class ExoPlayerBackend(
 		}
 
 		override fun onVideoSizeChanged(size: VideoSize) {
-			listener?.onVideoSizeChange(size.width, size.height)
+			if (size != VideoSize.UNKNOWN) {
+				listener?.onVideoSizeChange(size.width, size.height)
+			}
 		}
 
 		override fun onCues(cueGroup: CueGroup) {
@@ -254,6 +256,10 @@ class ExoPlayerBackend(
 		}
 
 		exoPlayer.seekTo(position.inWholeMilliseconds)
+	}
+
+	override fun setScrubbing(scrubbing: Boolean) {
+		exoPlayer.isScrubbingModeEnabled = scrubbing
 	}
 
 	override fun setSpeed(speed: Float) {


### PR DESCRIPTION
This is an enabler for upcoming changes, this new scrubbing API is not used right now.

**Changes**
- Add scrubbing API to PlayerState
- Fix emitting VideoSize when still unknown in ExoPlayerBackend
- Fix warning logs in PlaySessionService using wrong argument for the exception
- Fix division by zero issue in VideoSize.aspectRatio

**Issues**

Part of #1057 
