### PR TITLE
Fix wrongly-cropped Trickplay images when video is vertical

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
@@ -7,7 +7,9 @@ import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
 import coil3.request.Disposable
 import coil3.request.ImageRequest
+import coil3.request.maxBitmapSize
 import coil3.request.transformations
+import coil3.size.Dimension
 import coil3.size.Size
 import coil3.toBitmap
 import org.jellyfin.androidtv.util.coil.SubsetTransformation
@@ -73,6 +75,7 @@ class CustomSeekProvider(
 		imageRequests[index] = imageLoader.enqueue(ImageRequest.Builder(context).apply {
 			data(url)
 			size(Size.ORIGINAL)
+			maxBitmapSize(Size(Dimension.Undefined, Dimension.Undefined))
 			httpHeaders(NetworkHeaders.Builder().apply {
 				set(
 					key = "Authorization",


### PR DESCRIPTION
**Changes**
Disabled `maxBitmapSize` feature of Coil's ImageRequest to avoid scaling of Trickplay tile images before the cropping.

**Issues**
Usually when the video is vertical, the Trickplay tile image created by Jellyfin with the default 10x10 matrix is higher than 4096 pixels. Then, Coil scales it down even if using `Size.ORIGINAL` which makes the Trickplay transformation to crop the image in the wrong position and size, while also harming its quality.

**Sources**
[Documentation](https://coil-kt.github.io/coil/api/coil-core/coil3.request/max-bitmap-size.html)
