### PR TITLE
fix: clear only audio stream index on media item start

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -72,7 +72,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     List<BaseItemDto> mItems;
     VideoManager mVideoManager;
     int mCurrentIndex;
-    int mLastIndex;
     protected long mCurrentPosition = 0;
     private PlaybackState mPlaybackState = PlaybackState.IDLE;
 
@@ -612,11 +611,12 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        if (mCurrentIndex != mLastIndex) {
-            clearPlaybackSessionOptions();
-            mCurrentOptions.setAudioStreamIndex(null);
-            mLastIndex = mCurrentIndex;
-        }
+        // Clear last set audio stream index on start of every item.
+        // We cannot clear all options because baking in subs during transcoding
+        // will restart playback and this will end in an infinite loop.
+        // see@[PlaybackController.setSubtitleIndex]
+        // Not nice but will do it until the new playback rewrite is also available for video
+        mCurrentOptions.setAudioStreamIndex(null);
 
         mStartPosition = position;
         mCurrentStreamInfo = response;


### PR DESCRIPTION
Before clearPlaybackSessionOptions() was called which also cleared the subtitle index, but because baking in subs will restart the playback this lead to an infinite loop.

**Changes**
Use only a minimal amount of code changes inside the old playback code, because to many side effects.

**Issues**
