### PR TITLE
Use DialogBase for InAppScreensaver

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/dialog/DialogBase.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/dialog/DialogBase.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
@@ -32,6 +33,7 @@ fun DialogBase(
 	visible: Boolean,
 	onDismissRequest: () -> Unit,
 	modifier: Modifier = Modifier,
+	scrimColor: Color = JellyfinTheme.colorScheme.scrim,
 	enterTransition: EnterTransition = fadeIn(tween(300)),
 	exitTransition: ExitTransition = fadeOut(tween(300)),
 	contentAlignment: Alignment = Alignment.Center,
@@ -56,7 +58,6 @@ fun DialogBase(
 				decorFitsSystemWindows = false
 			),
 		) {
-			val scrimColor = JellyfinTheme.colorScheme.scrim
 			Box(
 				modifier = modifier
 					.fillMaxSize()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/screensaver/InAppScreensaver.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/screensaver/InAppScreensaver.kt
@@ -1,13 +1,10 @@
 package org.jellyfin.androidtv.ui.screensaver
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -17,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import org.jellyfin.androidtv.integration.dream.composable.DreamHost
 import org.jellyfin.androidtv.ui.InteractionTrackerViewModel
+import org.jellyfin.androidtv.ui.base.dialog.DialogBase
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -24,23 +22,23 @@ fun InAppScreensaver() {
 	val interactionTrackerViewModel = koinViewModel<InteractionTrackerViewModel>()
 	val visible by interactionTrackerViewModel.visible.collectAsState()
 
-	AnimatedVisibility(
+	DialogBase(
 		visible = visible,
-		enter = fadeIn(tween(1_000)),
-		exit = fadeOut(tween(1_000)),
+		onDismissRequest = {
+			interactionTrackerViewModel.notifyInteraction(canCancel = true, userInitiated = false)
+		},
+		scrimColor = Color.Black,
+		enterTransition = fadeIn(tween(1_000)),
+		exitTransition = fadeOut(tween(1_000)),
+		modifier = Modifier
+			.fillMaxSize()
+			.clickable(
+				interactionSource = remember { MutableInteractionSource() },
+				indication = null,
+			) {
+				interactionTrackerViewModel.notifyInteraction(canCancel = true, userInitiated = false)
+			}
 	) {
-		Box(
-			modifier = Modifier
-				.fillMaxSize()
-				.background(Color.Black)
-				.clickable(
-					interactionSource = remember { MutableInteractionSource() },
-					indication = null,
-				) {
-					interactionTrackerViewModel.notifyInteraction(canCancel = true, userInitiated = false)
-				}
-		) {
-			DreamHost()
-		}
+		DreamHost()
 	}
 }


### PR DESCRIPTION
**Changes**

Update the InAppScreensaver composable to use the DialogBase instead of a Box. This fixes an issue where  the settings UI would be shown on top of the screensaver if both are active at the same time, because dialogs are in a separate window.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
