### PR TITLE
Remove profile picture from ClockUserView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ClockUserView.kt
@@ -4,16 +4,12 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.RelativeLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.databinding.ClockUserBugBinding
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
-import org.jellyfin.androidtv.util.ImageHelper
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -25,9 +21,7 @@ class ClockUserView @JvmOverloads constructor(
 ) : RelativeLayout(context, attrs, defStyleAttr, defStyleRes), KoinComponent {
 	private val binding: ClockUserBugBinding = ClockUserBugBinding.inflate(LayoutInflater.from(context), this, true)
 	private val userPreferences by inject<UserPreferences>()
-	private val userRepository by inject<UserRepository>()
 	private val navigationRepository by inject<NavigationRepository>()
-	private val imageHelper by inject<ImageHelper>()
 
 	var isVideoPlayer = false
 		set(value) {
@@ -39,15 +33,6 @@ class ClockUserView @JvmOverloads constructor(
 
 	init {
 		updateClockVisibility()
-
-		val currentUser = userRepository.currentUser.value
-
-		binding.clockUserImage.load(
-			url = currentUser?.let(imageHelper::getPrimaryImageUrl),
-			placeholder = ContextCompat.getDrawable(context, R.drawable.ic_user)
-		)
-
-		binding.clockUserImage.isVisible = currentUser != null
 
 		binding.home.setOnClickListener {
 			navigationRepository.reset(Destinations.home, clearHistory = true)

--- a/app/src/main/res/layout/clock_user_bug.xml
+++ b/app/src/main/res/layout/clock_user_bug.xml
@@ -17,18 +17,6 @@
         android:contentDescription="@string/lbl_home"
         android:src="@drawable/ic_house" />
 
-    <Space
-        android:layout_width="8dp"
-        android:layout_height="0dp" />
-
-    <org.jellyfin.androidtv.ui.AsyncImageView
-        android:id="@+id/clock_user_image"
-        android:layout_width="41dp"
-        android:layout_height="41dp"
-        android:padding="4dp"
-        app:circleCrop="true"
-        tools:src="@drawable/ic_user" />
-
     <TextClock
         android:id="@+id/clock"
         android:layout_width="wrap_content"


### PR DESCRIPTION
**Changes**

Remove the profile picture of the current user from the ClockUserView used in the browsing UI. It isn't clickable like the profile picture in the toolbar(s) and the positioning is different making it inconsistent with the home page. It will be back once we support the toolbar in browsing UI, unsure if that's with 0.20 though.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
