### PR TITLE
Add VC-1 to device direct play profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/constant/Codec.kt
@@ -66,6 +66,7 @@ object Codec {
 		const val VP8 = "vp8"
 		const val VP9 = "vp9"
 		const val AV1 = "av1"
+		const val VC1 = "vc1"
 	}
 
 	object Subtitle {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -200,6 +200,8 @@ class MediaCodecCapabilitiesTest(
 		}?.second ?: 0
 	}
 
+	fun supportsVc1(): Boolean = hasCodecForMime(MimeTypes.VIDEO_VC1)
+
 	private fun getDecoderLevel(mime: String, profile: Int): Int {
 		var maxLevel = 0
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -91,9 +91,11 @@ fun createDeviceProfile(
 	val avcHigh10Level = mediaTest.getAVCHigh10Level()
 	val supportsAV1 = mediaTest.supportsAV1()
 	val supportsAV1Main10 = mediaTest.supportsAV1Main10()
+	val supportsVC1 = mediaTest.supportsVc1()
 	val maxResolutionAVC = mediaTest.getMaxResolution(MimeTypes.VIDEO_H264)
 	val maxResolutionHevc = mediaTest.getMaxResolution(MimeTypes.VIDEO_H265)
 	val maxResolutionAV1 = mediaTest.getMaxResolution(MimeTypes.VIDEO_AV1)
+	val maxResolutionVC1 = mediaTest.getMaxResolution(MimeTypes.VIDEO_VC1)
 
 	/// HDR capabilities
 
@@ -170,6 +172,7 @@ fun createDeviceProfile(
 			Codec.Video.HEVC,
 			Codec.Video.MPEG,
 			Codec.Video.MPEG2VIDEO,
+			Codec.Video.VC1,
 			Codec.Video.VP8,
 			Codec.Video.VP9,
 		)
@@ -323,6 +326,19 @@ fun createDeviceProfile(
 		}
 	}
 
+	// VC1 profile
+	codecProfile {
+		type = CodecType.VIDEO
+		codec = Codec.Video.VC1
+
+		conditions {
+			when {
+				!supportsVC1 -> ProfileConditionValue.VIDEO_PROFILE equals "none"
+				else -> ProfileConditionValue.VIDEO_PROFILE notEquals "none"
+			}
+		}
+	}
+
 	// Get max resolutions for common codecs
 	// AVC
 	codecProfile {
@@ -354,6 +370,17 @@ fun createDeviceProfile(
 		conditions {
 			ProfileConditionValue.WIDTH lowerThanOrEquals maxResolutionAV1.width
 			ProfileConditionValue.HEIGHT lowerThanOrEquals maxResolutionAV1.height
+		}
+	}
+
+	// VC1
+	codecProfile {
+		type = CodecType.VIDEO
+		codec = Codec.Video.VC1
+
+		conditions {
+			ProfileConditionValue.WIDTH lowerThanOrEquals maxResolutionVC1.width
+			ProfileConditionValue.HEIGHT lowerThanOrEquals maxResolutionVC1.height
 		}
 	}
 


### PR DESCRIPTION
**Changes**
Adds VC-1 video codec detection to the device profile if the device support it

VC-1 is a video codec used on HD-DVDs and early Blu-Rays, but probably not much else. Some devices do support hardware decoding for it, notably NVIDIA Shield TVs.

**Code assistance**
No AI used

I tested on NVIDIA shield 2019 non-pro, NVIDIA Shield 2017 Pro, & Chromecast w/ Google TV (to make sure a device w/o VC-1 support doesn't attempt direct play)

**Issues**
Not sure there are any issues for this.