### PR TITLE
Fix AVC high 10 reporting as main 10 in device profile

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -202,7 +202,7 @@ fun createDeviceProfile(
 					"main",
 					"baseline",
 					"constrained baseline",
-					if (supportsAVCHigh10) "main 10" else null
+					if (supportsAVCHigh10) "high 10" else null
 				)
 			}
 		}


### PR DESCRIPTION
**Changes**

- Fix AVC high 10 reporting as main 10 in device profile
<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
