### PR TITLE
Update client name for crash reports

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/telemetry/TelemetryService.kt
@@ -68,8 +68,12 @@ object TelemetryService {
 			// Create connection
 			val connection = URL(url).openConnection() as HttpURLConnection
 			// Add authorization
+			val clientName = buildString {
+				append("Jellyfin Android TV")
+				if (BuildConfig.DEBUG) append(" (debug)")
+			}
 			val authorization = AuthorizationHeaderBuilder.buildHeader(
-				clientName = BuildConfig.APPLICATION_ID,
+				clientName = clientName,
 				clientVersion = BuildConfig.VERSION_NAME,
 				deviceId = "",
 				deviceName = "",


### PR DESCRIPTION
Copy the client name used by the SDK to the crash reporting so it is consistent. The name is used for the log files written by the server.

**Changes**
- Update client name for crash reports
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
