### PR TITLE
Use MediaSource runtime when available

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/VideoPlayerAdapter.java
@@ -65,8 +65,11 @@ public class VideoPlayerAdapter extends PlayerAdapter {
 
     @Override
     public long getDuration() {
-        return getCurrentlyPlayingItem() != null && getCurrentlyPlayingItem().getRunTimeTicks() != null ?
-                getCurrentlyPlayingItem().getRunTimeTicks() / 10000 : -1;
+        Long runTimeTicks = null;
+        if (getCurrentMediaSource() != null) runTimeTicks = getCurrentMediaSource().getRunTimeTicks();
+        if (runTimeTicks == null && getCurrentlyPlayingItem() != null) runTimeTicks = getCurrentlyPlayingItem().getRunTimeTicks();
+        if (runTimeTicks != null) return runTimeTicks / 10000;
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
For items with multiple versions (movies) or files that lazily probe the media info (like strm files) the runtime on an item may not be set or correct. This PR changes our (old) player to prefer the media source for getting the runtime instead.

**Changes**
- Use MediaSource runtime when available

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Partially fixes #5145
