### PR TITLE
Allow selecting external video player app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,11 @@
                 android:host="youtube.com"
                 android:scheme="https" />
         </intent>
+
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="video/*" />
+        </intent>
     </queries>
 
     <application
@@ -47,10 +52,10 @@
         android:icon="@mipmap/app_icon"
         android:label="@string/app_name"
         android:largeHeap="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.Jellyfin"
-        android:usesCleartextTraffic="true"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:usesCleartextTraffic="true">
 
         <!-- Screensaver -->
         <service

--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/ExternalAppRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/ExternalAppRepository.kt
@@ -1,0 +1,62 @@
+package org.jellyfin.androidtv.data.repository
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import androidx.core.net.toUri
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.util.componentName
+
+class ExternalAppRepository(
+	private val userPreferences: UserPreferences,
+) {
+	companion object {
+		const val SAMPLE_VIDEO_URL = "http://jellyfin.local/query.mp4"
+		const val MEDIA_TYPE_VIDEO = "video/*"
+	}
+
+	private val externalPlayerAppIntent = Intent(Intent.ACTION_VIEW).apply {
+		setDataAndTypeAndNormalize(SAMPLE_VIDEO_URL.toUri(), MEDIA_TYPE_VIDEO)
+	}
+
+	fun getExternalPlayerApps(context: Context): List<ResolveInfo> = context.packageManager
+		.queryIntentActivities(externalPlayerAppIntent, 0)
+		// Hide apps with priority below zero (system stubs)
+		.filter { it.priority >= 0 }
+
+	fun getCurrentExternalPlayerApp(context: Context): ActivityInfo? {
+		// Validate if external app should be used at all
+		val useExternalPlayer = userPreferences[UserPreferences.useExternalPlayer]
+		if (!useExternalPlayer) return null
+
+		// Resolve external app information
+		val resolvedInfo = userPreferences[UserPreferences.externalPlayerComponentName]
+			.takeIf { it.isNotEmpty() }
+			?.let(ComponentName::unflattenFromString)
+			?.runCatching { context.packageManager.getActivityInfo(this, 0) }
+			?.getOrNull()
+		if (resolvedInfo != null) return resolvedInfo
+
+		// Fallback in case the app is uninstalled or unavailable for some other reason
+		val externalApps = getExternalPlayerApps(context)
+
+		// System default
+		val systemDefault = externalApps.find { it.isDefault }?.activityInfo
+		if (systemDefault != null) return systemDefault
+
+		// First compatible, or none
+		return externalApps.firstOrNull()?.activityInfo
+	}
+
+	fun setExternalPlayerapp(activityInfo: ActivityInfo?) {
+		if (activityInfo == null) {
+			userPreferences[UserPreferences.useExternalPlayer] = false
+			userPreferences[UserPreferences.externalPlayerComponentName] = ""
+		} else {
+			userPreferences[UserPreferences.useExternalPlayer] = true
+			userPreferences[UserPreferences.externalPlayerComponentName] = activityInfo.componentName.flattenToShortString()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -20,6 +20,7 @@ import org.jellyfin.androidtv.data.eventhandling.SocketHandler
 import org.jellyfin.androidtv.data.model.DataRefreshService
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository
 import org.jellyfin.androidtv.data.repository.CustomMessageRepositoryImpl
+import org.jellyfin.androidtv.data.repository.ExternalAppRepository
 import org.jellyfin.androidtv.data.repository.ItemMutationRepository
 import org.jellyfin.androidtv.data.repository.ItemMutationRepositoryImpl
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
@@ -140,6 +141,7 @@ val appModule = module {
 	single<NavigationRepository> { NavigationRepositoryImpl(Destinations.home) }
 	single<SearchRepository> { SearchRepositoryImpl(get()) }
 	single<MediaSegmentRepository> { MediaSegmentRepositoryImpl(get(), get()) }
+	single<ExternalAppRepository> { ExternalAppRepository(get()) }
 
 	viewModel { StartupViewModel(get(), get(), get(), get()) }
 	viewModel { UserLoginViewModel(get(), get(), get(), get(defaultDeviceInfo)) }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -100,6 +100,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var useExternalPlayer = booleanPreference("external_player", false)
 
 		/**
+		 * Component name for the external playback application.
+		 */
+		var externalPlayerComponentName = stringPreference("external_player_component", "")
+
+		/**
 		 * Change refresh rate to match media when device supports it
 		 */
 		var refreshRateSwitchingBehavior = enumPreference("refresh_rate_switching_behavior", RefreshRateSwitchingBehavior.DISABLED)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListMessage.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/list/ListMessage.kt
@@ -1,0 +1,25 @@
+package org.jellyfin.androidtv.ui.base.list
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
+
+@Composable
+fun ListMessage(
+	modifier: Modifier = Modifier,
+	content: @Composable () -> Unit,
+) {
+	Box(
+		modifier = modifier
+			.padding(12.dp),
+	) {
+		ProvideTextStyle(LocalTextStyle.current.copy(color = JellyfinTheme.colorScheme.listCaption)) {
+			content()
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.model.DataRefreshService
+import org.jellyfin.androidtv.data.repository.ExternalAppRepository
+import org.jellyfin.androidtv.util.componentName
 import org.jellyfin.androidtv.util.sdk.getDisplayName
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
@@ -72,6 +74,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 
 	private val videoQueueManager by inject<VideoQueueManager>()
 	private val dataRefreshService by inject<DataRefreshService>()
+	private val externalAppRepository by inject<ExternalAppRepository>()
 	private val api by inject<ApiClient>()
 
 	private val playVideoLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -154,6 +157,12 @@ class ExternalPlayerActivity : FragmentActivity() {
 				MediaType.AUDIO -> "audio/*"
 				else -> null
 			}
+
+			// Set configured app to launch
+			externalAppRepository
+				.getCurrentExternalPlayerApp(this@ExternalPlayerActivity)
+				?.componentName
+				?.let(::setComponent)
 
 			setDataAndTypeAndNormalize(url.toUri(), mediaType)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -116,11 +116,6 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 				setTitle(R.string.preference_enable_pgs)
 				bind(userPreferences, UserPreferences.pgsDirectPlay)
 			}
-
-			checkbox {
-				setTitle(R.string.pref_external_player)
-				bind(userPreferences, UserPreferences.useExternalPlayer)
-			}
 		}
 
 		category {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.Settings
 import org.jellyfin.androidtv.ui.settings.screen.license.SettingsLicenseScreen
 import org.jellyfin.androidtv.ui.settings.screen.license.SettingsLicensesScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackInactivityPromptScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackPlayerScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackPrerollsScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentScreen
@@ -39,6 +40,7 @@ object Routes {
 	const val CUSTOMIZATION_SUBTITLES_BACKGROUND_COLOR = "/customization/subtitles/background-color"
 	const val CUSTOMIZATION_SUBTITLES_EDGE_COLOR = "/customization/subtitles/edge-color"
 	const val PLAYBACK = "/playback"
+	const val PLAYBACK_PLAYER = "/playback/player"
 	const val PLAYBACK_NEXT_UP = "/playback/next-up"
 	const val PLAYBACK_NEXT_UP_BEHAVIOR = "/playback/next-up/behavior"
 	const val PLAYBACK_INACTIVITY_PROMPT = "/playback/inactivity-prompt"
@@ -93,6 +95,9 @@ val routes = mapOf<String, RouteComposable>(
 	},
 	Routes.PLAYBACK to {
 		SettingsPlaybackScreen()
+	},
+	Routes.PLAYBACK_PLAYER to {
+		SettingsPlaybackPlayerScreen()
 	},
 	Routes.PLAYBACK_NEXT_UP to {
 		SettingsPlaybackNextUpScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPlayerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPlayerScreen.kt
@@ -1,0 +1,100 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil3.compose.rememberAsyncImagePainter
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ExternalAppRepository
+import org.jellyfin.androidtv.ui.base.LocalShapes
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListMessage
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.jellyfin.androidtv.util.componentName
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackPlayerScreen() {
+	val externalAppRepository = koinInject<ExternalAppRepository>()
+	val context = LocalContext.current
+	val router = LocalRouter.current
+	val packageManager = context.packageManager
+
+	val externalPlayerApps = remember(context) { externalAppRepository.getExternalPlayerApps(context) }
+	val currentExternalPlayer = remember(context) { externalAppRepository.getCurrentExternalPlayerApp(context) }
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback).uppercase()) },
+				headingContent = { Text(stringResource(R.string.playback_video_player)) },
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = {
+					Image(
+						painter = rememberAsyncImagePainter(R.mipmap.app_icon),
+						contentDescription = null,
+						modifier = Modifier
+							.size(32.dp)
+							.clip(LocalShapes.current.small)
+					)
+				},
+				headingContent = { Text(stringResource(R.string.app_name)) },
+				trailingContent = { RadioButton(checked = currentExternalPlayer == null) },
+				captionContent = { Text(stringResource(R.string.video_player_internal)) },
+				onClick = {
+					externalAppRepository.setExternalPlayerapp(null)
+					router.back()
+				}
+			)
+		}
+
+		item { ListSection(headingContent = { Text(stringResource(R.string.video_player_external)) }) }
+
+		if (externalPlayerApps.isEmpty()) {
+			item {
+				ListMessage {
+					Text(stringResource(R.string.playback_video_player_external_empty))
+				}
+			}
+		}
+
+		items(externalPlayerApps) { app ->
+			val icon = remember(app, packageManager) { app.loadIcon(packageManager) }
+			val displayName = remember(app, packageManager) { app.loadLabel(packageManager).toString() }
+
+			ListButton(
+				leadingContent = {
+					Image(
+						painter = rememberAsyncImagePainter(icon),
+						contentDescription = null,
+						modifier = Modifier
+							.size(32.dp)
+							.clip(LocalShapes.current.small)
+					)
+				},
+				headingContent = { Text(displayName) },
+				trailingContent = { RadioButton(checked = currentExternalPlayer?.componentName == app.activityInfo.componentName) },
+				captionContent = { Text(stringResource(R.string.video_player_external)) },
+				onClick = {
+					externalAppRepository.setExternalPlayerapp(app.activityInfo)
+					router.back()
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackScreen.kt
@@ -1,14 +1,23 @@
 package org.jellyfin.androidtv.ui.settings.screen.playback
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil3.compose.rememberAsyncImagePainter
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.data.repository.ExternalAppRepository
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.LocalShapes
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
@@ -23,6 +32,7 @@ import org.koin.compose.koinInject
 fun SettingsPlaybackScreen() {
 	val context = LocalContext.current
 	val router = LocalRouter.current
+	val externalAppRepository = koinInject<ExternalAppRepository>()
 	val userPreferences = koinInject<UserPreferences>()
 
 	SettingsColumn {
@@ -30,6 +40,27 @@ fun SettingsPlaybackScreen() {
 			ListSection(
 				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
 				headingContent = { Text(stringResource(R.string.pref_playback)) },
+			)
+		}
+
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_tv_play), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.playback_video_player)) },
+				trailingContent = {
+					val iconDrawable = remember(context) {
+						externalAppRepository.getCurrentExternalPlayerApp(context)?.loadIcon(context.packageManager)
+					}
+					Image(
+						painter = if (iconDrawable == null) rememberAsyncImagePainter(R.mipmap.app_icon)
+						else rememberAsyncImagePainter(iconDrawable),
+						contentDescription = null,
+						modifier = Modifier
+							.size(24.dp)
+							.clip(LocalShapes.current.small)
+					)
+				},
+				onClick = { router.push(Routes.PLAYBACK_PLAYER) }
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/ActivityInfoExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ActivityInfoExtensions.kt
@@ -1,0 +1,9 @@
+package org.jellyfin.androidtv.util
+
+import android.content.ComponentName
+import android.content.pm.ActivityInfo
+
+/**
+ * Get the [ComponentName] for this [ActivityInfo].
+ */
+val ActivityInfo.componentName get() = ComponentName(packageName, name)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -576,6 +576,10 @@
     <string name="color_presets">Presets</string>
     <string name="color_custom">Customize color</string>
     <string name="color_alpha">Transparency</string>
+    <string name="playback_video_player">Video player</string>
+    <string name="video_player_internal">Built-in video player</string>
+    <string name="video_player_external">External app</string>
+    <string name="playback_video_player_external_empty">You don\'t have any video player apps installed on your device that can open Jellyfin videos.</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>
         <item quantity="other">%1$s seconds</item>


### PR DESCRIPTION
**Changes**

Add a new "Video player" setting where either the app itself (Jellyfin) can be selected or an external app. This replaces the previous "use external player" option and gives more flexibility as some Android TV variants make it quite hard to set the default video app, in addition a user might not want to use their system default from the Jellyfin app.

If the selected app is uninstalled or unavailable for any other reason we'll automatically fall back to a different external app, if possible.

| | |
|:--- | ---:|
| <img width="558" height="814" alt="image" src="https://github.com/user-attachments/assets/a06291ca-bd2c-4037-9184-7cbec45bc893" /> | <img width="558" height="814" alt="image" src="https://github.com/user-attachments/assets/c752923d-341c-42ae-a8a1-aa3628617d00" /> |



**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
