### PR TITLE
Fix speechRecognizer not using BCP47 tag for language extra

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/speech/speechRecognizer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/speech/speechRecognizer.kt
@@ -112,7 +112,7 @@ fun rememberSpeechRecognizer(
 	}
 
 	fun startListening() {
-		val language = context.locale.language
+		val language = context.locale.toLanguageTag()
 		Timber.i("Starting to listen for $language speech")
 
 		val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {


### PR DESCRIPTION
The extra requires a BCP47 language tag but we only supplied the ISO 639-1 language code which is not correct.

**Changes**
- Fix speechRecognizer not using BCP47 tag for language extra

**Issues**
Fixes #5070
