### PR TITLE
Use media source instead of item in switchAudioStream

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -759,15 +759,15 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (!(isPlaying() || isPaused()) || index < 0)
             return;
 
-        BaseItemDto currentItem = getCurrentlyPlayingItem();
-        if (currentItem == null
-                || currentItem.getMediaStreams() == null
-                || index >= currentItem.getMediaStreams().size()) {
+        MediaSourceInfo currentMediaSource = getCurrentMediaSource();
+        if (currentMediaSource == null
+                || currentMediaSource.getMediaStreams() == null
+                || index >= currentMediaSource.getMediaStreams().size()) {
             return;
         }
 
         String lastAudioIsoCode = videoQueueManager.getValue().getLastPlayedAudioLanguageIsoCode();
-        String currentAudioIsoCode = currentItem.getMediaStreams().get(index).getLanguage();
+        String currentAudioIsoCode = currentMediaSource.getMediaStreams().get(index).getLanguage();
 
         if (currentAudioIsoCode != null
                 && (lastAudioIsoCode == null || !lastAudioIsoCode.equals(currentAudioIsoCode))) {
@@ -790,12 +790,12 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         // get current timestamp first
         refreshCurrentPosition();
 
-        if (!isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.AUDIO, getCurrentlyPlayingItem().getMediaStreams())) {
-            mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
+        if (!isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.AUDIO, currentMediaSource.getMediaStreams())) {
+            mCurrentOptions.setMediaSourceId(currentMediaSource.getId());
             mCurrentOptions.setAudioStreamIndex(index);
         } else {
             startSpinner();
-            mCurrentOptions.setMediaSourceId(getCurrentMediaSource().getId());
+            mCurrentOptions.setMediaSourceId(currentMediaSource.getId());
             mCurrentOptions.setAudioStreamIndex(index);
             stop();
             playInternal(getCurrentlyPlayingItem(), mCurrentPosition, mCurrentOptions);
@@ -1273,6 +1273,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         if (hasInitializedVideoManager()) {
             duration = mVideoManager.getDuration();
+        } else if (getCurrentMediaSource() != null && getCurrentMediaSource().getRunTimeTicks() != null) {
+            duration = getCurrentMediaSource().getRunTimeTicks() / 10000;
         } else if (getCurrentlyPlayingItem() != null && getCurrentlyPlayingItem().getRunTimeTicks() != null) {
             duration = getCurrentlyPlayingItem().getRunTimeTicks() / 10000;
         }


### PR DESCRIPTION
Similar to #5153 but for audio source switching.

For items with multiple versions (movies) or files that lazily probe the media info (like strm files) the source metadata on an item may not be set or incorrect. This PR changes our (old) player to prefer the media source in the switchAudioStream and getDuration methods in the playback controller.

**Changes**

- Use media source instead of item in switchAudioStream
- Use media source instead of item in getDuration

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5145
