### PR TITLE
Fix logo constraints in DreamContentLibraryShowcase

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentLibraryShowcase.kt
@@ -2,9 +2,10 @@ package org.jellyfin.androidtv.integration.dream.composable
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,12 +51,17 @@ fun DreamContentLibraryShowcase(
 			.overscan(),
 	) {
 		if (content.logo != null) {
-			Image(
-				bitmap = content.logo.asImageBitmap(),
-				contentDescription = content.item.name,
-				modifier = Modifier
-					.height(75.dp)
-			)
+			BoxWithConstraints {
+				Image(
+					bitmap = content.logo.asImageBitmap(),
+					contentDescription = content.item.name,
+					modifier = Modifier
+						.sizeIn(
+							maxWidth = maxWidth * 0.35f,
+							maxHeight = 75.dp
+						)
+				)
+			}
 		} else {
 			Text(
 				text = content.item.name.orEmpty(),


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Add constraint so the item logos in the screensaver never exceed 35% of screen width
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #4960
