### PR TITLE
Add preference to force DoVi Profile 7 Direct Play

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -119,6 +119,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var ac3Enabled = booleanPreference("pref_bitstream_ac3", true)
 
+		/**
+		 * Enable Dolby Vision Profile 7 Direct Play
+		 */
+		var dolbyVisionELDirectPlay = booleanPreference("pref_dolby_vision_profile_7_direct", false)
+
 		/* Live TV */
 		/**
 		 * Use direct play

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -185,6 +185,17 @@ fun SettingsPlaybackAdvancedScreen() {
 			)
 		}
 
+		item {
+			var dolbyVisionELDirectPlay by rememberPreference(userPreferences, UserPreferences.dolbyVisionELDirectPlay)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.lbl_force_dovi_profile_7)) },
+				captionContent = { Text(stringResource(R.string.desc_force_dovi_profile_7)) },
+				trailingContent = { Checkbox(checked = dolbyVisionELDirectPlay) },
+				onClick = { dolbyVisionELDirectPlay = !dolbyVisionELDirectPlay }
+			)
+		}
+
 		item { ListSection(headingContent = { Text(stringResource(R.string.pref_live_tv_cat)) }) }
 
 		item {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -85,6 +85,7 @@ fun createDeviceProfile(
 	downMixAudio = userPreferences[UserPreferences.audioBehaviour] == AudioBehavior.DOWNMIX_TO_STEREO,
 	assDirectPlay = false,
 	pgsDirectPlay = userPreferences[UserPreferences.pgsDirectPlay],
+	dolbyVisionELDirectPlay = userPreferences[UserPreferences.dolbyVisionELDirectPlay],
 )
 
 fun createDeviceProfile(
@@ -94,6 +95,7 @@ fun createDeviceProfile(
 	downMixAudio: Boolean,
 	assDirectPlay: Boolean,
 	pgsDirectPlay: Boolean,
+	dolbyVisionELDirectPlay: Boolean,
 ) = buildDeviceProfile {
 	val allowedAudioCodecs = when {
 		downMixAudio -> downmixSupportedAudioCodecs
@@ -444,8 +446,10 @@ fun createDeviceProfile(
 		add(VideoRangeType.DOVI_INVALID)
 
 		if (!supportsHevcDolbyVisionEL) {
-			add(VideoRangeType.DOVI_WITH_EL)
-			if (!supportsHevcHDR10Plus && !KnownDefects.hevcDoviHdr10PlusBug) add(VideoRangeType.DOVI_WITH_ELHDR10_PLUS)
+			if (!dolbyVisionELDirectPlay) {
+				add(VideoRangeType.DOVI_WITH_EL)
+				if (!supportsHevcHDR10Plus && !KnownDefects.hevcDoviHdr10PlusBug) add(VideoRangeType.DOVI_WITH_ELHDR10_PLUS)
+			}
 
 			if (!supportsHevcDolbyVision) {
 				add(VideoRangeType.DOVI)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="lbl_new_premieres">New premieres</string>
     <string name="lbl_bitstream_ac3">Bitstream Dolby Digital audio</string>
     <string name="desc_bitstream_ac3">Requires capable hardware</string>
+    <string name="lbl_force_dovi_profile_7">Direct play Dolby Vision Profile 7</string>
+    <string name="desc_force_dovi_profile_7">Ignores device compatibility checks</string>
     <string name="desc_audio_night_mode">Levels out audio volume automatically</string>
     <string name="lbl_zoom">Zoom</string>
     <string name="lbl_auto_crop">Auto crop</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Add user preference to override Dolby Vision Profile 7 device compatibility checks and force Direct Play.

Some devices can play Dolby Vision Profile 7 content with partial support (e.g., base layer or base layer + metadata), but our current detection only identifies full or no support. This can result in unnecessary remuxing/transcodes and poor playback on certain devices (e.g., Nvidia Shield 2019).

**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/5073 (workaround)
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/5091

**Notes**
- This setting would also bring us more in line with other Android TV media server clients (e.g., Plex).
