### PR TITLE
Add display HDR capabilities to device profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -82,7 +82,7 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 	)
 	install(media3SessionPlugin(get(), mediaSessionOptions))
 
-	val deviceProfileBuilder = { createDeviceProfile(userPreferences, false) }
+	val deviceProfileBuilder = { createDeviceProfile(androidContext(), userPreferences, false) }
 	install(jellyfinPlugin(get(), deviceProfileBuilder, ProcessLifecycleOwner.get().lifecycle))
 
 	// Options

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -528,6 +528,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             internalOptions.setMediaSourceId(currentMediaSource.getId());
         }
         DeviceProfile internalProfile = DeviceProfileKt.createDeviceProfile(
+                mFragment.getContext(),
                 userPreferences.getValue(),
                 !internalOptions.getEnableDirectStream()
         );

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -1,14 +1,27 @@
 package org.jellyfin.androidtv.util.profile
 
+import android.content.Context
 import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.util.Size
+import android.view.Display
+import androidx.core.content.ContextCompat
 import timber.log.Timber
 
-class MediaCodecCapabilitiesTest {
+class MediaCodecCapabilitiesTest(
+	private val context: Context,
+) {
+	private val display by lazy { ContextCompat.getDisplayOrDefault(context) }
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
+
+	@Suppress("DEPRECATION")
+	private val supportedHdrTypes by lazy {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) display.mode.supportedHdrTypes.toList()
+		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) display.hdrCapabilities.supportedHdrTypes.toList()
+		else emptyList()
+	}
 
 	// AVC levels as reported by ffprobe are multiplied by 10, e.g. level 4.1 is 41. Level 1b is set to 9
 	private val avcLevels = listOf(
@@ -193,4 +206,15 @@ class MediaCodecCapabilitiesTest {
 		return Size(maxWidth, maxHeight)
 	}
 
+	fun supportsDolbyVision(): Boolean {
+		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)
+	}
+
+	fun supportsHdr10(): Boolean {
+		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10)
+	}
+
+	fun supportsHdr10Plus(): Boolean {
+		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -71,7 +71,7 @@ fun createDeviceProfileReport(
 	appendDetails("Generated device profile") {
 		appendCodeBlock(
 			language = "json",
-			code = createDeviceProfile(userPreferences, disableDirectPlay = false)
+			code = createDeviceProfile(context, userPreferences, disableDirectPlay = false)
 				.let(ApiSerializer::encodeRequestBody)
 				?.let(::formatJson)
 		)
@@ -203,6 +203,7 @@ fun createDeviceProfileReport(
 		if (isO) appendItem("Wide color gamut") { appendValue(display.isWideColorGamut.toString()) }
 		if (isQ) appendItem("Preferred wide color space") { appendValue(display.preferredWideGamutColorSpace.toString()) }
 		if (isN) {
+			@Suppress("DEPRECATION")
 			val supportedHdrTypes = if (isUpsideDownCake) display.mode.supportedHdrTypes.toList()
 			else display.hdrCapabilities.supportedHdrTypes.toList()
 


### PR DESCRIPTION
I have not been able to test this on an actual HDR10+ capable device. I only know it correctly detects there is NO support on my shield and emulators.

**Changes**
- Add codec profile rules for Dolby Vision, HDR10 and HDR10+

**Issues**

Fixes #4860
