### PR TITLE
Fix audio track not persisting across episode transitions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -607,7 +607,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        mCurrentOptions.setAudioStreamIndex(null); // reset audio stream index to allow auto selection on new item
+        // Note: audioStreamIndex is already set by buildExoPlayerOptions() based on user's language preference
+        // Don't reset it here as it would override the user's audio track selection
 
         mStartPosition = position;
         mCurrentStreamInfo = response;


### PR DESCRIPTION
**Changes**
Removed an unnecessary reset of audioStreamIndex in startItem() that was overriding the language preference already set by buildExoPlayerOptions(). The existing mechanism that stores the user's audio language was working correctly—it was just being immediately undone.

**Code assistance**
Debugging guidance to trace the audio preference flow and identify where it was being reset.

**Issues**
