### PR TITLE
Do not clear audio stream index when starting item

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -607,13 +607,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        // Clear last set audio stream index on start of every item.
-        // We cannot clear all options because baking in subs during transcoding
-        // will restart playback and this will end in an infinite loop.
-        // see@[PlaybackController.setSubtitleIndex]
-        // Not nice but will do it until the new playback rewrite is also available for video
-        mCurrentOptions.setAudioStreamIndex(null);
-
         mStartPosition = position;
         mCurrentStreamInfo = response;
         mCurrentOptions.setMediaSourceId(response.getMediaSource().getId());


### PR DESCRIPTION
Once again partially reverts #5071/#5086. We have an issue in the `VideoManager.getExoPlayerTrack()` method that returns wrong indexes for some specific media. I've spend over two hours trying to figure it out but unfortunately everything I do breaks other stuff again 🫠.

So doing the band-aid approach and remove the one line that causes the looping. Now it "just" restarts the stream a single time. Which is still awful but at least without looping....

**Changes**
- Do not clear audio stream index when starting item

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5129
