### PR TITLE
Remove brief descriptions from settings screens

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsDeveloperScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsDeveloperScreen.kt
@@ -35,7 +35,6 @@ fun SettingsDeveloperScreen() {
 			ListSection(
 				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
 				headingContent = { Text(stringResource(R.string.pref_developer_link)) },
-				captionContent = { Text(stringResource(R.string.pref_developer_link_description)) },
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -32,7 +32,6 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_users), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_login)) },
-				captionContent = { Text(stringResource(R.string.pref_login_description)) },
 				onClick = { router.push(Routes.AUTHENTICATION) }
 			)
 		}
@@ -41,7 +40,6 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_adjust), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_customization)) },
-				captionContent = { Text(stringResource(R.string.pref_customization_description)) },
 				onClick = { context.startActivity(ActivityDestinations.customizationPreferences(context)) }
 			)
 		}
@@ -50,7 +48,6 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_next), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback)) },
-				captionContent = { Text(stringResource(R.string.pref_playback_description)) },
 				onClick = { context.startActivity(ActivityDestinations.playbackPreferences(context)) }
 			)
 		}
@@ -59,7 +56,6 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_error), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_telemetry_category)) },
-				captionContent = { Text(stringResource(R.string.pref_telemetry_description)) },
 				onClick = { router.push(Routes.TELEMETRY) }
 			)
 
@@ -69,7 +65,6 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_flask), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_developer_link)) },
-				captionContent = { Text(stringResource(R.string.pref_developer_link_description)) },
 				onClick = { router.push(Routes.DEVELOPER) }
 			)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsTelemetryScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsTelemetryScreen.kt
@@ -23,7 +23,6 @@ fun SettingsTelemetryScreen() {
 			ListSection(
 				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
 				headingContent = { Text(stringResource(R.string.pref_telemetry_category)) },
-				captionContent = { Text(stringResource(R.string.pref_telemetry_description)) },
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationScreen.kt
@@ -43,13 +43,11 @@ fun SettingsAuthenticationScreen(launchedFromLogin: Boolean = false) {
 			ListSection(
 				overlineContent = { Text(stringResource(R.string.app_name).uppercase()) },
 				headingContent = { Text(stringResource(R.string.pref_login)) },
-				captionContent = { Text(stringResource(R.string.pref_login_description)) },
 			)
 		} else item {
 			ListSection(
 				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
 				headingContent = { Text(stringResource(R.string.pref_login)) },
-				captionContent = { Text(stringResource(R.string.pref_login_description)) },
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicensesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicensesScreen.kt
@@ -33,7 +33,6 @@ fun SettingsLicensesScreen() {
 			ListSection(
 				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
 				headingContent = { Text(stringResource(R.string.licenses_link)) },
-				captionContent = { Text(stringResource(R.string.licenses_link_description)) },
 			)
 		}
 


### PR DESCRIPTION
**Changes**

Remove the brief descriptions shown beneath setting screen titles. They are not really helpful as they barely describe the section. They'll likely be replaced with more specific descriptions on top of the screens when necessary later (so not beneath the links to those screens).

| | |
|---|---|
| <img alt="afbeelding" src="https://github.com/user-attachments/assets/9f618aa0-f1aa-4b10-a6f0-4f60dc13c635" /> | <img alt="afbeelding" src="https://github.com/user-attachments/assets/90474a48-36c7-4b20-ae63-f0f6b6a4c3e6" /> |


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
