### PR TITLE
Only use 10.11 video range types on 10.11 servers

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/model/Server.kt
@@ -18,7 +18,7 @@ data class Server(
 	val setupCompleted: Boolean = true,
 	var dateLastAccessed: Instant = Instant.MIN,
 ) {
-	private val serverVersion = version?.let(ServerVersion::fromString)
+	val serverVersion = version?.let(ServerVersion::fromString)
 	val versionSupported = serverVersion != null && serverVersion >= ServerRepository.minimumServerVersion
 
 	operator fun compareTo(other: ServerVersion): Int = serverVersion?.compareTo(other) ?: -1

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/ServerRepository.kt
@@ -39,9 +39,13 @@ import org.jellyfin.sdk.model.api.BrandingOptions as BrandingOptionsDto
 interface ServerRepository {
 	val storedServers: StateFlow<List<Server>>
 	val discoveredServers: StateFlow<List<Server>>
+	val currentServer: StateFlow<Server?>
+
 
 	suspend fun loadStoredServers()
 	suspend fun loadDiscoveryServers()
+
+	fun setCurrentServer(server: Server?)
 
 	fun addServer(address: String): Flow<ServerAdditionState>
 	suspend fun getServer(id: UUID, eagerUpdate: Boolean = false): Server?
@@ -67,6 +71,9 @@ class ServerRepositoryImpl(
 	private val _discoveredServers = MutableStateFlow(emptyList<Server>())
 	override val discoveredServers = _discoveredServers.asStateFlow()
 
+	private val _currentServer = MutableStateFlow<Server?>(null)
+	override val currentServer = _currentServer.asStateFlow()
+
 	// Loading data
 	override suspend fun loadStoredServers() {
 		authenticationStore.getServers()
@@ -85,6 +92,10 @@ class ServerRepositoryImpl(
 				servers += server
 				_discoveredServers.emit(servers.toList())
 			}
+	}
+
+	override fun setCurrentServer(server: Server?) {
+		_currentServer.value = server
 	}
 
 	// Mutating data

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.auth.model.Server
 import org.jellyfin.androidtv.auth.store.AuthenticationPreferences
 import org.jellyfin.androidtv.auth.store.AuthenticationStore
 import org.jellyfin.androidtv.preference.PreferencesRepository
@@ -111,12 +112,15 @@ class SessionRepositoryImpl(
 	override fun destroyCurrentSession() {
 		Timber.i("Destroying current session")
 
-		userRepository.updateCurrentUser(null)
+		userRepository.setCurrentUser(null)
+		serverRepository.setCurrentServer(null)
 		_currentSession.value = null
 		_state.value = SessionRepositoryState.READY
 	}
 
 	private suspend fun setCurrentSession(session: Session?): Boolean {
+		var server: Server? = null
+
 		if (session != null) {
 			// No change in session - don't switch
 			if (currentSession.value?.userId == session.userId) return true
@@ -126,13 +130,13 @@ class SessionRepositoryImpl(
 			authenticationPreferences[AuthenticationPreferences.lastUserId] = session.userId.toString()
 
 			// Check if server version is supported
-			val server = serverRepository.getServer(session.serverId, true)
+			server = serverRepository.getServer(session.serverId, true)
 			if (server == null || !server.versionSupported) return false
 		}
 
 		// Update session after binding the apiclient settings
 		val deviceInfo = session?.let { defaultDeviceInfo.forUser(it.userId) } ?: defaultDeviceInfo
-		Timber.i("Updating current session. userId=${session?.userId}")
+		Timber.i("Updating current session. userId=${session?.userId} server=${server?.serverVersion}")
 
 		val applied = userApiClient.applySession(session, deviceInfo)
 		if (applied && session != null) {
@@ -140,7 +144,8 @@ class SessionRepositoryImpl(
 				val user = withContext(Dispatchers.IO) {
 					userApiClient.userApi.getCurrentUser().content
 				}
-				userRepository.updateCurrentUser(user)
+				userRepository.setCurrentUser(user)
+				serverRepository.setCurrentServer(server)
 			} catch (err: ApiClientException) {
 				Timber.e(err, "Unable to authenticate: bad response when getting user info")
 				destroyCurrentSession()
@@ -152,7 +157,8 @@ class SessionRepositoryImpl(
 			telemetryPreferences[TelemetryPreferences.crashReportUrl] = crashReportUrl
 			telemetryPreferences[TelemetryPreferences.crashReportToken] = session.accessToken
 		} else {
-			userRepository.updateCurrentUser(null)
+			userRepository.setCurrentUser(null)
+			serverRepository.setCurrentServer(null)
 		}
 		preferencesRepository.onSessionChanged()
 		_currentSession.value = session

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/UserRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/UserRepository.kt
@@ -10,13 +10,13 @@ import org.jellyfin.sdk.model.api.UserDto
 interface UserRepository {
 	val currentUser: StateFlow<UserDto?>
 
-	fun updateCurrentUser(user: UserDto?)
+	fun setCurrentUser(user: UserDto?)
 }
 
 class UserRepositoryImpl : UserRepository {
 	override val currentUser = MutableStateFlow<UserDto?>(null)
 
-	override fun updateCurrentUser(user: UserDto?) {
+	override fun setCurrentUser(user: UserDto?) {
 		currentUser.value = user
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -26,4 +26,9 @@ val authModule = module {
 	single<SessionRepository> {
 		SessionRepositoryImpl(get(), get(), get(), get(), get(defaultDeviceInfo), get(), get(), get())
 	}
+
+	factory {
+		val serverRepository = get<ServerRepository>()
+		serverRepository.currentServer.value?.serverVersion ?: ServerRepository.minimumServerVersion
+	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -82,7 +82,7 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 	)
 	install(media3SessionPlugin(get(), mediaSessionOptions))
 
-	val deviceProfileBuilder = { createDeviceProfile(androidContext(), userPreferences) }
+	val deviceProfileBuilder = { createDeviceProfile(androidContext(), userPreferences, get()) }
 	install(jellyfinPlugin(get(), deviceProfileBuilder, ProcessLifecycleOwner.get().lifecycle))
 
 	// Options

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.ui.playback;
 
+import static org.koin.java.KoinJavaComponent.get;
 import static org.koin.java.KoinJavaComponent.inject;
 
 import android.annotation.TargetApi;
@@ -32,6 +33,7 @@ import org.jellyfin.androidtv.util.apiclient.Response;
 import org.jellyfin.androidtv.util.profile.DeviceProfileKt;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.sdk.api.client.ApiClient;
+import org.jellyfin.sdk.model.ServerVersion;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.BaseItemKind;
 import org.jellyfin.sdk.model.api.DeviceProfile;
@@ -529,7 +531,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         }
         DeviceProfile internalProfile = DeviceProfileKt.createDeviceProfile(
                 mFragment.getContext(),
-                userPreferences.getValue()
+                userPreferences.getValue(),
+                get(ServerVersion.class)
         );
         internalOptions.setProfile(internalProfile);
         return internalOptions;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -23,6 +23,7 @@ import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.androidtv.util.profile.createDeviceProfileReport
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.clientLogApi
+import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 
@@ -149,7 +150,7 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 					lifecycleScope.launch {
 						runCatching {
 							withContext(Dispatchers.IO) {
-								api.clientLogApi.logFile(createDeviceProfileReport(context, userPreferences)).content
+								api.clientLogApi.logFile(createDeviceProfileReport(context, userPreferences, get())).content
 							}
 						}.fold(
 							onSuccess = { result ->

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.MimeTypes
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AudioBehavior
+import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.CodecType
 import org.jellyfin.sdk.model.api.DlnaProfileType
 import org.jellyfin.sdk.model.api.EncodingContext
@@ -56,6 +57,7 @@ private fun UserPreferences.getMaxBitrate(): Int {
 fun createDeviceProfile(
 	context: Context,
 	userPreferences: UserPreferences,
+	serverVersion: ServerVersion,
 ) = createDeviceProfile(
 	mediaTest = MediaCodecCapabilitiesTest(context),
 	maxBitrate = userPreferences.getMaxBitrate(),
@@ -63,6 +65,7 @@ fun createDeviceProfile(
 	downMixAudio = userPreferences[UserPreferences.audioBehaviour] == AudioBehavior.DOWNMIX_TO_STEREO,
 	assDirectPlay = userPreferences[UserPreferences.assDirectPlay],
 	pgsDirectPlay = userPreferences[UserPreferences.pgsDirectPlay],
+	jellyfinTenEleven = serverVersion >= ServerVersion(10, 11, 0),
 )
 
 fun createDeviceProfile(
@@ -72,6 +75,7 @@ fun createDeviceProfile(
 	downMixAudio: Boolean,
 	assDirectPlay: Boolean,
 	pgsDirectPlay: Boolean,
+	jellyfinTenEleven: Boolean,
 ) = buildDeviceProfile {
 	val allowedAudioCodecs = when {
 		downMixAudio -> downmixSupportedAudioCodecs
@@ -368,10 +372,12 @@ fun createDeviceProfile(
 		conditions {
 			if (!supportsDolbyVisionDisplay) {
 				ProfileConditionValue.VIDEO_RANGE_TYPE notEquals VideoRangeType.DOVI.serialName
-				ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithEL"
-				if (!supportsHdr10PlusDisplay) {
-					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithHDR10Plus"
-					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithELHDR10Plus"
+				if (jellyfinTenEleven) {
+					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithEL"
+					if (!supportsHdr10PlusDisplay) {
+						ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithHDR10Plus"
+						ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithELHDR10Plus"
+					}
 				}
 				if (!supportsHdr10Display)
 					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals VideoRangeType.DOVI_WITH_HDR10.serialName
@@ -398,7 +404,7 @@ fun createDeviceProfile(
 				ProfileConditionValue.VIDEO_RANGE_TYPE notEquals VideoRangeType.DOVI.serialName
 				if (supportsHdr10Display && !supportsAV1HDR10)
 					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals VideoRangeType.DOVI_WITH_HDR10.serialName
-				if (supportsHdr10PlusDisplay && !supportsAV1HDR10Plus)
+				if (jellyfinTenEleven && supportsHdr10PlusDisplay && !supportsAV1HDR10Plus)
 					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithHDR10Plus"
 			}
 			if (supportsHdr10PlusDisplay && !mediaTest.supportsAV1HDR10Plus()) {
@@ -419,14 +425,16 @@ fun createDeviceProfile(
 
 		conditions {
 			if (supportsDolbyVisionDisplay && !supportsHevcDolbyVisionEL) {
-				ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithEL"
-				if (supportsHdr10PlusDisplay && !supportsHevcHDR10Plus)
-					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithELHDR10Plus"
+				if (jellyfinTenEleven) {
+					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithEL"
+					if (supportsHdr10PlusDisplay && !supportsHevcHDR10Plus)
+						ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithELHDR10Plus"
+				}
 				if (!supportsHevcDolbyVision) {
 					ProfileConditionValue.VIDEO_RANGE_TYPE notEquals VideoRangeType.DOVI.serialName
 					if (supportsHdr10Display && !supportsHevcHDR10)
 						ProfileConditionValue.VIDEO_RANGE_TYPE notEquals VideoRangeType.DOVI_WITH_HDR10.serialName
-					if (supportsHdr10PlusDisplay && !supportsHevcHDR10Plus)
+					if (jellyfinTenEleven && supportsHdr10PlusDisplay && !supportsHevcHDR10Plus)
 						ProfileConditionValue.VIDEO_RANGE_TYPE notEquals "DOVIWithHDR10Plus"
 				}
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -18,6 +18,7 @@ import org.jellyfin.androidtv.util.appendSection
 import org.jellyfin.androidtv.util.appendValue
 import org.jellyfin.androidtv.util.buildMarkdown
 import org.jellyfin.sdk.api.client.util.ApiSerializer
+import org.jellyfin.sdk.model.ServerVersion
 import kotlin.time.Duration.Companion.nanoseconds
 
 private val prettyPrintJson = Json { prettyPrint = true }
@@ -66,6 +67,7 @@ enum class HdrFormats(val label: String) {
 fun createDeviceProfileReport(
 	context: Context,
 	userPreferences: UserPreferences,
+	serverVersion: ServerVersion,
 ) = buildMarkdown {
 	// Header
 	appendLine("---")
@@ -79,9 +81,10 @@ fun createDeviceProfileReport(
 
 	// Device profile send to server
 	appendDetails("Generated device profile") {
+		appendLine("- Server compatibility: $serverVersion")
 		appendCodeBlock(
 			language = "json",
-			code = createDeviceProfile(context, userPreferences)
+			code = createDeviceProfile(context, userPreferences, serverVersion)
 				.let(ApiSerializer::encodeRequestBody)
 				?.let(::formatJson)
 		)


### PR DESCRIPTION
> I just found the cause of various playback related issues that made the app transcode all the time. Current device profile does not work with Jellyfin 10.10 because I misread the condition code on the server 🤐
> 
> \- me in chat, some minutes ago

**Changes**
- Keep track of current server in server repository
- Only use 10.11 video range types on 10.11 servers

**Issues**

Fixes #4967
Fixes #4962
Fixes #4931
