### PR TITLE
fix: audio track selection on subsequent video media items

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -72,7 +72,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     List<BaseItemDto> mItems;
     VideoManager mVideoManager;
     int mCurrentIndex;
-    int mLastIndex;
     protected long mCurrentPosition = 0;
     private PlaybackState mPlaybackState = PlaybackState.IDLE;
 
@@ -612,11 +611,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        if (mCurrentIndex != mLastIndex) {
-            clearPlaybackSessionOptions();
-            mCurrentOptions.setAudioStreamIndex(null);
-            mLastIndex = mCurrentIndex;
-        }
+        // clear options on start of every item
+        clearPlaybackSessionOptions();
 
         mStartPosition = position;
         mCurrentStreamInfo = response;
@@ -891,6 +887,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         wasSeeking = false;
         burningSubs = false;
         mCurrentStreamInfo = null;
+        mCurrentOptions.setAudioStreamIndex(null);
     }
 
     public void next() {


### PR DESCRIPTION
It seems that I introduced some audio track selection issues with [this](https://github.com/jellyfin/jellyfin-androidtv/pull/4713) change.

I wasn't aware that the `VideoQueueManager` state is not cleared when navigating back to the episode detail screen.

**Changes**
Reset `VideoOptions` in `PlaybackController` during start of a media item.

**Issues**
Didn't created one
