### PR TITLE
Don't show exception message as toast

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseRecordingsFragment.java
@@ -17,13 +17,14 @@ import org.jellyfin.androidtv.ui.GridButton;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
-import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.sdk.model.api.BaseItemDto;
 import org.jellyfin.sdk.model.api.TimerInfoDto;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import timber.log.Timber;
 
 public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
     @Override
@@ -90,7 +91,7 @@ public class BrowseRecordingsFragment extends EnhancedBrowseFragment {
             }
             return null;
         }, exception -> {
-            Utils.showToast(getContext(), exception.getLocalizedMessage());
+            Timber.e(exception, "Failed to get Live TV recordings / timers");
             return null;
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseViewFragment.java
@@ -29,6 +29,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import timber.log.Timber;
+
 public class BrowseViewFragment extends EnhancedBrowseFragment {
     private boolean isLiveTvLibrary;
 
@@ -175,7 +177,7 @@ public class BrowseViewFragment extends EnhancedBrowseFragment {
 
                     return null;
                 }, exception -> {
-                    Utils.showToast(getContext(), exception.getLocalizedMessage());
+                    Timber.e(exception, "Failed to get Live TV recordings / timers");
                     return null;
                 });
 


### PR DESCRIPTION
Exceptions are for developers, not for end-users.

**Changes**
- Don't show exception message as toast. If it is null (which is possible) the toast would even crash the app!

**Issues**

Fixes #5011
