### PR TITLE
Add "Recently Released" and Combined Section Options to Home Screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/HomeSectionType.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/HomeSectionType.kt
@@ -21,5 +21,8 @@ enum class HomeSectionType(
 	ACTIVE_RECORDINGS("activerecordings", R.string.home_section_active_recordings),
 	NEXT_UP("nextup", R.string.home_section_next_up),
 	LIVE_TV("livetv", R.string.home_section_livetv),
+	RECENTLY_RELEASED("recentlyreleased", R.string.home_section_recently_released),
+	RECENTLY_RELEASED_ADDED("recentlyreleasedadded", R.string.home_section_recently_released_added),
+	RECENTLY_ADDED_RELEASED("recentlyaddedreleased", R.string.home_section_recently_added_released),
 	NONE("none", R.string.home_section_none),
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentDoubledRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentDoubledRow.kt
@@ -1,0 +1,98 @@
+package org.jellyfin.androidtv.ui.home
+
+import android.content.Context
+import androidx.leanback.widget.Row
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.repository.UserRepository
+import org.jellyfin.androidtv.constant.ChangeTriggerType
+import org.jellyfin.androidtv.data.repository.ItemRepository
+import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
+import org.jellyfin.androidtv.ui.presentation.CardPresenter
+import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.CollectionType
+import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.SortOrder
+import org.jellyfin.sdk.model.api.request.GetItemsRequest
+import org.jellyfin.sdk.model.api.request.GetLatestMediaRequest
+
+class HomeFragmentDoubledRow(
+	private val userRepository: UserRepository,
+	private val userViews: Collection<BaseItemDto>,
+	private val releasedFirst: Boolean,
+) : HomeFragmentRow {
+	override fun addToRowsAdapter(context: Context, cardPresenter: CardPresenter, rowsAdapter: MutableObjectAdapter<Row>) {
+		// Get configuration (to find excluded items)
+		val configuration = userRepository.currentUser.value?.configuration
+
+		// Create a list of views to include
+		val latestItemsExcludes = configuration?.latestItemsExcludes.orEmpty()
+		userViews
+			.filterNot { item -> item.collectionType in EXCLUDED_COLLECTION_TYPES || item.id in latestItemsExcludes }
+			.forEach { item ->
+				// Create rows based on the order specified
+				if (releasedFirst) {
+					// Recently Released first, then Recently Added
+					addRecentlyReleasedRow(context, cardPresenter, rowsAdapter, item)
+					addRecentlyAddedRow(context, cardPresenter, rowsAdapter, item)
+				} else {
+					// Recently Added first, then Recently Released
+					addRecentlyAddedRow(context, cardPresenter, rowsAdapter, item)
+					addRecentlyReleasedRow(context, cardPresenter, rowsAdapter, item)
+				}
+			}
+	}
+
+	private fun addRecentlyReleasedRow(
+		context: Context,
+		cardPresenter: CardPresenter,
+		rowsAdapter: MutableObjectAdapter<Row>,
+		item: BaseItemDto
+	) {
+		val request = GetItemsRequest(
+			fields = ItemRepository.itemFields,
+			imageTypeLimit = 1,
+			parentId = item.id,
+			recursive = true,
+			limit = ITEM_LIMIT,
+			sortBy = setOf(ItemSortBy.PREMIERE_DATE),
+			sortOrder = setOf(SortOrder.DESCENDING),
+		)
+
+		val title = context.getString(R.string.lbl_recently_released_in, item.name)
+		val row = HomeFragmentBrowseRowDefRow(BrowseRowDef(title, request, 0, false, true, arrayOf(ChangeTriggerType.LibraryUpdated)))
+		row.addToRowsAdapter(context, cardPresenter, rowsAdapter)
+	}
+
+	private fun addRecentlyAddedRow(
+		context: Context,
+		cardPresenter: CardPresenter,
+		rowsAdapter: MutableObjectAdapter<Row>,
+		item: BaseItemDto
+	) {
+		val request = GetLatestMediaRequest(
+			fields = ItemRepository.itemFields,
+			imageTypeLimit = 1,
+			parentId = item.id,
+			groupItems = true,
+			limit = ITEM_LIMIT,
+		)
+
+		val title = context.getString(R.string.lbl_latest_in, item.name)
+		val row = HomeFragmentBrowseRowDefRow(BrowseRowDef(title, request, arrayOf(ChangeTriggerType.LibraryUpdated)))
+		row.addToRowsAdapter(context, cardPresenter, rowsAdapter)
+	}
+
+	companion object {
+		// Collections excluded from doubled rows
+		private val EXCLUDED_COLLECTION_TYPES = arrayOf(
+			CollectionType.PLAYLISTS,
+			CollectionType.LIVETV,
+			CollectionType.BOXSETS,
+			CollectionType.BOOKS,
+		)
+
+		// Maximum amount of items loaded for a row
+		private const val ITEM_LIMIT = 50
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -22,6 +22,18 @@ class HomeFragmentHelper(
 		return HomeFragmentLatestRow(userRepository, userViews)
 	}
 
+	fun loadRecentlyReleased(userViews: Collection<BaseItemDto>): HomeFragmentRow {
+		return HomeFragmentRecentlyReleasedRow(userRepository, userViews)
+	}
+
+	fun loadRecentlyReleasedAdded(userViews: Collection<BaseItemDto>): HomeFragmentRow {
+		return HomeFragmentDoubledRow(userRepository, userViews, releasedFirst = true)
+	}
+
+	fun loadRecentlyAddedReleased(userViews: Collection<BaseItemDto>): HomeFragmentRow {
+		return HomeFragmentDoubledRow(userRepository, userViews, releasedFirst = false)
+	}
+
 	fun loadResume(title: String, includeMediaTypes: Collection<MediaType>): HomeFragmentRow {
 		val query = GetResumeItemsRequest(
 			limit = ITEM_LIMIT_RESUME,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentRecentlyReleasedRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentRecentlyReleasedRow.kt
@@ -1,0 +1,62 @@
+package org.jellyfin.androidtv.ui.home
+
+import android.content.Context
+import androidx.leanback.widget.Row
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.repository.UserRepository
+import org.jellyfin.androidtv.constant.ChangeTriggerType
+import org.jellyfin.androidtv.data.repository.ItemRepository
+import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
+import org.jellyfin.androidtv.ui.presentation.CardPresenter
+import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.CollectionType
+import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.SortOrder
+import org.jellyfin.sdk.model.api.request.GetItemsRequest
+
+class HomeFragmentRecentlyReleasedRow(
+	private val userRepository: UserRepository,
+	private val userViews: Collection<BaseItemDto>,
+) : HomeFragmentRow {
+	override fun addToRowsAdapter(context: Context, cardPresenter: CardPresenter, rowsAdapter: MutableObjectAdapter<Row>) {
+		// Get configuration (to find excluded items)
+		val configuration = userRepository.currentUser.value?.configuration
+
+		// Create a list of views to include
+		val latestItemsExcludes = configuration?.latestItemsExcludes.orEmpty()
+		userViews
+			.filterNot { item -> item.collectionType in EXCLUDED_COLLECTION_TYPES || item.id in latestItemsExcludes }
+			.map { item ->
+				// Create query to get items sorted by premiere date
+				val request = GetItemsRequest(
+					fields = ItemRepository.itemFields,
+					imageTypeLimit = 1,
+					parentId = item.id,
+					recursive = true,
+					limit = ITEM_LIMIT,
+					sortBy = setOf(ItemSortBy.PREMIERE_DATE),
+					sortOrder = setOf(SortOrder.DESCENDING),
+				)
+
+				val title = context.getString(R.string.lbl_recently_released_in, item.name)
+				HomeFragmentBrowseRowDefRow(BrowseRowDef(title, request, 0, false, true, arrayOf(ChangeTriggerType.LibraryUpdated)))
+			}.forEach { row ->
+				// Add row to adapter
+				row.addToRowsAdapter(context, cardPresenter, rowsAdapter)
+			}
+	}
+
+	companion object {
+		// Collections excluded from recently released row (same as latest media)
+		private val EXCLUDED_COLLECTION_TYPES = arrayOf(
+			CollectionType.PLAYLISTS,
+			CollectionType.LIVETV,
+			CollectionType.BOXSETS,
+			CollectionType.BOOKS,
+		)
+
+		// Maximum amount of items loaded for a row
+		private const val ITEM_LIMIT = 50
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -119,6 +119,9 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 			// Actually add the sections
 			for (section in homesections) when (section) {
 				HomeSectionType.LATEST_MEDIA -> rows.add(helper.loadRecentlyAdded(userViewsRepository.views.first()))
+				HomeSectionType.RECENTLY_RELEASED -> rows.add(helper.loadRecentlyReleased(userViewsRepository.views.first()))
+				HomeSectionType.RECENTLY_RELEASED_ADDED -> rows.add(helper.loadRecentlyReleasedAdded(userViewsRepository.views.first()))
+				HomeSectionType.RECENTLY_ADDED_RELEASED -> rows.add(helper.loadRecentlyAddedReleased(userViewsRepository.views.first()))
 				HomeSectionType.LIBRARY_TILES_SMALL -> rows.add(HomeFragmentViewsRow(small = false))
 				HomeSectionType.LIBRARY_BUTTONS -> rows.add(HomeFragmentViewsRow(small = true))
 				HomeSectionType.RESUME -> rows.add(helper.loadResumeVideo())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="msg_not_implemented">" not implemented"</string>
     <string name="lbl_latest">Recently added</string>
     <string name="lbl_latest_in">Recently added in %1$s</string>
+    <string name="lbl_recently_released_in">Recently released in %1$s</string>
     <string name="lbl_by_name">By name</string>
     <string name="lbl_favorites">Favorites</string>
     <string name="lbl_coming_up">Coming up</string>
@@ -403,6 +404,9 @@
     <string name="home_section_next_up">Next up</string>
     <string name="home_section_livetv">Live TV</string>
     <string name="home_section_none">None</string>
+    <string name="home_section_recently_released">Recently released media</string>
+    <string name="home_section_recently_released_added">Recently Released / Added</string>
+    <string name="home_section_recently_added_released">Recently Added / Released</string>
     <string name="home_section_i">Home section %1$d</string>
     <string name="searchable_hint">Search Jellyfin</string>
     <string name="searchable_settings_description">Media</string>


### PR DESCRIPTION
Changes
This PR introduces new home screen section options that organize media by release date instead of added date, providing users with more control over how recent content is displayed.

The new options include:

•Recently Released – Shows media sorted by release date using metadata.
•Recently Released then Recently Added – Displays all libraries in two ordered sections:

Library 1 Recently Released
Library 1 Recently Added
Library 2 Recently Released
Library 2 Recently Added
Library 3 Recently Released
Library 3 Recently Added
•Recently Added then Recently Released – Same as above, but with "Added" sections shown before "Released".

These options were initially generated using GitHub Copilot and subsequently refined and tested locally. Verified functionality includes proper sorting by metadata release date and correct rendering of both standalone and combined sections.

