### PR TITLE
Fix seekbar getting stuck in seek mode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.times
 
 @Immutable
@@ -136,8 +137,9 @@ fun Seekbar(
 				if (isScrubbing && isKeyUp && onScrubbing != null) {
 					scrubCancelJob?.cancel()
 					scrubCancelJob = coroutineScope.launch {
-						delay(300)
+						delay(300.milliseconds)
 						onScrubbing(false)
+						progressOverride = null
 					}
 				}
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

Fix a bug where the seekbar would get stuck in the seeking/scrubbing mode because it never reset progressOverride.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
