### PR TITLE
Allow prioritization of AC3 over AAC

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -125,6 +125,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var ac3Enabled = booleanPreference("pref_bitstream_ac3", true)
 
+		/**
+		 * Prefer AC3 over AAC
+		 */
+		var ac3Preferred = booleanPreference("prefer_ac3", false)
+
 		/* Live TV */
 		/**
 		 * Use direct play

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -133,6 +133,13 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				setContent(R.string.desc_bitstream_ac3)
 				bind(userPreferences, UserPreferences.ac3Enabled)
 			}
+
+			checkbox {
+				setTitle(R.string.lbl_prefer_ac3)
+				setContent(R.string.desc_prefer_ac3)
+				bind(userPreferences, UserPreferences.ac3Preferred)
+				depends { userPreferences[UserPreferences.ac3Enabled] }
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -62,23 +62,40 @@ fun createDeviceProfile(
 	mediaTest = MediaCodecCapabilitiesTest(context),
 	maxBitrate = userPreferences.getMaxBitrate(),
 	isAC3Enabled = userPreferences[UserPreferences.ac3Enabled],
+	isAC3Preferred = userPreferences[UserPreferences.ac3Preferred],
 	downMixAudio = userPreferences[UserPreferences.audioBehaviour] == AudioBehavior.DOWNMIX_TO_STEREO,
 	assDirectPlay = false,
 	pgsDirectPlay = userPreferences[UserPreferences.pgsDirectPlay],
 )
 
+private fun createSupportedAudioCodecs(
+	isAC3Enabled: Boolean,
+	isAC3Preferred: Boolean
+): Array<String> {
+	if (!isAC3Enabled) return supportedAudioCodecs
+		.filterNot { it == Codec.Audio.AC3 || it == Codec.Audio.EAC3 }
+		.toTypedArray()
+
+	if (isAC3Preferred) return supportedAudioCodecs
+		.filterNot { it == Codec.Audio.AC3 }
+		.toMutableList()
+		.apply { add(0, Codec.Audio.AC3) }
+		.toTypedArray()
+
+	return supportedAudioCodecs
+}
+
 fun createDeviceProfile(
 	mediaTest: MediaCodecCapabilitiesTest,
 	maxBitrate: Int,
 	isAC3Enabled: Boolean,
+	isAC3Preferred: Boolean,
 	downMixAudio: Boolean,
 	assDirectPlay: Boolean,
 	pgsDirectPlay: Boolean,
 ) = buildDeviceProfile {
-	val allowedAudioCodecs = when {
-		downMixAudio -> downmixSupportedAudioCodecs
-		!isAC3Enabled -> supportedAudioCodecs.filterNot { it == Codec.Audio.EAC3 || it == Codec.Audio.AC3 }.toTypedArray()
-		else -> supportedAudioCodecs
+	val allowedAudioCodecs = if (downMixAudio) downmixSupportedAudioCodecs else {
+		createSupportedAudioCodecs(isAC3Enabled, isAC3Preferred)
 	}
 
 	val supportsHevc = mediaTest.supportsHevc()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="lbl_new_premieres">New premieres</string>
     <string name="lbl_bitstream_ac3">Bitstream Dolby Digital audio</string>
     <string name="desc_bitstream_ac3">Requires capable hardware</string>
+    <string name="lbl_prefer_ac3">Prefer transcoding to Dolby Digital</string>
+    <string name="desc_prefer_ac3">Prioritize AC3 over AAC</string>
     <string name="desc_audio_night_mode">Levels out audio volume automatically</string>
     <string name="lbl_zoom">Zoom</string>
     <string name="lbl_auto_crop">Auto crop</string>


### PR DESCRIPTION
This PR allows users to prioritize transcoding into AC3 over AAC. This behavior can be configured in the advanced settings menu if bit streaming of Dolby Digital audio is enabled.

Further details:
- If the corresponding setting is enabled in the advanced playback menu and a file is transcoded (no matter if transcoding happens only for audio or for audio & video), Jellyfin now prioritizes audio transcoding into AC3 instead of AAC.
- Because AC3 is one of Dolby Digitals audio codecs, this setting only can be modified if bit streaming of Dolby Digital audio is enabled.
- As ffmpeg currently cannot transcode any audio into EAC3 (https://github.com/jellyfin/jellyfin/issues/9045), I focused on AC3. Prioritizing EAC3 currently wouldn’t have any impact on the transcoding of audio streams.
- If the source audio is encoded in EAC3, it will be kept and only video will be transcoded. This behavior does not change in comparison to the current version and is exactly the same in other clients.
- Direct Play does not have a prioritization of audio codecs, so changing the order of the codecs in that part of the device profile does not have an impact on streaming.

I tested all of these aspects on a FireTV stick and several emulated Android TVs.

**Changes**
The order of the audio codecs in the device profile changes their priorities, thus making AC3 the first element tells the Jellyfin server to prefer it over AAC. `jellyfin-web` handles this the same way if you configure a preferred audio codec ([jellyfin-web:apphost.js](https://github.com/jellyfin/jellyfin-web/blob/3215be4cd8d2c0db5d487f239dac728dd017f4cf/src/components/apphost.js#L108)). 

Considerations while implementing:
- I tried to make the new checkbox automatically turn off if Dolby Digital bit streaming is disabled, but changing the `ac3Preferred` user preference in addition to the `ac3Enabled` user preference does not trigger a refresh for the new checkbox.
- I didn't see any use cases right now for a selection of a specific preferred codec (as implemented in the web client).
- Same goes for selecting a specific video codec, I think the current implementation (using HVEC whenever possible) is the best way to handle this.

**Issues**
Fixes #2867, #2602, #2991, #2432 and possibly a lot of similar issues.
Rework for #3109.
Rework for some parts of #3110.