### PR TITLE
Disallow seeking when duration is unknown

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragment.java
@@ -363,7 +363,9 @@ public class AudioNowPlayingFragment extends Fragment {
         time = Math.round(time / 1000L) * 1000L;
 
         mCurrentPos.setText(TimeUtils.formatMillis(time));
-        mRemainingTime.setText("-" + TimeUtils.formatMillis(duration - time));
+
+        if (duration == 0L) mRemainingTime.setText(null);
+        else mRemainingTime.setText("-" + TimeUtils.formatMillis(duration - time));
     }
 
     private void addGenres(TextView textView) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
@@ -12,6 +12,7 @@ import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.koin.compose.koinInject
+import kotlin.time.Duration
 import kotlin.time.times
 
 @Composable
@@ -40,5 +41,6 @@ fun PlayerSeekbar(
 		onSeek = { progress -> playbackManager.state.seek(progress) },
 		modifier = modifier,
 		colors = colors,
+		enabled = positionInfo.duration > Duration.ZERO,
 	)
 }

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -222,7 +222,7 @@ class ExoPlayerBackend(
 	}
 
 	override fun seekTo(position: Duration) {
-		if (!exoPlayer.isCommandAvailable(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)) {
+		if (!exoPlayer.isCommandAvailable(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM) || !exoPlayer.isCurrentMediaItemSeekable) {
 			Timber.w("Trying to seek but ExoPlayer doesn't support it for the current item")
 		}
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

In some cases ExoPlayer doesn't know the duration of the media it is playing. In such case, we should disable the seekbar as seeking will result in undefined behavior (crashes/skipping to next entry/other weird things). Additionally, hide the "remaining time" from the music player.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
