### PR TITLE
Fix crash in FullDetailsFragmentHelper.resumePlayback

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -270,12 +270,10 @@ fun FullDetailsFragment.resumePlayback(v: View) {
 				getString(R.string.msg_video_playback_error),
 				Toast.LENGTH_LONG
 			).show()
-		}
-
-		if (nextUpEpisode?.userData?.playbackPositionTicks == 0L) {
+		} else if (nextUpEpisode.userData?.playbackPositionTicks == 0L) {
 			play(nextUpEpisode, 0, false)
 		} else {
-			showResumeMenu(v, nextUpEpisode!!)
+			showResumeMenu(v, nextUpEpisode)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
- Fix crash in FullDetailsFragmentHelper.resumePlayback when the server returns no next up entry

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5114