### PR TITLE
Add device-specific profile override support

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/DeviceProfileBuilderOverrideManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/DeviceProfileBuilderOverrideManager.kt
@@ -1,0 +1,114 @@
+package org.jellyfin.androidtv.util.profile
+
+import org.jellyfin.sdk.model.api.CodecProfile
+import org.jellyfin.sdk.model.api.ContainerProfile
+import org.jellyfin.sdk.model.api.DirectPlayProfile
+import org.jellyfin.sdk.model.api.ProfileCondition
+import org.jellyfin.sdk.model.api.TranscodingProfile
+import org.jellyfin.sdk.model.deviceprofile.DeviceProfileBuilder
+import timber.log.Timber
+
+/// Rudimentary override handling for device profile
+// Consider moving this override logic into the SDK -- DeviceProfileBuilder should handle this
+// TODO Handle partially overlapping profiles by separating into their own distinct profile
+object DeviceProfileBuilderOverrideManager {
+    fun applyOverrideProfiles(builder: DeviceProfileBuilder, vararg overrides: CodecProfile) =
+        applyOverrideProfiles(
+            overrides,
+            builder.codecProfiles,
+            match = { existing, override ->
+                existing.type == override.type &&
+                        existing.codec == override.codec &&
+                        existing.container == override.container &&
+                        existing.subContainer == override.subContainer
+            },
+            conditions = { existing, override ->
+                removeConflictingConditions(existing.conditions, override.conditions)
+                removeConflictingConditions(existing.applyConditions, override.applyConditions)
+
+                existing.conditions.isEmpty() && existing.applyConditions.isEmpty()
+            }
+        )
+
+    fun applyOverrideProfiles(builder: DeviceProfileBuilder, vararg overrides: TranscodingProfile) =
+        applyOverrideProfiles(
+            overrides,
+            builder.transcodingProfiles,
+            match = { existing, override -> existing.type == override.type }
+        )
+
+    fun applyOverrideProfiles(builder: DeviceProfileBuilder, vararg overrides: DirectPlayProfile) =
+        applyOverrideProfiles(
+            overrides,
+            builder.directPlayProfiles,
+            match = { existing, override -> existing.type == override.type }
+        )
+
+    fun applyOverrideProfiles(builder: DeviceProfileBuilder, vararg overrides: ContainerProfile) =
+        applyOverrideProfiles(
+            overrides,
+            builder.containerProfiles,
+            match = { existing, override -> existing.type == override.type },
+            conditions = { existing, override ->
+                removeConflictingConditions(existing.conditions, override.conditions)
+
+                existing.conditions.isEmpty()
+            }
+        )
+
+    private inline fun <T> applyOverrideProfiles(
+        overrides: Array<out T>,
+        profiles: MutableCollection<T>,
+        crossinline match: (T, T) -> Boolean,
+        crossinline conditions: (T, T) -> Boolean = { _, _ -> true }
+    ) {
+        try {
+            overrides.forEach { override ->
+                profiles.removeIf { existing ->
+                    if (!match(existing, override)) return@removeIf false
+                    if (!conditions(existing, override)) return@removeIf false
+
+                    true
+                }
+
+                profiles.add(override)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to apply override profiles")
+        }
+    }
+
+    // Remove condition values that conflict with override conditions
+    private fun removeConflictingConditions(
+        existing: List<ProfileCondition>,
+        overrides: List<ProfileCondition>
+    ) {
+        overrides.forEach { override ->
+            val iterator = (existing as MutableList).listIterator()
+
+            for (current in iterator.asSequence()) {
+                if (current.property != override.property) continue
+
+                removeOverlappingValues(current.value, override.value)?.let { newValue ->
+                    iterator.set(current.copy(value = newValue))
+                } ?: iterator.remove()
+            }
+        }
+    }
+
+    // Remove values that conflict with override values
+    private fun removeOverlappingValues(
+        existingValue: String?,
+        overrideValue: String?,
+        delimiter: String = "|"
+    ): String? {
+        if (existingValue.isNullOrBlank() || overrideValue.isNullOrBlank()) return existingValue
+
+        val existingValues = existingValue.split(delimiter)
+        val overrideValues = overrideValue.split(delimiter)
+
+        val remaining = existingValues.filterNot { it in overrideValues }
+
+        return remaining.joinToString(delimiter).ifEmpty { null }
+    }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/DeviceProfileOverrideSerializer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/DeviceProfileOverrideSerializer.kt
@@ -1,0 +1,23 @@
+package org.jellyfin.androidtv.util.profile
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.jellyfin.androidtv.util.profile.model.CodecProfileDto
+import org.jellyfin.sdk.model.api.CodecProfile
+
+// Map DTO profiles to profiles during deserialization
+object CodecProfileSerializer : KSerializer<CodecProfile> {
+	private val dtoSerializer = CodecProfileDto.serializer()
+	override val descriptor: SerialDescriptor = dtoSerializer.descriptor
+
+	override fun deserialize(decoder: Decoder): CodecProfile {
+		val dto = dtoSerializer.deserialize(decoder)
+		return dto.toCodecProfile()
+	}
+
+	override fun serialize(encoder: Encoder, value: CodecProfile) {
+		// Overrides are never serialized
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/DeviceProfileOverrides.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/DeviceProfileOverrides.kt
@@ -1,0 +1,64 @@
+package org.jellyfin.androidtv.util.profile
+
+import android.content.Context
+import android.content.res.Resources
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.util.profile.model.*
+import org.jellyfin.sdk.model.api.CodecProfile
+import org.jellyfin.sdk.model.api.ContainerProfile
+import org.jellyfin.sdk.model.api.DirectPlayProfile
+import org.jellyfin.sdk.model.api.TranscodingProfile
+import timber.log.Timber
+import java.io.IOException
+
+class DeviceProfileOverrides (
+	private val context: Context
+) {
+	private val jsonParser = Json { ignoreUnknownKeys = true }
+
+	private val overrides: List<Profiles> by lazy {
+		try {
+			val resource = context.resources.openRawResource(R.raw.profile_overrides)
+			val json = resource.use { stream -> stream.bufferedReader().use { it.readText() } }
+			val decoded = jsonParser.decodeFromString<List<OverrideRule>>(json)
+
+			val loadedOverrides = decoded
+				.filter { it.devices.any { device -> device.matchesCurrentDevice() } }
+				.map { it.profiles }
+
+			Timber.d("Loaded device profile overrides: %s", loadedOverrides.joinToString())
+
+			loadedOverrides
+		} catch (e: Exception) {
+			when (e) {
+				is Resources.NotFoundException ->
+					Timber.e(e, "Device profile overrides resource not found.")
+				is IOException ->
+					Timber.e(e, "Failed to read device profile overrides resource.")
+				is SerializationException ->
+					Timber.e(e, "Failed to decode device profile overrides JSON.")
+				else ->
+					Timber.e(e, "An unexpected error occurred while loading device profile overrides.")
+			}
+			emptyList()
+		}
+	}
+
+	fun getTranscodingOverrides(): List<TranscodingProfile> =
+		getProfileOverrides { it.transcodingProfiles }
+
+	fun getDirectPlayOverrides(): List<DirectPlayProfile> =
+		getProfileOverrides { it.directPlayProfiles }
+
+	fun getContainerOverrides(): List<ContainerProfile> =
+		getProfileOverrides { it.containerProfiles }
+
+	fun getCodecOverrides(): List<CodecProfile> =
+		getProfileOverrides { it.codecProfiles }
+
+	private inline fun <T> getProfileOverrides(selector: (Profiles) -> List<T>?): List<T> {
+		return overrides.flatMap { selector(it) ?: emptyList() }
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -58,6 +58,7 @@ fun createDeviceProfile(
 	userPreferences: UserPreferences,
 ) = createDeviceProfile(
 	mediaTest = MediaCodecCapabilitiesTest(context),
+	profileOverrides = DeviceProfileOverrides(context),
 	maxBitrate = userPreferences.getMaxBitrate(),
 	isAC3Enabled = userPreferences[UserPreferences.ac3Enabled],
 	downMixAudio = userPreferences[UserPreferences.audioBehaviour] == AudioBehavior.DOWNMIX_TO_STEREO,
@@ -67,6 +68,7 @@ fun createDeviceProfile(
 
 fun createDeviceProfile(
 	mediaTest: MediaCodecCapabilitiesTest,
+	profileOverrides: DeviceProfileOverrides,
 	maxBitrate: Int,
 	isAC3Enabled: Boolean,
 	downMixAudio: Boolean,
@@ -145,6 +147,10 @@ fun createDeviceProfile(
 		audioCodec(Codec.Audio.MP3)
 	}
 
+	// Device transcode overrides
+	DeviceProfileBuilderOverrideManager.
+		applyOverrideProfiles(this, *profileOverrides.getTranscodingOverrides().toTypedArray())
+
 	/// Direct play profiles
 	// Video
 	directPlayProfile {
@@ -185,6 +191,10 @@ fun createDeviceProfile(
 
 		audioCodec(*allowedAudioCodecs)
 	}
+
+	// Device direct play overrides
+	DeviceProfileBuilderOverrideManager.
+		applyOverrideProfiles(this, *profileOverrides.getDirectPlayOverrides().toTypedArray())
 
 	/// Codec profiles
 	// H264 profile
@@ -449,6 +459,10 @@ fun createDeviceProfile(
 			ProfileConditionValue.AUDIO_CHANNELS lowerThanOrEquals if (downMixAudio) 2 else 8
 		}
 	}
+
+	// Device codec overrides
+	DeviceProfileBuilderOverrideManager.
+		applyOverrideProfiles(this, *profileOverrides.getCodecOverrides().toTypedArray())
 
 	/// Subtitle profiles
 	// Jellyfin server only supports WebVTT subtitles in HLS, other text subtitles will be converted to WebVTT

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -281,5 +281,10 @@ fun createDeviceProfileReport(
 		appendItem("Device brand") { appendValue(Build.BRAND) }
 		appendItem("Device product") { appendValue(Build.PRODUCT) }
 		appendItem("Device model") { appendValue(Build.MODEL) }
+		appendItem("Device manufacturer") { appendValue(Build.MANUFACTURER) }
+		appendItem("Device codename") { appendValue(Build.DEVICE) }
+		appendItem("Device hardware") { appendValue(Build.HARDWARE) }
+		if(isS) appendItem("Device SKU") { appendValue(Build.SKU) }
+		if(isS) appendItem("Device SOC") { appendValue(Build.SOC_MODEL) }
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/model/DeviceProfileOverrideEntries.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/model/DeviceProfileOverrideEntries.kt
@@ -1,0 +1,125 @@
+package org.jellyfin.androidtv.util.profile.model
+
+import android.os.Build
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.jellyfin.androidtv.util.profile.CodecProfileSerializer
+import org.jellyfin.sdk.model.api.CodecProfile
+import org.jellyfin.sdk.model.api.CodecType
+import org.jellyfin.sdk.model.api.ContainerProfile
+import org.jellyfin.sdk.model.api.DirectPlayProfile
+import org.jellyfin.sdk.model.api.ProfileCondition
+import org.jellyfin.sdk.model.api.ProfileConditionType
+import org.jellyfin.sdk.model.api.ProfileConditionValue
+import org.jellyfin.sdk.model.api.TranscodingProfile
+import timber.log.Timber
+
+enum class DeviceIdentifier(val string: String) {
+	MANUFACTURER("Manufacturer"),
+	MODEL("Model"),
+	DEVICE("Device"),
+	PRODUCT("Product"),
+	BRAND("Brand"),
+	HARDWARE("Hardware"),
+	SKU("SKU"),
+	SOC_MODEL("SOCModel");
+}
+
+@Serializable
+data class OverrideRule(
+	@SerialName("Devices")
+	val devices: List<Device>,
+	@SerialName("Profiles")
+	val profiles: Profiles
+)
+
+@Serializable
+data class Device(
+	@SerialName("Name")
+	val name: String?,
+	@SerialName("Identifiers")
+	val identifiers: Map<String, String>
+) {
+	fun matchesCurrentDevice(): Boolean =
+		identifiers.all { (key, value) ->
+			val identifier = DeviceIdentifier.entries.find { it.string == key }
+			when (identifier) {
+				DeviceIdentifier.MANUFACTURER -> Build.MANUFACTURER.equals(value, true)
+				DeviceIdentifier.MODEL -> Build.MODEL.equals(value, true)
+				DeviceIdentifier.DEVICE -> Build.DEVICE.equals(value, true)
+				DeviceIdentifier.PRODUCT -> Build.PRODUCT.equals(value, true)
+				DeviceIdentifier.BRAND -> Build.BRAND.equals(value, true)
+				DeviceIdentifier.HARDWARE -> Build.HARDWARE.equals(value, true)
+				DeviceIdentifier.SKU -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+					Build.SKU.equals(value, true)
+
+				DeviceIdentifier.SOC_MODEL -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+					Build.SOC_MODEL.equals(value, true)
+
+				null -> {
+					Timber.w("Unknown identifier key in profile_overrides: $key")
+					false
+				}
+			}
+		}
+}
+
+@Serializable
+data class Profiles(
+	@SerialName("TranscodingProfiles")
+	val transcodingProfiles: List<TranscodingProfile>? = null,
+	@SerialName("DirectPlayProfiles")
+	val directPlayProfiles: List<DirectPlayProfile>? = null,
+	@SerialName("CodecProfiles")
+	val codecProfiles: List<@Serializable(CodecProfileSerializer::class) CodecProfile>? = null,
+	@SerialName("ContainerProfiles")
+	val containerProfiles: List<ContainerProfile>? = null
+)
+
+
+// Adds DTO objects add defaults for `applyConditions` and `isRequired`
+@Serializable
+data class CodecProfileDto(
+	@SerialName("Type")
+	val type: CodecType,
+	@SerialName("Codec")
+	val codec: String? = null,
+	@SerialName("Container")
+	val container: String? = null,
+	@SerialName("SubContainer")
+	val subContainer: String? = null,
+	@SerialName("Conditions")
+	val conditions: List<ProfileConditionDto>,
+	@SerialName("ApplyConditions")
+	val applyConditions: List<ProfileCondition>? = null
+) {
+	fun toCodecProfile(): CodecProfile =
+		CodecProfile(
+			type = type,
+			codec = codec,
+			container = container,
+			subContainer = subContainer,
+			conditions = conditions.map { it.toProfileCondition() },
+			applyConditions = applyConditions ?: emptyList()
+		)
+}
+
+@Serializable
+data class ProfileConditionDto(
+	@SerialName("Condition")
+	val condition: ProfileConditionType,
+	@SerialName("Property")
+	val property: ProfileConditionValue,
+	@SerialName("Value")
+	val value: String? = null,
+	@SerialName("IsRequired")
+	val isRequired: Boolean? = null
+) {
+	fun toProfileCondition(): ProfileCondition =
+		ProfileCondition(
+			condition = condition,
+			property = property,
+			value = value,
+			isRequired = isRequired ?: false
+		)
+}

--- a/app/src/main/res/raw/profile_overrides.json
+++ b/app/src/main/res/raw/profile_overrides.json
@@ -1,0 +1,47 @@
+[
+  {
+    "Devices": [
+      {
+        "Name": "Amazon Fire TV 4K Max (2nd Gen)",
+        "Identifiers": {
+          "Model": "AFTKRT"
+        }
+      },
+      {
+        "Name": "Amazon Fire TV 4K Max (1st Gen)",
+        "Identifiers": {
+          "Model": "AFTKA"
+        }
+      },
+      {
+        "Name": "Amazon Fire TV 4K (2nd Gen)",
+        "Identifiers": {
+          "Model": "AFTKM"
+        }
+      }
+    ],
+    "Profiles": {
+      "CodecProfiles": [
+        {
+          "Type": "Video",
+          "Codec": "hevc",
+          "Conditions": [
+            {
+              "Condition": "NotEquals",
+              "Property": "VideoRangeType",
+              "Value": "DOVIWithHDR10Plus",
+              "IsRequired": false
+            },
+            {
+              "Condition": "NotEquals",
+              "Property": "VideoRangeType",
+              "Value": "DOVIWithELHDR10Plus",
+              "IsRequired": false
+            }
+          ],
+          "ApplyConditions": []
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
**Changes**
This allows storing and applying device-specific overrides to the device profile.

This is useful for handling devices that incorrectly report capabilities or have known issues (e.g., a faulty hardware decoder).

Additionally, this fixes Dolby Vision playback with an HDR10+ base layer on Fire TVs.

**Issues**
Fixes #4892
