### PR TITLE
Add new settings UI

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -43,6 +43,7 @@ import org.jellyfin.androidtv.ui.search.SearchFragmentDelegate
 import org.jellyfin.androidtv.ui.search.SearchRepository
 import org.jellyfin.androidtv.ui.search.SearchRepositoryImpl
 import org.jellyfin.androidtv.ui.search.SearchViewModel
+import org.jellyfin.androidtv.ui.settings.compat.SettingsViewModel
 import org.jellyfin.androidtv.ui.startup.ServerAddViewModel
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
@@ -148,6 +149,7 @@ val appModule = module {
 	viewModel { PhotoPlayerViewModel(get()) }
 	viewModel { SearchViewModel(get()) }
 	viewModel { DreamViewModel(get(), get(), get(), get(), get()) }
+	viewModel { SettingsViewModel() }
 
 	single { BackgroundService(get(), get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
@@ -21,9 +21,22 @@ fun colorScheme(): ColorScheme = ColorScheme(
 	onInputFocused = Color(0xFFDDDDDD),
 	recording = Color(0xB3FF7474),
 	onRecording = Color(0xFFDDDDDD),
-	popover = Color(0xFF212225),
 	badge = Color(0xFF62676F),
 	onBadge = Color(0xFFE8EAED),
+	listHeader = Color(0xFFE0E0E0),
+	listOverline = Color(0x66FFFFFF),
+	listHeadline = Color(0xFFFFFFFF),
+	listCaption = Color(0x99FFFFFF),
+	listButton = Color(0x00000000),
+	onListButton = Color(0xFFDDDDDD),
+	listButtonFocused = Color(0xFF36363B),
+	onListButtonFocused = Color(0xFF444444),
+	listButtonDisabled = Color(0x33747474),
+	onListButtonDisabled = Color(0xFF686868),
+	listButtonActive = Color(0xFF36363B),
+	onListButtonActive = Color(0xFFDDDDDD),
+	surface = Color(0xFF212225),
+	scrim = Color(0xAB000000),
 )
 
 @Immutable
@@ -48,10 +61,24 @@ data class ColorScheme(
 	val recording: Color,
 	val onRecording: Color,
 
-	val popover: Color,
-
 	val badge: Color,
 	val onBadge: Color,
+
+	val listHeader: Color,
+	val listOverline: Color,
+	val listHeadline: Color,
+	val listCaption: Color,
+	val listButton: Color,
+	val onListButton: Color,
+	val listButtonFocused: Color,
+	val onListButtonFocused: Color,
+	val listButtonDisabled: Color,
+	val onListButtonDisabled: Color,
+	val listButtonActive: Color,
+	val onListButtonActive: Color,
+
+	val surface: Color,
+	val scrim: Color,
 )
 
 val LocalColorScheme = staticCompositionLocalOf { colorScheme() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/dialog/DialogBase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/dialog/DialogBase.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.ui.base.dialog
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+
+@Composable
+fun DialogBase(
+	visible: Boolean,
+	onDismissRequest: () -> Unit,
+	modifier: Modifier = Modifier,
+	content: @Composable BoxScope.() -> Unit,
+) {
+	val popupPositionProvider = remember { DialogPositionProvider() }
+
+	val transition = updateTransition(visible)
+	val alpha by transition.animateFloat(
+		targetValueByState = { visible -> if (visible) 1f else 0f }
+	)
+
+	if (alpha != 0f) {
+		val focusRequester = remember { FocusRequester() }
+
+		Popup(
+			onDismissRequest = onDismissRequest,
+			properties = PopupProperties(
+				focusable = true,
+				dismissOnBackPress = true,
+				dismissOnClickOutside = true,
+			),
+			popupPositionProvider = popupPositionProvider,
+		) {
+			val scrimColor = JellyfinTheme.colorScheme.scrim
+			Box(
+				modifier = modifier
+					.fillMaxSize()
+					.background(scrimColor.copy(alpha = scrimColor.alpha * alpha))
+					.focusRequester(focusRequester)
+					.focusGroup(),
+				contentAlignment = Alignment.Center,
+			) {
+				content()
+			}
+		}
+
+		LaunchedEffect(focusRequester) {
+			focusRequester.requestFocus()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/dialog/DialogPositionProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/dialog/DialogPositionProvider.kt
@@ -1,0 +1,16 @@
+package org.jellyfin.androidtv.ui.base.dialog
+
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.PopupPositionProvider
+
+class DialogPositionProvider : PopupPositionProvider {
+	override fun calculatePosition(
+		anchorBounds: IntRect,
+		windowSize: IntSize,
+		layoutDirection: LayoutDirection,
+		popupContentSize: IntSize
+	): IntOffset = IntOffset.Zero
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/form/RadioButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/form/RadioButton.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.androidtv.ui.base.form
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+
+@Composable
+fun RadioButton(
+	checked: Boolean,
+	modifier: Modifier = Modifier,
+	shape: Shape = CircleShape,
+	containerColor: Color = JellyfinTheme.colorScheme.button,
+	contentColor: Color = JellyfinTheme.colorScheme.onButton
+) {
+	Box(
+		modifier = modifier
+			.defaultMinSize(minWidth = 18.dp, minHeight = 18.dp)
+			.background(if (checked) containerColor else Color.Unspecified, shape)
+			.border(if (checked) 0.dp else 2.dp, containerColor, shape),
+		contentAlignment = Alignment.Center,
+	) {
+		AnimatedVisibility(
+			visible = checked,
+			modifier = Modifier
+				.matchParentSize()
+		) {
+			Icon(
+				painterResource(R.drawable.ic_check),
+				tint = contentColor,
+				contentDescription = null,
+				modifier = Modifier
+					.padding(3.dp)
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListButton.kt
@@ -1,0 +1,63 @@
+package org.jellyfin.androidtv.ui.base.list
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.LocalShapes
+import org.jellyfin.androidtv.ui.base.button.ButtonBase
+import org.jellyfin.androidtv.ui.base.button.ButtonColors
+
+object ListButtonDefaults {
+	@ReadOnlyComposable
+	@Composable
+	fun colors(
+		containerColor: Color = JellyfinTheme.colorScheme.listButton,
+		contentColor: Color = JellyfinTheme.colorScheme.onListButton,
+		focusedContainerColor: Color = JellyfinTheme.colorScheme.listButtonFocused,
+		focusedContentColor: Color = JellyfinTheme.colorScheme.onListButtonFocused,
+		disabledContainerColor: Color = JellyfinTheme.colorScheme.listButtonDisabled,
+		disabledContentColor: Color = JellyfinTheme.colorScheme.onListButtonDisabled,
+	) = ButtonColors(
+		containerColor = containerColor,
+		contentColor = contentColor,
+		focusedContainerColor = focusedContainerColor,
+		focusedContentColor = focusedContentColor,
+		disabledContainerColor = disabledContainerColor,
+		disabledContentColor = disabledContentColor,
+	)
+}
+
+@Composable
+fun ListButton(
+	onClick: () -> Unit,
+	headingContent: @Composable () -> Unit,
+	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
+	colors: ButtonColors = ListButtonDefaults.colors(),
+	overlineContent: (@Composable () -> Unit)? = null,
+	captionContent: (@Composable () -> Unit)? = null,
+	leadingContent: (@Composable () -> Unit)? = null,
+	trailingContent: (@Composable () -> Unit)? = null,
+) {
+	ButtonBase(
+		onClick = onClick,
+		colors = colors,
+		enabled = enabled,
+		shape = LocalShapes.current.large,
+		modifier = modifier
+			.fillMaxWidth()
+	) {
+		ListItemContent(
+			headingContent = headingContent,
+			overlineContent = overlineContent,
+			captionContent = captionContent,
+			leadingContent = leadingContent,
+			trailingContent = trailingContent,
+			headingStyle = JellyfinTheme.typography.listHeadline
+				.copy(color = JellyfinTheme.colorScheme.listHeadline),
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListItemContent.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListItemContent.kt
@@ -1,0 +1,83 @@
+package org.jellyfin.androidtv.ui.base.list
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
+
+@Composable
+fun ListItemContent(
+	modifier: Modifier = Modifier,
+	headingContent: @Composable () -> Unit,
+	overlineContent: (@Composable () -> Unit)? = null,
+	captionContent: (@Composable () -> Unit)? = null,
+	leadingContent: (@Composable () -> Unit)? = null,
+	trailingContent: (@Composable () -> Unit)? = null,
+	headingStyle: TextStyle,
+) {
+	Row(
+		modifier = modifier
+			.padding(12.dp),
+		verticalAlignment = Alignment.CenterVertically,
+	) {
+		leadingContent?.let { content ->
+			Box(
+				modifier = Modifier
+					.sizeIn(minWidth = 24.dp),
+				contentAlignment = Alignment.Center,
+				content = {
+					ProvideTextStyle(LocalTextStyle.current.copy(color = JellyfinTheme.colorScheme.listCaption)) {
+						content()
+					}
+				}
+			)
+			Spacer(Modifier.width(14.dp))
+		}
+
+		Column(
+			modifier = Modifier
+				.weight(1f),
+		) {
+			overlineContent?.let { content ->
+				ProvideTextStyle(JellyfinTheme.typography.listOverline.copy(color = JellyfinTheme.colorScheme.listOverline)) {
+					content()
+				}
+				Spacer(Modifier.height(2.dp))
+			}
+
+			ProvideTextStyle(headingStyle) {
+				headingContent()
+			}
+
+			captionContent?.let { content ->
+				Spacer(Modifier.height(4.dp))
+				ProvideTextStyle(JellyfinTheme.typography.listCaption.copy(color = JellyfinTheme.colorScheme.listCaption)) {
+					content()
+				}
+			}
+		}
+
+		trailingContent?.let { content ->
+			Spacer(Modifier.width(16.dp))
+
+			Box(
+				modifier = Modifier
+					.sizeIn(minWidth = 24.dp),
+				contentAlignment = Alignment.Center,
+				content = { content() }
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListSection.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListSection.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.androidtv.ui.base.list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+
+@Composable
+fun ListSection(
+	modifier: Modifier = Modifier,
+	headingContent: @Composable () -> Unit,
+	overlineContent: (@Composable () -> Unit)? = null,
+	captionContent: (@Composable () -> Unit)? = null,
+	leadingContent: (@Composable () -> Unit)? = null,
+	trailingContent: (@Composable () -> Unit)? = null,
+) {
+	ListItemContent(
+		headingContent = headingContent,
+		overlineContent = overlineContent,
+		captionContent = captionContent,
+		leadingContent = leadingContent,
+		trailingContent = trailingContent,
+		headingStyle = JellyfinTheme.typography.listHeader
+			.copy(color = JellyfinTheme.colorScheme.listHeader),
+		modifier = modifier,
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/Popover.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/Popover.kt
@@ -39,11 +39,10 @@ fun Popover(
 	alignment: Alignment = Alignment.TopStart,
 	offset: DpOffset = DpOffset.Zero,
 	shape: Shape = PopoverDefaults.Shape,
-	backgroundColor: Color = JellyfinTheme.colorScheme.popover,
+	backgroundColor: Color = JellyfinTheme.colorScheme.surface,
 	content: @Composable BoxScope.() -> Unit,
 ) {
 	val density = LocalDensity.current
-	val focusRequester = remember { FocusRequester() }
 	val popupPositionProvider = remember(alignment, density, offset) {
 		PopoverMenuPositionProvider(
 			alignment = alignment,
@@ -60,6 +59,8 @@ fun Popover(
 	)
 
 	if (alpha != 0f) {
+		val focusRequester = remember { FocusRequester() }
+
 		Popup(
 			onDismissRequest = onDismissRequest,
 			properties = PopupProperties(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/typography.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/typography.kt
@@ -9,6 +9,30 @@ import androidx.compose.ui.unit.sp
 
 object TypographyDefaults {
 	val Default: TextStyle = TextStyle.Default
+
+	val ListHeader: TextStyle = Default.copy(
+		fontSize = 15.sp,
+		lineHeight = 20.sp,
+		fontWeight = FontWeight.W700,
+	)
+	val ListOverline: TextStyle = Default.copy(
+		fontSize = 10.sp,
+		lineHeight = 12.sp,
+		fontWeight = FontWeight.W600,
+		letterSpacing = 0.65.sp,
+	)
+	val ListHeadline: TextStyle = Default.copy(
+		fontSize = 14.sp,
+		lineHeight = 28.sp,
+		fontWeight = FontWeight.W600,
+	)
+	val ListCaption: TextStyle = Default.copy(
+		fontSize = 11.sp,
+		lineHeight = 14.sp,
+		fontWeight = FontWeight.W500,
+		letterSpacing = 0.1.sp,
+	)
+
 	val Badge: TextStyle = Default.copy(
 		fontSize = 11.sp,
 		fontWeight = FontWeight.W700,
@@ -19,7 +43,11 @@ object TypographyDefaults {
 @Immutable
 data class Typography(
 	val default: TextStyle = TypographyDefaults.Default,
-	val badge: TextStyle = TypographyDefaults.Badge,
+	val listHeader: TextStyle = TypographyDefaults.ListHeader,
+	val listOverline: TextStyle = TypographyDefaults.ListOverline,
+	val listHeadline: TextStyle = TypographyDefaults.ListHeadline,
+	val listCaption: TextStyle = TypographyDefaults.ListCaption,
+	val badge: TextStyle = TypographyDefaults.Badge
 )
 
 val LocalTypography = staticCompositionLocalOf { Typography() }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -27,6 +27,7 @@ import org.jellyfin.androidtv.ui.background.AppBackground
 import org.jellyfin.androidtv.ui.navigation.NavigationAction
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.screensaver.InAppScreensaver
+import org.jellyfin.androidtv.ui.settings.compat.MainActivitySettings
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.applyTheme
 import org.jellyfin.androidtv.util.isMediaSessionKeyEvent
@@ -75,6 +76,7 @@ class MainActivity : FragmentActivity() {
 
 		binding = ActivityMainBinding.inflate(layoutInflater)
 		binding.background.setContent { AppBackground() }
+		binding.settings.setContent { MainActivitySettings() }
 		binding.screensaver.setContent { InAppScreensaver() }
 		setContentView(binding.root)
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
@@ -9,7 +9,12 @@ import org.jellyfin.androidtv.ui.livetv.GuideOptionsScreen
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
-import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.AuthPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.CrashReportingPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.CustomizationPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.DeveloperPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.LicensesScreen
+import org.jellyfin.androidtv.ui.preference.screen.PlaybackPreferencesScreen
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import kotlin.time.Duration
 
@@ -26,7 +31,13 @@ object ActivityDestinations {
 		)
 	}
 
-	fun userPreferences(context: Context) = preferenceIntent<UserPreferencesScreen>(context)
+	fun authPreferences(context: Context) = preferenceIntent<AuthPreferencesScreen>(context)
+	fun customizationPreferences(context: Context) = preferenceIntent<CustomizationPreferencesScreen>(context)
+	fun playbackPreferences(context: Context) = preferenceIntent<PlaybackPreferencesScreen>(context)
+	fun crashReportingPreferences(context: Context) = preferenceIntent<CrashReportingPreferencesScreen>(context)
+	fun developerPreferences(context: Context) = preferenceIntent<DeveloperPreferencesScreen>(context)
+	fun licenses(context: Context) = preferenceIntent<LicensesScreen>(context)
+
 	fun displayPreferences(context: Context, displayPreferencesId: String, allowViewSelection: Boolean) =
 		preferenceIntent<DisplayPreferencesScreen>(
 			context,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/PreferencesActivity.kt
@@ -4,13 +4,12 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.ui.preference.screen.UserPreferencesScreen
 
 class PreferencesActivity : FragmentActivity(R.layout.fragment_content_view) {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
-		val screen = intent.extras?.getString(EXTRA_SCREEN) ?: UserPreferencesScreen::class.qualifiedName
+		val screen = requireNotNull(intent.extras?.getString(EXTRA_SCREEN))
 		val screenArgs = intent.extras?.getBundle(EXTRA_SCREEN_ARGS) ?: bundleOf()
 
 		supportFragmentManager

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/MainActivitySettings.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/MainActivitySettings.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.androidtv.ui.settings.compat
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.settings.composable.SettingsDialog
+import org.jellyfin.androidtv.ui.settings.screen.SettingsMainScreen
+import org.koin.compose.viewmodel.koinActivityViewModel
+
+@Composable
+fun MainActivitySettings() {
+	val viewModel = koinActivityViewModel<SettingsViewModel>()
+	val visible by viewModel.visible.collectAsState()
+
+	JellyfinTheme {
+		SettingsDialog(
+			visible = visible,
+			onDismissRequest = { viewModel.hide() }
+		) {
+			SettingsMainScreen()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/SettingsViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/SettingsViewModel.kt
@@ -1,0 +1,18 @@
+package org.jellyfin.androidtv.ui.settings.compat
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SettingsViewModel : ViewModel() {
+	private val _visible = MutableStateFlow(false)
+	val visible get() = _visible.asStateFlow()
+
+	fun show() {
+		_visible.value = true
+	}
+
+	fun hide() {
+		_visible.value = false
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/composable/SettingsDialog.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/composable/SettingsDialog.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.androidtv.ui.settings.composable
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import org.jellyfin.androidtv.ui.base.dialog.DialogBase
+
+@Composable
+fun SettingsDialog(
+	visible: Boolean,
+	onDismissRequest: () -> Unit,
+	modifier: Modifier = Modifier,
+	screen: @Composable BoxScope.() -> Unit,
+) {
+	DialogBase(
+		visible = visible,
+		onDismissRequest = onDismissRequest,
+		modifier = modifier,
+	) {
+		SettingsLayout(
+			modifier = Modifier
+				.align(Alignment.TopEnd),
+		) {
+			screen()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/composable/SettingsLayout.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/composable/SettingsLayout.kt
@@ -1,0 +1,32 @@
+package org.jellyfin.androidtv.ui.settings.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.LocalShapes
+
+@Composable
+fun SettingsLayout(
+	modifier: Modifier = Modifier,
+	content: @Composable BoxScope.() -> Unit,
+) {
+	Box(
+		modifier = modifier
+			.padding(12.dp)
+			.clip(LocalShapes.current.large)
+			.background(JellyfinTheme.colorScheme.surface)
+			.width(350.dp)
+			.fillMaxHeight()
+			.focusRestorer(),
+		content = content
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -1,0 +1,151 @@
+package org.jellyfin.androidtv.ui.settings.screen
+
+import android.os.Build
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.BuildConfig
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
+
+@Composable
+fun SettingsMainScreen() {
+	val context = LocalContext.current
+
+	Column(
+		modifier = Modifier
+			.verticalScroll(rememberScrollState())
+			.padding(6.dp),
+		verticalArrangement = Arrangement.spacedBy(4.dp),
+	) {
+		ListSection(
+			modifier = Modifier,
+			overlineContent = { Text(stringResource(R.string.app_name).uppercase()) },
+			headingContent = { Text(stringResource(R.string.settings)) },
+			captionContent = { Text(stringResource(R.string.settings_description)) },
+		)
+
+		ListButton(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_users),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.pref_login)) },
+			captionContent = { Text(stringResource(R.string.pref_login_description)) },
+			onClick = {
+				context.startActivity(ActivityDestinations.authPreferences(context))
+			}
+		)
+
+		ListButton(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_adjust),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.pref_customization)) },
+			captionContent = { Text(stringResource(R.string.pref_customization_description)) },
+			onClick = {
+				context.startActivity(ActivityDestinations.customizationPreferences(context))
+			}
+		)
+
+		ListButton(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_next),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.pref_playback)) },
+			captionContent = { Text(stringResource(R.string.pref_playback_description)) },
+			onClick = {
+				context.startActivity(ActivityDestinations.playbackPreferences(context))
+			}
+		)
+
+		ListButton(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_error),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.pref_telemetry_category)) },
+			captionContent = { Text(stringResource(R.string.pref_telemetry_description)) },
+			onClick = {
+				context.startActivity(ActivityDestinations.crashReportingPreferences(context))
+			}
+		)
+
+		ListButton(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_flask),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.pref_developer_link)) },
+			captionContent = { Text(stringResource(R.string.pref_developer_link_description)) },
+			onClick = {
+				context.startActivity(ActivityDestinations.developerPreferences(context))
+			}
+		)
+
+		ListSection(
+			modifier = Modifier,
+			headingContent = { Text(stringResource(R.string.pref_about_title)) },
+		)
+
+		ListSection(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_jellyfin),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text("Jellyfin app version") },
+			captionContent = { Text("jellyfin-androidtv ${BuildConfig.VERSION_NAME} ${BuildConfig.BUILD_TYPE}") },
+		)
+
+		ListSection(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_tv),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.pref_device_model)) },
+			captionContent = { Text("${Build.MANUFACTURER} ${Build.MODEL}") },
+		)
+
+		ListButton(
+			leadingContent = {
+				Icon(
+					painterResource(R.drawable.ic_guide),
+					contentDescription = null
+				)
+			},
+			headingContent = { Text(stringResource(R.string.licenses_link)) },
+			captionContent = { Text(stringResource(R.string.licenses_link_description)) },
+			onClick = {
+				context.startActivity(ActivityDestinations.licenses(context))
+			}
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
@@ -39,10 +39,12 @@ import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.playback.MediaManager
+import org.jellyfin.androidtv.ui.settings.compat.SettingsViewModel
 import org.jellyfin.androidtv.util.apiclient.getUrl
 import org.jellyfin.androidtv.util.apiclient.primaryImage
 import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinActivityViewModel
 
 enum class MainToolbarActiveButton {
 	User,
@@ -78,6 +80,7 @@ private fun MainToolbar(
 	val navigationRepository = koinInject<NavigationRepository>()
 	val mediaManager = koinInject<MediaManager>()
 	val sessionRepository = koinInject<SessionRepository>()
+	val settingsViewModel = koinActivityViewModel<SettingsViewModel>()
 	val activity = LocalActivity.current
 	val activeButtonColors = ButtonDefaults.colors(
 		containerColor = JellyfinTheme.colorScheme.buttonActive,
@@ -163,9 +166,7 @@ private fun MainToolbar(
 		end = {
 			ToolbarButtons {
 				IconButton(
-					onClick = {
-						activity?.startActivity(ActivityDestinations.userPreferences(activity))
-					},
+					onClick = { settingsViewModel.show() },
 				) {
 					Icon(
 						imageVector = ImageVector.vectorResource(R.drawable.ic_settings),

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,6 +19,11 @@
         android:layout_height="match_parent" />
 
     <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/settings"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <androidx.compose.ui.platform.ComposeView
         android:id="@+id/screensaver"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -550,6 +550,8 @@
     <string name="speech_error_unavailable">Speech recognition is unavailable on your device.</string>
     <string name="speech_error_unknown">An unexpected error occurred during speech recognition.</string>
     <string name="still_watching_label">Are you still watching?</string>
+    <string name="settings">Settings</string>
+    <string name="settings_description">Change the app to your own liking</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

This PR is part of a series for the new settings UI. The new UI is compose based and will make it much easier to add custom fields, descriptions, reactivity etc.

Focus of this PR:
- Rename "preferences" to "settings" as this seems to be a more broadly used term (in chat and other places)
- Add new foundational composable
  - DialogBase - similar to popover but used for fullscreen composables (e.g. dialogs)
  - ListSection & ListButton - the items shown in the screenshot below
  - RadioButton - Not used in this PR but will be used for actual setting pages
- Use new settings UI for the initial page of the user settings

What is missing:
- All subpages/individual settings still use the old UI. Including the library & authentication settings opened from other places
- Category cleanup - currently uses the exact same items as before on the main screen. this will likely change later
- Polishing - some animations are missing and will be added later

**Screenshots**
<img width="1920" height="1080" alt="96900006fd" src="https://github.com/user-attachments/assets/b8ae141e-aac4-43d3-9a60-ca9713a24a35" />

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
