### PR TITLE
Fix low quality card images

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseItemDtoBaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseItemDtoBaseRowItem.kt
@@ -130,7 +130,7 @@ open class BaseItemDtoBaseRowItem @JvmOverloads constructor(
 		val seriesPrimaryImage = baseItem?.seriesPrimaryImage
 
 		return when {
-			preferSeriesPoster && seriesPrimaryImage != null -> imageHelper.getImageUrl(seriesPrimaryImage)
+			preferSeriesPoster && seriesPrimaryImage != null -> imageHelper.getImageUrl(seriesPrimaryImage, fillWidth, fillHeight)
 
 			imageType == ImageType.BANNER -> imageHelper.getBannerImageUrl(
 				requireNotNull(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.java
@@ -391,10 +391,17 @@ public class CardPresenter extends Presenter {
         int fillWidth = Math.round(holder.getCardWidth() * holder.mCardView.getResources().getDisplayMetrics().density);
         int fillHeight = Math.round(holder.getCardHeight() * holder.mCardView.getResources().getDisplayMetrics().density);
 
-        holder.updateCardViewImage(
-                image == null ? rowItem.getImageUrl(holder.mCardView.getContext(), imageHelper.getValue(), mImageType, fillWidth, fillHeight) : imageHelper.getValue().getImageUrl(image),
-                image == null ? null : image.getBlurHash()
-        );
+        final String imageUrl;
+        final String blurHash;
+        if (image == null) {
+            imageUrl = rowItem.getImageUrl(holder.mCardView.getContext(), imageHelper.getValue(), mImageType, fillWidth, fillHeight);
+            blurHash = null;
+        } else {
+            imageUrl = imageHelper.getValue().getImageUrl(image, fillWidth, fillHeight);
+            blurHash = image.getBlurHash();
+        }
+
+        holder.updateCardViewImage(imageUrl, blurHash);
     }
 
     @Override

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/UserViewCardPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/UserViewCardPresenter.kt
@@ -13,6 +13,7 @@ import org.jellyfin.androidtv.util.apiclient.itemImages
 import org.jellyfin.sdk.model.api.ImageType
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import kotlin.math.roundToInt
 
 class UserViewCardPresenter(
 	val small: Boolean,
@@ -25,10 +26,24 @@ class UserViewCardPresenter(
 		fun setItem(rowItem: BaseRowItem?) {
 			val baseItem = rowItem?.baseItem
 
+			// Determine size
+			val cardWidth: Int
+			val cardHeight: Int
+			if (small) {
+				cardWidth = 133
+				cardHeight = 75
+			} else {
+				cardWidth = 224
+				cardHeight = 126
+			}
+
+			val fillWidth = (cardWidth * cardView.resources.displayMetrics.density).roundToInt()
+			val fillHeight = (cardHeight * cardView.resources.displayMetrics.density).roundToInt()
+
 			// Load image
 			val image = baseItem?.itemImages[ImageType.PRIMARY]
 			cardView.mainImageView.load(
-				url = image?.let(imageHelper::getImageUrl),
+				url = image?.let { imageHelper.getImageUrl(it, fillWidth, fillHeight) },
 				blurHash = image?.blurHash,
 				placeholder = ContextCompat.getDrawable(cardView.context, R.drawable.tile_land_folder),
 				aspectRatio = ImageHelper.ASPECT_RATIO_16_9,
@@ -39,11 +54,7 @@ class UserViewCardPresenter(
 			cardView.setTitleText(rowItem?.getName(cardView.context))
 
 			// Set size
-			if (small) {
-				cardView.setMainImageDimensions(133, 75)
-			} else {
-				cardView.setMainImageDimensions(224, 126)
-			}
+			cardView.setMainImageDimensions(cardWidth, cardHeight)
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -31,7 +31,8 @@ class ImageHelper(
 		const val MAX_PRIMARY_IMAGE_HEIGHT: Int = 370
 	}
 
-	fun getImageUrl(image: JellyfinImage): String = image.getUrl(api)
+	fun getImageUrl(image: JellyfinImage, fillWidth: Int, fillHeight: Int): String =
+		image.getUrl(api, null, null, fillWidth, fillHeight)
 
 	fun getImageAspectRatio(item: BaseItemDto, preferParentThumb: Boolean): Double {
 		if (preferParentThumb && (item.parentThumbItemId != null || item.seriesThumbImageTag != null)) {


### PR DESCRIPTION
**Changes**
In some cases card images are loaded from the server without limiting the image dimensions.  
This results in loading images in their original size and requires the client to scale them which results in low quality images.
To avoid low quality card images the scaling is moved to the server-side by requesting images with appropriate dimensions in all cases.

**Issues**
Fixes #4955
