### PR TITLE
Refactor audio night mode implementation

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -8,7 +8,6 @@ import android.media.audiofx.DynamicsProcessing;
 import android.media.audiofx.DynamicsProcessing.Limiter;
 import android.media.audiofx.Equalizer;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Handler;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -108,7 +107,7 @@ public class VideoManager {
             mExoPlayer.addAnalyticsListener(new AnalyticsListener() {
                 @Override
                 public void onAudioSessionIdChanged(AnalyticsListener.EventTime eventTime, int audioSessionId) {
-                    enableAudioNightMode(audioSessionId);
+                    VideoManagerHelperKt.applyAudioNightmode(audioSessionId);
                 }
             });
         }
@@ -652,42 +651,6 @@ public class VideoManager {
     private void stopProgressLoop() {
         if (progressLoop != null) {
             mHandler.removeCallbacks(progressLoop);
-        }
-    }
-
-    private void enableAudioNightMode(int audioSessionId) {
-        Timber.i("Enabling audio night mode for session %d", audioSessionId);
-        if (mEqualizer != null) mEqualizer.release();
-        if (mDynamicsProcessing != null) mDynamicsProcessing.release();
-
-        // Equaliser variables.
-        short eqDefault = (short) 0;
-        short eqSmallBoost = (short) 2;
-        short eqBigBoost = (short) 3;
-        mEqualizer = new Equalizer(0, audioSessionId);
-
-        // Compressor variables.
-        int attackTime = 30;
-        int releaseTime = 300;
-        int ratio = 10;
-        int threshold = -24;
-        int postGain = 3;
-
-        // Mid range boost to make dialogue louder.
-        mEqualizer.setBandLevel((short) 0, eqDefault);
-        mEqualizer.setBandLevel((short) 1, eqSmallBoost);
-        mEqualizer.setBandLevel((short) 2, eqBigBoost);
-        mEqualizer.setBandLevel((short) 3, eqSmallBoost);
-        mEqualizer.setBandLevel((short) 4, eqDefault);
-        mEqualizer.setEnabled(true);
-
-        // Compression of audio (available >= android.P only).
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            mDynamicsProcessing = new DynamicsProcessing(audioSessionId);
-            mLimiter = new Limiter(true, true, 1, attackTime, releaseTime, ratio, threshold, postGain);
-            mLimiter.setEnabled(true);
-            mDynamicsProcessing.setLimiterAllChannelsTo(mLimiter);
-            mDynamicsProcessing.setEnabled(true);
         }
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
@@ -1,8 +1,13 @@
 package org.jellyfin.androidtv.ui.playback
 
+import android.media.audiofx.AudioEffect
+import android.media.audiofx.DynamicsProcessing
+import android.media.audiofx.Equalizer
+import android.os.Build
 import androidx.core.net.toUri
 import org.jellyfin.playback.media3.exoplayer.mapping.getFfmpegSubtitleMimeType
 import org.jellyfin.sdk.model.api.MediaStream
+import timber.log.Timber
 
 /**
  * Return the media type for the codec found in this media stream. First tries to infer the media type from the streams delivery URL and
@@ -16,4 +21,50 @@ fun getSubtitleMediaStreamCodec(stream: MediaStream): String {
 	val urlExtensionMediaType = urlSubtitleExtension?.let { getFfmpegSubtitleMimeType(it, "") }?.ifBlank { null }
 
 	return urlExtensionMediaType ?: codecMediaType ?: urlSubtitleExtension ?: codec
+}
+
+private var audioEffect: AudioEffect? = null
+
+fun applyAudioNightmode(audioSessionId: Int) {
+	Timber.i("Enabling audio night mode for session $audioSessionId")
+
+	audioEffect?.release()
+
+	audioEffect = when {
+		// Use dynamics processinc on Android 9 (API 28) and newer
+		Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> DynamicsProcessing(0, audioSessionId, null).apply {
+			setLimiterAllChannelsTo(
+				DynamicsProcessing.Limiter(
+					true,
+					true,
+					1,
+					30f,
+					300f,
+					10f,
+					-24f,
+					3f
+				)
+			)
+
+			setPreEqAllChannelsTo(DynamicsProcessing.Eq(true, true, 5).apply {
+				getBand(0).gain = 0f
+				getBand(1).gain = 0.02f
+				getBand(2).gain = 0.03f
+				getBand(3).gain = 0.02f
+				getBand(4).gain = 0f
+			})
+
+			enabled = true
+		}
+
+		// Use more simple equalizer implementation on older versions
+		else -> Equalizer(0, audioSessionId).apply {
+			setBandLevel(0, 0)
+			setBandLevel(1, 2)
+			setBandLevel(2, 3)
+			setBandLevel(3, 2)
+			setBandLevel(4, 0)
+			enabled = true
+		}
+	}
 }


### PR DESCRIPTION
Experimental fix for an experimental feature :-). I'm not audio expert and have no idea what sane values are for the equalizer. So those are kept like before. The goal of this PR is to just make audio play non-silent again.

**Changes**

- Rewrite audio night mode implementation in Kotlin
- Never use both equalizer and dynamics processing. Add an equalizer to the dynamics processing instead

**Issues**

Fixes #4818
