### PR TITLE
Use fragmented MP4 as HLS container

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -123,7 +123,7 @@ fun createDeviceProfile(
 		type = DlnaProfileType.VIDEO
 		context = EncodingContext.STREAMING
 
-		container = Codec.Container.TS
+		container = Codec.Container.MP4
 		protocol = MediaStreamProtocol.HLS
 
 		if (supportsHevc) videoCodec(Codec.Video.HEVC)


### PR DESCRIPTION
Needs testing

**Changes**

Use fragmented MP4 instead of TS when transcoding video as this allows for more audio codecs and is more modern and better supported by media3.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
