### PR TITLE
Fix French label for goto series

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,7 +104,7 @@
     <string name="pref_audio_direct">Direct</string>
     <string name="pref_audio_compat">Sous-mixer en stéréo</string>
     <string name="lbl_audio_output">Sortie audio</string>
-    <string name="lbl_goto_series">Aller vers les séries</string>
+    <string name="lbl_goto_series">Aller vers la série</string>
     <string name="lbl_enable_debug">Activer les options de débogage</string>
     <string name="desc_debug">Affiche un bouton d\'envoi des logs sur l\'écran de la page d\'accueil</string>
     <string name="lbl_showing">Afficher</string>


### PR DESCRIPTION
**Changes**
This PR fixes a minor French translation issue.
The label lbl_goto_series previously displayed "Aller vers les séries", which is grammatically incorrect in context.
It is now updated to the correct singular form "Aller vers la série".

**Code assistance**
No automated code generation was used.
Only a manual translation correction was performed.

**Issues**
No issue was opened for this change.