### PR TITLE
Add new video player UI

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/Destinations.kt
@@ -20,8 +20,8 @@ import org.jellyfin.androidtv.ui.picture.PictureViewerFragment
 import org.jellyfin.androidtv.ui.playback.AudioNowPlayingFragment
 import org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment
 import org.jellyfin.androidtv.ui.playback.nextup.NextUpFragment
-import org.jellyfin.androidtv.ui.playback.rewrite.PlaybackRewriteFragment
 import org.jellyfin.androidtv.ui.playback.stillwatching.StillWatchingFragment
+import org.jellyfin.androidtv.ui.player.video.VideoPlayerFragment
 import org.jellyfin.androidtv.ui.search.SearchFragment
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ItemSortBy
@@ -134,8 +134,8 @@ object Destinations {
 		"Position" to (position ?: 0)
 	)
 
-	fun playbackRewritePlayer(position: Int?) = fragmentDestination<PlaybackRewriteFragment>(
-		PlaybackRewriteFragment.EXTRA_POSITION to position
+	fun videoPlayerNew(position: Int?) = fragmentDestination<VideoPlayerFragment>(
+		VideoPlayerFragment.EXTRA_POSITION to position
 	)
 
 	fun nextUp(item: UUID) = fragmentDestination<NextUpFragment>(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -60,7 +60,7 @@ class PlaybackLauncher(
 			if (userPreferences[UserPreferences.useExternalPlayer] && items.all { it.supportsExternalPlayer }) {
 				context.startActivity(ActivityDestinations.externalPlayer(context, position?.milliseconds ?: Duration.ZERO))
 			} else if (userPreferences[UserPreferences.playbackRewriteVideoEnabled]) {
-				val destination = Destinations.playbackRewritePlayer(position)
+				val destination = Destinations.videoPlayerNew(position)
 				navigationRepository.navigate(destination, replace)
 			} else {
 				val destination = Destinations.videoPlayer(position)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerHeader.kt
@@ -1,0 +1,33 @@
+package org.jellyfin.androidtv.ui.player.base
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.shared.toolbar.ToolbarClock
+
+@Composable
+fun PlayerHeader(
+	content: @Composable ColumnScope.() -> Unit,
+) {
+	Row(
+		horizontalArrangement = Arrangement.spacedBy(12.dp),
+		verticalAlignment = Alignment.Top,
+	) {
+		Column {
+			content()
+		}
+
+		Spacer(Modifier.weight(1f))
+
+		ToolbarClock(
+			modifier = Modifier.wrapContentWidth(unbounded = true)
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerOverlayLayout.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerOverlayLayout.kt
@@ -1,0 +1,83 @@
+package org.jellyfin.androidtv.ui.player.base
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import org.jellyfin.androidtv.ui.composable.modifier.overscan
+
+@Composable
+fun PlayerOverlayLayout(
+	visible: Boolean,
+	modifier: Modifier = Modifier,
+	header: (@Composable () -> Unit)? = null,
+	controls: (@Composable () -> Unit)? = null,
+) = Box(
+	modifier = modifier.fillMaxSize()
+) {
+	if (header != null) {
+		AnimatedVisibility(
+			visible = visible,
+			modifier = Modifier
+				.align(Alignment.TopCenter),
+			enter = slideInVertically() + fadeIn(),
+			exit = slideOutVertically() + fadeOut(),
+		) {
+			Box(
+				modifier = Modifier
+					.fillMaxWidth()
+					.fillMaxHeight(1f / 3)
+					.background(
+						brush = Brush.verticalGradient(
+							colors = listOf(
+								Color.Black.copy(alpha = 0.8f),
+								Color.Transparent,
+							)
+						)
+					)
+					.overscan()
+			) {
+				header()
+			}
+		}
+	}
+
+	if (controls != null) {
+		AnimatedVisibility(
+			visible = visible,
+			modifier = Modifier
+				.align(Alignment.BottomCenter),
+			enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+			exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+		) {
+			Box(
+				contentAlignment = Alignment.BottomCenter,
+				modifier = Modifier
+					.fillMaxWidth()
+					.fillMaxHeight(1f / 3)
+					.background(
+						brush = Brush.verticalGradient(
+							colors = listOf(
+								Color.Transparent,
+								Color.Black.copy(alpha = 0.8f),
+							)
+						)
+					)
+					.overscan(),
+			) {
+				controls()
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSubtitles.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSubtitles.kt
@@ -1,0 +1,20 @@
+package org.jellyfin.androidtv.ui.player.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.ui.PlayerSubtitleView
+import org.koin.compose.koinInject
+
+@Composable
+fun PlayerSubtitles(
+	modifier: Modifier = Modifier,
+	playbackManager: PlaybackManager = koinInject(),
+) = AndroidView(
+	factory = { context -> PlayerSubtitleView(context) },
+	modifier = modifier,
+	update = { view ->
+		view.playbackManager = playbackManager
+	}
+)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSurface.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSurface.kt
@@ -1,0 +1,22 @@
+package org.jellyfin.androidtv.ui.player.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.ui.PlayerSurfaceView
+import org.koin.compose.koinInject
+
+@Composable
+fun PlayerSurface(
+	modifier: Modifier = Modifier,
+	playbackManager: PlaybackManager = koinInject(),
+) {
+	AndroidView(
+		factory = { context -> PlayerSurfaceView(context) },
+		modifier = modifier,
+		update = { view ->
+			view.playbackManager = playbackManager
+		}
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/visibilityTimer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/visibilityTimer.kt
@@ -1,0 +1,57 @@
+package org.jellyfin.androidtv.ui.player.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+data class VisibilityTimerState(
+	val visible: Boolean,
+
+	val toggle: () -> Unit,
+	val show: () -> Unit,
+	val hide: () -> Unit
+)
+
+@Composable
+fun rememberVisibilityTimer(
+	timeout: Duration = 5.seconds
+): VisibilityTimerState {
+	val scope = rememberCoroutineScope()
+	var visible by remember { mutableStateOf(false) }
+	var timerJob by remember { mutableStateOf<Job?>(null) }
+
+	fun show() {
+		visible = true
+		timerJob?.cancel()
+		timerJob = scope.launch {
+			delay(timeout)
+			visible = false
+		}
+	}
+
+	fun hide() {
+		visible = false
+		timerJob?.cancel()
+		timerJob = null
+	}
+
+	fun toggle() {
+		if (visible) hide()
+		else show()
+	}
+
+	return VisibilityTimerState(
+		visible = visible,
+		toggle = ::toggle,
+		show = ::show,
+		hide = ::hide
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerControls.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerControls.kt
@@ -1,0 +1,127 @@
+package org.jellyfin.androidtv.ui.player.video
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onVisibilityChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.button.IconButton
+import org.jellyfin.androidtv.ui.player.base.PlayerSeekbar
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.PlayState
+import org.koin.compose.koinInject
+
+@Composable
+fun VideoPlayerControls(
+	playbackManager: PlaybackManager = koinInject()
+) {
+	val playState by playbackManager.state.playState.collectAsState()
+
+	Column(
+		verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Bottom),
+	) {
+		Row(
+			horizontalArrangement = Arrangement.spacedBy(12.dp),
+			modifier = Modifier
+				.focusRestorer()
+				.focusGroup()
+		) {
+			PlayPauseButton(playbackManager, playState)
+			RewindButton(playbackManager)
+			FastForwardButton(playbackManager)
+		}
+
+		PlayerSeekbar(
+			playbackManager = playbackManager,
+			modifier = Modifier
+				.fillMaxWidth()
+				.height(4.dp)
+		)
+	}
+}
+
+@Composable
+private fun PlayPauseButton(
+	playbackManager: PlaybackManager,
+	playState: PlayState,
+) {
+	val focusRequester = remember { FocusRequester() }
+	IconButton(
+		onClick = {
+			when (playState) {
+				PlayState.STOPPED,
+				PlayState.ERROR -> playbackManager.state.play()
+
+				PlayState.PLAYING -> playbackManager.state.pause()
+				PlayState.PAUSED -> playbackManager.state.unpause()
+			}
+		},
+		modifier = Modifier
+			.focusRequester(focusRequester)
+			.onVisibilityChanged {
+				focusRequester.requestFocus()
+			}
+	) {
+		AnimatedContent(playState) { playState ->
+			when (playState) {
+				PlayState.PLAYING -> {
+					Icon(
+						imageVector = ImageVector.vectorResource(R.drawable.ic_pause),
+						contentDescription = stringResource(R.string.lbl_pause),
+					)
+				}
+
+				PlayState.STOPPED,
+				PlayState.PAUSED,
+				PlayState.ERROR -> {
+					Icon(
+						imageVector = ImageVector.vectorResource(R.drawable.ic_play),
+						contentDescription = stringResource(R.string.lbl_play),
+					)
+				}
+			}
+		}
+	}
+}
+
+@Composable
+private fun RewindButton(
+	playbackManager: PlaybackManager,
+) = IconButton(
+	onClick = { playbackManager.state.rewind() },
+) {
+	Icon(
+		imageVector = ImageVector.vectorResource(R.drawable.ic_rewind),
+		contentDescription = stringResource(R.string.rewind),
+	)
+}
+
+@Composable
+private fun FastForwardButton(
+	playbackManager: PlaybackManager,
+) = IconButton(
+	onClick = { playbackManager.state.fastForward() },
+) {
+	Icon(
+		imageVector = ImageVector.vectorResource(R.drawable.ic_fast_forward),
+		contentDescription = stringResource(R.string.fast_forward),
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
@@ -1,11 +1,10 @@
-package org.jellyfin.androidtv.ui.playback.rewrite
+package org.jellyfin.androidtv.ui.player.video
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
+import androidx.fragment.compose.content
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -14,21 +13,17 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.ui.InteractionTrackerViewModel
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
+import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.queue.queue
-import org.jellyfin.playback.core.ui.PlayerSubtitleView
-import org.jellyfin.playback.core.ui.PlayerSurfaceView
 import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import timber.log.Timber
+import kotlin.time.Duration.Companion.milliseconds
 
-/**
- * Temporary fragment used for testing the playback rewrite. This will eventually be replaced with a
- * proper player user interface.
- */
-class PlaybackRewriteFragment : Fragment() {
+class VideoPlayerFragment : Fragment() {
 	companion object {
 		const val EXTRA_POSITION: String = "position"
 	}
@@ -50,11 +45,9 @@ class PlaybackRewriteFragment : Fragment() {
 		playbackManager.queue.addSupplier(queueSupplier)
 
 		// Set position
-		val position = arguments?.getInt(EXTRA_POSITION) ?: 0
-		if (position != 0) {
+		arguments?.getInt(EXTRA_POSITION)?.milliseconds?.let {
 			lifecycleScope.launch {
-				Timber.i("Skipping to queue item $position")
-				playbackManager.queue.setIndex(position, false)
+				playbackManager.state.seek(it)
 			}
 		}
 
@@ -76,16 +69,12 @@ class PlaybackRewriteFragment : Fragment() {
 		}
 	}
 
-	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-		return FrameLayout(requireContext()).apply {
-			addView(PlayerSurfaceView(requireContext()).also { view ->
-				view.playbackManager = playbackManager
-			})
-
-			addView(PlayerSubtitleView(requireContext()).also { view ->
-				view.playbackManager = playbackManager
-			})
-		}
+	override fun onCreateView(
+		inflater: LayoutInflater,
+		container: ViewGroup?,
+		savedInstanceState: Bundle?
+	) = content {
+		VideoPlayerScreen()
 	}
 
 	override fun onPause() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerHeader.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerHeader.kt
@@ -1,0 +1,41 @@
+package org.jellyfin.androidtv.ui.player.video
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.player.base.PlayerHeader
+import org.jellyfin.sdk.model.api.BaseItemDto
+
+@Composable
+@Stable
+fun VideoPlayerHeader(
+	item: BaseItemDto?,
+) {
+	PlayerHeader {
+		if (item != null) {
+			Text(
+				text = item.name.orEmpty(),
+				overflow = TextOverflow.Ellipsis,
+				maxLines = 1,
+				style = LocalTextStyle.current.copy(
+					color = Color.White,
+					fontSize = 22.sp
+				)
+			)
+
+			Text(
+				text = item.seriesName.orEmpty(),
+				overflow = TextOverflow.Ellipsis,
+				maxLines = 1,
+				style = LocalTextStyle.current.copy(
+					color = Color.White,
+					fontSize = 18.sp
+				)
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerOverlay.kt
@@ -1,0 +1,60 @@
+package org.jellyfin.androidtv.ui.player.video
+
+import androidx.compose.foundation.focusable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import org.jellyfin.androidtv.ui.composable.rememberQueueEntry
+import org.jellyfin.androidtv.ui.player.base.PlayerOverlayLayout
+import org.jellyfin.androidtv.ui.player.base.rememberVisibilityTimer
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.playback.jellyfin.queue.baseItemFlow
+import org.koin.compose.koinInject
+
+@Composable
+fun VideoPlayerOverlay(
+	modifier: Modifier = Modifier,
+	playbackManager: PlaybackManager = koinInject(),
+) {
+	val visibilityTimerState = rememberVisibilityTimer()
+
+	val entry by rememberQueueEntry(playbackManager)
+	val item = entry?.run { baseItemFlow.collectAsState(baseItem) }?.value
+
+	PlayerOverlayLayout(
+		modifier = modifier
+			.focusable()
+			.onPreviewKeyEvent {
+				if (visibilityTimerState.visible) visibilityTimerState.show()
+				false
+			}
+			.onKeyEvent {
+				if (it.key == Key.Back && visibilityTimerState.visible) {
+					visibilityTimerState.hide()
+					true
+				} else if (!it.nativeKeyEvent.isSystem && !visibilityTimerState.visible) {
+					visibilityTimerState.show()
+					true
+				} else {
+					false
+				}
+			},
+		visible = visibilityTimerState.visible,
+		header = {
+			VideoPlayerHeader(
+				item = item,
+			)
+		},
+		controls = {
+			VideoPlayerControls(
+				playbackManager = playbackManager,
+			)
+		},
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerScreen.kt
@@ -1,0 +1,58 @@
+package org.jellyfin.androidtv.ui.player.video
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import org.jellyfin.androidtv.data.service.BackgroundService
+import org.jellyfin.androidtv.ui.player.base.PlayerSubtitles
+import org.jellyfin.androidtv.ui.player.base.PlayerSurface
+import org.jellyfin.playback.core.PlaybackManager
+import org.koin.compose.koinInject
+
+private const val DefaultVideoAspectRatio = 16f / 9f
+
+@Composable
+fun VideoPlayerScreen() {
+	val backgroundService = koinInject<BackgroundService>()
+	LaunchedEffect(backgroundService) {
+		backgroundService.clearBackgrounds()
+	}
+
+	val playbackManager = koinInject<PlaybackManager>()
+	val videoSize by playbackManager.state.videoSize.collectAsState()
+	val aspectRatio = videoSize.aspectRatio.takeIf { !it.isNaN() && it > 0f } ?: DefaultVideoAspectRatio
+
+	Box(
+		modifier = Modifier
+			.background(Color.Black)
+			.fillMaxSize()
+	) {
+		PlayerSurface(
+			playbackManager = playbackManager,
+			modifier = Modifier
+				.aspectRatio(aspectRatio, videoSize.height < videoSize.width)
+				.fillMaxSize()
+				.align(Alignment.Center)
+		)
+
+		VideoPlayerOverlay(
+			playbackManager = playbackManager,
+		)
+
+		PlayerSubtitles(
+			playbackManager = playbackManager,
+			modifier = Modifier
+				.aspectRatio(aspectRatio, videoSize.height < videoSize.width)
+				.fillMaxSize()
+				.align(Alignment.Center)
+		)
+	}
+}


### PR DESCRIPTION
This PR adds the first (of many) changes for the new (video-)player user interface. It's built in two layers so everything is reusable for different player types. This will eventually be used for music, audiobooks, photos, live tv etc. as well. With this base it will be easier to add features as the UI can be developed at the same time.

This is not the final design. Things will change.

Currently the UI implements the following features:

- Display video with correct aspect ratio
- Display subtitles with correct aspect ratio
  - They are currently rendered on top of the controls, this may change in the future
- Display controls on any key press
  - Auto-hide after 5 seconds or on back press
- Play/pause control
- Rewind and fast forward controls
- Seekbar (already backported in #4844)

**Changes**

- Add composables for video and subtitle surfaces
- Add compose based video player

**Screenshots**

![Big Buck Bunny](https://github.com/user-attachments/assets/8c19c176-daa9-40a7-b484-ddd375f5b455)

**Issues**

Part of #1057 