### PR TITLE
Add display information to playback report

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.media.MediaCodecList
 import android.os.Build
 import android.util.Range
+import android.view.Display
+import android.view.Surface
+import androidx.core.content.ContextCompat
 import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -14,6 +17,7 @@ import org.jellyfin.androidtv.util.appendSection
 import org.jellyfin.androidtv.util.appendValue
 import org.jellyfin.androidtv.util.buildMarkdown
 import org.jellyfin.sdk.api.client.util.ApiSerializer
+import kotlin.time.Duration.Companion.nanoseconds
 
 private val prettyPrintJson = Json { prettyPrint = true }
 private fun formatJson(json: String) = prettyPrintJson.encodeToString(prettyPrintJson.parseToJsonElement(json))
@@ -40,6 +44,15 @@ private val featureNames = setOf(
 	"tunneled-playback",
 )
 
+// API levels
+private val isN = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N // API 24
+private val isO = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O // API 26
+private val isQ = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q // API 29
+private val isR = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R // API 30
+private val isS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S // API 31
+private val isUpsideDownCake = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE // API 34
+private val isBaklava = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA // API 36
+
 fun createDeviceProfileReport(
 	context: Context,
 	userPreferences: UserPreferences,
@@ -65,9 +78,6 @@ fun createDeviceProfileReport(
 	}
 
 	// Device capabilities used to generate profile
-	val isQ = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-	val isS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-
 	val codecs = MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
 		.filter { !it.isEncoder }
 		.sortedBy { if (isQ) it.canonicalName else it.name }
@@ -154,6 +164,65 @@ fun createDeviceProfileReport(
 			.distinct()
 			.sorted()
 			.forEach { type -> appendLine("- $type") }
+	}
+
+	appendDetails("Display information") {
+		val display = ContextCompat.getDisplayOrDefault(context)
+
+		// Basic information
+		appendItem("Id") { appendValue(display.displayId.toString()) }
+		appendItem("Name") { appendValue(display.name) }
+		if (isS && display.deviceProductInfo != null) {
+			val productInfo = requireNotNull(display.deviceProductInfo)
+			appendItem("Display product id") { appendValue(productInfo.productId) }
+			appendItem("Display bame") { appendValue(productInfo.name) }
+			appendItem("Display manufacture year") { appendValue(productInfo.manufactureYear.toString()) }
+			appendItem("Display manufacture week") { appendValue(productInfo.manufactureWeek.toString()) }
+			appendItem("Display manufacturer pnp id") { appendValue(productInfo.manufacturerPnpId) }
+			appendItem("Display model year") { appendValue(productInfo.modelYear.toString()) }
+		}
+		appendItem("Rotation") {
+			when (display.rotation) {
+				Surface.ROTATION_0 -> append("0°")
+				Surface.ROTATION_90 -> append("90°")
+				Surface.ROTATION_180 -> append("180°")
+				Surface.ROTATION_270 -> append("270°")
+				else -> appendValue("Unknown (${display.rotation}")
+			}
+		}
+
+		// Refresh rate and timing
+		appendItem("Refresh rate") { appendValue(display.refreshRate.toString()) }
+		if (isBaklava) appendItem("Adaptive refresh rate") { appendValue(display.hasArrSupport().toString()) }
+		appendItem("VSYNC offset") { appendValue(display.appVsyncOffsetNanos.nanoseconds.toString()) }
+		appendItem("Presentation deadline") { appendValue(display.presentationDeadlineNanos.nanoseconds.toString()) }
+		if (isR) appendItem("Minimal post processing") { appendValue(display.isMinimalPostProcessingSupported.toString()) }
+
+		// HDR
+		if (isO) appendItem("Any HDR") { appendValue(display.isHdr.toString()) }
+		if (isO) appendItem("Wide color gamut") { appendValue(display.isWideColorGamut.toString()) }
+		if (isQ) appendItem("Preferred wide color space") { appendValue(display.preferredWideGamutColorSpace.toString()) }
+		if (isN) {
+			val supportedHdrTypes = if (isUpsideDownCake) display.mode.supportedHdrTypes.toList()
+			else display.hdrCapabilities.supportedHdrTypes.toList()
+
+			appendItem("HDR capabilities") {
+				appendLine()
+				appendLine("- Dolby Vision: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)}")
+				appendLine("- HDR10: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10)}")
+				if (isQ) appendLine("- HDR10+: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)}")
+				appendLine("- HLG: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HLG)}")
+			}
+		}
+
+		if (isUpsideDownCake) appendItem("HDR/SDR ratio") {
+			appendLine()
+			appendItem("Available") { appendValue(display.isHdrSdrRatioAvailable.toString()) }
+			appendItem("Ratio") { appendValue(display.hdrSdrRatio.toString()) }
+			if (isBaklava) {
+				appendItem("Highest ratio") { appendValue(display.highestHdrSdrRatio.toString()) }
+			}
+		}
 	}
 
 	appendSection("App information") {


### PR DESCRIPTION
**Changes**

- Add display information to playback report

Looks like this

<details>
<summary>Display information</summary>

***Id***: `0`  
***Name***: `Built-in Screen`  
***Display product id***: `1`  
***Display bame***: `EMU_display_0`  
***Display manufacture year***: `2006`  
***Display manufacture week***: `27`  
***Display manufacturer pnp id***: `GGL`  
***Display model year***: `-1`  
***Rotation***: 0  
***Refresh rate***: `60.000004`  
***VSYNC offset***: `1ms`  
***Presentation deadline***: `16.666666ms`  
***Minimal post processing***: `false`  
***Any HDR***: `false`  
***Wide color gamut***: `false`  
***Preferred wide color space***: `null`  
***HDR capabilities***: 
- Dolby Vision: false
- HDR10: false
- HDR10+: false
- HLG: false
  
***HDR/SDR ratio***: 
***Available***: `false`  
***Ratio***: `1.0`  
  

</details>

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
