### PR TITLE
Remove display Dolby Vision checks

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -6,7 +6,6 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.util.Size
-import android.view.Display
 import androidx.core.content.ContextCompat
 import timber.log.Timber
 
@@ -15,13 +14,6 @@ class MediaCodecCapabilitiesTest(
 ) {
 	private val display by lazy { ContextCompat.getDisplayOrDefault(context) }
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
-
-	@Suppress("DEPRECATION")
-	private val supportedHdrTypes by lazy {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) display.mode.supportedHdrTypes.toList()
-		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) display.hdrCapabilities.supportedHdrTypes.toList()
-		else emptyList()
-	}
 
 	// Map common Dolby Vision Profiles to their corresponding CodecProfileLevel constant
 	private object DolbyVisionProfiles {
@@ -293,17 +285,5 @@ class MediaCodecCapabilitiesTest(
 		Timber.d("Computed max resolution for %s: %dx%d", mime, maxWidth, maxHeight)
 
 		return Size(maxWidth, maxHeight)
-	}
-
-	fun supportsDolbyVision(): Boolean {
-		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)
-	}
-
-	fun supportsHdr10(): Boolean {
-		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10)
-	}
-
-	fun supportsHdr10Plus(): Boolean {
-		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)
 	}
 }


### PR DESCRIPTION
Assumption: when the device has decoders available for dolby vision it should be able to output video, even if the display does not support dolby vision. Therefor, removing the display-checks from the device profile should avoid transcoding on devices that do support DV decoding without display support (e.g. nvidia shield connected to a non-dv tv).

**This is untested, hoping for community feedback before bringing this to a release**

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
