### PR TITLE
Fix SDR fallback selection over HDR for HLS streams

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AdaptiveHdrTrackSelection.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AdaptiveHdrTrackSelection.kt
@@ -1,0 +1,120 @@
+package org.jellyfin.androidtv.ui.playback
+
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Timeline
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.chunk.MediaChunk
+import androidx.media3.exoplayer.source.chunk.MediaChunkIterator
+import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
+import androidx.media3.exoplayer.trackselection.BaseTrackSelection
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection
+import androidx.media3.exoplayer.upstream.BandwidthMeter
+
+@OptIn(UnstableApi::class)
+class AdaptiveHdrTrackSelection(
+	private val delegate: AdaptiveTrackSelection
+) : BaseTrackSelection(
+	delegate.trackGroup,
+	IntArray(delegate.length()) { it },
+	TYPE_UNSET
+) {
+
+	companion object {
+		const val SELECTION_REASON_ADAPTIVE_HDR_UPGRADE = 1001
+	}
+
+	private var selectedIndex = 0
+
+	override fun getSelectedIndex(): Int = selectedIndex
+
+	override fun updateSelectedTrack(
+		playbackPositionUs: Long,
+		bufferedDurationUs: Long,
+		availableDurationUs: Long,
+		queue: List<MediaChunk>,
+		mediaChunkIterators: Array<out MediaChunkIterator>
+	) {
+		delegate.updateSelectedTrack(
+			playbackPositionUs,
+			bufferedDurationUs,
+			availableDurationUs,
+			queue,
+			mediaChunkIterators
+		)
+
+		upgradeSelectedToHdr(delegate.selectedIndex)?.let { selectedIndex = it }
+	}
+
+	override fun getSelectionReason(): Int =
+		if (selectedIndex != delegate.selectedIndex) SELECTION_REASON_ADAPTIVE_HDR_UPGRADE
+		else delegate.selectionReason
+
+	override fun getSelectionData(): Any? = delegate.selectionData
+
+	private fun upgradeSelectedToHdr(selected: Int): Int? {
+		val currentFormat = getFormat(selected)
+
+		if (currentFormat.hasHdrVideoRangeMetadata()) return selected
+
+		return (0 until length)
+			.firstOrNull { i ->
+				val format = getFormat(i)
+
+				format.bitrate == currentFormat.bitrate &&
+					format.width == currentFormat.width &&
+					format.height == currentFormat.height &&
+					format.frameRate == currentFormat.frameRate &&
+					format.hasHdrVideoRangeMetadata()
+			}
+	}
+
+	class Factory(
+		private val adaptiveFactory: AdaptiveTrackSelection.Factory =
+			AdaptiveTrackSelection.Factory()
+	) : ExoTrackSelection.Factory {
+
+		override fun createTrackSelections(
+			definitions: Array<out ExoTrackSelection.Definition?>,
+			bandwidthMeter: BandwidthMeter,
+			mediaPeriodId: MediaSource.MediaPeriodId,
+			timeline: Timeline
+		): Array<ExoTrackSelection?> {
+			val baseSelections = adaptiveFactory.createTrackSelections(
+				definitions,
+				bandwidthMeter,
+				mediaPeriodId,
+				timeline
+			)
+
+			return baseSelections.map { base ->
+				val adaptive = base as? AdaptiveTrackSelection
+				if (adaptive?.trackGroup?.isVideo() == true)
+					AdaptiveHdrTrackSelection(adaptive) else base
+			}.toTypedArray()
+		}
+	}
+}
+
+@OptIn(UnstableApi::class)
+private fun Format.hasHdrVideoRangeMetadata(): Boolean {
+	val metadata = this.metadata ?: return false
+	val hdrValues = listOf("PQ", "HLG")
+
+	return (0 until metadata.length())
+		.map { metadata[it] }
+		.any { entry ->
+			entry is VideoRangeHlsPlaylistParser.VideoRangeEntry &&
+				hdrValues.any { value -> entry.value.equals(value, true) }
+		}
+}
+
+@OptIn(UnstableApi::class)
+private fun TrackGroup.isVideo(): Boolean =
+	(0 until length).any {
+		MimeTypes.isVideo(getFormat(it).sampleMimeType)
+	}
+

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -28,11 +28,14 @@ import androidx.media3.common.TrackSelectionOverride;
 import androidx.media3.common.TrackSelectionParameters;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.HttpDataSource;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.analytics.AnalyticsListener;
+import androidx.media3.exoplayer.hls.HlsMediaSource;
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParserFactory;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.exoplayer.util.EventLogger;
@@ -70,6 +73,7 @@ public class VideoManager {
     private PlaybackOverlayFragmentHelper _helper;
     public ExoPlayer mExoPlayer;
     private PlayerView mExoPlayerView;
+    private DataSource.Factory mExoPlayerDataSourceFactory;
     private Handler mHandler = new Handler();
 
     private long mMetaDuration = -1;
@@ -202,7 +206,7 @@ public class VideoManager {
         defaultRendererFactory.setEnableDecoderFallback(true);
         defaultRendererFactory.setExtensionRendererMode(determineExoPlayerExtensionRendererMode());
 
-        DefaultTrackSelector trackSelector = new DefaultTrackSelector(context);
+        DefaultTrackSelector trackSelector = new DefaultTrackSelector(context, new AdaptiveHdrTrackSelection.Factory());
         trackSelector.setParameters(trackSelector.buildUponParameters()
                 .setAudioOffloadPreferences(new TrackSelectionParameters.AudioOffloadPreferences.Builder()
                         .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
@@ -216,9 +220,9 @@ public class VideoManager {
         DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory().setTsExtractorTimestampSearchBytes(TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES * 3);
         extractorsFactory.setConstantBitrateSeekingEnabled(true);
         extractorsFactory.setConstantBitrateSeekingAlwaysEnabled(true);
-        DefaultDataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, exoPlayerHttpDataSourceFactory);
+        mExoPlayerDataSourceFactory = new DefaultDataSource.Factory(context, exoPlayerHttpDataSourceFactory);
         exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
-        exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory));
+        exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(mExoPlayerDataSourceFactory, extractorsFactory));
 
         return exoPlayerBuilder;
     }
@@ -370,10 +374,29 @@ public class VideoManager {
                     .setSubtitleConfigurations(subtitleConfigurations)
                     .build();
 
-            mExoPlayer.setMediaItem(mediaItem);
+            setMediaItemOrSource(mediaItem);
             mExoPlayer.prepare();
         } catch (IllegalStateException e) {
             Timber.e(e, "Unable to set video path.  Probably backing out.");
+        }
+    }
+
+    private void setMediaItemOrSource(MediaItem mediaItem) {
+        String streamUrl = mediaItem.localConfiguration != null ? mediaItem.localConfiguration.uri.toString() : "";
+
+        // Media3 doesn't store the HLS VIDEO-RANGE attribute, so for master playlists we add
+        // an entry into each variant's Format metadata for use during track selection
+        if (streamUrl.contains("master.m3u8")) {
+            Timber.i("Trying to inject HLS VIDEO-RANGE into variant metadata");
+
+            HlsPlaylistParserFactory parserFactory = new VideoRangeHlsPlaylistParser.Factory();
+            HlsMediaSource.Factory hlsSourceFactory = new HlsMediaSource.Factory(mExoPlayerDataSourceFactory)
+                    .setPlaylistParserFactory(parserFactory);
+            HlsMediaSource hlsMediaSource = hlsSourceFactory.createMediaSource(mediaItem);
+
+            mExoPlayer.setMediaSource(hlsMediaSource);
+        } else {
+            mExoPlayer.setMediaItem(mediaItem);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoRangeHlsPlaylistParser.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoRangeHlsPlaylistParser.kt
@@ -1,0 +1,110 @@
+package org.jellyfin.androidtv.ui.playback
+
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.Metadata
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
+import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylist
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParser
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParserFactory
+import androidx.media3.exoplayer.upstream.ParsingLoadable
+import java.io.InputStream
+
+@OptIn(UnstableApi::class)
+class VideoRangeHlsPlaylistParser(
+	private val delegate: ParsingLoadable.Parser<HlsPlaylist>
+) : ParsingLoadable.Parser<HlsPlaylist> {
+
+	override fun parse(uri: Uri, inputStream: InputStream): HlsPlaylist {
+		val bytes = inputStream.readBytes()
+		val playlist = delegate.parse(uri, bytes.inputStream())
+
+		if (playlist !is HlsMultivariantPlaylist) return playlist
+
+		val text = bytes.toString(Charsets.UTF_8)
+		val hasRange = text.contains("VIDEO-RANGE=")
+
+		if (!hasRange) return playlist
+
+		val videoRangeMap = extractVideoRanges(text)
+
+		if (videoRangeMap.isEmpty()) return playlist
+
+		return injectVideoRangeMetadata(playlist, videoRangeMap)
+	}
+
+	private fun extractVideoRanges(text: String): Map<String, String> {
+		val regex = Regex(
+			"""#EXT-X-STREAM-INF:.*?VIDEO-RANGE=([A-Za-z0-9_-]+).*?\n([^\n]+)""",
+			RegexOption.DOT_MATCHES_ALL
+		)
+
+		return regex.findAll(text)
+			.associate { match ->
+				val (range, uri) = match.destructured
+				uri.trim() to range
+			}
+	}
+
+	private fun injectVideoRangeMetadata(
+        playlist: HlsMultivariantPlaylist,
+        videoRanges: Map<String, String>
+	): HlsMultivariantPlaylist {
+		val updatedVariants = playlist.variants.map { variant ->
+			val url = variant.url.toString()
+
+			val range = videoRanges.entries.firstOrNull {
+				url.endsWith(it.key)
+			}?.value ?: return@map variant
+
+			val newFormat = variant.format.buildUpon()
+				.setMetadata(
+					mergeMetadata(
+						variant.format.metadata,
+						range
+					)
+				)
+				.build()
+
+			variant.copyWithFormat(newFormat)
+		}
+
+		return HlsMultivariantPlaylist(
+            playlist.baseUri,
+            playlist.tags,
+            updatedVariants,
+            playlist.videos,
+            playlist.audios,
+            playlist.subtitles,
+            playlist.closedCaptions,
+            playlist.muxedAudioFormat,
+            playlist.muxedCaptionFormats,
+            playlist.hasIndependentSegments,
+            playlist.variableDefinitions,
+            playlist.sessionKeyDrmInitData
+        )
+	}
+
+	private fun mergeMetadata(existing: Metadata?, range: String): Metadata {
+		val entry = VideoRangeEntry(range)
+		return existing?.copyWithAppendedEntries(entry) ?: Metadata(entry)
+	}
+
+	data class VideoRangeEntry(val value: String) : Metadata.Entry
+
+	@OptIn(UnstableApi::class)
+	class Factory : HlsPlaylistParserFactory {
+		override fun createPlaylistParser(): ParsingLoadable.Parser<HlsPlaylist> =
+			VideoRangeHlsPlaylistParser(HlsPlaylistParser())
+
+		override fun createPlaylistParser(
+            multivariantPlaylist: HlsMultivariantPlaylist,
+            previousMediaPlaylist: HlsMediaPlaylist?
+		): ParsingLoadable.Parser<HlsPlaylist> =
+			VideoRangeHlsPlaylistParser(
+                HlsPlaylistParser(multivariantPlaylist, previousMediaPlaylist)
+			)
+	}
+}


### PR DESCRIPTION
This PR fixes an issue where ExoPlayer selects an SDR fallback variant (typically a transcode) instead of an available HDR variant (typically a remux) when playing HLS streams.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Wrap the HLS playlist parser to map the `VIDEO-RANGE` attribute to variant streams and add it to their `Format` metadata (`VideoRangeEntry`)
- Wrap the adaptive track selection to prefer HDR variants over SDR when tracks are otherwise equivalent (resolution, bitrate, and frame rate)

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
- Code review

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #5245

**Additional**
- Has not been tested with Live TV; behavior could be scoped to transcodes and remuxes.
- Feedback, suggestions, and testing are greatly appreciated.