### PR TITLE
Calculate playback progress using derived state

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui.player.base
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -11,7 +12,9 @@ import org.jellyfin.androidtv.ui.base.SeekbarDefaults
 import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.PositionInfo
 import org.koin.compose.koinInject
+import kotlin.time.Duration
 import kotlin.time.times
 
 @Composable
@@ -27,11 +30,14 @@ fun PlayerSeekbar(
 		active = positionInfo.active,
 		duration = positionInfo.duration,
 	)
+	val seekbarProgress by remember {
+		derivedStateOf { determinePlayerProgress(progress, positionInfo) }
+	}
 	val seekForwardAmount = remember { playbackManager.options.defaultFastForwardAmount() }
 	val seekRewindAmount = remember { playbackManager.options.defaultRewindAmount() }
 
 	Seekbar(
-		progress = progress.toDouble() * positionInfo.duration,
+		progress = seekbarProgress,
 		buffer = positionInfo.buffer,
 		duration = positionInfo.duration,
 		seekForwardAmount = seekForwardAmount,
@@ -42,3 +48,8 @@ fun PlayerSeekbar(
 		colors = colors,
 	)
 }
+
+private fun determinePlayerProgress(
+	progress: Float,
+	positionInfo: PositionInfo
+): Duration = progress.toDouble() * positionInfo.duration


### PR DESCRIPTION
**Changes**
Calculate playback progress using derived state in order to prevent recompositions

The PlayerSeekbar was being recomposed on every frame due to the calculation of the progress being "unstable" from the perspective of the Seekbar Composable.

Layout inspector screenshots were taken after ~20s with a change to increase the player overlay visibility timeout.

Layout inspection before:
<img width="870" height="427" alt="Screenshot 2025-08-26 at 3 31 38 PM" src="https://github.com/user-attachments/assets/4087de0c-64c2-4901-9ed9-877ef56f04f6" />

The solution is to remember the progress calculation and pass that to the Seekbar.

Layout inspector after:
<img width="864" height="420" alt="Screenshot 2025-08-26 at 3 34 47 PM" src="https://github.com/user-attachments/assets/95ec4f89-e51c-426a-bdb7-90ef7113fb1e" />
Notice the number of recompositions have been reduced and the recompositions of the Seekbar have been moved to the "skipped" column.
