### PR TITLE
Add RangeControl composable and use color tokens for Seekbar

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/Seekbar.kt
@@ -41,10 +41,10 @@ object SeekbarDefaults {
 	@ReadOnlyComposable
 	@Composable
 	fun colors(
-		backgroundColor: Color = Color(0xCC4B4B4B),
-		bufferColor: Color = Color(0x40FFFFFF),
-		progressColor: Color = Color(0xFF00A4DC),
-		knobColor: Color = Color.White,
+		backgroundColor: Color = JellyfinTheme.colorScheme.rangeControlBackground,
+		bufferColor: Color = JellyfinTheme.colorScheme.seekbarBuffer,
+		progressColor: Color = JellyfinTheme.colorScheme.rangeControlFill,
+		knobColor: Color = JellyfinTheme.colorScheme.rangeControlKnob,
 	) = SeekbarColors(
 		backgroundColor = backgroundColor,
 		bufferColor = bufferColor,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/colorScheme.kt
@@ -19,6 +19,10 @@ fun colorScheme(): ColorScheme = ColorScheme(
 	onInput = Color(0xE6CCCCCC),
 	inputFocused = Color(0xE6CCCCCC),
 	onInputFocused = Color(0xFFDDDDDD),
+	rangeControlBackground = Color(0xCC4B4B4B),
+	rangeControlFill = Color(0xFF00A4DC),
+	rangeControlKnob = Color(0xFFFFFFFF),
+	seekbarBuffer = Color(0x40FFFFFF),
 	recording = Color(0xB3FF7474),
 	onRecording = Color(0xFFDDDDDD),
 	badge = Color(0xFF62676F),
@@ -57,6 +61,11 @@ data class ColorScheme(
 	val onInput: Color,
 	val inputFocused: Color,
 	val onInputFocused: Color,
+
+	val rangeControlBackground: Color,
+	val rangeControlFill: Color,
+	val rangeControlKnob: Color,
+	val seekbarBuffer: Color,
 
 	val recording: Color,
 	val onRecording: Color,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/form/RangeControl.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/form/RangeControl.kt
@@ -1,0 +1,123 @@
+package org.jellyfin.androidtv.ui.base.form
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+
+@Immutable
+data class RangeControlColors(
+	val backgroundColor: Color,
+	val fillColor: Color,
+	val knobColor: Color,
+)
+
+object RangeControlDefaults {
+	@ReadOnlyComposable
+	@Composable
+	fun colors(
+		backgroundColor: Color = JellyfinTheme.colorScheme.rangeControlBackground,
+		fillColor: Color = JellyfinTheme.colorScheme.rangeControlFill,
+		knobColor: Color = JellyfinTheme.colorScheme.rangeControlKnob,
+	) = RangeControlColors(
+		backgroundColor = backgroundColor,
+		fillColor = fillColor,
+		knobColor = knobColor,
+	)
+}
+
+@Composable
+fun RangeControl(
+	modifier: Modifier = Modifier,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+	min: Float = 0f,
+	max: Float = 1f,
+	value: Float = 0f,
+	stepForward: Float = 0.01f,
+	stepBackward: Float = stepForward,
+	onValueChange: ((vakye: Float) -> Unit)? = null,
+	enabled: Boolean = true,
+	colors: RangeControlColors = RangeControlDefaults.colors(),
+) {
+	val focused by interactionSource.collectIsFocusedAsState()
+	var valueOverride by remember { mutableStateOf<Float?>(null) }
+	val visibleValue = valueOverride ?: value
+	val knobAlpha by animateFloatAsState(if (focused) 1f else 0f)
+
+	Box(
+		modifier = modifier
+			.onKeyEvent {
+				if (!enabled) return@onKeyEvent false
+
+				val isForward = it.key == Key.DirectionRight
+				val isRewind = it.key == Key.DirectionLeft
+				val isScrubbing = isForward || isRewind
+				val isKeyDown = it.type == KeyEventType.KeyDown
+
+				val newValue = when {
+					isKeyDown && isForward -> (visibleValue + stepForward).coerceAtMost(max)
+					isKeyDown && isRewind -> (visibleValue - stepBackward).coerceAtLeast(min)
+					else -> visibleValue
+				}
+
+				if (visibleValue != newValue) {
+					valueOverride = newValue
+					if (onValueChange != null) onValueChange(newValue)
+				}
+
+				return@onKeyEvent isScrubbing
+			}
+			.focusable(interactionSource = interactionSource, enabled = enabled)
+			.drawWithContent {
+				val barCornerRadius = CornerRadius(size.minDimension, size.minDimension)
+
+				// Background bar
+				drawRoundRect(
+					color = colors.backgroundColor,
+					cornerRadius = barCornerRadius,
+				)
+
+				// Get percental value based on min/max options
+				val valuePercentage = (visibleValue - min) / max
+
+				// Value fill bar
+				if (visibleValue > 0f) {
+					drawRoundRect(
+						color = colors.fillColor,
+						size = size.copy(
+							width = valuePercentage * size.width,
+						),
+						cornerRadius = barCornerRadius,
+					)
+				}
+
+				// Progress knob
+				drawCircle(
+					color = colors.knobColor,
+					alpha = knobAlpha,
+					center = center.copy(
+						x = valuePercentage * size.width,
+					),
+					radius = size.minDimension * 2,
+				)
+			}
+	)
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Add a new "RangeControl" composable that is similar to the existing Seekbar composable. While both are similar (a bar that can be mutated using a knob) they'll end up being quite different over time (e.g. seekbar will need chapter markers and probably different seeking behavior). They'll share (some) color tokens but otherwise we'll keep them separate.

Additionally remove hardcoded colors from the seekbar defaults and move them to the color scheme.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
