### PR TITLE
Fix rememberPreference not saving for AsyncPreferenceStore

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import org.jellyfin.preference.Preference
+import org.jellyfin.preference.store.AsyncPreferenceStore
 import org.jellyfin.preference.store.PreferenceStore
 
 /**
@@ -29,7 +30,10 @@ fun <ME, MV, T : Enum<T>> rememberPreference(
 ): MutableState<T> {
 	val mutableState = remember { mutableStateOf(store[preference]) }
 	LaunchedEffect(mutableState.value) {
-		if (store[preference] != mutableState.value) store[preference] = mutableState.value
+		if (store[preference] != mutableState.value) {
+			store[preference] = mutableState.value
+			if (store is AsyncPreferenceStore) store.commit()
+		}
 	}
 	return mutableState
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

The AsyncPreferenceStore requires its commit function to be called for actually saving values.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
