### PR TITLE
Flatten HDR codec profile conditions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -436,11 +436,19 @@ fun createDeviceProfile(
 	}
 
 	// Display
+	// Note: The codec profiles use a workaround to create correct behavior
+	// The notEquals condition will always fail the ConditionProcessor test in the server so we use applyConditions to only have the codec
+	// profile be active when the media in question uses one of the unsupported range types. The server will then use the value of the
+	// notEquals in the StreamBuilder to create a correct transcode pipeline
 	if (unsupportedRangeTypes.isNotEmpty()) codecProfile {
 		type = CodecType.VIDEO
 
 		conditions {
 			ProfileConditionValue.VIDEO_RANGE_TYPE notEquals unsupportedRangeTypes.joinToString("|")
+		}
+
+		applyConditions {
+			ProfileConditionValue.VIDEO_RANGE_TYPE inCollection unsupportedRangeTypes
 		}
 	}
 
@@ -453,6 +461,10 @@ fun createDeviceProfile(
 		conditions {
 			ProfileConditionValue.VIDEO_RANGE_TYPE notEquals unsupportedRangeTypesAv1.joinToString("|")
 		}
+
+		applyConditions {
+			ProfileConditionValue.VIDEO_RANGE_TYPE inCollection unsupportedRangeTypesAv1
+		}
 	}
 
 	// HEVC
@@ -462,6 +474,10 @@ fun createDeviceProfile(
 
 		conditions {
 			ProfileConditionValue.VIDEO_RANGE_TYPE notEquals unsupportedRangeTypesHevc.joinToString("|")
+		}
+
+		applyConditions {
+			ProfileConditionValue.VIDEO_RANGE_TYPE inCollection unsupportedRangeTypesHevc
 		}
 	}
 


### PR DESCRIPTION
This builds on a few assumptions according to [this comment](https://github.com/jellyfin/jellyfin-androidtv/issues/4952#issuecomment-3403336242):

- A ProfileConditionValue should never be added twice per codec
- If a ProfileConditionValue is defined globally (no set codec) it should be completely redefined when creating a codec specific one

This results for us in 3 codec profiles, one global and two (after the global one) for av1 and hevc. If no HDR is supported at all the last two are equal to the global one, otherwise they might disregard some range types that the display supports but the codec decoder doesn't.

<details>
<summary>Emulator profile before</summary>

```json
        {
            "Type": "Video",
            "Conditions": [
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "DOVI",
                    "IsRequired": false
                },
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "DOVIWithEL",
                    "IsRequired": false
                },
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "DOVIWithHDR10Plus",
                    "IsRequired": false
                },
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "DOVIWithELHDR10Plus",
                    "IsRequired": false
                },
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "DOVIWithHDR10",
                    "IsRequired": false
                },
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "HDR10Plus",
                    "IsRequired": false
                },
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "HDR10",
                    "IsRequired": false
                }
            ],
            "ApplyConditions": []
        },
```

</details>

<details>
<summary>Emulator profile after (this PR)</summary>

```json
        {
            "Type": "Video",
            "Conditions": [
                {
                    "Condition": "NotEquals",
                    "Property": "VideoRangeType",
                    "Value": "DOVIInvalid|DOVI|DOVIWithEL|DOVIWithHDR10Plus|DOVIWithELHDR10Plus|DOVIWithHDR10|HDR10Plus|HDR10",
                    "IsRequired": false
                }
            ],
            "ApplyConditions": [
                {
                    "Condition": "EqualsAny",
                    "Property": "VideoRangeType",
                    "Value": "DOVIInvalid|DOVI|DOVIWithEL|DOVIWithHDR10Plus|DOVIWithELHDR10Plus|DOVIWithHDR10|HDR10Plus|HDR10",
                    "IsRequired": false
                }
            ]
        },
```

</details>

**Issues**

Fixes #4952