### PR TITLE
Migrate telemetry settings to compose

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
@@ -1,0 +1,22 @@
+package org.jellyfin.androidtv.ui.settings.compat
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import org.jellyfin.preference.Preference
+import org.jellyfin.preference.store.PreferenceStore
+
+/**
+ * Utility to wrap the [PreferenceStore] getter/setter as [MutableState] to recompose whne the value is changed. Uses a **local** state for
+ * the preference, updates to the preference not done via this function won't trigger recomposition or update its value.
+ */
+@Composable
+fun <ME, MV, T : Any> rememberPreference(store: PreferenceStore<ME, MV>, preference: Preference<T>): MutableState<T> {
+	val mutableState = remember { mutableStateOf(store[preference]) }
+	LaunchedEffect(mutableState.value) {
+		if (store[preference] != mutableState.value) store[preference] = mutableState.value
+	}
+	return mutableState
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -2,11 +2,14 @@ package org.jellyfin.androidtv.ui.settings
 
 import androidx.compose.runtime.Composable
 import org.jellyfin.androidtv.ui.settings.screen.SettingsMainScreen
+import org.jellyfin.androidtv.ui.settings.screen.SettingsTelemetryScreen
 
 object Routes {
 	const val MAIN = "/"
+	const val TELEMETRY = "/telemetry"
 }
 
 val routes = mapOf<String, @Composable () -> Unit>(
 	Routes.MAIN to ::SettingsMainScreen,
+	Routes.TELEMETRY to ::SettingsTelemetryScreen
 )

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -19,10 +19,13 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.Routes
 
 @Composable
 fun SettingsMainScreen() {
 	val context = LocalContext.current
+	val router = LocalRouter.current
 
 	Column(
 		modifier = Modifier
@@ -89,7 +92,7 @@ fun SettingsMainScreen() {
 			headingContent = { Text(stringResource(R.string.pref_telemetry_category)) },
 			captionContent = { Text(stringResource(R.string.pref_telemetry_description)) },
 			onClick = {
-				context.startActivity(ActivityDestinations.crashReportingPreferences(context))
+				router.push(Routes.TELEMETRY)
 			}
 		)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsTelemetryScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsTelemetryScreen.kt
@@ -1,0 +1,80 @@
+package org.jellyfin.androidtv.ui.settings.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.TelemetryPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsTelemetryScreen() {
+	val telemetryPreferences = koinInject<TelemetryPreferences>()
+
+	Column(
+		modifier = Modifier
+			.verticalScroll(rememberScrollState())
+			.padding(6.dp),
+		verticalArrangement = Arrangement.spacedBy(4.dp),
+	) {
+		ListSection(
+			modifier = Modifier,
+			overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
+			headingContent = { Text(stringResource(R.string.pref_telemetry_category)) },
+			captionContent = { Text(stringResource(R.string.pref_telemetry_description)) },
+		)
+
+		var crashReportEnabled by rememberPreference(telemetryPreferences, TelemetryPreferences.crashReportEnabled)
+		ListButton(
+			headingContent = { Text(stringResource(R.string.pref_crash_reports)) },
+			trailingContent = {
+				RadioButton(
+					checked = crashReportEnabled,
+				)
+			},
+			captionContent = {
+				if (crashReportEnabled) {
+					Text(stringResource(R.string.pref_crash_reports_enabled))
+				} else {
+					Text(stringResource(R.string.pref_crash_reports_disabled))
+				}
+			},
+			onClick = {
+				crashReportEnabled = !crashReportEnabled
+			}
+		)
+
+		var crashReportIncludeLogs by rememberPreference(telemetryPreferences, TelemetryPreferences.crashReportIncludeLogs)
+		ListButton(
+			headingContent = { Text(stringResource(R.string.pref_crash_report_logs)) },
+			trailingContent = {
+				RadioButton(
+					checked = crashReportIncludeLogs,
+				)
+			},
+			captionContent = {
+				if (crashReportIncludeLogs) {
+					Text(stringResource(R.string.pref_crash_report_logs_enabled))
+				} else {
+					Text(stringResource(R.string.pref_crash_report_logs_disabled))
+				}
+			},
+			onClick = {
+				crashReportIncludeLogs = !crashReportIncludeLogs
+			}
+		)
+	}
+}


### PR DESCRIPTION
**Changes**

Rewrite the existing `CrashReportingPreferencesScreen` using compose within the new settings UI. This is mostly a proof of concept to see what parts of the new UI need improvement, although it's perfectly usable as-is.

<img width="562" height="820" alt="image" src="https://github.com/user-attachments/assets/4b294861-4d7b-4e6c-9cbd-e1f79a0d8cad" />


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
