### PR TITLE
Add option to open single items in an external player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -1227,6 +1227,10 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         });
     }
 
+    void playExternal(final BaseItemDto item) {
+        playbackHelper.getValue().retrieveAndPlayExternal(item.getId(), false, getContext());
+    }
+
     void play(final List<BaseItemDto> items, final int pos, final boolean shuffle) {
         if (items.isEmpty()) return;
         if (shuffle) Collections.shuffle(items);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -87,6 +87,11 @@ fun FullDetailsFragment.showDetailsMenu(
 		item(getString(R.string.lbl_play_trailers)) { playTrailers() }
 	}
 
+	// Add external player option for video items
+	if (playbackHelper.value.supportsExternalPlayer(baseItemDto) && !playbackHelper.value.userPrefersExternalPlayer) {
+		item(getString(R.string.lbl_play_external)) { playExternal(baseItemDto) }
+	}
+
 	if (favButton?.isVisible == false) {
 		val favoriteStringRes = when (baseItemDto.userData?.isFavorite) {
 			true -> R.string.lbl_remove_favorite

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -20,20 +20,19 @@ class PlaybackLauncher(
 	private val navigationRepository: NavigationRepository,
 	private val userPreferences: UserPreferences,
 ) {
-	private val BaseItemDto.supportsExternalPlayer
-		get() = when (type) {
-			BaseItemKind.MOVIE,
-			BaseItemKind.EPISODE,
-			BaseItemKind.VIDEO,
-			BaseItemKind.SERIES,
-			BaseItemKind.SEASON,
-			BaseItemKind.RECORDING,
-			BaseItemKind.TV_CHANNEL,
-			BaseItemKind.PROGRAM,
-				-> true
+	fun supportsExternalPlayer(dto: BaseItemDto) = when (dto.type) {
+		BaseItemKind.MOVIE,
+		BaseItemKind.EPISODE,
+		BaseItemKind.VIDEO,
+		BaseItemKind.SERIES,
+		BaseItemKind.SEASON,
+		BaseItemKind.RECORDING,
+		BaseItemKind.TV_CHANNEL,
+		BaseItemKind.PROGRAM,
+			-> true
 
-			else -> false
-		}
+		else -> false
+	}
 
 	@JvmOverloads
 	fun launch(
@@ -43,6 +42,7 @@ class PlaybackLauncher(
 		replace: Boolean = false,
 		itemsPosition: Int = 0,
 		shuffle: Boolean = false,
+		forceExternalPlayer: Boolean = false,
 	) {
 		val isAudio = items.any { it.mediaType == MediaType.AUDIO }
 
@@ -57,7 +57,7 @@ class PlaybackLauncher(
 
 			if (items.isEmpty()) return
 
-			if (userPreferences[UserPreferences.useExternalPlayer] && items.all { it.supportsExternalPlayer }) {
+			if ((userPreferences[UserPreferences.useExternalPlayer] || forceExternalPlayer) && items.all { supportsExternalPlayer(it) }) {
 				context.startActivity(ActivityDestinations.externalPlayer(context, position?.milliseconds ?: Duration.ZERO))
 			} else if (userPreferences[UserPreferences.playbackRewriteVideoEnabled]) {
 				val destination = Destinations.videoPlayerNew(position)

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -48,6 +48,7 @@ public class KeyProcessor {
     public static final int MENU_INSTANT_MIX = 11;
     public static final int MENU_CLEAR_QUEUE = 12;
     public static final int MENU_TOGGLE_SHUFFLE = 13;
+    public static final int MENU_PLAY_EXTERNAL = 14;
 
     private final Lazy<MediaManager> mediaManager = KoinJavaComponent.<MediaManager>inject(MediaManager.class);
     private final Lazy<NavigationRepository> navigationRepository = KoinJavaComponent.<NavigationRepository>inject(NavigationRepository.class);
@@ -215,6 +216,11 @@ public class KeyProcessor {
                     menu.getMenu().add(0, MENU_PLAY_FIRST_UNWATCHED, order++, R.string.lbl_play_first_unwatched);
                 }
                 menu.getMenu().add(0, MENU_PLAY, order++, isFolder ? R.string.lbl_play_all : R.string.lbl_play);
+
+                // Add external player option for supported video items, but only if the user doesn't prefer to watch everything in an external player
+                if (playbackHelper.getValue().supportsExternalPlayer(item) && !playbackHelper.getValue().getUserPrefersExternalPlayer()) {
+                    menu.getMenu().add(0, MENU_PLAY_EXTERNAL, order++, R.string.lbl_play_external);
+                }
                 if (isFolder) {
                     menu.getMenu().add(0, MENU_PLAY_SHUFFLE, order++, R.string.lbl_shuffle_all);
                 }
@@ -287,6 +293,9 @@ public class KeyProcessor {
             switch (menuItem.getItemId()) {
                 case MENU_PLAY:
                     playbackHelper.getValue().retrieveAndPlay(item.getId(), false, activity);
+                    return true;
+                case MENU_PLAY_EXTERNAL:
+                    playbackHelper.getValue().retrieveAndPlayExternal(item.getId(), false, activity);
                     return true;
                 case MENU_PLAY_SHUFFLE:
                     playbackHelper.getValue().retrieveAndPlay(item.getId(), true, activity);

--- a/app/src/main/java/org/jellyfin/androidtv/util/PlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/PlaybackHelper.kt
@@ -14,6 +14,12 @@ interface PlaybackHelper {
 		outerResponse: Response<List<BaseItemDto>>,
 	)
 
+	val userPrefersExternalPlayer: Boolean
+
+	fun supportsExternalPlayer(item: BaseItemDto): Boolean
+
+	fun retrieveAndPlayExternal(itemId: UUID, shuffle: Boolean, context: Context)
+
 	fun retrieveAndPlay(itemId: UUID, shuffle: Boolean, context: Context)
 
 	fun retrieveAndPlay(itemIds: List<UUID>, shuffle: Boolean, position: Long?, index: Int?, context: Context)

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -66,6 +66,12 @@ class SdkPlaybackHelper(
 		}
 	}
 
+	override val userPrefersExternalPlayer: Boolean
+		get() = userPreferences[UserPreferences.useExternalPlayer]
+
+	override fun supportsExternalPlayer(item: BaseItemDto) =
+		playbackLauncher.supportsExternalPlayer(item)
+
 	private suspend fun getItems(
 		mainItem: BaseItemDto,
 		allowIntros: Boolean,
@@ -258,7 +264,13 @@ class SdkPlaybackHelper(
 		}
 	}
 
-	override fun retrieveAndPlay(itemId: UUID, shuffle: Boolean, context: Context) {
+	override fun retrieveAndPlay(itemId: UUID, shuffle: Boolean, context: Context) =
+		retrieveAndPlay(itemId, shuffle, context, false)
+
+	override fun retrieveAndPlayExternal(itemId: UUID, shuffle: Boolean, context: Context) =
+		retrieveAndPlay(itemId, shuffle, context, true)
+
+	fun retrieveAndPlay(itemId: UUID, shuffle: Boolean, context: Context, forceExternalPlayer: Boolean) {
 		getScope(context).launch {
 			val resumeSubtractDuration =
 				userPreferences[UserPreferences.resumeSubtractDuration].toIntOrNull()?.seconds
@@ -281,6 +293,7 @@ class SdkPlaybackHelper(
 				playbackControllerContainer.playbackController?.hasFragment() == true,
 				0,
 				shuffle,
+				forceExternalPlayer
 			)
 		}
 	}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="lbl_play_all">Play all</string>
     <string name="lbl_shuffle_all">Shuffle all</string>
     <string name="lbl_play">Play</string>
+    <string name="lbl_play_external">Open in external player</string>
     <string name="lbl_pause">Pause</string>
     <string name="lbl_exit">Exit</string>
     <string name="lbl_cancel">Cancel</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Motivation**
The internal player works for me 95% of the time, however it fails for some specific media types. I want to have an option to open just those entries in an external player without changing my global settings.

**Changes**
- Add general context menu option to open in external player
- Add context menu option in FullDetailsFragment
- Add new string "Open in external player", translation needed

**Code assistance**
LLM (Claude) was used to identify relevant files, code changes were mainly done by hand.

**Issues**
none that I know of