### PR TITLE
Fix Vimu Player Integration

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
@@ -63,7 +64,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 		private const val API_VIMU_SEEK_POSITION = "startfrom"
 		private const val API_VIMU_RESUME = "forceresume"
 		private const val API_VIMU_RESULT_ID = "net.gtvbox.videoplayer.result"
-		private const val API_VIMU_RESULT_ERROR = 4;
+		private const val API_VIMU_RESULT_ERROR = 4
 
 		// The extra keys used by various video players to read the end position
 		private val resultPositionExtras = arrayOf(API_MX_RESULT_POSITION, API_VLC_RESULT_POSITION)
@@ -77,7 +78,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 		Timber.i("Playback finished with result code ${result.resultCode}")
 		videoQueueManager.setCurrentMediaPosition(videoQueueManager.getCurrentMediaPosition() + 1)
 
-		if (!activityResultOk(result.data, result.resultCode)) {
+		if (result.isError) {
 			Toast.makeText(this, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()
 			finish()
 		} else {
@@ -85,12 +86,9 @@ class ExternalPlayerActivity : FragmentActivity() {
 		}
 	}
 
-	private fun activityResultOk(result: Intent?, resultCode: Int): Boolean {
-		val action = result?.action ?: "";
-		return when (action) {
-			API_VIMU_RESULT_ID -> resultCode != API_VIMU_RESULT_ERROR
-			else -> resultCode == RESULT_OK
-		}
+	private val ActivityResult.isError get() = when (data?.action) {
+		API_VIMU_RESULT_ID -> resultCode == API_VIMU_RESULT_ERROR
+		else -> resultCode != RESULT_OK
 	}
 
 	private var currentItem: Pair<BaseItemDto, MediaSourceInfo>? = null


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Since decoupling external player support (https://github.com/jellyfin/jellyfin-androidtv/commit/9fc1efb35df14c29e0a873f7fa9aadef0ff5e1ff), the app has been mishandling the activity `resultCode` from Vimu.

Currently, the app compares `resultCode` against `RESULT_OK` (-1). However, the [Vimu API documentation](https://www.vimu.tv/player-api) specifies the following result codes on player close:

> *  1 - playback completed (to the end)
> * 0 - playback was interrupted. In that case interrupt "position" integer and total "duration" integer will be returned in the intent data.
> * _**4 - playback failed with a error**_

(emphasis mine)

This change refactors the result code check to see if the activity result is from Vimu (`result.data.action == "net.gtvbox.videoplayer.result"`) and, if so, treat the result as an error if the code is 4. Otherwise, fallback to the existing `RESULT_OK` check.

**Code assistance**
NA

**Issues**
Fixes #5092 

**Notes**
I tested this change on my own Android TV device which has Vimu. Testing steps are as follows:
1. Open a video item in Vimu
2. Skip a few minutes in
3. Exit the player; the "Failed to load video" toast should not pop up, and you should be able to resume the video from the point in time where it was stopped