### PR TITLE
Changed audio preferences to include and respect default language from server

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/eventhandling/SocketHandler.kt
@@ -126,7 +126,7 @@ class SocketHandler(
 				val index = message["index"]?.toIntOrNull() ?: return@onEach
 
 				withContext(Dispatchers.Main) {
-					playbackControllerContainer.playbackController?.switchAudioStream(index)
+					playbackControllerContainer.playbackController?.switchAudioStreamByUser(index)
 				}
 			}
 			.launchIn(coroutineScope)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserSettingPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserSettingPreferences.kt
@@ -4,6 +4,7 @@ import org.jellyfin.androidtv.constant.HomeSectionType
 import org.jellyfin.androidtv.preference.store.DisplayPreferencesStore
 import org.jellyfin.preference.enumPreference
 import org.jellyfin.preference.intPreference
+import org.jellyfin.preference.stringPreference
 import org.jellyfin.sdk.api.client.ApiClient
 
 class UserSettingPreferences(
@@ -16,6 +17,7 @@ class UserSettingPreferences(
 	companion object {
 		val skipBackLength = intPreference("skipBackLength", 10_000)
 		val skipForwardLength = intPreference("skipForwardLength", 30_000)
+		val preferredAudioLanguage = stringPreference("preferredAudioLanguage", "")
 
 		val homesection0 = enumPreference("homesection0", HomeSectionType.LIBRARY_TILES_SMALL)
 		val homesection1 = enumPreference("homesection1", HomeSectionType.RESUME)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.ui.playback;
 
 import static org.koin.java.KoinJavaComponent.inject;
+import static org.koin.java.KoinJavaComponent.get;
 
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
@@ -13,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.jellyfin.androidtv.R;
+import org.jellyfin.androidtv.auth.repository.UserRepository;
 import org.jellyfin.androidtv.data.compat.PlaybackException;
 import org.jellyfin.androidtv.data.compat.StreamInfo;
 import org.jellyfin.androidtv.data.compat.VideoOptions;
@@ -41,6 +43,7 @@ import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
 import org.jellyfin.sdk.model.api.PlayMethod;
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod;
+import org.jellyfin.sdk.model.api.UserDto;
 import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
 import org.koin.java.KoinJavaComponent;
 
@@ -736,16 +739,46 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         return null;
     }
 
+    private Integer preferredAudioLanguageTrack(MediaSourceInfo info) {
+        if (info == null) {
+            return null;
+        }
+
+        UserRepository userRepo = KoinJavaComponent.<UserRepository>get(UserRepository.class);
+        UserDto currentUser = userRepo.getCurrentUser().getValue();
+        if (currentUser == null || currentUser.getConfiguration() == null) {
+            return null;
+        }
+            
+        String preferredLanguage = currentUser.getConfiguration().getAudioLanguagePreference();
+        if (preferredLanguage == null || preferredLanguage.isEmpty()) {
+            return null;
+        }
+
+        for (MediaStream track : info.getMediaStreams()) {
+            if (track.getType() == MediaStreamType.AUDIO
+                && track.getLanguage() != null 
+                && track.getLanguage().equals(preferredLanguage)
+            ) {
+                return track.getIndex();
+            }
+        }
+        return null;
+    }
+
     private void setDefaultAudioIndex(StreamInfo info) {
         if (mDefaultAudioIndex != -1)
             return;
 
         Integer lastChosenLanguage = lastChosenLanguageAudioTrack(info.getMediaSource());
+        Integer preferredLanguage = preferredAudioLanguageTrack(info.getMediaSource());
         Integer remoteDefault = info.getMediaSource().getDefaultAudioStreamIndex();
         Integer bestGuess = bestGuessAudioTrack(info.getMediaSource());
 
         if (lastChosenLanguage != null)
             mDefaultAudioIndex = lastChosenLanguage;
+        else if (preferredLanguage != null)
+            mDefaultAudioIndex = preferredLanguage;
         else if (remoteDefault != null)
             mDefaultAudioIndex = remoteDefault;
         else if (bestGuess != null)
@@ -753,7 +786,16 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         Timber.d("default audio index set to %s", mDefaultAudioIndex);
     }
 
-    public void switchAudioStream(int index) {
+    public void switchAudioStreamByUser(int index) {
+        switchAudioStreamInternal(index, true);
+    }
+
+    public void switchAudioStreamAutomatically(int index) {
+        switchAudioStreamInternal(index, false);
+    }
+
+
+    private void switchAudioStreamInternal(int index, boolean isManualSelection) {
         if (!(isPlaying() || isPaused()) || index < 0)
             return;
 
@@ -767,8 +809,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         String lastAudioIsoCode = videoQueueManager.getValue().getLastPlayedAudioLanguageIsoCode();
         String currentAudioIsoCode = currentItem.getMediaStreams().get(index).getLanguage();
 
-        if (currentAudioIsoCode != null
-                && (lastAudioIsoCode == null || !lastAudioIsoCode.equals(currentAudioIsoCode))) {
+        if (isManualSelection && currentAudioIsoCode != null && (lastAudioIsoCode == null || !lastAudioIsoCode.equals(currentAudioIsoCode))) {
             videoQueueManager.getValue().setLastPlayedAudioLanguageIsoCode(
                     currentAudioIsoCode
             );
@@ -1211,14 +1252,14 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             // select an audio track
             int eligibleAudioTrack = mDefaultAudioIndex;
 
-            // if track switching is done without rebuilding the stream, mCurrentOptions is updated
-            // otherwise, use the server default
-            if (mCurrentOptions.getAudioStreamIndex() != null) {
+            if (mDefaultAudioIndex != -1) {
+                eligibleAudioTrack = mDefaultAudioIndex;
+            } else if (mCurrentOptions.getAudioStreamIndex() != null) {
                 eligibleAudioTrack = mCurrentOptions.getAudioStreamIndex();
             } else if (getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
                 eligibleAudioTrack = getCurrentMediaSource().getDefaultAudioStreamIndex();
             }
-            switchAudioStream(eligibleAudioTrack);
+            switchAudioStreamAutomatically(eligibleAudioTrack);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/action/SelectAudioAction.kt
@@ -45,7 +45,7 @@ class SelectAudioAction(
 				popup = null
 			}
 			setOnMenuItemClickListener { item ->
-				playbackController.switchAudioStream(item.itemId)
+				playbackController.switchAudioStreamByUser(item.itemId)
 				true
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsLanguageList.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/dsl/OptionsLanguageList.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.ui.preference.dsl
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceCategory
+import java.util.UUID
+
+class OptionsLanguageList(
+	private val context: Context
+) : OptionsItemMutable<String>() {
+	var entries: Map<String, String> = emptyMap()
+	private var listPreference: ListPreference? = null
+	private var onEntriesUpdated: (() -> Unit)? = null
+
+	fun setTitle(@StringRes resId: Int) {
+		title = context.getString(resId)
+	}
+	
+	fun setOnEntriesUpdated(callback: () -> Unit) {
+		onEntriesUpdated = callback
+	}
+	
+	fun updateEntries(newEntries: Map<String, String>) {
+		entries = newEntries
+		listPreference?.let { pref ->
+			pref.entryValues = entries.keys.toTypedArray()
+			pref.entries = entries.values.toTypedArray()
+			val currentValue = binder.get()
+			pref.value = currentValue
+		}
+		onEntriesUpdated?.invoke()
+	}
+
+	override fun build(category: PreferenceCategory, container: OptionsUpdateFunContainer) {
+		listPreference = ListPreference(context).also {
+			it.isPersistent = false
+			it.key = UUID.randomUUID().toString()
+			category.addPreference(it)
+			it.isEnabled = dependencyCheckFun() && enabled
+			it.isVisible = visible
+			it.title = title
+			it.dialogTitle = title
+			it.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
+			it.entryValues = entries.keys.toTypedArray()
+			it.entries = entries.values.toTypedArray()
+			it.value = binder.get()
+			it.setOnPreferenceChangeListener { _, newValue ->
+				binder.set(newValue.toString())
+				it.value = binder.get()
+				container()
+				false
+			}
+		}
+
+		container += {
+			listPreference?.isEnabled = dependencyCheckFun() && enabled
+		}
+	}
+}
+
+@OptionsDSL
+fun OptionsCategory.languageList(init: OptionsLanguageList.() -> Unit) {
+	this += OptionsLanguageList(context).apply { init() }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,6 +443,9 @@
     <string name="pref_video">Video</string>
     <string name="pref_subtitles">Subtitles</string>
     <string name="pref_audio">Audio</string>
+    <string name="pref_preferred_audio_language">Preferred audio language</string>
+    <string name="pref_preferred_audio_language_description">Automatically select audio tracks in this language when available</string>
+    <string name="pref_preferred_audio_language_none">None (use default)</string>
     <string name="pref_direct_stream_live_off">Transcoding is used when necessary</string>
     <string name="pref_direct_stream_live_on">Transcoding is disabled</string>
     <string name="home_section_resume_book">Continue reading</string>


### PR DESCRIPTION
Implement preferred audio language selection, sync of property from server, and update audio stream switching methods

I needed this myself to use Jellyfin because my 4yos Bluey sessions were a constant "select audio language" annoyance that kept me using a different media server.

Haven't done anything with subtitles but if this PR looks acceptable audio wise I can probably look into the subtitles side as well, either in this or a separate PR.

**Changes**
- Added a new preference for selecting the preferred audio language in UserSettingPreferences.
- Updated PlaybackController to handle audio stream switching based on user preference.
- Refactored switchAudioStream methods for clarity and added automatic selection logic.
- Introduced OptionsLanguageList for managing audio language options in the preferences screen.
- Updated UI components to reflect changes in audio stream selection behavior.

**Issues**
Fixes #2289  (partly)