### PR TITLE
Remove libass preference in non-development builds

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/DeveloperPreferencesScreen.kt
@@ -47,13 +47,13 @@ class DeveloperPreferencesScreen : OptionsFragment() {
 
 					bind(userPreferences, UserPreferences.playbackRewriteVideoEnabled)
 				}
-			}
 
-			checkbox {
-				setTitle(R.string.preference_enable_libass)
-				setContent(R.string.enable_playback_module_description)
+				checkbox {
+					setTitle(R.string.preference_enable_libass)
+					setContent(R.string.enable_playback_module_description)
 
-				bind(userPreferences, UserPreferences.assDirectPlay)
+					bind(userPreferences, UserPreferences.assDirectPlay)
+				}
 			}
 
 			checkbox {


### PR DESCRIPTION
Thanks to @JPVenson reminding me about this. We've recently added the libass-android library to allow direct-play of the ssa and ass formats for subtitles. Unfortunately the library has been plagued with memory issues causing the app to crash and has a non-transparent release pipeline. So far it doesn't appear that work is being done on these issues.
This PR removes the support from the UI in releases (e.g. upcoming 0.19 version) to avoid users creating issues even though we already tell them no support is provided.

**Changes**
- Move the "assDirectPlay" preference in the developer preference UI to require a development build (e.g. debug build without version information)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
