### PR TITLE
Migrate screensaver customization settings to compose

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -10,12 +10,8 @@ import org.jellyfin.androidtv.ui.preference.dsl.OptionsFragment
 import org.jellyfin.androidtv.ui.preference.dsl.checkbox
 import org.jellyfin.androidtv.ui.preference.dsl.enum
 import org.jellyfin.androidtv.ui.preference.dsl.link
-import org.jellyfin.androidtv.ui.preference.dsl.list
 import org.jellyfin.androidtv.ui.preference.dsl.optionsScreen
-import org.jellyfin.androidtv.util.getQuantityString
 import org.koin.android.ext.android.inject
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 class CustomizationPreferencesScreen : OptionsFragment() {
 	private val userPreferences: UserPreferences by inject()
@@ -86,70 +82,6 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 				setContent(R.string.pref_libraries_description)
 				icon = R.drawable.ic_grid
 				withFragment<LibrariesPreferencesScreen>()
-			}
-		}
-
-		category {
-			setTitle(R.string.pref_screensaver)
-
-			checkbox {
-				setTitle(R.string.pref_screensaver_inapp_enabled)
-				setContent(R.string.pref_screensaver_inapp_enabled_description)
-				bind(userPreferences, UserPreferences.screensaverInAppEnabled)
-			}
-
-			@Suppress("MagicNumber")
-			list {
-				setTitle(R.string.pref_screensaver_inapp_timeout)
-
-				entries = mapOf(
-					30.seconds to context.getQuantityString(R.plurals.seconds, 30),
-					1.minutes to context.getQuantityString(R.plurals.minutes, 1),
-					2.5.minutes to context.getQuantityString(R.plurals.minutes, 2.5),
-					5.minutes to context.getQuantityString(R.plurals.minutes, 5),
-					10.minutes to context.getQuantityString(R.plurals.minutes, 10),
-					15.minutes to context.getQuantityString(R.plurals.minutes, 15),
-					30.minutes to context.getQuantityString(R.plurals.minutes, 30),
-				).mapKeys { it.key.inWholeMilliseconds.toString() }
-
-				bind {
-					get { userPreferences[UserPreferences.screensaverInAppTimeout].toString() }
-					set { value -> userPreferences[UserPreferences.screensaverInAppTimeout] = value.toLong() }
-					default { UserPreferences.screensaverInAppTimeout.defaultValue.toString() }
-				}
-
-				depends { userPreferences[UserPreferences.screensaverInAppEnabled] }
-			}
-
-			checkbox {
-				setTitle(R.string.pref_screensaver_ageratingrequired_title)
-				setContent(
-					R.string.pref_screensaver_ageratingrequired_enabled,
-					R.string.pref_screensaver_ageratingrequired_disabled,
-				)
-
-				bind(userPreferences, UserPreferences.screensaverAgeRatingRequired)
-			}
-
-			list {
-				setTitle(R.string.pref_screensaver_ageratingmax)
-
-				// Note: Must include 13 (default value)
-				// We may want to fetch this mapping from the server in the future
-				@Suppress("MagicNumber")
-				val ages = setOf(5, 10, 13, 14, 16, 18, 21)
-
-				entries = buildMap {
-					put("0", getString(R.string.pref_screensaver_ageratingmax_zero))
-					ages.forEach { age -> put(age.toString(), getString(R.string.pref_screensaver_ageratingmax_entry, age)) }
-					put("-1", getString(R.string.pref_screensaver_ageratingmax_unlimited))
-				}
-
-				bind {
-					get { userPreferences[UserPreferences.screensaverAgeRatingMax].toString() }
-					set { value -> userPreferences[UserPreferences.screensaverAgeRatingMax] = value.toInt() }
-					default { UserPreferences.screensaverAgeRatingMax.defaultValue.toString() }
-				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -24,6 +24,9 @@ import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsP
 import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentsScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.nextup.SettingsPlaybackNextUpBehaviorScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.nextup.SettingsPlaybackNextUpScreen
+import org.jellyfin.androidtv.ui.settings.screen.screensaver.SettingsScreensaverAgeRatingScreen
+import org.jellyfin.androidtv.ui.settings.screen.screensaver.SettingsScreensaverScreen
+import org.jellyfin.androidtv.ui.settings.screen.screensaver.SettingsScreensaverTimeoutScreen
 import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 
@@ -35,6 +38,9 @@ object Routes {
 	const val AUTHENTICATION_SERVER_USER = "/authentication/server/{serverId}/user/{userId}"
 	const val AUTHENTICATION_SORT_BY = "/authentication/sort-by"
 	const val AUTHENTICATION_AUTO_SIGN_IN = "/authentication/auto-sign-in"
+	const val CUSTOMIZATION_SCREENSAVER = "/customization/screensaver"
+	const val CUSTOMIZATION_SCREENSAVER_TIMEOUT = "/customization/screensaver/timeout"
+	const val CUSTOMIZATION_SCREENSAVER_AGE_RATING = "/customization/screensaver/age-rating"
 	const val CUSTOMIZATION_SUBTITLES = "/customization/subtitles"
 	const val CUSTOMIZATION_SUBTITLES_TEXT_COLOR = "/customization/subtitles/text-color"
 	const val CUSTOMIZATION_SUBTITLES_BACKGROUND_COLOR = "/customization/subtitles/background-color"
@@ -80,6 +86,15 @@ val routes = mapOf<String, RouteComposable>(
 	},
 	Routes.AUTHENTICATION_AUTO_SIGN_IN to {
 		SettingsAuthenticationAutoSignInScreen()
+	},
+	Routes.CUSTOMIZATION_SCREENSAVER to {
+		SettingsScreensaverScreen()
+	},
+	Routes.CUSTOMIZATION_SCREENSAVER_TIMEOUT to {
+		SettingsScreensaverTimeoutScreen()
+	},
+	Routes.CUSTOMIZATION_SCREENSAVER_AGE_RATING to {
+		SettingsScreensaverAgeRatingScreen()
 	},
 	Routes.CUSTOMIZATION_SUBTITLES to {
 		SettingsSubtitlesScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -44,6 +44,15 @@ fun SettingsMainScreen() {
 			)
 		}
 
+		// TODO: Temporarily added to root - should be accessed via customization screen instead
+		item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_photos), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_screensaver)) },
+				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER) }
+			)
+		}
+
 		item {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_next), contentDescription = null) },

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverAgeRatingScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverAgeRatingScreen.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.androidtv.ui.settings.screen.screensaver
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsScreensaverAgeRatingScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var screensaverAgeRatingMax by rememberPreference(userPreferences, UserPreferences.screensaverAgeRatingMax)
+	val options = getScreensaverAgeRatingOptions()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_screensaver).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_screensaver_ageratingmax)) },
+			)
+		}
+
+		items(options) { (ageRating, heading) ->
+			ListButton(
+				headingContent = { Text(heading) },
+				trailingContent = { RadioButton(checked = screensaverAgeRatingMax == ageRating) },
+				onClick = {
+					screensaverAgeRatingMax = ageRating
+					router.back()
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverScreen.kt
@@ -1,0 +1,80 @@
+package org.jellyfin.androidtv.ui.settings.screen.screensaver
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.Checkbox
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsScreensaverScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.settings_title).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_screensaver)) },
+			)
+		}
+
+		item {
+			var screensaverInAppEnabled by rememberPreference(userPreferences, UserPreferences.screensaverInAppEnabled)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_screensaver_inapp_enabled)) },
+				trailingContent = { Checkbox(checked = screensaverInAppEnabled) },
+				captionContent = { Text(stringResource(R.string.pref_screensaver_inapp_enabled_description)) },
+				onClick = { screensaverInAppEnabled = !screensaverInAppEnabled }
+			)
+		}
+
+		item {
+			var screensaverInAppTimeout by rememberPreference(userPreferences, UserPreferences.screensaverInAppTimeout)
+			val caption = getScreensaverTimeoutOptions()
+				.firstOrNull { (duration) -> duration.inWholeMilliseconds == screensaverInAppTimeout }
+				?.second.orEmpty()
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_screensaver_inapp_timeout)) },
+				captionContent = { Text(caption) },
+				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER_TIMEOUT) }
+			)
+		}
+
+		item {
+			var screensaverAgeRatingRequired by rememberPreference(userPreferences, UserPreferences.screensaverAgeRatingRequired)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_screensaver_ageratingrequired_title)) },
+				trailingContent = { Checkbox(checked = screensaverAgeRatingRequired) },
+				captionContent = { Text(stringResource(R.string.pref_screensaver_ageratingrequired_enabled)) },
+				onClick = { screensaverAgeRatingRequired = !screensaverAgeRatingRequired }
+			)
+		}
+
+		item {
+			var screensaverAgeRatingMax by rememberPreference(userPreferences, UserPreferences.screensaverAgeRatingMax)
+			val caption = getScreensaverAgeRatingOptions()
+				.firstOrNull { (ageRating) -> ageRating == screensaverAgeRatingMax }
+				?.second.orEmpty()
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_screensaver_ageratingmax)) },
+				captionContent = { Text(caption) },
+				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER_AGE_RATING) }
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverTimeoutScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverTimeoutScreen.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.androidtv.ui.settings.screen.screensaver
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsScreensaverTimeoutScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var screensaverInAppTimeout by rememberPreference(userPreferences, UserPreferences.screensaverInAppTimeout)
+	val options = getScreensaverTimeoutOptions()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_screensaver).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_screensaver_inapp_timeout)) },
+			)
+		}
+
+		items(options) { (duration, heading) ->
+			ListButton(
+				headingContent = { Text(heading) },
+				trailingContent = { RadioButton(checked = screensaverInAppTimeout == duration.inWholeMilliseconds) },
+				onClick = {
+					screensaverInAppTimeout = duration.inWholeMilliseconds
+					router.back()
+				}
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/strings.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/strings.kt
@@ -1,0 +1,33 @@
+package org.jellyfin.androidtv.ui.settings.screen.screensaver
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.util.getQuantityString
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@Composable
+@Stable
+fun getScreensaverAgeRatingOptions() = buildList {
+	add(0 to stringResource(R.string.pref_screensaver_ageratingmax_zero))
+	setOf(5, 10, 13, 14, 16, 18, 21)
+		.forEach { age -> add(age to stringResource(R.string.pref_screensaver_ageratingmax_entry, age)) }
+	add(-1 to stringResource(R.string.pref_screensaver_ageratingmax_unlimited))
+}
+
+@Composable
+@Stable
+fun getScreensaverTimeoutOptions() = buildList {
+	val context = LocalContext.current
+
+	add(30.seconds to context.getQuantityString(R.plurals.seconds, 30))
+	add(1.minutes to context.getQuantityString(R.plurals.minutes, 1))
+	add(2.5.minutes to context.getQuantityString(R.plurals.minutes, 2.5))
+	add(5.minutes to context.getQuantityString(R.plurals.minutes, 5))
+	add(10.minutes to context.getQuantityString(R.plurals.minutes, 10))
+	add(15.minutes to context.getQuantityString(R.plurals.minutes, 15))
+	add(30.minutes to context.getQuantityString(R.plurals.minutes, 30))
+}


### PR DESCRIPTION
**Changes**

Rewrite the screensaver settings in compose and temporarily allow access to it from main settings (as the other customization options will be done in a different PR).

Builds on top of #5281.

| | |
| --- | --- |
| <img width="557" height="817" alt="image" src="https://github.com/user-attachments/assets/88831cf1-1820-40bb-baa6-f144d4310221" /> | |
| <img width="557" height="817" alt="image" src="https://github.com/user-attachments/assets/a4a24d2b-6698-435f-a4b2-0368cf7fd8db" /> | <img width="557" height="817" alt="image" src="https://github.com/user-attachments/assets/ee5cefa2-0af8-4ed5-aedc-c8804c2656f2" /> |


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
