### PR TITLE
Fix music playback sort order to match web client

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -152,7 +152,9 @@ class SdkPlaybackHelper(
 					isMissing = false,
 					mediaTypes = listOf(MediaType.AUDIO),
 					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(
-						ItemSortBy.ALBUM_ARTIST,
+						ItemSortBy.ALBUM,
+						ItemSortBy.PARENT_INDEX_NUMBER,
+						ItemSortBy.INDEX_NUMBER,
 						ItemSortBy.SORT_NAME
 					),
 					recursive = true,
@@ -168,7 +170,12 @@ class SdkPlaybackHelper(
 				val response by api.itemsApi.getItems(
 					isMissing = false,
 					mediaTypes = listOf(MediaType.AUDIO),
-					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(ItemSortBy.SORT_NAME),
+					sortBy = if (shuffle) listOf(ItemSortBy.RANDOM) else listOf(
+						ItemSortBy.ALBUM,
+						ItemSortBy.PARENT_INDEX_NUMBER,
+						ItemSortBy.INDEX_NUMBER,
+						ItemSortBy.SORT_NAME
+					),
 					recursive = true,
 					limit = ITEM_QUERY_LIMIT,
 					fields = ItemRepository.itemFields,


### PR DESCRIPTION
Tracks were sorted only by SortName, causing incorrect playback order across albums.
Now uses: Album, ParentIndexNumber, IndexNumber, SortName to ensure tracks play
in correct album and track sequence.

**Changes**
- Update MUSIC_ARTIST and MUSIC_ALBUM sort order
- Album → disc number → track number → name
- Aligns with jellyfin-web implementation

**Code assistance**
None

**Issues**
