### PR TITLE
Fix "shuffle all" not working for music album/artist

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -151,7 +151,7 @@ class SdkPlaybackHelper(
 				val response by api.itemsApi.getItems(
 					isMissing = false,
 					mediaTypes = listOf(MediaType.AUDIO),
-					sortBy = listOf(
+					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(
 						ItemSortBy.ALBUM_ARTIST,
 						ItemSortBy.SORT_NAME
 					),
@@ -168,7 +168,7 @@ class SdkPlaybackHelper(
 				val response by api.itemsApi.getItems(
 					isMissing = false,
 					mediaTypes = listOf(MediaType.AUDIO),
-					sortBy = listOf(ItemSortBy.SORT_NAME),
+					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(ItemSortBy.SORT_NAME),
 					recursive = true,
 					limit = ITEM_QUERY_LIMIT,
 					fields = ItemRepository.itemFields,


### PR DESCRIPTION
Not all branches in the SdkPlaybackHelper.getItemsToPlay function respected the shuffle parameter.

**Changes**

- Support shuffle parameter in `SdkPlaybackHelper.getItemsToPlay` for music album
- Support shuffle parameter in `SdkPlaybackHelper.getItemsToPlay` for music artist


**Issues**

Fixes #4648
