### PR TITLE
Migrate playback settings to compose

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/ActivityDestinations.kt
@@ -10,7 +10,8 @@ import org.jellyfin.androidtv.ui.playback.ExternalPlayerActivity
 import org.jellyfin.androidtv.ui.preference.PreferencesActivity
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.screen.CustomizationPreferencesScreen
-import org.jellyfin.androidtv.ui.preference.screen.PlaybackPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.PlaybackAdvancedPreferencesScreen
+import org.jellyfin.androidtv.ui.preference.screen.SubtitlePreferencesScreen
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import kotlin.time.Duration
 
@@ -28,7 +29,8 @@ object ActivityDestinations {
 	}
 
 	fun customizationPreferences(context: Context) = preferenceIntent<CustomizationPreferencesScreen>(context)
-	fun playbackPreferences(context: Context) = preferenceIntent<PlaybackPreferencesScreen>(context)
+	fun subtitlePreferences(context: Context) = preferenceIntent<SubtitlePreferencesScreen>(context)
+	fun playbackAdvancedPreferences(context: Context) = preferenceIntent<PlaybackAdvancedPreferencesScreen>(context)
 
 	fun displayPreferences(context: Context, displayPreferencesId: String, allowViewSelection: Boolean) =
 		preferenceIntent<DisplayPreferencesScreen>(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.getQualityProfiles
 import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.UserSettingPreferences
+import org.jellyfin.androidtv.preference.constant.AudioBehavior
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
 import org.jellyfin.androidtv.preference.constant.ZoomMode
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
@@ -21,6 +23,7 @@ import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.preference.dsl.seekbar
 import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.androidtv.util.profile.createDeviceProfileReport
+import org.jellyfin.preference.store.PreferenceStore
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.clientLogApi
 import org.koin.android.ext.android.get
@@ -30,7 +33,11 @@ import timber.log.Timber
 class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 	private val api: ApiClient by inject()
 	private val userPreferences: UserPreferences by inject()
+	private val userSettingPreferences: UserSettingPreferences by inject()
 	private var deviceProfileReported = false
+
+	override val stores: Array<PreferenceStore<*, *>>
+		get() = arrayOf(userSettingPreferences)
 
 	override val screen by optionsScreen {
 		setTitle(R.string.pref_playback)
@@ -55,9 +62,17 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				bind(userPreferences, UserPreferences.resumeSubtractDuration)
 			}
 
-			checkbox {
-				setTitle(R.string.lbl_tv_queuing)
-				bind(userPreferences, UserPreferences.mediaQueuingEnabled)
+			@Suppress("MagicNumber")
+			seekbar {
+				setTitle(R.string.skip_forward_length)
+				setContent(R.string.skip_forward_length)
+				min = 5_000
+				max = 30_000
+				increment = 5_000
+				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
+					override fun display(value: Int) = "${value / 1000}s"
+				}
+				bind(userSettingPreferences, UserSettingPreferences.skipForwardLength)
 			}
 		}
 
@@ -120,6 +135,15 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 
 		category {
 			setTitle(R.string.pref_audio)
+
+			category {
+				setTitle(R.string.pref_audio)
+
+				enum<AudioBehavior> {
+					setTitle(R.string.lbl_audio_output)
+					bind(userPreferences, UserPreferences.audioBehaviour)
+				}
+			}
 
 			checkbox {
 				setTitle(R.string.pref_audio_night_mode)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/SubtitlePreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/SubtitlePreferencesScreen.kt
@@ -5,103 +5,27 @@ import androidx.compose.ui.graphics.toArgb
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
-import org.jellyfin.androidtv.preference.constant.AudioBehavior
-import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
-import org.jellyfin.androidtv.preference.constant.NextUpBehavior
-import org.jellyfin.androidtv.preference.constant.StillWatchingBehavior
-import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
-import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.ui.preference.custom.DurationSeekBarPreference
 import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.colorList
-import org.jellyfin.androidtv.ui.preference.dsl.enum
-import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
 import org.jellyfin.androidtv.ui.preference.dsl.seekbar
 import org.jellyfin.preference.store.PreferenceStore
-import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.koin.android.ext.android.inject
 import kotlin.math.roundToInt
 
-class PlaybackPreferencesScreen : OptionsFragment() {
+class SubtitlePreferencesScreen : OptionsFragment() {
 	private val userPreferences: UserPreferences by inject()
 	private val userSettingPreferences: UserSettingPreferences by inject()
-	private val mediaSegmentRepository: MediaSegmentRepository by inject()
 
 	override val stores: Array<PreferenceStore<*, *>>
 		get() = arrayOf(userSettingPreferences)
 
 	override val screen by optionsScreen {
-		setTitle(R.string.pref_playback)
+		setTitle(R.string.pref_subtitles)
 
 		category {
-			setTitle(R.string.pref_customization)
-
-			enum<NextUpBehavior> {
-				setTitle(R.string.pref_next_up_behavior_title)
-				bind(userPreferences, UserPreferences.nextUpBehavior)
-				depends { userPreferences[UserPreferences.mediaQueuingEnabled] }
-			}
-
-			@Suppress("MagicNumber")
-			seekbar {
-				setTitle(R.string.pref_next_up_timeout_title)
-				setContent(R.string.pref_next_up_timeout_summary)
-				min = 0 // value of 0 disables timer
-				max = 30_000
-				increment = 1_000
-				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-					override fun display(value: Int): String = when (value) {
-						NEXTUP_TIMER_DISABLED -> getString(R.string.pref_next_up_timeout_disabled)
-						else -> "${value / 1000}s"
-					}
-				}
-				bind(userPreferences, UserPreferences.nextUpTimeout)
-				depends {
-					userPreferences[UserPreferences.mediaQueuingEnabled]
-						&& userPreferences[UserPreferences.nextUpBehavior] != NextUpBehavior.DISABLED
-				}
-			}
-
-			enum<StillWatchingBehavior> {
-				setTitle(R.string.pref_still_watching_behavior_title)
-				bind(userPreferences, UserPreferences.stillWatchingBehavior)
-				depends { userPreferences[UserPreferences.mediaQueuingEnabled] }
-			}
-
-			checkbox {
-				setTitle(R.string.lbl_enable_cinema_mode)
-				setContent(R.string.sum_enable_cinema_mode)
-				bind(userPreferences, UserPreferences.cinemaModeEnabled)
-			}
-
-			@Suppress("MagicNumber")
-			seekbar {
-				setTitle(R.string.skip_forward_length)
-				setContent(R.string.skip_forward_length)
-				min = 5_000
-				max = 30_000
-				increment = 5_000
-				valueFormatter = object : DurationSeekBarPreference.ValueFormatter() {
-					override fun display(value: Int) = "${value / 1000}s"
-				}
-				bind(userSettingPreferences, UserSettingPreferences.skipForwardLength)
-			}
-		}
-
-		category {
-			setTitle(R.string.pref_audio)
-
-			enum<AudioBehavior> {
-				setTitle(R.string.lbl_audio_output)
-				bind(userPreferences, UserPreferences.audioBehaviour)
-			}
-		}
-
-		category {
-			setTitle(R.string.pref_subtitles)
-
 			@Suppress("MagicNumber")
 			colorList {
 				setTitle(R.string.lbl_subtitle_text_color)
@@ -254,39 +178,6 @@ class PlaybackPreferencesScreen : OptionsFragment() {
 					set { checked -> userPreferences[UserPreferences.subtitlesTextWeight] = if (checked) boldWeight else normalWeight }
 					default { false }
 				}
-			}
-		}
-
-		category {
-			setTitle(R.string.pref_mediasegment_actions)
-
-			for (segmentType in MediaSegmentRepository.SupportedTypes) {
-				enum<MediaSegmentAction> {
-					when (segmentType) {
-						MediaSegmentType.UNKNOWN -> R.string.segment_type_unknown
-						MediaSegmentType.COMMERCIAL -> R.string.segment_type_commercial
-						MediaSegmentType.PREVIEW -> R.string.segment_type_preview
-						MediaSegmentType.RECAP -> R.string.segment_type_recap
-						MediaSegmentType.OUTRO -> R.string.segment_type_outro
-						MediaSegmentType.INTRO -> R.string.segment_type_intro
-					}.let(::setTitle)
-
-					bind {
-						get { mediaSegmentRepository.getDefaultSegmentTypeAction(segmentType) }
-						set { value -> mediaSegmentRepository.setDefaultSegmentTypeAction(segmentType, value) }
-						default { MediaSegmentAction.NOTHING }
-					}
-				}
-			}
-		}
-
-		category {
-			setTitle(R.string.advanced_settings)
-
-			link {
-				setTitle(R.string.pref_playback_advanced)
-				icon = R.drawable.ic_more
-				withFragment<PlaybackAdvancedPreferencesScreen>()
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -11,6 +11,14 @@ import org.jellyfin.androidtv.ui.settings.screen.authentication.SettingsAuthenti
 import org.jellyfin.androidtv.ui.settings.screen.authentication.SettingsAuthenticationSortByScreen
 import org.jellyfin.androidtv.ui.settings.screen.license.SettingsLicenseScreen
 import org.jellyfin.androidtv.ui.settings.screen.license.SettingsLicensesScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackInactivityPromptScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackPrerollsScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentsScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.nextup.SettingsPlaybackNextUpBehaviorScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.nextup.SettingsPlaybackNextUpScreen
+import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 
 object Routes {
@@ -21,6 +29,13 @@ object Routes {
 	const val AUTHENTICATION_SERVER_USER = "/authentication/server/{serverId}/user/{userId}"
 	const val AUTHENTICATION_SORT_BY = "/authentication/sort-by"
 	const val AUTHENTICATION_AUTO_SIGN_IN = "/authentication/auto-sign-in"
+	const val PLAYBACK = "/playback"
+	const val PLAYBACK_NEXT_UP = "/playback/next-up"
+	const val PLAYBACK_NEXT_UP_BEHAVIOR = "/playback/next-up/behavior"
+	const val PLAYBACK_INACTIVITY_PROMPT = "/playback/inactivity-prompt"
+	const val PLAYBACK_PREROLLS = "/playback/prerolls"
+	const val PLAYBACK_MEDIA_SEGMENTS = "/playback/media-segments"
+	const val PLAYBACK_MEDIA_SEGMENT = "/playback/media-segments/{segmentType}"
 	const val TELEMETRY = "/telemetry"
 	const val DEVELOPER = "/developer"
 	const val LICENSES = "/licenses"
@@ -53,6 +68,29 @@ val routes = mapOf<String, RouteComposable>(
 	},
 	Routes.AUTHENTICATION_AUTO_SIGN_IN to {
 		SettingsAuthenticationAutoSignInScreen()
+	},
+	Routes.PLAYBACK to {
+		SettingsPlaybackScreen()
+	},
+	Routes.PLAYBACK_NEXT_UP to {
+		SettingsPlaybackNextUpScreen()
+	},
+	Routes.PLAYBACK_NEXT_UP_BEHAVIOR to {
+		SettingsPlaybackNextUpBehaviorScreen()
+	},
+	Routes.PLAYBACK_INACTIVITY_PROMPT to {
+		SettingsPlaybackInactivityPromptScreen()
+	},
+	Routes.PLAYBACK_PREROLLS to {
+		SettingsPlaybackPrerollsScreen()
+	},
+	Routes.PLAYBACK_MEDIA_SEGMENTS to {
+		SettingsPlaybackMediaSegmentsScreen()
+	},
+	Routes.PLAYBACK_MEDIA_SEGMENT to { context ->
+		SettingsPlaybackMediaSegmentScreen(
+			segmentType = context.parameters["segmentType"]?.let(MediaSegmentType::fromNameOrNull)!!,
+		)
 	},
 	Routes.TELEMETRY to {
 		SettingsTelemetryScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -48,7 +48,7 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_next), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback)) },
-				onClick = { context.startActivity(ActivityDestinations.playbackPreferences(context)) }
+				onClick = { router.push(Routes.PLAYBACK) }
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackInactivityPromptScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackInactivityPromptScreen.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.StillWatchingBehavior
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackInactivityPromptScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var stillWatchingBehavior by rememberPreference(userPreferences, UserPreferences.stillWatchingBehavior)
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_playback_inactivity_prompt)) },
+			)
+		}
+
+		items(StillWatchingBehavior.entries) { entry ->
+			ListButton(
+				headingContent = { Text(stringResource(entry.nameRes)) },
+				trailingContent = { RadioButton(checked = stillWatchingBehavior == entry) },
+				onClick = {
+					stillWatchingBehavior = entry
+					router.back()
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPrerollsScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPrerollsScreen.kt
@@ -1,0 +1,40 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.Checkbox
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackPrerollsScreen() {
+	val userPreferences = koinInject<UserPreferences>()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_playback_prerolls)) },
+			)
+		}
+
+		item {
+			var cinemaModeEnabled by rememberPreference(userPreferences, UserPreferences.cinemaModeEnabled)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_prerolls_enabled)) },
+				trailingContent = { Checkbox(checked = cinemaModeEnabled) },
+				captionContent = { Text(stringResource(R.string.pref_prerolls_enabled_description)) },
+				onClick = { cinemaModeEnabled = !cinemaModeEnabled }
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackScreen.kt
@@ -1,0 +1,86 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackScreen() {
+	val context = LocalContext.current
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_playback)) },
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_next_up), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_playback_next_up)) },
+				onClick = { router.push(Routes.PLAYBACK_NEXT_UP) }
+			)
+		}
+
+		item {
+			var stillWatchingBehavior by rememberPreference(userPreferences, UserPreferences.stillWatchingBehavior)
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_zzz), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_playback_inactivity_prompt)) },
+				captionContent = { Text(stringResource(stillWatchingBehavior.nameRes)) },
+				onClick = { router.push(Routes.PLAYBACK_INACTIVITY_PROMPT) }
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_trailer), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_playback_prerolls)) },
+				onClick = { router.push(Routes.PLAYBACK_PREROLLS) }
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_subtitles), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_customization_subtitles)) },
+				onClick = { context.startActivity(ActivityDestinations.subtitlePreferences(context)) }
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_clapperboard), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_playback_media_segments)) },
+				onClick = { router.push(Routes.PLAYBACK_MEDIA_SEGMENTS) }
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_more), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_playback_advanced)) },
+				onClick = { context.startActivity(ActivityDestinations.playbackAdvancedPreferences(context)) }
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentScreen.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.jellyfin.sdk.model.api.MediaSegmentType
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackMediaSegmentScreen(
+	segmentType: MediaSegmentType
+) {
+	val router = LocalRouter.current
+	val mediaSegmentRepository = koinInject<MediaSegmentRepository>()
+	val action = mediaSegmentRepository.getDefaultSegmentTypeAction(segmentType)
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback_media_segments).uppercase()) },
+				headingContent = { Text(stringResource(segmentType.nameRes)) },
+			)
+		}
+
+		items(MediaSegmentAction.entries) { entry ->
+			ListButton(
+				headingContent = { Text(stringResource(entry.nameRes)) },
+				trailingContent = { RadioButton(checked = action == entry) },
+				onClick = {
+					mediaSegmentRepository.setDefaultSegmentTypeAction(segmentType, entry)
+					router.back()
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentsScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentsScreen.kt
@@ -1,0 +1,46 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
+import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackMediaSegmentsScreen() {
+	val router = LocalRouter.current
+	val mediaSegmentRepository = koinInject<MediaSegmentRepository>()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_playback_media_segments)) },
+			)
+		}
+
+		items(MediaSegmentRepository.SupportedTypes) { segmentType ->
+			val action = mediaSegmentRepository.getDefaultSegmentTypeAction(segmentType)
+
+			ListButton(
+				headingContent = { Text(stringResource(segmentType.nameRes)) },
+				captionContent = { Text(stringResource(action.nameRes)) },
+				onClick = {
+					router.push(
+						route = Routes.PLAYBACK_MEDIA_SEGMENT,
+						parameters = mapOf(
+							"segmentType" to segmentType.toString(),
+						),
+					)
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/strings.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/strings.kt
@@ -1,0 +1,14 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.sdk.model.api.MediaSegmentType
+
+val MediaSegmentType.nameRes
+	get() = when (this) {
+		MediaSegmentType.UNKNOWN -> R.string.segment_type_unknown
+		MediaSegmentType.COMMERCIAL -> R.string.segment_type_commercial
+		MediaSegmentType.PREVIEW -> R.string.segment_type_preview
+		MediaSegmentType.RECAP -> R.string.segment_type_recap
+		MediaSegmentType.OUTRO -> R.string.segment_type_outro
+		MediaSegmentType.INTRO -> R.string.segment_type_intro
+	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpBehaviorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpBehaviorScreen.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback.nextup
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.NextUpBehavior
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackNextUpBehaviorScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var nextUpBehavior by rememberPreference(userPreferences, UserPreferences.nextUpBehavior)
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback_next_up).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_next_up_behavior_title)) },
+			)
+		}
+
+		items(NextUpBehavior.entries) { entry ->
+			ListButton(
+				headingContent = { Text(stringResource(entry.nameRes)) },
+				trailingContent = { RadioButton(checked = nextUpBehavior == entry) },
+				onClick = {
+					nextUpBehavior = entry
+					router.back()
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpScreen.kt
@@ -1,0 +1,106 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback.nextup
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.NEXTUP_TIMER_DISABLED
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.Checkbox
+import org.jellyfin.androidtv.ui.base.form.RangeControl
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListControl
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+import kotlin.math.roundToInt
+
+@Composable
+fun SettingsPlaybackNextUpScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_playback_next_up)) },
+			)
+		}
+
+		item {
+			var mediaQueuingEnabled by rememberPreference(userPreferences, UserPreferences.mediaQueuingEnabled)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_media_queueing)) },
+				trailingContent = { Checkbox(checked = mediaQueuingEnabled) },
+				captionContent = { Text(stringResource(R.string.pref_media_queueing_description)) },
+				onClick = { mediaQueuingEnabled = !mediaQueuingEnabled }
+			)
+		}
+
+		item {
+			var nextUpBehavior by rememberPreference(userPreferences, UserPreferences.nextUpBehavior)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_next_up_behavior_title)) },
+				captionContent = { Text(stringResource(nextUpBehavior.nameRes)) },
+				onClick = { router.push(Routes.PLAYBACK_NEXT_UP_BEHAVIOR) }
+			)
+		}
+
+		item {
+			var nextUpTimeout by rememberPreference(userPreferences, UserPreferences.nextUpTimeout)
+			val interactionSource = remember { MutableInteractionSource() }
+
+			ListControl(
+				headingContent = { Text(stringResource(R.string.pref_next_up_timeout_title)) },
+				captionContent = { Text(stringResource(R.string.pref_next_up_timeout_summary)) },
+				interactionSource = interactionSource,
+			) {
+				Row(
+					verticalAlignment = Alignment.CenterVertically,
+				) {
+					RangeControl(
+						modifier = Modifier
+							.height(4.dp)
+							.weight(1f),
+						interactionSource = interactionSource,
+						// 0 - 30 seconds with 1 second increment
+						min = 0f,
+						max = 30_000f,
+						stepForward = 1_000f,
+						value = nextUpTimeout.toFloat(),
+						onValueChange = { nextUpTimeout = it.roundToInt() }
+					)
+
+					Spacer(Modifier.width(8.dp))
+
+					Box(
+						modifier = Modifier.sizeIn(minWidth = 32.dp),
+						contentAlignment = Alignment.CenterEnd
+					) {
+						if (nextUpTimeout == NEXTUP_TIMER_DISABLED) Text(stringResource(R.string.pref_next_up_timeout_disabled))
+						else Text("${nextUpTimeout / 1000}s")
+					}
+				}
+			}
+		}
+	}
+}

--- a/app/src/main/res/drawable/ic_next_up.xml
+++ b/app/src/main/res/drawable/ic_next_up.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M22,3H5A2,2 0 0,0 3,5V9H5V5H22V19H5V15H3V19A2,2 0 0,0 5,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M7,15V13H0V11H7V9L11,12L7,15M20,13H13V11H20V13M20,9H13V7H20V9M17,17H13V15H17V17Z" />
+</vector>
+

--- a/app/src/main/res/drawable/ic_subtitles.xml
+++ b/app/src/main/res/drawable/ic_subtitles.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,4A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4H20M20,18V6H4V18H20M6,10H8V12H6V10M6,14H14V16H6V14M16,14H18V16H16V14M10,10H18V12H10V10Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_zzz.xml
+++ b/app/src/main/res/drawable/ic_zzz.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M23,12H17V10L20.39,6H17V4H23V6L19.62,10H23V12M15,16H9V14L12.39,10H9V8H15V10L11.62,14H15V16M7,20H1V18L4.39,14H1V12H7V14L3.62,18H7V20Z" />
+</vector>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -553,6 +553,15 @@
     <string name="settings">Settings</string>
     <string name="settings_description">Change the app to your own liking</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
+    <string name="pref_playback_next_up">Next up</string>
+    <string name="pref_playback_media_segments">Media segments</string>
+    <string name="pref_customization_subtitles">Subtitles</string>
+    <string name="pref_playback_prerolls">Prerolls</string>
+    <string name="pref_playback_inactivity_prompt">Inactivity prompt</string>
+    <string name="pref_prerolls_enabled">Enable cinema mode</string>
+    <string name="pref_prerolls_enabled_description">Play custom intros before movies</string>
+    <string name="pref_media_queueing">Queue all episodes</string>
+    <string name="pref_media_queueing_description">Add subsequent episodes to the queue when playing TV series</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

- Migrate playback settings to compose
- Adds categories (screens) for: next up, inactivity prompt, prerolls, subtitles and media segments
- The advanced playback preferences will come later, using old UI for now
- The subtitles will come later, using old UI for now
<!-- Describe your changes here in 1-5 sentences. -->

**Screenshots**

Note not complete, some screens missing

| | |
| --- | --- |
| <img width="560" height="820" alt="afbeelding" src="https://github.com/user-attachments/assets/489ca53d-061b-414c-814a-0378c9611a84" /> | <img width="560" height="820" alt="afbeelding" src="https://github.com/user-attachments/assets/aea20312-a81c-400d-af86-16224a7b3f74" /> |
| <img width="560" height="820" alt="afbeelding" src="https://github.com/user-attachments/assets/1170e305-d9ee-4fe3-bc34-e62115cf8646" /> | <img width="560" height="820" alt="afbeelding" src="https://github.com/user-attachments/assets/a35e5dfc-9ec6-4c8c-93b0-556a55434800" /> | 
| <img width="560" height="820" alt="afbeelding" src="https://github.com/user-attachments/assets/59258edd-1043-4f0f-9b19-9be692cf969f" /> | |


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
