### PR TITLE
Use JellyfinTheme in full compose fragments

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/JellyfinTheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/JellyfinTheme.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.ui.base
 
+import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
@@ -14,7 +15,9 @@ fun JellyfinTheme(
 	CompositionLocalProvider(
 		LocalColorScheme provides colorScheme,
 		LocalShapes provides shapes,
-		LocalTypography provides typography
+		LocalTypography provides typography,
+		// Disable overscroll
+		LocalOverscrollFactory provides null,
 	) {
 		ProvideTextStyle(value = typography.default, content = content)
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -241,11 +241,13 @@ class NextUpFragment : Fragment() {
 		container: ViewGroup?,
 		savedInstanceState: Bundle?,
 	) = content {
-		val id = remember(arguments) { arguments?.getString(ARGUMENT_ITEM_ID)?.toUUIDOrNull() }
-		if (id != null) {
-			NextUpScreen(
-				itemId = id,
-			)
+		JellyfinTheme {
+			val id = remember(arguments) { arguments?.getString(ARGUMENT_ITEM_ID)?.toUUIDOrNull() }
+			if (id != null) {
+				NextUpScreen(
+					itemId = id,
+				)
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/stillwatching/StillWatchingFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/stillwatching/StillWatchingFragment.kt
@@ -248,11 +248,13 @@ class StillWatchingFragment : Fragment() {
 		container: ViewGroup?,
 		savedInstanceState: Bundle?,
 	) = content {
-		val id = remember(arguments) { arguments?.getString(ARGUMENT_ITEM_ID)?.toUUIDOrNull() }
-		if (id != null) {
-			StillWatchingScreen(
-				itemId = id,
-			)
+		JellyfinTheme {
+			val id = remember(arguments) { arguments?.getString(ARGUMENT_ITEM_ID)?.toUUIDOrNull() }
+			if (id != null) {
+				StillWatchingScreen(
+					itemId = id,
+				)
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/photo/PhotoPlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/photo/PhotoPlayerFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
@@ -46,6 +47,8 @@ class PhotoPlayerFragment : Fragment() {
 		container: ViewGroup?,
 		savedInstanceState: Bundle?
 	) = content {
-		PhotoPlayerScreen()
+		JellyfinTheme {
+			PhotoPlayerScreen()
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
 import org.jellyfin.playback.core.PlaybackManager
@@ -50,7 +51,9 @@ class VideoPlayerFragment : Fragment() {
 		container: ViewGroup?,
 		savedInstanceState: Bundle?
 	) = content {
-		VideoPlayerScreen()
+		JellyfinTheme {
+			VideoPlayerScreen()
+		}
 	}
 
 	override fun onPause() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ConnectHelpAlertFragment.kt
@@ -33,6 +33,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.LocalTextStyle
 import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 import org.jellyfin.androidtv.ui.base.Text
@@ -112,8 +113,10 @@ class ConnectHelpAlertFragment : Fragment() {
 		container: ViewGroup?,
 		savedInstanceState: Bundle?
 	) = content {
-		ConnectHelpAlert(
-			onClose = { parentFragmentManager.popBackStack() },
-		)
+		JellyfinTheme {
+			ConnectHelpAlert(
+				onClose = { parentFragmentManager.popBackStack() },
+			)
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SplashFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/SplashFragment.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 
 @Composable
 fun SplashScreen() {
@@ -49,6 +50,8 @@ class SplashFragment : Fragment() {
 		container: ViewGroup?,
 		savedInstanceState: Bundle?
 	) = content {
-		SplashScreen()
+		JellyfinTheme {
+			SplashScreen()
+		}
 	}
 }


### PR DESCRIPTION
Currently we do not use compose for hosting the navigation, as such we need to apply the JellyfinTheme to each screen individually. So far we did not do that yet. This PR fixes that.

**Changes**
- Use JellyfinTheme in full compose fragments
- Disable overscroll effect for scrollable composables
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
