### PR TITLE
Avoid stopping speech recognizer when not active

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/speech/speechRecognizer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/speech/speechRecognizer.kt
@@ -124,6 +124,8 @@ fun rememberSpeechRecognizer(
 	}
 
 	fun stopListening() {
+		if (status !is SpeechRecognizerStatus.Listening) return
+
 		Timber.i("Stopping speech recognition")
 		speechRecognizer.stopListening()
 	}


### PR DESCRIPTION
App would show a toast for an "unexpected error" whenever you successfully searched using voice... oops

**Changes**
- Avoid stopping speech recognizer when not active

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
