### PR TITLE
Add older FireTV 4K Device and fix the Issues with DOVIWithHDR10 Videos

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -100,6 +100,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var useExternalPlayer = booleanPreference("external_player", false)
 
 		/**
+		 * Allows the user to manually disable HDR10/HDR10+ Playback
+		 */
+		var disableHDR10 = booleanPreference("disable_hdr10", false)
+
+		/**
 		 * Change refresh rate to match media when device supports it
 		 */
 		var refreshRateSwitchingBehavior = enumPreference("refresh_rate_switching_behavior", RefreshRateSwitchingBehavior.DISABLED)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -106,6 +106,11 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.pref_external_player)
 				bind(userPreferences, UserPreferences.useExternalPlayer)
 			}
+
+			checkbox {
+				setTitle(R.string.preference_disable_hdr10_playback)
+				bind(userPreferences, UserPreferences.disableHDR10)
+			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
@@ -9,7 +9,7 @@ private val modelsWithDoViHdr10PlusBug = listOf(
 	"AFTKRT", // Amazon Fire TV 4K Max (2nd Gen)
 	"AFTKA", // Amazon Fire TV 4K Max (1st Gen)
 	"AFTKM", // Amazon Fire TV 4K (2nd Gen)
-	"AFTMM", // Amazon Fire TV 4K (1nd Gen)
+	"AFTMM", // Amazon Fire TV 4K (1st Gen)
 )
 
 object KnownDefects {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
@@ -9,6 +9,7 @@ private val modelsWithDoViHdr10PlusBug = listOf(
 	"AFTKRT", // Amazon Fire TV 4K Max (2nd Gen)
 	"AFTKA", // Amazon Fire TV 4K Max (1st Gen)
 	"AFTKM", // Amazon Fire TV 4K (2nd Gen)
+	"AFTMM", // Amazon Fire TV 4K (1nd Gen)
 )
 
 object KnownDefects {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -430,6 +430,7 @@ fun createDeviceProfile(
 		}
 
 		if (jellyfinTenEleven && KnownDefects.hevcDoviHdr10PlusBug) {
+			add("DOVIWithHDR10")
 			add("DOVIWithHDR10Plus")
 			add("DOVIWithELHDR10Plus")
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -66,6 +66,7 @@ fun createDeviceProfile(
 	assDirectPlay = false,
 	pgsDirectPlay = userPreferences[UserPreferences.pgsDirectPlay],
 	jellyfinTenEleven = serverVersion >= ServerVersion(10, 11, 0),
+	dolbyVisionHDR10Disabled = userPreferences[UserPreferences.disableHDR10]
 )
 
 fun createDeviceProfile(
@@ -76,6 +77,7 @@ fun createDeviceProfile(
 	assDirectPlay: Boolean,
 	pgsDirectPlay: Boolean,
 	jellyfinTenEleven: Boolean,
+	dolbyVisionHDR10Disabled: Boolean
 ) = buildDeviceProfile {
 	val allowedAudioCodecs = when {
 		downMixAudio -> downmixSupportedAudioCodecs
@@ -430,9 +432,16 @@ fun createDeviceProfile(
 		}
 
 		if (jellyfinTenEleven && KnownDefects.hevcDoviHdr10PlusBug) {
-			add("DOVIWithHDR10")
 			add("DOVIWithHDR10Plus")
 			add("DOVIWithELHDR10Plus")
+		}
+
+		if (jellyfinTenEleven && dolbyVisionHDR10Disabled) {
+			add("DOVIWithHDR10")
+			if (!KnownDefects.hevcDoviHdr10PlusBug) {
+				add("DOVIWithHDR10Plus")
+				add("DOVIWithELHDR10Plus")
+			}
 		}
 	}
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -590,4 +590,5 @@
     <string name="lbl_still_watching_very_long">8 Folgen oder 240 Minuten</string>
     <string name="still_watching_label">Bist du noch am schauen?</string>
     <string name="pref_subtitles_position">Versatz von unten</string>
+    <string name="preference_disable_hdr10_playback">DolbyVision HDR10/HDR10+ Playback deaktivieren</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -590,4 +590,5 @@
     <string name="speech_error_no_permission">No permission to use the microphone. Please enable it in system settings.</string>
     <string name="speech_error_unknown">An unexpected error occurred during speech recognition.</string>
     <string name="pref_subtitles_position">Offset from bottom</string>
+    <string name="preference_disable_hdr10_playback">Disable DolbyVision HDR10/HDR10+ Playback</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -550,6 +550,7 @@
     <string name="speech_error_unavailable">Speech recognition is unavailable on your device.</string>
     <string name="speech_error_unknown">An unexpected error occurred during speech recognition.</string>
     <string name="still_watching_label">Are you still watching?</string>
+    <string name="preference_disable_hdr10_playback">Disable DolbyVision HDR10/HDR10+ Playback</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
The previous fix did still not work for DOVIWithHDR10 Videos, also a older Device was mentioned here https://github.com/jellyfin/jellyfin-androidtv/issues/4892#issuecomment-3445945775