### PR TITLE
Don't overwrite displayPreferencesId in ItemRowAdapterHelper.retrieveUserViews

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -235,7 +235,6 @@ fun ItemRowAdapter.retrieveUserViews(api: ApiClient, userViewsRepository: UserVi
 
 			val filteredItems = response.items
 				.filter { userViewsRepository.isSupported(it.collectionType) }
-				.map { it.copy(displayPreferencesId = it.id.toString()) }
 
 			setItems(
 				items = filteredItems,


### PR DESCRIPTION
**Changes**

The ids are already set by the server, no need to manually set them. That only causes issues because the server sets it to item id without dashes and the client sets it to the item id with dashes which can cause issues.

I'm not sure if 10.10 has different behavior so not backporting it.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
