### PR TITLE
Trim whitespace from search query

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
@@ -59,9 +59,8 @@ class SearchFragment : Fragment() {
 		LaunchedEffect(Unit) {
 			val extraQuery = arguments?.getString(EXTRA_QUERY)
 			if (!extraQuery.isNullOrBlank()) {
-				val trimmedQuery = extraQuery.trim()
-				query = query.copy(text = trimmedQuery)
-				viewModel.searchImmediately(trimmedQuery)
+				query = query.copy(text = extraQuery)
+				viewModel.searchImmediately(extraQuery)
 				resultFocusRequester.requestFocus()
 			} else {
 				textInputFocusRequester.requestFocus()
@@ -97,10 +96,10 @@ class SearchFragment : Fragment() {
 					query = query.text,
 					onQueryChange = {
 						query = query.copy(text = it)
-						viewModel.searchDebounced(query.text.trim())
+						viewModel.searchDebounced(query.text)
 					},
 					onQuerySubmit = {
-						viewModel.searchImmediately(query.text.trim())
+						viewModel.searchImmediately(query.text)
 						// Note: We MUST change the focus to somewhere else when the keyboard is submitted because some vendors (like Amazon)
 						// will otherwise just keep showing a (fullscreen) keyboard, soft-locking the app.
 						resultFocusRequester.requestFocus()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchFragment.kt
@@ -59,8 +59,9 @@ class SearchFragment : Fragment() {
 		LaunchedEffect(Unit) {
 			val extraQuery = arguments?.getString(EXTRA_QUERY)
 			if (!extraQuery.isNullOrBlank()) {
-				query = query.copy(text = extraQuery)
-				viewModel.searchImmediately(extraQuery)
+				val trimmedQuery = extraQuery.trim()
+				query = query.copy(text = trimmedQuery)
+				viewModel.searchImmediately(trimmedQuery)
 				resultFocusRequester.requestFocus()
 			} else {
 				textInputFocusRequester.requestFocus()
@@ -96,10 +97,10 @@ class SearchFragment : Fragment() {
 					query = query.text,
 					onQueryChange = {
 						query = query.copy(text = it)
-						viewModel.searchDebounced(query.text)
+						viewModel.searchDebounced(query.text.trim())
 					},
 					onQuerySubmit = {
-						viewModel.searchImmediately(query.text)
+						viewModel.searchImmediately(query.text.trim())
 						// Note: We MUST change the focus to somewhere else when the keyboard is submitted because some vendors (like Amazon)
 						// will otherwise just keep showing a (fullscreen) keyboard, soft-locking the app.
 						resultFocusRequester.requestFocus()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/search/SearchViewModel.kt
@@ -48,12 +48,13 @@ class SearchViewModel(
 	fun searchImmediately(query: String) = searchDebounced(query, 0.milliseconds)
 
 	fun searchDebounced(query: String, debounce: Duration = debounceDuration): Boolean {
-		if (query == previousQuery) return false
-		previousQuery = query
+		val trimmed = query.trim()
+		if (trimmed == previousQuery) return false
+		previousQuery = trimmed
 
 		searchJob?.cancel()
 
-		if (query.isBlank()) {
+		if (trimmed.isBlank()) {
 			_searchResultsFlow.value = emptyList()
 			return true
 		}
@@ -63,7 +64,7 @@ class SearchViewModel(
 
 			_searchResultsFlow.value = groups.map { (stringRes, itemKinds) ->
 				async {
-					val result = searchRepository.search(query, itemKinds)
+					val result = searchRepository.search(trimmed, itemKinds)
 					val items = result.getOrNull().orEmpty()
 
 					SearchResultGroup(stringRes, items)


### PR DESCRIPTION
**Changes**
Trim any leading/trailing whitespace from the user's input before performing the search - my phone adds a trailing space when using autocomplete, e.g. `"movie "` which does not match anything in my library.

NOTE: I didnt bother `.trim()`-ing the `SearchVoiceInput` query text as I assume that wouldn't have any leading/trailling whitespace, but I can update the PR if it makes sense.

**Issues**
[This](https://github.com/jellyfin/jellyfin/pull/11896) is an unmerged/unfinished PR for performing the trim server-side where it was suggested that the trim be performed client-side.
