### PR TITLE
Add support for multiple badges for media with hybrid HDR or HDR with fallback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -189,23 +189,25 @@ fun InfoRowMediaDetails(mediaSource: MediaSourceInfo) {
 		}
 	}
 
-	// Video stream
-	val videoCodecName = when {
-		!videoStream?.videoDoViTitle.isNullOrBlank() -> stringResource(R.string.dolby_vision)
-		videoStream?.videoRangeType != null && videoStream.videoRangeType != VideoRangeType.SDR && videoStream.videoRangeType != VideoRangeType.UNKNOWN ->
-			videoStream.videoRangeType.serialName.uppercase()
-
-		else -> videoStream?.codec?.uppercase()
+	// Video range
+	val videoRangeNames: Set<String> = when (videoStream?.videoRangeType) {
+		VideoRangeType.SDR -> setOf(stringResource(R.string.sdr))
+		VideoRangeType.HDR10 -> setOf(stringResource(R.string.hdr10))
+		VideoRangeType.HDR10_PLUS -> setOf(stringResource(R.string.hdr10_plus))
+		VideoRangeType.HLG -> setOf(stringResource(R.string.hlg))
+		VideoRangeType.DOVI -> setOf(stringResource(R.string.dolby_vision))
+		VideoRangeType.DOVI_WITH_HDR10 -> setOf(stringResource(R.string.dolby_vision), stringResource(R.string.hdr10))
+		VideoRangeType.DOVI_WITH_HLG -> setOf(stringResource(R.string.dolby_vision), stringResource(R.string.hlg))
+		VideoRangeType.DOVI_WITH_SDR -> setOf(stringResource(R.string.dolby_vision), stringResource(R.string.sdr))
+		VideoRangeType.DOVI_WITH_EL -> setOf(stringResource(R.string.dolby_vision_with_el))
+		VideoRangeType.DOVI_WITH_HDR10_PLUS -> setOf(stringResource(R.string.dolby_vision), stringResource(R.string.hdr10_plus))
+		VideoRangeType.DOVI_WITH_ELHDR10_PLUS -> setOf(stringResource(R.string.dolby_vision_with_el), stringResource(R.string.hdr10_plus))
+		VideoRangeType.DOVI_INVALID -> setOf(stringResource(R.string.dolby_vision))
+		else -> emptySet()
 	}
-	if (!videoCodecName.isNullOrBlank()) {
-		InfoRowItem(
-			contentDescription = null,
-			colors = InfoRowColors.Default,
-		) {
-			Text(videoCodecName)
-		}
+	videoRangeNames.forEach {
+		InfoRowItem(contentDescription = null, colors = InfoRowColors.Default) { Text(it) }
 	}
-
 	// Audio stream
 	val audioCodecName = when {
 		audioStream?.profile?.contains("Dolby Atmos", ignoreCase = true) == true -> stringResource(R.string.dolby_atmos)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/InfoRowItem.kt
@@ -48,7 +48,7 @@ fun InfoRowItem(
 	ProvideTextStyle(
 		value = TextStyle(
 			color = foregroundColor,
-			fontSize = if (backgroundColor.alpha > 0f) 12.sp else 16.sp,
+			fontSize = if (backgroundColor.alpha > 0f) 10.sp else 16.sp,
 			fontWeight = if (backgroundColor.alpha > 0f) FontWeight.W600 else FontWeight.W500,
 		)
 	) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -590,4 +590,9 @@
         <item quantity="one">%1$s album</item>
         <item quantity="other">%1$s albums</item>
     </plurals>
+    <string name="hdr10_plus">HDR10+</string>
+    <string name="dolby_vision_with_el">Dolby Vision with EL</string>
+    <string name="sdr">SDR</string>
+    <string name="hdr10">HDR10</string>
+    <string name="hlg">HLG</string>
 </resources>


### PR DESCRIPTION
**Changes**

- Added support for displaying multiple info row badges for media that has multiple Dynamic HDR or Dynamic HDR with SDR fallbacks. 
- Slightly reduced the InfoRowItem badge size to avoid cutting the last badges off when there are many.

**Issues**
#4978

**Notes**
- Requires changes from #5037