### PR TITLE
Fix truncated labels under buttons in media view UI

### DIFF
--- a/app/src/main/res/layout/view_row_details.xml
+++ b/app/src/main/res/layout/view_row_details.xml
@@ -179,7 +179,7 @@
         <LinearLayout
             android:id="@+id/fdButtonRow"
             android:layout_width="0dp"
-            android:layout_height="70dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:divider="@drawable/blank10x10"
             android:orientation="horizontal"


### PR DESCRIPTION
**Changes**
Changed button row layout's height to be adaptive to its content instead of a fixed `70dp` value.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/4936
