### PR TITLE
Use AAC over HLS for music transcoding

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -140,9 +140,10 @@ fun createDeviceProfile(
 		type = DlnaProfileType.AUDIO
 		context = EncodingContext.STREAMING
 
-		container = Codec.Container.MP3
+		container = Codec.Container.TS
+		protocol = MediaStreamProtocol.HLS
 
-		audioCodec(Codec.Audio.MP3)
+		audioCodec(Codec.Audio.AAC)
 	}
 
 	/// Direct play profiles


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

The mp3 files produced by the server when transcoding do not contain a duration (or at least ExoPlayer can't find/parse it). This caused a variety of issues like seeking crashing the app or skipping the entire track, the time remaining showing extremely glitchy and preventing the lyrics from scrolling. (For the UI fixes see #5239).

This PR updates our transcoding profile to use AAC using an HLS playlist which results in compatible audio files with a duration. In my (brief) testing this also looks to be more efficient on the transcoder.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5138
