### PR TITLE
Fix scaling of profile pictures in UserCardView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
@@ -5,6 +5,7 @@ import android.graphics.Rect
 import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.widget.ImageView
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
@@ -158,6 +159,7 @@ class UserCardView @JvmOverloads constructor(
 				if (image != null) {
 					AsyncImage(
 						modifier = Modifier.fillMaxSize(),
+						scaleType = ImageView.ScaleType.CENTER_CROP,
 						url = image,
 					)
 				} else {


### PR DESCRIPTION
Use crop scaling instead of center inside to avoid ugly bars.

**Changes**
- Fix scaling of profile pictures in UserCardView



**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
