### PR TITLE
User PIN protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ local.properties
 .kotlin/
 build/
 captures/
+android-sdk/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
 	implementation(libs.androidx.fragment)
 	implementation(libs.androidx.fragment.compose)
 	implementation(libs.androidx.leanback.core)
+	implementation(libs.androidx.gridlayout)
 	implementation(libs.androidx.leanback.preference)
 	implementation(libs.androidx.navigation3.ui)
 	implementation(libs.androidx.preference)

--- a/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
@@ -16,4 +16,6 @@ val preferenceModule = module {
 	single { UserPreferences(get()) }
 	single { SystemPreferences(get()) }
 	single { TelemetryPreferences(get()) }
+
+	single { org.jellyfin.androidtv.preference.repository.UserPinRepository(get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/repository/UserPinRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/repository/UserPinRepository.kt
@@ -1,0 +1,38 @@
+package org.jellyfin.androidtv.preference.repository
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import org.jellyfin.preference.store.SharedPreferenceStore
+import org.jellyfin.preference.stringPreference
+import java.security.MessageDigest
+import java.util.UUID
+
+class UserPinRepository(context: Context) : SharedPreferenceStore(
+    sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+) {
+    private fun getPinPreference(userId: UUID) = stringPreference("user_pin_$userId", "")
+
+    fun setPin(userId: UUID, pin: String) {
+        val hash = hashPin(pin)
+        this[getPinPreference(userId)] = hash
+    }
+
+    fun removePin(userId: UUID) {
+        delete(getPinPreference(userId))
+    }
+
+    fun hasPin(userId: UUID): Boolean {
+        return sharedPreferences.contains("user_pin_$userId")
+    }
+
+    fun verifyPin(userId: UUID, pin: String): Boolean {
+        val storedHash = this[getPinPreference(userId)]
+        if (storedHash.isEmpty()) return false
+        return storedHash == hashPin(pin)
+    }
+
+    private fun hashPin(pin: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(pin.toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerUserScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerUserScreen.kt
@@ -22,15 +22,31 @@ import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
+import androidx.fragment.app.FragmentActivity
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import org.jellyfin.androidtv.preference.repository.UserPinRepository
+import org.jellyfin.androidtv.ui.startup.PinDialogFragment
 import java.util.UUID
 
 @Composable
 fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 	val router = LocalRouter.current
-	val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+	val lifecycleOwner = LocalLifecycleOwner.current
+	val lifecycleScope = lifecycleOwner.lifecycleScope
 	val serverRepository = koinInject<ServerRepository>()
 	val serverUserRepository = koinInject<ServerUserRepository>()
 	val authenticationRepository = koinInject<AuthenticationRepository>()
+	val userPinRepository = koinInject<UserPinRepository>()
+
+	val context = LocalContext.current
+	val fragmentManager = remember(context) {
+		generateSequence(context) { (it as? android.content.ContextWrapper)?.baseContext }
+			.filterIsInstance<FragmentActivity>()
+			.firstOrNull()?.supportFragmentManager
+	}
 
 	LaunchedEffect(serverRepository) { serverRepository.loadStoredServers() }
 
@@ -39,6 +55,39 @@ fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 	}.collectAsState(null)
 
 	val user = remember(server) { server?.let(serverUserRepository::getStoredServerUsers)?.find { user -> user.id == userId } }
+	
+	var hasPin by remember(userId) { mutableStateOf(userPinRepository.hasPin(userId)) }
+
+	DisposableEffect(lifecycleOwner, fragmentManager) {
+		if (fragmentManager != null) {
+			// Result listener for Setting a PIN (Initial set or Change after verification)
+			fragmentManager.setFragmentResultListener("pin_set_request", lifecycleOwner) { _, _ ->
+				hasPin = userPinRepository.hasPin(userId)
+			}
+
+			// Result listener for Verifying before Changing
+			fragmentManager.setFragmentResultListener("pin_verify_change_request", lifecycleOwner) { _, result ->
+				if (result.getBoolean(PinDialogFragment.RESULT_EXTRA_SUCCESS)) {
+					// Verification successful, now show SET dialog
+					PinDialogFragment.newInstance(userId, "pin_set_request", PinDialogFragment.Companion.Mode.SET).show(fragmentManager, "pin_dialog_set")
+				}
+			}
+
+			// Result listener for Verifying before Removing
+			fragmentManager.setFragmentResultListener("pin_verify_remove_request", lifecycleOwner) { _, result ->
+				if (result.getBoolean(PinDialogFragment.RESULT_EXTRA_SUCCESS)) {
+					// Verification successful, remove PIN
+					userPinRepository.removePin(userId)
+					hasPin = false
+				}
+			}
+		}
+		onDispose {
+			fragmentManager?.clearFragmentResultListener("pin_set_request")
+			fragmentManager?.clearFragmentResultListener("pin_verify_change_request")
+			fragmentManager?.clearFragmentResultListener("pin_verify_remove_request")
+		}
+	}
 
 	SettingsColumn {
 		item {
@@ -46,6 +95,46 @@ fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 				overlineContent = { Text(server?.name?.uppercase().orEmpty()) },
 				headingContent = { Text(user?.name.orEmpty()) },
 			)
+		}
+
+		item {
+			if (hasPin) {
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_lock_outline), contentDescription = null) },
+					headingContent = { Text(stringResource(R.string.lbl_change_pin)) },
+					onClick = {
+						fragmentManager?.let {
+							// Verify first
+							PinDialogFragment.newInstance(userId, "pin_verify_change_request", PinDialogFragment.Companion.Mode.VERIFY).show(it, "pin_dialog_verify_change")
+						}
+					}
+				)
+			} else {
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_lock_outline), contentDescription = null) },
+					headingContent = { Text(stringResource(R.string.lbl_set_pin)) },
+					onClick = {
+						fragmentManager?.let {
+							PinDialogFragment.newInstance(userId, "pin_set_request", PinDialogFragment.Companion.Mode.SET).show(it, "pin_dialog_set")
+						}
+					}
+				)
+			}
+		}
+
+		if (hasPin) {
+			item {
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_lock_open_outline), contentDescription = null) },
+					headingContent = { Text(stringResource(R.string.lbl_remove_pin)) },
+					onClick = {
+						fragmentManager?.let {
+							// Verify first
+							PinDialogFragment.newInstance(userId, "pin_verify_remove_request", PinDialogFragment.Companion.Mode.VERIFY).show(it, "pin_dialog_verify_remove")
+						}
+					}
+				)
+			}
 		}
 
 		item {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/PinDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/PinDialogFragment.kt
@@ -1,0 +1,188 @@
+package org.jellyfin.androidtv.ui.startup
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.Button
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.databinding.FragmentPinDialogBinding
+import org.jellyfin.androidtv.preference.repository.UserPinRepository
+import org.koin.android.ext.android.inject
+import java.util.UUID
+
+class PinDialogFragment : DialogFragment() {
+
+    companion object {
+        const val ARG_USER_ID = "user_id"
+        const val ARG_REQUEST_KEY = "request_key"
+        const val ARG_MODE = "mode"
+        const val RESULT_KEY_PIN_ENTERED = "result_pin_entered"
+        const val RESULT_EXTRA_SUCCESS = "success"
+
+        enum class Mode {
+            VERIFY,
+            SET
+        }
+
+        fun newInstance(userId: UUID, requestKey: String = RESULT_KEY_PIN_ENTERED, mode: Mode = Mode.VERIFY): PinDialogFragment {
+            return PinDialogFragment().apply {
+                arguments = bundleOf(
+                    ARG_USER_ID to userId.toString(),
+                    ARG_REQUEST_KEY to requestKey,
+                    ARG_MODE to mode.name
+                )
+            }
+        }
+    }
+
+    private var _binding: FragmentPinDialogBinding? = null
+    private val binding get() = _binding!!
+    private val userPinRepository: UserPinRepository by inject()
+
+    private val userId: UUID by lazy { UUID.fromString(requireArguments().getString(ARG_USER_ID)) }
+    private val requestKey: String by lazy { requireArguments().getString(ARG_REQUEST_KEY)!! }
+    private val mode: Mode by lazy { Mode.valueOf(requireArguments().getString(ARG_MODE)!!) }
+
+    private var currentPin = ""
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentPinDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.title.text = if (mode == Mode.SET) getString(R.string.lbl_set_pin) else getString(R.string.lbl_enter_pin)
+        updatePinDisplay()
+
+        setupKeypad()
+    }
+
+    private fun setupKeypad() {
+        val buttons = listOf(
+            "1", "2", "3",
+            "4", "5", "6",
+            "7", "8", "9",
+            null, "0", null // null for non-digit spots in grid order if 0 is center bottom
+        )
+        // My layout has buttons manually added.
+        // Let's attach listeners based on ID or traversing the grid.
+        
+        // Manual mapping based on layout I created
+        val grid = binding.keypadGrid
+        for (i in 0 until grid.childCount) {
+            val child = grid.getChildAt(i)
+            if (child is Button) {
+                val text = child.text.toString()
+                if (text.all { it.isDigit() }) {
+                    child.setOnClickListener { onPinDigit(text.toInt()) }
+                } else if (text == "⌫") {
+                    child.setOnClickListener { onDelete() }
+                } else if (text == "OK") {
+                    child.setOnClickListener { onEnter() }
+                    // Request focus for OK button as default
+                    child.post { child.requestFocus() }
+                }
+            }
+        }
+    }
+
+    private fun updatePinDisplay() {
+        binding.pinInput.setText(currentPin)
+    }
+
+    private fun onPinDigit(digit: Int) {
+        currentPin += digit.toString()
+        updatePinDisplay()
+    }
+
+    private fun onDelete() {
+        if (currentPin.isNotEmpty()) {
+            currentPin = currentPin.dropLast(1)
+            updatePinDisplay()
+        }
+    }
+
+    private var tempPin: String? = null
+
+    private fun onEnter() {
+        if (mode == Mode.SET) {
+            if (currentPin.isNotEmpty()) {
+                if (tempPin == null) {
+                    // First entry
+                    tempPin = currentPin
+                    currentPin = ""
+                    updatePinDisplay()
+                    binding.title.text = getString(R.string.lbl_reenter_pin)
+                } else {
+                    // Confirmation entry
+                    if (currentPin == tempPin) {
+                        userPinRepository.setPin(userId, currentPin)
+                        Toast.makeText(context, R.string.lbl_pin_set, Toast.LENGTH_SHORT).show()
+                        setFragmentResult(requestKey, bundleOf(RESULT_EXTRA_SUCCESS to true))
+                        dismiss()
+                    } else {
+                        Toast.makeText(context, R.string.lbl_pin_mismatch, Toast.LENGTH_SHORT).show()
+                        // Reset to start
+                        tempPin = null
+                        currentPin = ""
+                        updatePinDisplay()
+                        binding.title.text = getString(R.string.lbl_set_pin)
+                    }
+                }
+            }
+        } else {
+            if (userPinRepository.verifyPin(userId, currentPin)) {
+                setFragmentResult(requestKey, bundleOf(RESULT_EXTRA_SUCCESS to true))
+                dismiss()
+            } else {
+                Toast.makeText(context, R.string.lbl_incorrect_pin, Toast.LENGTH_SHORT).show()
+                currentPin = ""
+                updatePinDisplay()
+            }
+        }
+    }
+    
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        
+        // Handle physical keyboard / remote number keys
+        dialog.setOnKeyListener { _, keyCode, event ->
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                 when (keyCode) {
+                     in KeyEvent.KEYCODE_0..KeyEvent.KEYCODE_9 -> {
+                         onPinDigit(keyCode - KeyEvent.KEYCODE_0)
+                         true
+                     }
+                     KeyEvent.KEYCODE_DEL -> {
+                         onDelete()
+                         true
+                     }
+                     KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER -> {
+                         // Let the focused view handle it (e.g. OK button)
+                         // But if focus is elsewhere (e.g. Input field which is not focusable?), we might want to handle it?
+                         // The grid buttons are focusable.
+                         false
+                     }
+                     else -> false
+                 }
+            } else false
+        }
+        return dialog
+    }
+    
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/drawable/ic_lock_open_outline.xml
+++ b/app/src/main/res/drawable/ic_lock_open_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M18,8h-1V6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h2c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2H6c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2zM18,20H6V10h12v10zM12,13c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lock_outline.xml
+++ b/app/src/main/res/drawable/ic_lock_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1V6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2H6c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2zM8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2H8.9V6zM18,20H6V10h12v10z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_pin_dialog.xml
+++ b/app/src/main/res/layout/fragment_pin_dialog.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Leanback.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/lbl_enter_pin"
+        app:layout_constraintBottom_toTopOf="@+id/pin_input"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <EditText
+        android:id="@+id/pin_input"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:background="@null"
+        android:focusable="false"
+        android:gravity="center"
+        android:inputType="numberPassword"
+        android:textColor="@color/white"
+        android:textSize="24sp"
+        android:letterSpacing="0.2"
+        app:layout_constraintBottom_toTopOf="@+id/keypad_grid"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        tools:text="1234" />
+
+    <androidx.gridlayout.widget.GridLayout
+        android:id="@+id/keypad_grid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        app:columnCount="3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pin_input">
+
+        <!-- Buttons 1-9 generated programmatically or defined here -->
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="1"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="2"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="3"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="4"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="5"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="6"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="7"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="8"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="9"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/btn_delete"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="⌫"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="0"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/btn_enter"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="OK"
+            android:textSize="16sp" />
+
+    </androidx.gridlayout.widget.GridLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -621,4 +621,13 @@
         <item quantity="one">%1$s album</item>
         <item quantity="other">%1$s albums</item>
     </plurals>
+    <string name="lbl_enter_pin">Enter PIN</string>
+    <string name="lbl_set_pin">Set PIN</string>
+    <string name="lbl_change_pin">Change PIN</string>
+    <string name="lbl_remove_pin">Remove PIN</string>
+    <string name="lbl_pin_removed">PIN removed</string>
+    <string name="lbl_pin_set">PIN set</string>
+    <string name="lbl_incorrect_pin">Incorrect PIN</string>
+    <string name="lbl_pin_mismatch">PINs do not match</string>
+    <string name="lbl_reenter_pin">Re-enter PIN</string>
 </resources>

--- a/app/src/test/java/org/jellyfin/androidtv/preference/repository/UserPinRepositoryTest.kt
+++ b/app/src/test/java/org/jellyfin/androidtv/preference/repository/UserPinRepositoryTest.kt
@@ -1,0 +1,78 @@
+package org.jellyfin.androidtv.preference.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class UserPinRepositoryTest {
+
+    private val context = mockk<Context>()
+    private val sharedPreferences = mockk<SharedPreferences>()
+    private val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+
+    private lateinit var repository: UserPinRepository
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(PreferenceManager::class)
+        every { PreferenceManager.getDefaultSharedPreferences(context) } returns sharedPreferences
+        every { sharedPreferences.edit() } returns editor
+
+        repository = UserPinRepository(context)
+    }
+
+    @Test
+    fun `setPin stores hashed pin`() {
+        val userId = UUID.randomUUID()
+        val pin = "1234"
+        val key = "user_pin_$userId"
+        val slotKey = slot<String>()
+        val slotValue = slot<String>()
+
+        every { editor.putString(capture(slotKey), capture(slotValue)) } returns editor
+
+        repository.setPin(userId, pin)
+
+        verify { editor.putString(key, any()) }
+        assertTrue(slotValue.captured.isNotEmpty())
+        assertFalse(slotValue.captured == pin) // Should be hashed
+    }
+
+    @Test
+    fun `verifyPin returns true for correct pin`() {
+        val userId = UUID.randomUUID()
+        val pin = "1234"
+        val key = "user_pin_$userId"
+        
+        // We need to capture what setPin stores to verify it against verifyPin logic which re-hashes
+        // Or we just test that verifyPin uses getString and hashes input.
+        
+        // Let's implement setPin effectively in the mock
+        val storedHash = "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4" // SHA-256 for 1234
+        every { sharedPreferences.getString(key, "") } returns storedHash
+
+        assertTrue(repository.verifyPin(userId, pin))
+    }
+
+    @Test
+    fun `verifyPin returns false for incorrect pin`() {
+        val userId = UUID.randomUUID()
+        val pin = "1234"
+        val key = "user_pin_$userId"
+        
+        val storedHash = "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4" // SHA-256 for 1234
+        every { sharedPreferences.getString(key, "") } returns storedHash
+
+        assertFalse(repository.verifyPin(userId, "0000"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-compose-ui = "1.10.1"
 androidx-constraintlayout = "2.2.1"
 androidx-core = "1.17.0"
 androidx-fragment = "1.8.9"
+androidx-gridlayout = "1.1.0"
 androidx-leanback = "1.2.0"
 androidx-lifecycle = "2.10.0"
 androidx-media3 = "1.9.0"
@@ -73,6 +74,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-fragment-compose = { module = "androidx.fragment:fragment-compose", version.ref = "androidx-fragment" }
+androidx-gridlayout = { module = "androidx.gridlayout:gridlayout", version.ref = "androidx-gridlayout" }
 androidx-leanback-core = { module = "androidx.leanback:leanback", version.ref = "androidx-leanback" }
 androidx-leanback-preference = { module = "androidx.leanback:leanback-preference", version.ref = "androidx-leanback" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Tackles issue #3509 to provide PIN configuration for users (local storage used) so content not available for some users is not accessible. If a PIN protected user doesn't change the account before leaving app, next user to open the app will be able to access first user's content; this is not addressed here.

I'm a developer myself, but I'm not familiar with Android TV apps nor the architecture used in this app. Changes made by LLM make sense, but an experienced contributor's eye is needed, functionality was tested on a real TV though.

In order to manage PIN for a user:
1. Select cog icon in upper right corner.
2. Go to Login settings.
3. Select server.
4. Select user.
5. Manage PIN.

> Path to setting was LLM's idea ¯\\\_(ツ)\_/¯

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
Code generated by Antigravity (Gemini 3 Pro, Planning mode).

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #3509
