### PR TITLE
Change seekbar seeking to be relative to the current position

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
@@ -20,8 +20,6 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.trickplayApi
 import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
-import kotlin.math.ceil
-import kotlin.math.min
 
 class CustomSeekProvider(
 	private val videoPlayerAdapter: VideoPlayerAdapter,
@@ -32,19 +30,46 @@ class CustomSeekProvider(
 	private val forwardTime: Long
 ) : PlaybackSeekDataProvider() {
 	private val imageRequests = mutableMapOf<Int, Disposable>()
+	private var currentSeekPositions = LongArray(0)
 
 	private var cachedPlaceholderThumbnail: Bitmap? = null
 
 	override fun getSeekPositions(): LongArray {
 		if (!videoPlayerAdapter.canSeek()) return LongArray(0)
 
-		val duration = videoPlayerAdapter.duration
-		val size = ceil(duration.toDouble() / forwardTime.toDouble()).toInt() + 1
-		return LongArray(size) { i -> min(i * forwardTime, duration) }
+		val currentSeekPosition = videoPlayerAdapter.currentPosition
+		val videoEndPosition = videoPlayerAdapter.duration
+
+		val firstSeekPosition = currentSeekPosition % forwardTime
+		val lastSeekPosition = videoEndPosition - ((videoEndPosition - currentSeekPosition) % forwardTime)
+		val seekPositionCount = ((lastSeekPosition - firstSeekPosition) / forwardTime).toInt() + 1
+
+		val seekPositions = ArrayList<Long>(seekPositionCount + 2) // intermediate seek positions + beginning + end position
+		seekPositions.add(0L)
+		// Omit the first seek position if it represents the beginning of the video
+		if (firstSeekPosition != 0L) {
+			seekPositions.add(firstSeekPosition)
+		}
+		// Add all available seek positions but the last one
+		for (i in 1..<seekPositionCount - 1) {
+			seekPositions.add(firstSeekPosition + (i * forwardTime))
+		}
+		// Omit the last seek position if it represents the end of the video
+		if (lastSeekPosition != videoEndPosition) {
+			seekPositions.add(lastSeekPosition)
+		}
+		// Omit the video end seek position if it represents the beginning of the video
+		if (videoEndPosition != 0L) {
+			seekPositions.add(videoEndPosition)
+		}
+
+		currentSeekPositions = seekPositions.toLongArray()
+		return currentSeekPositions
 	}
 
 	override fun getThumbnail(index: Int, callback: ResultCallback) {
 		if (!trickPlayEnabled) return
+		if (index >= currentSeekPositions.size) return
 
 		val currentRequest = imageRequests[index]
 		if (currentRequest?.isDisposed == false) currentRequest.dispose()
@@ -58,7 +83,7 @@ class CustomSeekProvider(
 		val trickPlayInfo = trickPlayResolutions?.values?.firstOrNull()
 		if (trickPlayInfo == null) return
 
-		val currentTimeMs = (index * forwardTime).coerceIn(0, videoPlayerAdapter.duration)
+		val currentTimeMs = currentSeekPositions[index]
 		val currentTile = currentTimeMs.floorDiv(trickPlayInfo.interval).toInt()
 
 		val tileSize = trickPlayInfo.tileWidth * trickPlayInfo.tileHeight
@@ -114,6 +139,8 @@ class CustomSeekProvider(
 			if (!request.isDisposed) request.dispose()
 		}
 		imageRequests.clear()
+
+		currentSeekPositions = LongArray(0)
 	}
 
 	fun getPlaceholderThumbnail(width: Int, height: Int): Bitmap {

--- a/app/src/test/kotlin/ui/playback/overlay/CustomSeekProviderTests.kt
+++ b/app/src/test/kotlin/ui/playback/overlay/CustomSeekProviderTests.kt
@@ -6,24 +6,37 @@ import io.mockk.every
 import io.mockk.mockk
 
 class CustomSeekProviderTests : FunSpec({
-	test("CustomSeekProvider.seekPositions with simple duration") {
+	test("CustomSeekProvider.seekPositions with simple duration from beginning") {
 		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
 			every { canSeek() } returns true
 			every { duration } returns 30000L
+			every { currentPosition } returns 0L
 		}
 		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
 
-		customSeekProvider.seekPositions shouldBe arrayOf(0L, 10000L, 20000L, 30000L)
+		customSeekProvider.seekPositions shouldBe longArrayOf(0L, 10000L, 20000L, 30000L)
 	}
 
-	test("CustomSeekProvider.seekPositions with odd duration") {
+	test("CustomSeekProvider.seekPositions with simple duration from end") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 30000L
+			every { currentPosition } returns 30000L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(0L, 10000L, 20000L, 30000L)
+	}
+
+	test("CustomSeekProvider.seekPositions with odd duration from beginning") {
 		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
 			every { canSeek() } returns true
 			every { duration } returns 45000L
+			every { currentPosition } returns 0L
 		}
 		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
 
-		customSeekProvider.seekPositions shouldBe arrayOf(0L, 10000, 20000, 30000, 40000, 45000)
+		customSeekProvider.seekPositions shouldBe longArrayOf(0L, 10000, 20000, 30000, 40000, 45000)
 	}
 
 	test("CustomSeekProvider.seekPositions with seek disabled") {
@@ -34,4 +47,81 @@ class CustomSeekProviderTests : FunSpec({
 
 		customSeekProvider.seekPositions.size shouldBe 0
 	}
+
+	test("CustomSeekProvider.seekPositions from a mid-video position") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 60_000L
+			every { currentPosition } returns 32_500L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(
+			0, 2500, 12500, 22500, 32500, 42500, 52500, 60000
+		)
+	}
+
+	test("CustomSeekProvider.seekPositions from a near-beginning position") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 60_000L
+			every { currentPosition } returns 10_500L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(
+			0, 500, 10500, 20500, 30500, 40500, 50500, 60000
+		)
+	}
+
+	test("CustomSeekProvider.seekPositions from a within first second position") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 60_000L
+			every { currentPosition } returns 500L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(
+			0, 500, 10500, 20500, 30500, 40500, 50500, 60000
+		)
+	}
+
+	test("CustomSeekProvider.seekPositions from a near-end position") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 60_000L
+			every { currentPosition } returns 49_500L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(
+			0, 9500, 19500, 29500, 39500, 49500, 59500, 60000
+		)
+	}
+
+	test("CustomSeekProvider.seekPositions from within a last second position") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 60_000L
+			every { currentPosition } returns 59_500L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(
+			0, 9500, 19500, 29500, 39500, 49500, 59500, 60000
+		)
+	}
+
+	test("CustomSeekProvider.seekPositions with zero duration") {
+		val videoPlayerAdapter = mockk<VideoPlayerAdapter> {
+			every { canSeek() } returns true
+			every { duration } returns 0L
+			every { currentPosition } returns 0L
+		}
+		val customSeekProvider = CustomSeekProvider(videoPlayerAdapter, mockk(), mockk(), mockk(), false, 10_000)
+
+		customSeekProvider.seekPositions shouldBe longArrayOf(0)
+	}
 })
+


### PR DESCRIPTION
**Changes**
Currently the available seek positions are fixed at multiples of the configured seek amount.  
Now seek positions are calculated relatively to the current position in increments of the configured seek amount.

**Issues**
Fixes #4427
