### PR TITLE
Fix navigation issues in AudioNowPlayingFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -10,11 +10,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.PopupMenu;
-import android.widget.ScrollView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -46,8 +46,6 @@ import kotlin.Lazy;
 import timber.log.Timber;
 
 public class AudioNowPlayingFragment extends Fragment {
-    private ImageButton homeButton;
-
     private TextView mGenreRow;
     private ImageButton mPlayPauseButton;
     private ImageButton mNextButton;
@@ -57,7 +55,7 @@ public class AudioNowPlayingFragment extends Fragment {
     private ImageButton mAlbumButton;
     private ImageButton mArtistButton;
     private TextView mCounter;
-    private ScrollView mScrollView;
+    private NestedScrollView mScrollView;
 
     private DisplayMetrics mMetrics;
 
@@ -90,8 +88,7 @@ public class AudioNowPlayingFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         FragmentAudioNowPlayingBinding binding = FragmentAudioNowPlayingBinding.inflate(getLayoutInflater(), container, false);
 
-        homeButton = binding.clock.getHomeButton();
-        homeButton.setOnFocusChangeListener(mainAreaFocusListener);
+        binding.clock.setVideoPlayer(true);
 
         mArtistName = binding.artistTitle;
         mGenreRow = binding.genreRow;
@@ -283,18 +280,21 @@ public class AudioNowPlayingFragment extends Fragment {
     private View.OnFocusChangeListener mainAreaFocusListener = new View.OnFocusChangeListener() {
         @Override
         public void onFocusChange(View v, boolean hasFocus) {
-            if (!mScrollView.hasFocus() && v != homeButton) {
-                if (queueRowHasFocus) return;
-                // when the playback control buttons lose focus, and the home button is not focused
-                // the only other focusable object is the queue row.
-                // Scroll to the bottom of the scrollView
-                mScrollView.smoothScrollTo(0, mScrollView.getHeight() - 1);
+            View rowsFragmentView = mRowsFragment.getView();
+            if (rowsFragmentView == null) return;
+
+            if (mRowsFragment.getView().hasFocus()) {
+                if (!queueRowHasFocus) {
+                    mScrollView.smoothScrollTo(0, mScrollView.getBottom());
+                }
+
                 queueRowHasFocus = true;
             } else {
-                if (!queueRowHasFocus) return;
+                if (queueRowHasFocus) {
+                    mScrollView.smoothScrollTo(0, 0);
+                }
+
                 queueRowHasFocus = false;
-                //scroll so entire main area is in view
-                mScrollView.smoothScrollTo(0, 0);
             }
         }
     };
@@ -400,12 +400,5 @@ public class AudioNowPlayingFragment extends Fragment {
             popupMenu.dismiss();
             popupMenu = null;
         }
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-
-        homeButton.setOnFocusChangeListener(null);
     }
 }

--- a/app/src/main/res/layout/fragment_audio_now_playing.xml
+++ b/app/src/main/res/layout/fragment_audio_now_playing.xml
@@ -36,12 +36,13 @@
         android:layout_marginStart="4dp"
         android:minHeight="22sp" />
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/mainScroller"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/genreRow"
         android:layout_marginTop="10dp"
+        android:overScrollMode="never"
         android:scrollbars="none">
 
         <RelativeLayout
@@ -244,5 +245,5 @@
 
         </RelativeLayout>
 
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </RelativeLayout>


### PR DESCRIPTION
Some focus issue makes the "home" button inacessible. Tried multiple ways of solving it but I'm quite sure compose interop is just not having fun with it, probably because of the scroll view. So disable the home button for now.

Might have enough time to redesign this entire screen with compose before 0.19. Not sure.

**Changes**

- Disable home button
- Move from ScrollView -> NestedScrollView and update the scrollTo handling
  - This fixes an old issue where smooth scroll would just happen instantly
  - Also fixes some regression where we never scrolled anymore

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
