### PR TITLE
Show placeholder thumbnail while Trickplay thumbnail loads

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomSeekProvider.kt
@@ -33,7 +33,7 @@ class CustomSeekProvider(
 ) : PlaybackSeekDataProvider() {
 	private val imageRequests = mutableMapOf<Int, Disposable>()
 
-	private var cachedThumbnailPlaceholder: Bitmap? = null
+	private var cachedPlaceholderThumbnail: Bitmap? = null
 
 	override fun getSeekPositions(): LongArray {
 		if (!videoPlayerAdapter.canSeek()) return LongArray(0)
@@ -117,14 +117,14 @@ class CustomSeekProvider(
 	}
 
 	fun getPlaceholderThumbnail(width: Int, height: Int): Bitmap {
-		if (cachedThumbnailPlaceholder?.width == width && cachedThumbnailPlaceholder?.height == height) {
-			return cachedThumbnailPlaceholder!!
+		if (cachedPlaceholderThumbnail?.width == width && cachedPlaceholderThumbnail?.height == height) {
+			return cachedPlaceholderThumbnail!!
 		}
 
 		val color = ContextCompat.getColor(context, R.color.black_transparent_light)
 		val result = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
 		result.eraseColor(color)
-		cachedThumbnailPlaceholder = result
+		cachedPlaceholderThumbnail = result
 		return result
 	}
 }


### PR DESCRIPTION
**Changes**
Introducing a placeholder thumbnail that is displayed while the actual Trickplay thumbnail is being loaded. This provides visual feedback to the user and improves the perceived performance of Trickplay seeking.

The placeholder is a simple black transparent bitmap matching the dimensions of the expected thumbnail and it is cached to avoid redundant creations and memory allocations.
