### PR TITLE
Add navigation support to settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
 	implementation(libs.androidx.fragment.compose)
 	implementation(libs.androidx.leanback.core)
 	implementation(libs.androidx.leanback.preference)
+	implementation(libs.androidx.navigation3.ui)
 	implementation(libs.androidx.preference)
 	implementation(libs.androidx.appcompat)
 	implementation(libs.androidx.tvprovider)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/router.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/router.kt
@@ -1,0 +1,82 @@
+package org.jellyfin.androidtv.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+
+class Router(
+	val routes: Map<String, @Composable (() -> Unit)>,
+	val backStack: SnapshotStateList<String>,
+) {
+	// Route resolving
+
+	fun resolve(route: String): @Composable (() -> Unit)? = routes[route]
+	fun verifyRoute(route: String) = require(resolve(route) != null) { "Invalid route $route" }
+
+	// Route manipulation
+
+	fun push(route: String) {
+		verifyRoute(route)
+
+		backStack.add(route)
+	}
+
+	fun replace(route: String) {
+		verifyRoute(route)
+
+		backStack.removeLastOrNull()
+		backStack.add(route)
+	}
+
+	fun back() {
+		backStack.removeLastOrNull()
+	}
+}
+
+val LocalRouter = compositionLocalOf<Router> { error("No router provided") }
+
+@Composable
+fun ProvideRouter(
+	routes: Map<String, @Composable () -> Unit>,
+	defaultRoute: String,
+	content: @Composable () -> Unit,
+) {
+	val backStack = remember { mutableStateListOf(defaultRoute) }
+	val router = remember(routes, backStack) {
+		Router(
+			routes = routes,
+			backStack = backStack,
+		)
+	}
+
+	CompositionLocalProvider(
+		LocalRouter provides router,
+		content = content
+	)
+}
+
+@Composable
+fun RouterContent(
+	router: Router = LocalRouter.current,
+	fallbackRoute: String = "/"
+) {
+	NavDisplay(
+		backStack = router.backStack,
+		onBack = { router.back() },
+		entryDecorators = listOf(
+			rememberSaveableStateHolderNavEntryDecorator(),
+		),
+		entryProvider = { route ->
+			NavEntry(route) {
+				val route = router.resolve(route) ?: router.resolve(fallbackRoute)
+				if (route != null) route()
+			}
+		}
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/MainActivitySettings.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/MainActivitySettings.kt
@@ -4,8 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.navigation.ProvideRouter
+import org.jellyfin.androidtv.ui.navigation.RouterContent
+import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsDialog
-import org.jellyfin.androidtv.ui.settings.screen.SettingsMainScreen
+import org.jellyfin.androidtv.ui.settings.routes
 import org.koin.compose.viewmodel.koinActivityViewModel
 
 @Composable
@@ -14,11 +17,13 @@ fun MainActivitySettings() {
 	val visible by viewModel.visible.collectAsState()
 
 	JellyfinTheme {
-		SettingsDialog(
-			visible = visible,
-			onDismissRequest = { viewModel.hide() }
-		) {
-			SettingsMainScreen()
+		ProvideRouter(routes, Routes.MAIN) {
+			SettingsDialog(
+				visible = visible,
+				onDismissRequest = { viewModel.hide() }
+			) {
+				RouterContent()
+			}
 		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.androidtv.ui.settings
+
+import androidx.compose.runtime.Composable
+import org.jellyfin.androidtv.ui.settings.screen.SettingsMainScreen
+
+object Routes {
+	const val MAIN = "/"
+}
+
+val routes = mapOf<String, @Composable () -> Unit>(
+	Routes.MAIN to ::SettingsMainScreen,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidx-fragment = "1.8.9"
 androidx-leanback = "1.2.0"
 androidx-lifecycle = "2.10.0"
 androidx-media3 = "1.8.0"
+androidx-navigation3 = "1.0.0"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.4.0"
 androidx-startup = "1.2.0"
@@ -75,6 +76,7 @@ androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", 
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }


### PR DESCRIPTION
**Changes**

- Add a new router utility, should eventually be used as our main navigation too (with support for more complex URL based route matching). Based on recently released jetpack.navigation3 library.
- Use router for settings

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
