### PR TITLE
Fix a NullPointerException crash when next up episode has no user item data

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1072,7 +1072,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         boolean isSeries = mBaseItem.getType() == BaseItemKind.SERIES;
         boolean isFinished = mBaseItem.getUserData().getPlayed();
         boolean isStarted = mBaseItem.getUserData().getPlayedPercentage() != null && mBaseItem.getUserData().getPlayedPercentage() > 0;
-        if (!isStarted && nextUpEpisode != null) {
+        if (!isStarted && nextUpEpisode != null && nextUpEpisode.getUserData() != null) {
             isStarted = nextUpEpisode.getUserData().getPlaybackPositionTicks() > 0;
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Next episodes that were never played may not include user data and this is causing a full client crash. not happening in the normal jellyfin app.
i started seeing this behavior after using the plugin https://github.com/pelluch/jellyfin-plugin-disable-user-data
to speed-up jellyfin

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
`
12-21 22:46:30.404 I/ItemRowAdapterHelperKt(27126): Creating items from 0 existing and 1 new, adapter size is 0 12-21 22:46:30.407 E/ACRA (27126): ACRA caught a NullPointerException for org.jellyfin.androidtv 12-21 22:46:30.407 E/ACRA (27126): java.lang.NullPointerException: Attempt to invoke virtual method 'long org.jellyfin.sdk.model.api.UserItemDataDto.getPlaybackPositionTicks()' on a null object reference 12-21 22:46:30.407 E/ACRA (27126): at org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragment.handleResumeButtonAndFocus(FullDetailsFragment.java:1076) 12-21 22:46:30.407 E/ACRA (27126): at org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragment.lambda$addButtons$6$org-jellyfin-androidtv-ui-itemdetail-FullDetailsFragment(FullDetailsFragment.java:794) 12-21 22:46:30.407 E/ACRA (27126): at org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragment$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0) 12-21 22:46:30.407 E/ACRA (27126): at org.jellyfin.androidtv.ui.itemdetail.FullDetailsFragmentHelperKt$getNextUpEpisode$1.invokeSuspend(FullDetailsFragmentHelper.kt:235) 12-21 22:46:30.407 E/ACRA (27126): at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34) 12-21 22:46:30.407 E/ACRA (27126): at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100) 12-21 22:46:30.407 E/ACRA (27126): at android.os.Handler.handleCallback(Handler.java:938) 12-21 22:46:30.407 E/ACRA (27126): at android.os.Handler.dispatchMessage(Handler.java:99) 12-21 22:46:30.407 E/ACRA (27126): at android.os.Looper.loop(Looper.java:223) 12-21 22:46:30.407 E/ACRA (27126): at android.app.ActivityThread.main(ActivityThread.java:7668) 12-21 22:46:30.407 E/ACRA (27126): at java.lang.reflect.Method.invoke(Native Method) 12-21 22:46:30.407 E/ACRA (27126): at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 12-21 22:46:30.407 E/ACRA (27126): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 12-21 22:46:30.407 E/ACRA (27126): Suppressed: kotlinx.coro`
