### PR TITLE
Add seekbar to music playback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
@@ -27,13 +26,14 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jellyfin.androidtv.integration.dream.model.DreamContent
+import org.jellyfin.androidtv.ui.base.SeekbarDefaults
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.blurHashPainter
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
-import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
+import org.jellyfin.androidtv.ui.player.base.PlayerSeekbar
 import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
 import org.jellyfin.androidtv.util.apiclient.getUrl
 import org.jellyfin.androidtv.util.apiclient.itemImages
@@ -55,9 +55,10 @@ fun DreamContentNowPlaying(
 	val api = koinInject<ApiClient>()
 	val playbackManager = koinInject<PlaybackManager>()
 	val lyrics = content.entry.run { lyricsFlow.collectAsState(lyrics) }.value
-	val progress = rememberPlayerProgress(playbackManager)
 
-	val primaryImage = content.item.itemImages[ImageType.PRIMARY] ?: content.item.albumPrimaryImage ?: content.item.parentImages[ImageType.PRIMARY]
+	val primaryImage = content.item.itemImages[ImageType.PRIMARY]
+		?: content.item.albumPrimaryImage
+		?: content.item.parentImages[ImageType.PRIMARY]
 
 	// Background
 	if (primaryImage?.blurHash != null) {
@@ -139,20 +140,16 @@ fun DreamContentNowPlaying(
 
 			Spacer(modifier = Modifier.height(10.dp))
 
-			Box(
+			PlayerSeekbar(
+				playbackManager = playbackManager,
+				colors = SeekbarDefaults.colors(
+					backgroundColor = Color.White.copy(alpha = 0.2f),
+					progressColor = Color.White,
+					bufferColor = Color.Transparent,
+				),
 				modifier = Modifier
 					.fillMaxWidth()
 					.height(4.dp)
-					.clip(RoundedCornerShape(2.dp))
-					.drawWithContent {
-						// Background
-						drawRect(Color.White, alpha = 0.2f)
-						// Foreground
-						drawRect(
-							Color.White,
-							size = size.copy(width = progress * size.width)
-						)
-					}
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamHeader.kt
@@ -6,15 +6,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.sp
-import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
-import org.jellyfin.androidtv.ui.composable.rememberCurrentTime
+import org.jellyfin.androidtv.ui.shared.toolbar.ToolbarClock
 
 @Composable
 fun DreamHeader(
@@ -32,13 +27,6 @@ fun DreamHeader(
 		modifier = Modifier
 			.align(Alignment.TopEnd),
 	) {
-		val currentTime by rememberCurrentTime()
-		Text(
-			text = currentTime,
-			style = TextStyle(
-				color = Color.White,
-				fontSize = 20.sp
-			),
-		)
+		ToolbarClock()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
@@ -1,0 +1,189 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.times
+
+@Immutable
+data class SeekbarColors(
+	val backgroundColor: Color,
+	val bufferColor: Color,
+	val progressColor: Color,
+	val knobColor: Color,
+)
+
+object SeekbarDefaults {
+	@ReadOnlyComposable
+	@Composable
+	fun colors(
+		backgroundColor: Color = Color(0xCC4B4B4B),
+		bufferColor: Color = Color(0x40FFFFFF),
+		progressColor: Color = Color(0xFF00A4DC),
+		knobColor: Color = Color.White,
+	) = SeekbarColors(
+		backgroundColor = backgroundColor,
+		bufferColor = bufferColor,
+		progressColor = progressColor,
+		knobColor = knobColor,
+	)
+}
+
+@Composable
+fun Seekbar(
+	modifier: Modifier = Modifier,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+	progress: Duration = Duration.ZERO,
+	buffer: Duration = Duration.ZERO,
+	duration: Duration = Duration.ZERO,
+	seekForwardAmount: Duration = duration / 100,
+	seekRewindAmount: Duration = duration / 100,
+	onScrubbing: ((scrubbing: Boolean) -> Unit)? = null,
+	onSeek: ((progress: Duration) -> Unit)? = null,
+	enabled: Boolean = true,
+	colors: SeekbarColors = SeekbarDefaults.colors(),
+) {
+	val durationMs = duration.inWholeMilliseconds.toFloat()
+	val progressPercentage = progress.inWholeMilliseconds.toFloat() / durationMs
+	val bufferPercentage = buffer.inWholeMilliseconds.toFloat() / durationMs
+	val seekForwardPercentage = seekForwardAmount.inWholeMilliseconds.toFloat() / durationMs
+	val seekRewindPercentage = seekRewindAmount.inWholeMilliseconds.toFloat() / durationMs
+
+	Seekbar(
+		modifier = modifier,
+		interactionSource = interactionSource,
+		progress = progressPercentage,
+		buffer = bufferPercentage,
+		seekForwardAmount = seekForwardPercentage,
+		seekRewindAmount = seekRewindPercentage,
+		onScrubbing = onScrubbing,
+		onSeek = if (onSeek == null) null else { progress -> onSeek(progress.toDouble() * duration) },
+		enabled = enabled,
+		colors = colors,
+	)
+}
+
+@Composable
+fun Seekbar(
+	modifier: Modifier = Modifier,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+	progress: Float = 0f,
+	buffer: Float = 0f,
+	seekForwardAmount: Float = 0.01f,
+	seekRewindAmount: Float = 0.01f,
+	onScrubbing: ((scrubbing: Boolean) -> Unit)? = null,
+	onSeek: ((progress: Float) -> Unit)? = null,
+	enabled: Boolean = true,
+	colors: SeekbarColors = SeekbarDefaults.colors(),
+) {
+	val coroutineScope = rememberCoroutineScope()
+	val focused by interactionSource.collectIsFocusedAsState()
+	var progressOverride by remember { mutableStateOf<Float?>(null) }
+	val visibleProgress = progressOverride ?: progress
+	val knobAlpha by animateFloatAsState(if (focused) 1f else 0f)
+	var scrubCancelJob by remember { mutableStateOf<Job?>(null) }
+
+	Box(
+		modifier = modifier
+			.onKeyEvent {
+				if (!enabled) return@onKeyEvent false
+
+				val isForward = it.key == Key.DirectionRight
+				val isRewind = it.key == Key.DirectionLeft
+				val isScrubbing = isForward || isRewind
+				val isKeyUp = it.type == KeyEventType.KeyUp
+				val isKeyDown = it.type == KeyEventType.KeyDown
+
+				val newProgress = when {
+					isKeyDown && isForward -> (visibleProgress + seekForwardAmount).coerceAtMost(1f)
+					isKeyDown && isRewind -> (visibleProgress - seekRewindAmount).coerceAtLeast(0f)
+					else -> visibleProgress
+				}
+
+				if (isScrubbing && isKeyDown && onScrubbing != null) {
+					scrubCancelJob?.cancel()
+					onScrubbing(true)
+				}
+
+				if (visibleProgress != newProgress) {
+					progressOverride = newProgress
+					if (onSeek != null) onSeek(newProgress)
+				}
+
+				if (isScrubbing && isKeyUp && onScrubbing != null) {
+					scrubCancelJob?.cancel()
+					scrubCancelJob = coroutineScope.launch {
+						delay(300)
+						onScrubbing(false)
+					}
+				}
+
+				return@onKeyEvent isScrubbing
+			}
+			.focusable(interactionSource = interactionSource, enabled = enabled)
+			.drawWithContent {
+				val barCornerRadius = CornerRadius(size.minDimension, size.minDimension)
+
+				// Background bar
+				drawRoundRect(
+					color = colors.backgroundColor,
+					cornerRadius = barCornerRadius,
+				)
+
+				// Buffer bar
+				if (buffer > 0f) {
+					drawRoundRect(
+						color = colors.bufferColor,
+						size = size.copy(
+							width = buffer * size.width,
+						),
+						cornerRadius = barCornerRadius,
+					)
+				}
+
+				// Progress bar
+				if (visibleProgress > 0f) {
+					drawRoundRect(
+						color = colors.progressColor,
+						size = size.copy(
+							width = visibleProgress * size.width,
+						),
+						cornerRadius = barCornerRadius,
+					)
+				}
+
+				// Progress knob
+				drawCircle(
+					color = colors.knobColor,
+					alpha = knobAlpha,
+					center = center.copy(
+						x = visibleProgress * size.width,
+					),
+					radius = size.minDimension * 2,
+				)
+			}
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,6 +30,7 @@ import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.androidtv.ui.composable.rememberQueueEntry
+import org.jellyfin.androidtv.ui.player.base.PlayerSeekbar
 import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
 import org.jellyfin.androidtv.util.apiclient.getUrl
 import org.jellyfin.androidtv.util.apiclient.itemImages
@@ -41,6 +44,25 @@ import org.jellyfin.playback.jellyfin.queue.baseItemFlow
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.ImageType
 import org.koin.compose.koinInject
+
+fun initializePlayerProgress(
+	playerProgress: ComposeView,
+	playbackManager: PlaybackManager,
+) {
+	playerProgress.setContent {
+		Box(
+			modifier = Modifier
+				.padding(horizontal = 10.dp, vertical = 20.dp)
+		) {
+			PlayerSeekbar(
+				playbackManager = playbackManager,
+				modifier = Modifier
+					.fillMaxWidth()
+					.height(4.dp)
+			)
+		}
+	}
+}
 
 fun initializePreviewView(
 	lyricsView: ComposeView,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
@@ -1,0 +1,44 @@
+package org.jellyfin.androidtv.ui.player.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import org.jellyfin.androidtv.ui.base.Seekbar
+import org.jellyfin.androidtv.ui.base.SeekbarColors
+import org.jellyfin.androidtv.ui.base.SeekbarDefaults
+import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.PlayState
+import org.koin.compose.koinInject
+import kotlin.time.times
+
+@Composable
+fun PlayerSeekbar(
+	modifier: Modifier = Modifier,
+	colors: SeekbarColors = SeekbarDefaults.colors(),
+	playbackManager: PlaybackManager = koinInject<PlaybackManager>(),
+) {
+	val playState by playbackManager.state.playState.collectAsState()
+	val positionInfo = playbackManager.state.positionInfo
+	val progress = rememberPlayerProgress(
+		playing = playState == PlayState.PLAYING,
+		active = positionInfo.active,
+		duration = positionInfo.duration,
+	)
+	val seekForwardAmount = remember { playbackManager.options.defaultFastForwardAmount() }
+	val seekRewindAmount = remember { playbackManager.options.defaultRewindAmount() }
+
+	Seekbar(
+		progress = progress.toDouble() * positionInfo.duration,
+		buffer = positionInfo.buffer,
+		duration = positionInfo.duration,
+		seekForwardAmount = seekForwardAmount,
+		seekRewindAmount = seekRewindAmount,
+		onScrubbing = { scrubbing -> playbackManager.state.setScrubbing(scrubbing) },
+		onSeek = { progress -> playbackManager.state.seek(progress) },
+		modifier = modifier,
+		colors = colors,
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/Toolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/Toolbar.kt
@@ -50,12 +50,15 @@ fun Toolbar(
 }
 
 @Composable
-fun ToolbarClock() {
+fun ToolbarClock(
+	modifier: Modifier = Modifier,
+) {
 	val currentTime by rememberCurrentTime()
 	Text(
 		text = currentTime,
 		fontSize = 20.sp,
 		color = Color.White,
+		modifier = modifier,
 	)
 }
 

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -118,17 +118,11 @@
                         android:textSize="16sp"
                         tools:text="0:00" />
 
-                    <ProgressBar
+                    <androidx.compose.ui.platform.ComposeView
                         android:id="@+id/playerProgress"
-                        style="@style/player_progress"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="10dp"
-                        android:layout_marginTop="20dp"
-                        android:layout_marginEnd="10dp"
-                        android:layout_marginBottom="20dp"
-                        android:layout_weight="1"
-                        android:maxHeight="5sp" />
+                        android:layout_weight="1" />
 
                     <TextView
                         android:id="@+id/remainingTime"


### PR DESCRIPTION
This change backports the new seekbar composable from the new video player user interface and uses it for music playback. It uses the scrubber API from #4843 which results in seeking being extremely smooth (in my testing).

**Changes**
- Use the ToolbarClock composable in the screensaver to avoid duplicate code
- Add a new seekbar composable
- Use new seekbar composable in (audio) now playing screen
- Use new seekbar composable in screensaver

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
