### PR TITLE
Add badge composable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Badge.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Badge.kt
@@ -1,0 +1,37 @@
+package org.jellyfin.androidtv.ui.base
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Badge(
+	modifier: Modifier = Modifier,
+	shape: Shape = CircleShape,
+	containerColor: Color = JellyfinTheme.colorScheme.badge,
+	contentColor: Color = JellyfinTheme.colorScheme.onBadge,
+	content: @Composable BoxScope.() -> Unit,
+) {
+	ProvideTextStyle(JellyfinTheme.typography.badge.copy(color = contentColor)) {
+		Box(
+			modifier = modifier
+				.defaultMinSize(minWidth = 24.dp, minHeight = 24.dp)
+				.wrapContentSize()
+				.background(containerColor, shape)
+				.padding(horizontal = 6.dp, vertical = 3.dp),
+			contentAlignment = Alignment.Center,
+		) {
+			content()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
@@ -22,6 +22,8 @@ fun colorScheme(): ColorScheme = ColorScheme(
 	recording = Color(0xB3FF7474),
 	onRecording = Color(0xFFDDDDDD),
 	popover = Color(0xFF212225),
+	badge = Color(0xFF62676F),
+	onBadge = Color(0xFFE8EAED),
 )
 
 @Immutable
@@ -47,6 +49,9 @@ data class ColorScheme(
 	val onRecording: Color,
 
 	val popover: Color,
+
+	val badge: Color,
+	val onBadge: Color,
 )
 
 val LocalColorScheme = staticCompositionLocalOf { colorScheme() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/typography.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/typography.kt
@@ -3,14 +3,23 @@ package org.jellyfin.androidtv.ui.base
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
 
 object TypographyDefaults {
 	val Default: TextStyle = TextStyle.Default
+	val Badge: TextStyle = Default.copy(
+		fontSize = 11.sp,
+		fontWeight = FontWeight.W700,
+		textAlign = TextAlign.Center,
+	)
 }
 
 @Immutable
 data class Typography(
 	val default: TextStyle = TypographyDefaults.Default,
+	val badge: TextStyle = TypographyDefaults.Badge,
 )
 
 val LocalTypography = staticCompositionLocalOf { Typography() }


### PR DESCRIPTION
The badge composable is a simple badge that can be used to show numbers in a list item or on top of an item card. It's been ready for a while now and I'm using it in multiple WIP branches so it makes sense to merge it early.

**Changes**
- Add badge composable

**Screenshots**

<img src="https://github.com/user-attachments/assets/a04f889f-be73-42d4-92fc-08a3edbac248" />

On top of an item card

<img src="https://github.com/user-attachments/assets/5947b9ce-62fe-4e86-be5f-a0c8dff61f8f" />

In a list item

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
