### PR TITLE
Infer subtitle format from media stream path for external players

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -119,12 +119,16 @@ class ExternalPlayerActivity : FragmentActivity() {
 			?.sortedWith(compareBy<MediaStream> { it.isDefault }.thenBy { it.index })
 			.orEmpty()
 
-		val subtitleUrls = externalSubtitles.map {
+		val subtitleUrls = externalSubtitles.map { mediaStream ->
+			// We cannot use the DeliveryUrl as that is only populated when using the playback info API, which we skip as we'll always direct
+			// play when using external players. We need to infer the subtitle format based on its path (similar to how the server
+			// calculates it)
+			val format = mediaStream.path?.substringAfterLast('.', missingDelimiterValue = mediaStream.codec.orEmpty()) ?: "srt"
 			api.subtitleApi.getSubtitleUrl(
 				routeItemId = item.id,
 				routeMediaSourceId = mediaSource.id.toString(),
-				routeIndex = it.index,
-				routeFormat = it.codec.orEmpty(),
+				routeIndex = mediaStream.index,
+				routeFormat = format,
 			)
 		}.toTypedArray()
 		val subtitleNames = externalSubtitles.map { it.displayTitle ?: it.title.orEmpty() }.toTypedArray()


### PR DESCRIPTION
The server **requires** the format to be set in the URL (although it does contain code to handle it missing...) but the only place it exposes this is when it sets the `deliveryUrl` field on the media stream. This only happens when posting a device profile to the playback info endpoint though.
However, we avoid doing any API calls for external playback right now so this the only way to work around the external subtitle format requirement is to infer it from the path. This is also how the server determines the format (although with some additional handling for unsupported formats and PGS).

This will do for now, until fixed server-side.

**Changes**
- Infer subtitle format from media stream path for external players
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**

Fixes #5095
