### PR TITLE
Avoid divide by zero in Seekbar

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
@@ -67,7 +67,7 @@ fun Seekbar(
 	enabled: Boolean = true,
 	colors: SeekbarColors = SeekbarDefaults.colors(),
 ) {
-	val durationMs = duration.inWholeMilliseconds.toFloat()
+	val durationMs = duration.inWholeMilliseconds.toFloat().coerceAtLeast(1f)
 	val progressPercentage = progress.inWholeMilliseconds.toFloat() / durationMs
 	val bufferPercentage = buffer.inWholeMilliseconds.toFloat() / durationMs
 	val seekForwardPercentage = seekForwardAmount.inWholeMilliseconds.toFloat() / durationMs


### PR DESCRIPTION
When the seekbar is not fully initialized yet (e.g. audio is still loading) the duration can be 0. If we then try to calculate the progress/buffer/seek percentages we're dividing by zero, which in Kotlin causes NaN. This can then later cause an exception when trying to seek.

**Changes**

Make sure the duration is always at least 1ms so calculations work correctly.

**Issues**

Fixes #5101