### PR TITLE
Fix focus always forced to first queue item in AudioNowPlayingFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -263,9 +263,6 @@ public class AudioNowPlayingFragment extends Fragment {
         @Override
         public void onProgress(long pos) {
             setCurrentTime(pos);
-            if (mAudioQueuePresenter != null && !queueRowHasFocus && mAudioQueuePresenter.getPosition() != mediaManager.getValue().getCurrentAudioQueuePosition()) {
-                mAudioQueuePresenter.setPosition(mediaManager.getValue().getCurrentAudioQueuePosition());
-            }
         }
 
         @Override


### PR DESCRIPTION
I believe this was a workaround for bad code.

**Changes**
- Fix focus always forced to first queue item in AudioNowPlayingFragment

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
