### PR TITLE
Use transparent buttons in player controls

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerOverlayLayout.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerOverlayLayout.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -110,7 +111,13 @@ fun PlayerOverlayLayout(
 					)
 					.overscan(),
 			) {
-				controls()
+				JellyfinTheme(
+					colorScheme = JellyfinTheme.colorScheme.copy(
+						button = Color.Transparent
+					)
+				) {
+					controls()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Applies to both video and photo players.

**Changes**
- Use transparent buttons in player controls

**Screenshots**

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb60309b-4501-496e-b09d-646375d69b9f" />

(see before at #4865)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
