### PR TITLE
Fix tinting in account switcher button fallback icon

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -109,14 +108,21 @@ private fun MainToolbar(
 					colors = if (activeButton == MainToolbarActiveButton.User) activeButtonColors else ButtonDefaults.colors(),
 					contentPadding = if (userImageVisible) PaddingValues(3.dp) else IconButtonDefaults.ContentPadding,
 				) {
-					Image(
-						painter = if (userImageVisible) userImagePainter else rememberVectorPainter(ImageVector.vectorResource(R.drawable.ic_user)),
-						contentDescription = stringResource(R.string.lbl_switch_user),
-						contentScale = ContentScale.Crop,
-						modifier = Modifier
-							.aspectRatio(1f)
-							.clip(IconButtonDefaults.Shape)
-					)
+					if (!userImageVisible) {
+						Icon(
+							imageVector = ImageVector.vectorResource(R.drawable.ic_user),
+							contentDescription = stringResource(R.string.lbl_switch_user),
+						)
+					} else {
+						Image(
+							painter = userImagePainter,
+							contentDescription = stringResource(R.string.lbl_switch_user),
+							contentScale = ContentScale.Crop,
+							modifier = Modifier
+								.aspectRatio(1f)
+								.clip(IconButtonDefaults.Shape)
+						)
+					}
 				}
 
 				NowPlayingComposable(


### PR DESCRIPTION
When we don't have an image the button should behave the same as other icon buttons, which requires the icon composable to set the tinting.

**Changes**
- Fix tinting in account switcher button fallback icon

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5193
