### PR TITLE
Remove shortcut preferences

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.preference
 
 import android.content.Context
-import android.view.KeyEvent
 import androidx.preference.PreferenceManager
 import org.jellyfin.androidtv.preference.UserPreferences.Companion.screensaverInAppEnabled
 import org.jellyfin.androidtv.preference.constant.AppTheme
@@ -135,16 +134,6 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Use direct play
 		 */
 		var liveTvDirectPlayEnabled = booleanPreference("pref_live_direct", true)
-
-		/**
-		 * Shortcut used for changing the audio track
-		 */
-		var shortcutAudioTrack = intPreference("shortcut_audio_track", KeyEvent.KEYCODE_MEDIA_AUDIO_TRACK)
-
-		/**
-		 * Shortcut used for changing the subtitle track
-		 */
-		var shortcutSubtitleTrack = intPreference("shortcut_subtitle_track", KeyEvent.KEYCODE_CAPTIONS)
 
 		/* Developer options */
 		/**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/CustomPlaybackTransportControlGlue.java
@@ -380,10 +380,10 @@ public class CustomPlaybackTransportControlGlue extends PlaybackTransportControl
 
         VideoPlayerAdapter playerAdapter = getPlayerAdapter();
 
-        if (playerAdapter.hasSubs() && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutSubtitleTrack())) {
+        if (playerAdapter.hasSubs() && keyCode == KeyEvent.KEYCODE_CAPTIONS) {
             closedCaptionsAction.handleClickAction(playbackController, getPlayerAdapter(), getContext(), v);
         }
-        if (playerAdapter.hasMultiAudio() && keyCode == KoinJavaComponent.<UserPreferences>get(UserPreferences.class).get(UserPreferences.Companion.getShortcutAudioTrack())) {
+        if (playerAdapter.hasMultiAudio() && keyCode == KeyEvent.KEYCODE_MEDIA_AUDIO_TRACK) {
             selectAudioAction.handleClickAction(playbackController, getPlayerAdapter(), getContext(), v);
         }
         return super.onKey(v, keyCode, event);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -12,7 +12,6 @@ import org.jellyfin.androidtv.ui.preference.dsl.enum
 import org.jellyfin.androidtv.ui.preference.dsl.link
 import org.jellyfin.androidtv.ui.preference.dsl.list
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
-import org.jellyfin.androidtv.ui.preference.dsl.shortcut
 import org.jellyfin.androidtv.util.getQuantityString
 import org.koin.android.ext.android.inject
 import kotlin.time.Duration.Companion.minutes
@@ -151,20 +150,6 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 					set { value -> userPreferences[UserPreferences.screensaverAgeRatingMax] = value.toInt() }
 					default { UserPreferences.screensaverAgeRatingMax.defaultValue.toString() }
 				}
-			}
-		}
-
-		category {
-			setTitle(R.string.pref_behavior)
-
-			shortcut {
-				setTitle(R.string.pref_audio_track_button)
-				bind(userPreferences, UserPreferences.shortcutAudioTrack)
-			}
-
-			shortcut {
-				setTitle(R.string.pref_subtitle_track_button)
-				bind(userPreferences, UserPreferences.shortcutSubtitleTrack)
 			}
 		}
 	}


### PR DESCRIPTION
**Changes**

Temporarily remove the support to set custom keys for the audio & subtitle menus in the player UI. I have nothing against these but there's a few problems that makes removing them (for now) easier;
- They're not used much
- They're incomplete (there's much more stuff that can be done with the remote)
- They're not working in the new player UI
- They require composables that does not exist yet in the new settings UI

Once the new settings and video player UI is ready we can revisit these.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
