### PR TITLE
Fix audio track improperly defaults to system language

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -210,6 +210,11 @@ public class VideoManager {
                         .build()
                 )
                 .setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true)
+                // Disable audio track selection by default to prevent ExoPlayer from using system locale
+                // as a fallback. The app will explicitly enable and select the correct audio track
+                // in setExoPlayerTrack(), called from PlaybackController.switchAudioStream().
+                // See: https://github.com/jellyfin/jellyfin-androidtv/issues/5189
+                .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, true)
                 .build()
         );
         exoPlayerBuilder.setTrackSelector(trackSelector);
@@ -525,6 +530,8 @@ public class VideoManager {
 
         try {
             TrackSelectionParameters.Builder mExoPlayerSelectionParams = mExoPlayer.getTrackSelectionParameters().buildUpon();
+            // Re-enable the track type (especially audio) since we disabled it by default
+            mExoPlayerSelectionParams.setTrackTypeDisabled(chosenTrackType, false);
             mExoPlayerSelectionParams.setOverrideForType(new TrackSelectionOverride(matchedGroup, 0));
             mExoPlayer.setTrackSelectionParameters(mExoPlayerSelectionParams.build());
         } catch (Exception e) {


### PR DESCRIPTION
ExoPlayer's DefaultTrackSelector was using the device's system locale to auto-select audio tracks before the app could apply the user's preferred audio language. This fix sets setPreferredAudioLanguage("und") (undefined) on the track selector, which disables the system locale preference and allows PlaybackController.switchAudioStream() to control audio track selection based on user/server preferences.

Code assistance (Gemini) was used to:
Research ExoPlayer's DefaultTrackSelector behavior for audio language selection

Issues

Fixes #5189   
