### PR TITLE
Avoid NPE in JellyfinImage helpers

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/apiclient/JellyfinImage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/apiclient/JellyfinImage.kt
@@ -120,68 +120,78 @@ val BaseItemDto.parentImages
 	}.associateBy { it.type }
 
 val BaseItemDto.parentBackdropImages
-	get() = parentBackdropImageTags?.mapIndexed { index, tag ->
-		JellyfinImage(
-			item = requireNotNull(parentBackdropItemId),
-			source = JellyfinImageSource.PARENT,
-			type = ImageType.BACKDROP,
-			tag = tag,
-			blurHash = imageBlurHashes?.get(ImageType.BACKDROP)?.get(tag),
-			aspectRatio = null,
-			index = index,
-		)
+	get() = parentBackdropItemId?.let { parentBackdropItemId ->
+		parentBackdropImageTags?.mapIndexed { index, tag ->
+			JellyfinImage(
+				item = parentBackdropItemId,
+				source = JellyfinImageSource.PARENT,
+				type = ImageType.BACKDROP,
+				tag = tag,
+				blurHash = imageBlurHashes?.get(ImageType.BACKDROP)?.get(tag),
+				aspectRatio = null,
+				index = index,
+			)
+		}
 	}.orEmpty()
 
 val BaseItemDto.albumPrimaryImage
 	get() = albumPrimaryImageTag?.let { albumPrimaryImageTag ->
-		JellyfinImage(
-			item = requireNotNull(albumId),
-			source = JellyfinImageSource.ALBUM,
-			type = ImageType.PRIMARY,
-			tag = albumPrimaryImageTag,
-			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(albumPrimaryImageTag),
-			aspectRatio = null,
-			index = null,
-		)
+		albumId?.let { albumId ->
+			JellyfinImage(
+				item = albumId,
+				source = JellyfinImageSource.ALBUM,
+				type = ImageType.PRIMARY,
+				tag = albumPrimaryImageTag,
+				blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(albumPrimaryImageTag),
+				aspectRatio = null,
+				index = null,
+			)
+		}
 	}
 
 val BaseItemDto.channelPrimaryImage
 	get() = channelPrimaryImageTag?.let { channelPrimaryImageTag ->
-		JellyfinImage(
-			item = requireNotNull(channelId),
-			source = JellyfinImageSource.CHANNEL,
-			type = ImageType.PRIMARY,
-			tag = channelPrimaryImageTag,
-			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(channelPrimaryImageTag),
-			aspectRatio = null,
-			index = null,
-		)
+		channelId?.let { channelId ->
+			JellyfinImage(
+				item = channelId,
+				source = JellyfinImageSource.CHANNEL,
+				type = ImageType.PRIMARY,
+				tag = channelPrimaryImageTag,
+				blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(channelPrimaryImageTag),
+				aspectRatio = null,
+				index = null,
+			)
+		}
 	}
 
 val BaseItemDto.seriesPrimaryImage
 	get() = seriesPrimaryImageTag?.let { seriesPrimaryImageTag ->
-		JellyfinImage(
-			item = requireNotNull(seriesId),
-			source = JellyfinImageSource.SERIES,
-			type = ImageType.PRIMARY,
-			tag = seriesPrimaryImageTag,
-			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(seriesPrimaryImageTag),
-			aspectRatio = null,
-			index = null,
-		)
+		seriesId?.let { seriesId ->
+			JellyfinImage(
+				item = seriesId,
+				source = JellyfinImageSource.SERIES,
+				type = ImageType.PRIMARY,
+				tag = seriesPrimaryImageTag,
+				blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(seriesPrimaryImageTag),
+				aspectRatio = null,
+				index = null,
+			)
+		}
 	}
 
 val BaseItemDto.seriesThumbImage
 	get() = seriesThumbImageTag?.let { seriesThumbImageTag ->
-		JellyfinImage(
-			item = requireNotNull(seriesId),
-			source = JellyfinImageSource.SERIES,
-			type = ImageType.THUMB,
-			tag = seriesThumbImageTag,
-			blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(seriesThumbImageTag),
-			aspectRatio = null,
-			index = null,
-		)
+		seriesId?.let { seriesId ->
+			JellyfinImage(
+				item = seriesId,
+				source = JellyfinImageSource.SERIES,
+				type = ImageType.THUMB,
+				tag = seriesThumbImageTag,
+				blurHash = imageBlurHashes?.get(ImageType.PRIMARY)?.get(seriesThumbImageTag),
+				aspectRatio = null,
+				index = null,
+			)
+		}
 	}
 
 val BaseItemDto.images


### PR DESCRIPTION
The server is supposed to NOT send image tags if the related item id is not set (e.g. albumId & albumPrimaryImageTag) but for _some_ reason it does in 10.11. This PR adds more safe checks to avoid crashes.

**Changes**
- Avoid NPE in JellyfinImage helpers

**Issues**

Fixes #4906 
