### PR TITLE
fix: stuttering 4k HEVC streaming on Raspberry Pi 4b

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
@@ -3,7 +3,7 @@ package org.jellyfin.androidtv.util.profile
 import android.os.Build
 
 /**
- * List of devie models with known HEVC DoVi/HDR10+ playback issues.
+ * List of device models with known HEVC DoVi/HDR10+ playback issues.
  */
 private val modelsWithDoViHdr10PlusBug = listOf(
 	"AFTKRT", // Amazon Fire TV 4K Max (2nd Gen)
@@ -11,6 +11,14 @@ private val modelsWithDoViHdr10PlusBug = listOf(
 	"AFTKM", // Amazon Fire TV 4K (2nd Gen)
 )
 
+/**
+ * List of device models that only support HEVC 1080p, even though reported higher-res support.
+ */
+private val modelsWithHevcMax1080 = listOf(
+	"Pi 4 Model B Rev 1.1", // Raspberry Pi 4b
+)
+
 object KnownDefects {
 	val hevcDoviHdr10PlusBug = Build.MODEL in modelsWithDoViHdr10PlusBug
+	val hevcMax1080 = Build.MODEL in modelsWithHevcMax1080
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -395,8 +395,17 @@ fun createDeviceProfile(
 		codec = Codec.Video.HEVC
 
 		conditions {
-			ProfileConditionValue.WIDTH lowerThanOrEquals maxResolutionHevc.width
-			ProfileConditionValue.HEIGHT lowerThanOrEquals maxResolutionHevc.height
+			when {
+				KnownDefects.hevcMax1080 -> {
+					ProfileConditionValue.WIDTH lowerThanOrEquals 1920
+					ProfileConditionValue.HEIGHT lowerThanOrEquals 1080
+				}
+				else -> {
+					ProfileConditionValue.WIDTH lowerThanOrEquals maxResolutionHevc.width
+					ProfileConditionValue.HEIGHT lowerThanOrEquals maxResolutionHevc.height
+				}
+			}
+
 		}
 	}
 


### PR DESCRIPTION
**Changes**
I am running Android TV on a Raspberry Pi 4 and have a lot of 4K HEVC encoded movies that I want to stream using Jellyfin.
Even though the Raspberry Pi seems to be able to decode 4k HEVC with hardware acceleration,
the practical implementation in ffpmeg apparently is so inefficient that I am still experiencing only ~5 fps. (see dev comment: http://disq.us/p/34flfsd)

As a workaround, I am proposing to limit reported HEVC decoding support to 1080p, which then results in server side transcoding, fixing the stuttering playback.

I am aware that this is a bit of a "quick fix", but I am so far unfamiliar how all parts fit together.
Is there another preferred way this could be implemented?

**Code assistance**
No AI was used.
