### PR TITLE
Migrate authentication settings to compose

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
@@ -9,10 +9,11 @@ import org.jellyfin.androidtv.ui.livetv.GuideOptionsScreen
 import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
-import org.jellyfin.androidtv.ui.preference.screen.AuthPreferencesScreen
 import org.jellyfin.androidtv.ui.preference.screen.CustomizationPreferencesScreen
 import org.jellyfin.androidtv.ui.preference.screen.PlaybackPreferencesScreen
 import org.jellyfin.androidtv.ui.startup.StartupActivity
+import org.jellyfin.androidtv.ui.startup.preference.EditServerScreen
+import java.util.UUID
 import kotlin.time.Duration
 
 object ActivityDestinations {
@@ -28,7 +29,11 @@ object ActivityDestinations {
 		)
 	}
 
-	fun authPreferences(context: Context) = preferenceIntent<AuthPreferencesScreen>(context)
+	fun editServerPreferences(context: Context, serverId: UUID) = preferenceIntent<EditServerScreen>(
+		context,
+		EditServerScreen.ARG_SERVER_UUID to serverId,
+	)
+
 	fun customizationPreferences(context: Context) = preferenceIntent<CustomizationPreferencesScreen>(context)
 	fun playbackPreferences(context: Context) = preferenceIntent<PlaybackPreferencesScreen>(context)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
@@ -20,3 +20,16 @@ fun <ME, MV, T : Any> rememberPreference(store: PreferenceStore<ME, MV>, prefere
 	}
 	return mutableState
 }
+
+@Composable
+@JvmName("rememberEnumPreference")
+fun <ME, MV, T : Enum<T>> rememberPreference(
+	store: PreferenceStore<ME, MV>,
+	preference: Preference<T>
+): MutableState<T> {
+	val mutableState = remember { mutableStateOf(store[preference]) }
+	LaunchedEffect(mutableState.value) {
+		if (store[preference] != mutableState.value) store[preference] = mutableState.value
+	}
+	return mutableState
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -4,11 +4,17 @@ import org.jellyfin.androidtv.ui.navigation.RouteComposable
 import org.jellyfin.androidtv.ui.settings.screen.SettingsDeveloperScreen
 import org.jellyfin.androidtv.ui.settings.screen.SettingsMainScreen
 import org.jellyfin.androidtv.ui.settings.screen.SettingsTelemetryScreen
+import org.jellyfin.androidtv.ui.settings.screen.authentication.SettingsAuthenticationAutoSignInScreen
+import org.jellyfin.androidtv.ui.settings.screen.authentication.SettingsAuthenticationScreen
+import org.jellyfin.androidtv.ui.settings.screen.authentication.SettingsAuthenticationSortByScreen
 import org.jellyfin.androidtv.ui.settings.screen.license.SettingsLicenseScreen
 import org.jellyfin.androidtv.ui.settings.screen.license.SettingsLicensesScreen
 
 object Routes {
 	const val MAIN = "/"
+	const val AUTHENTICATION = "/authentication"
+	const val AUTHENTICATION_SORT_BY = "/authentication/sort-by"
+	const val AUTHENTICATION_AUTO_SIGN_IN = "/authentication/auto-sign-in"
 	const val TELEMETRY = "/telemetry"
 	const val DEVELOPER = "/developer"
 	const val LICENSES = "/licenses"
@@ -17,6 +23,9 @@ object Routes {
 
 val routes = mapOf<String, RouteComposable>(
 	Routes.MAIN to { SettingsMainScreen() },
+	Routes.AUTHENTICATION to { SettingsAuthenticationScreen() },
+	Routes.AUTHENTICATION_SORT_BY to { SettingsAuthenticationSortByScreen() },
+	Routes.AUTHENTICATION_AUTO_SIGN_IN to { SettingsAuthenticationAutoSignInScreen() },
 	Routes.TELEMETRY to { SettingsTelemetryScreen() },
 	Routes.DEVELOPER to { SettingsDeveloperScreen() },
 	Routes.LICENSES to { SettingsLicensesScreen() },

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -49,9 +49,7 @@ fun SettingsMainScreen() {
 			},
 			headingContent = { Text(stringResource(R.string.pref_login)) },
 			captionContent = { Text(stringResource(R.string.pref_login_description)) },
-			onClick = {
-				context.startActivity(ActivityDestinations.authPreferences(context))
-			}
+			onClick = { router.push(Routes.AUTHENTICATION) }
 		)
 
 		ListButton(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationAutoSignInScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationAutoSignInScreen.kt
@@ -1,0 +1,140 @@
+package org.jellyfin.androidtv.ui.settings.screen.authentication
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.repository.AuthenticationRepository
+import org.jellyfin.androidtv.auth.repository.ServerRepository
+import org.jellyfin.androidtv.auth.repository.ServerUserRepository
+import org.jellyfin.androidtv.auth.store.AuthenticationPreferences
+import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.button.IconButtonDefaults
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsAuthenticationAutoSignInScreen() {
+	val router = LocalRouter.current
+	val serverRepository = koinInject<ServerRepository>()
+	val serverUserRepository = koinInject<ServerUserRepository>()
+	val authenticationRepository = koinInject<AuthenticationRepository>()
+	val authenticationPreferences = koinInject<AuthenticationPreferences>()
+	var autoLoginUserBehavior by rememberPreference(authenticationPreferences, AuthenticationPreferences.autoLoginUserBehavior)
+	var autoLoginServerId by rememberPreference(authenticationPreferences, AuthenticationPreferences.autoLoginServerId)
+	var autoLoginUserId by rememberPreference(authenticationPreferences, AuthenticationPreferences.autoLoginUserId)
+
+	LaunchedEffect(serverRepository) {
+		serverRepository.loadStoredServers()
+	}
+
+	val storedServers by serverRepository.storedServers.collectAsState()
+
+	LazyColumn(
+		modifier = Modifier
+			.padding(6.dp),
+		verticalArrangement = Arrangement.spacedBy(4.dp),
+	) {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_login).uppercase()) },
+				headingContent = { Text(stringResource(R.string.auto_sign_in)) },
+			)
+		}
+
+		item {
+			ListButton(
+				headingContent = { Text(stringResource(R.string.user_picker_disable_title)) },
+				captionContent = { Text(stringResource(R.string.user_picker_disable_summary)) },
+				trailingContent = { RadioButton(checked = autoLoginUserBehavior == UserSelectBehavior.DISABLED) },
+				onClick = {
+					autoLoginUserBehavior = UserSelectBehavior.DISABLED
+					router.back()
+				}
+			)
+		}
+
+		item {
+			ListButton(
+				headingContent = { Text(stringResource(R.string.user_picker_last_user_title)) },
+				captionContent = { Text(stringResource(R.string.user_picker_last_user_summary)) },
+				trailingContent = { RadioButton(checked = autoLoginUserBehavior == UserSelectBehavior.LAST_USER) },
+				onClick = {
+					autoLoginUserBehavior = UserSelectBehavior.LAST_USER
+					router.back()
+				}
+			)
+		}
+
+		for (server in storedServers) {
+			item {
+				ListSection(
+					headingContent = { Text(server.name) },
+				)
+			}
+
+			val users = serverUserRepository.getStoredServerUsers(server)
+			val serverId = server.id.toString()
+			items(users) { user ->
+				val userId = user.id.toString()
+				val userImagePainter = rememberAsyncImagePainter(authenticationRepository.getUserImageUrl(server, user))
+				val userImageState by userImagePainter.state.collectAsState()
+				val userImageVisible = userImageState is AsyncImagePainter.State.Success
+
+				ListButton(
+					leadingContent = {
+						if (!userImageVisible) {
+							Icon(
+								imageVector = ImageVector.vectorResource(R.drawable.ic_user),
+								contentDescription = null,
+							)
+						} else {
+							Image(
+								painter = userImagePainter,
+								contentDescription = null,
+								contentScale = ContentScale.Crop,
+								modifier = Modifier
+									.width(24.dp)
+									.aspectRatio(1f)
+									.clip(IconButtonDefaults.Shape)
+							)
+						}
+					},
+					headingContent = { Text(user.name) },
+					trailingContent = { RadioButton(checked = autoLoginUserBehavior == UserSelectBehavior.SPECIFIC_USER && autoLoginServerId == serverId && autoLoginUserId == userId) },
+					onClick = {
+						autoLoginUserBehavior = UserSelectBehavior.SPECIFIC_USER
+						autoLoginServerId = serverId
+						autoLoginUserId = userId
+
+						router.back()
+					}
+				)
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationScreen.kt
@@ -1,0 +1,139 @@
+package org.jellyfin.androidtv.ui.settings.screen.authentication
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.repository.ServerRepository
+import org.jellyfin.androidtv.auth.repository.ServerUserRepository
+import org.jellyfin.androidtv.auth.repository.SessionRepository
+import org.jellyfin.androidtv.auth.store.AuthenticationPreferences
+import org.jellyfin.androidtv.preference.constant.UserSelectBehavior
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsAuthenticationScreen() {
+	val context = LocalContext.current
+	val router = LocalRouter.current
+	val serverRepository = koinInject<ServerRepository>()
+	val serverUserRepository = koinInject<ServerUserRepository>()
+	val authenticationPreferences = koinInject<AuthenticationPreferences>()
+	val sessionRepository = koinInject<SessionRepository>()
+
+	LaunchedEffect(serverRepository) {
+		serverRepository.loadStoredServers()
+	}
+
+	val storedServers by serverRepository.storedServers.collectAsState()
+
+	LazyColumn(
+		modifier = Modifier
+			.padding(6.dp),
+		verticalArrangement = Arrangement.spacedBy(4.dp),
+	) {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_login)) },
+				captionContent = { Text(stringResource(R.string.pref_login_description)) },
+			)
+		}
+
+		item {
+			var autoLoginUserBehavior by rememberPreference(authenticationPreferences, AuthenticationPreferences.autoLoginUserBehavior)
+			var autoLoginServerId by rememberPreference(authenticationPreferences, AuthenticationPreferences.autoLoginServerId)
+			var autoLoginUserId by rememberPreference(authenticationPreferences, AuthenticationPreferences.autoLoginUserId)
+			val autoLoginServer = remember(storedServers, autoLoginServerId) {
+				storedServers.find { server -> server.id == autoLoginServerId.toUUIDOrNull() }
+			}
+			val autoLoginUser = remember(autoLoginServer, autoLoginUserId) {
+				val users = autoLoginServer?.let(serverUserRepository::getStoredServerUsers)
+				users?.find { user -> user.id == autoLoginUserId.toUUIDOrNull() }
+			}
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.auto_sign_in)) },
+				captionContent = {
+					when (autoLoginUserBehavior) {
+						UserSelectBehavior.DISABLED -> Text(stringResource(R.string.user_picker_disable_title))
+						UserSelectBehavior.LAST_USER -> Text(stringResource(R.string.user_picker_last_user_title))
+						UserSelectBehavior.SPECIFIC_USER -> Text(autoLoginUser?.name ?: stringResource(R.string.loading))
+					}
+				},
+				onClick = { router.push(Routes.AUTHENTICATION_AUTO_SIGN_IN) }
+			)
+		}
+
+		item {
+			var sortBy by rememberPreference(authenticationPreferences, AuthenticationPreferences.sortBy)
+			ListButton(
+				headingContent = { Text(stringResource(R.string.sort_accounts_by)) },
+				captionContent = { Text(stringResource(sortBy.nameRes)) },
+				onClick = { router.push(Routes.AUTHENTICATION_SORT_BY) }
+			)
+		}
+
+		if (storedServers.isNotEmpty()) {
+			item {
+				ListSection(
+					modifier = Modifier,
+					headingContent = { Text(stringResource(R.string.lbl_manage_servers)) },
+				)
+			}
+
+			items(storedServers) { server ->
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_house), contentDescription = server.name) },
+					headingContent = { Text(server.name) },
+					captionContent = { Text(server.address) },
+					onClick = {
+						context.startActivity(ActivityDestinations.editServerPreferences(context, server.id))
+					}
+				)
+			}
+		}
+
+		// Disallow changing the "always authenticate" option from the login screen
+		// because that would allow a kid to disable the function to access a parent's account
+		if (sessionRepository.currentSession.value != null) {
+			item {
+				ListSection(
+					modifier = Modifier,
+					headingContent = { Text(stringResource(R.string.advanced_settings)) },
+				)
+			}
+
+			item {
+				var alwaysAuthenticate by rememberPreference(authenticationPreferences, AuthenticationPreferences.alwaysAuthenticate)
+				ListButton(
+					headingContent = { Text(stringResource(R.string.always_authenticate)) },
+					trailingContent = { RadioButton(checked = alwaysAuthenticate) },
+					captionContent = { Text(stringResource(R.string.always_authenticate_description)) },
+					onClick = { alwaysAuthenticate = !alwaysAuthenticate }
+				)
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationSortByScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationSortByScreen.kt
@@ -1,0 +1,53 @@
+package org.jellyfin.androidtv.ui.settings.screen.authentication
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.auth.model.AuthenticationSortBy
+import org.jellyfin.androidtv.auth.store.AuthenticationPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsAuthenticationSortByScreen() {
+	val router = LocalRouter.current
+	val authenticationPreferences = koinInject<AuthenticationPreferences>()
+	var sortBy by rememberPreference(authenticationPreferences, AuthenticationPreferences.sortBy)
+
+	LazyColumn(
+		modifier = Modifier
+			.padding(6.dp),
+		verticalArrangement = Arrangement.spacedBy(4.dp),
+	) {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_login).uppercase()) },
+				headingContent = { Text(stringResource(R.string.sort_accounts_by)) },
+			)
+		}
+
+		items(AuthenticationSortBy.entries) { entry ->
+			ListButton(
+				headingContent = { Text(stringResource(entry.nameRes)) },
+				trailingContent = { RadioButton(checked = sortBy == entry) },
+				onClick = {
+					sortBy = entry
+					router.back()
+				}
+			)
+		}
+	}
+}


### PR DESCRIPTION
**Changes**

- Migrate authentication settings to compose
  - Note: server/user editing still with old UI 🙃 
- Add profile pictures to user selector

<img width="558" height="822" alt="afbeelding" src="https://github.com/user-attachments/assets/6c6b653d-fe6a-48ed-9db2-63c9aefbdc8f" /> <img width="558" height="811" alt="afbeelding" src="https://github.com/user-attachments/assets/162b14e1-d7af-4af7-9ebf-73b43ae9fe28" />

<img width="560" height="817" alt="afbeelding" src="https://github.com/user-attachments/assets/d2eb5afb-8c7c-4f39-8b94-f82b70614fd5" /> <img width="555" height="815" alt="afbeelding" src="https://github.com/user-attachments/assets/deb7d9ee-da19-4b21-a706-ff259eccb087" />



**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
