### PR TITLE
Add media toasts to new video player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToast.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToast.kt
@@ -1,0 +1,105 @@
+package org.jellyfin.androidtv.ui.player.base.toast
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
+
+data class MediaToastColors(
+	val backgroundColor: Color,
+	val iconColor: Color,
+	val progressBackgroundColor: Color,
+	val progressFillColor: Color,
+)
+
+object MediaToastDefaults {
+	@ReadOnlyComposable
+	@Composable
+	fun colors(
+		backgroundColor: Color = Color.Black.copy(alpha = 0.5f),
+		iconColor: Color = Color.White,
+		progressBackgroundColor: Color = Color.Black,
+		progressFillColor: Color = JellyfinTheme.colorScheme.rangeControlFill,
+	) = MediaToastColors(
+		backgroundColor = backgroundColor,
+		iconColor = iconColor,
+		progressBackgroundColor = progressBackgroundColor,
+		progressFillColor = progressFillColor,
+	)
+
+}
+
+@Composable
+fun MediaToast(
+	visible: Boolean,
+	icon: @Composable () -> Unit,
+	modifier: Modifier = Modifier,
+	progress: Float? = null,
+	colors: MediaToastColors = MediaToastDefaults.colors(),
+) {
+	AnimatedVisibility(
+		visible = visible,
+		enter = fadeIn() + scaleIn(initialScale = 0.8f),
+		exit = fadeOut() + scaleOut(targetScale = 1.2f),
+		modifier = modifier
+			.fillMaxSize()
+			.wrapContentSize(Alignment.Center)
+	) {
+		Box(
+			modifier = Modifier
+				.size(96.dp)
+				.drawWithContent {
+					// Toast background
+					drawCircle(colors.backgroundColor)
+
+					// Toast icon
+					drawContent()
+
+					// Toast progress
+					if (progress != null) {
+						val width = 4.dp.toPx()
+
+						// Background
+						drawCircle(
+							style = Stroke(width),
+							color = colors.progressBackgroundColor,
+							alpha = 0.4f,
+						)
+
+						// Foreground
+						drawArc(
+							style = Stroke(width, cap = StrokeCap.Round),
+							color = colors.progressFillColor,
+							useCenter = false,
+							startAngle = -90f,
+							sweepAngle = 360f * progress,
+						)
+					}
+				}
+				.padding(16.dp),
+			contentAlignment = Alignment.Center,
+		) {
+			ProvideTextStyle(LocalTextStyle.current.copy(color = colors.iconColor)) {
+				icon()
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToastData.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToastData.kt
@@ -1,0 +1,8 @@
+package org.jellyfin.androidtv.ui.player.base.toast
+
+import androidx.annotation.DrawableRes
+
+data class MediaToastData(
+	@DrawableRes val icon: Int,
+	val progress: Float? = null,
+)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToastRegistry.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToastRegistry.kt
@@ -1,0 +1,47 @@
+package org.jellyfin.androidtv.ui.player.base.toast
+
+import androidx.annotation.DrawableRes
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+
+class MediaToastRegistry(
+	private val coroutineScope: CoroutineScope,
+) {
+	companion object {
+		val TOAST_DURATION = 700.milliseconds
+	}
+
+	private val _current = MutableStateFlow<MediaToastData?>(null)
+	val current = _current.asStateFlow()
+
+	private var unsetJob: Job? = null
+
+	fun emit(data: MediaToastData) {
+		if (current.value == data) return
+
+		_current.value = data
+
+		unsetJob?.cancel()
+		unsetJob = coroutineScope.launch {
+			delay(TOAST_DURATION)
+			_current.value = null
+		}
+	}
+
+	fun emit(
+		@DrawableRes icon: Int,
+		progress: Float? = null,
+	) {
+		val data = MediaToastData(
+			icon = icon,
+			progress = progress,
+		)
+		emit(data)
+	}
+}
+

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToasts.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/toast/MediaToasts.kt
@@ -1,0 +1,29 @@
+package org.jellyfin.androidtv.ui.player.base.toast
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import org.jellyfin.androidtv.ui.base.Icon
+
+@Composable
+fun MediaToasts(mediaToastRegistry: MediaToastRegistry) {
+	val data by mediaToastRegistry.current.collectAsState()
+
+	MediaToast(
+		visible = data != null,
+		icon = {
+			data?.icon?.let { icon ->
+				Icon(
+					imageVector = ImageVector.vectorResource(icon),
+					contentDescription = null,
+					modifier = Modifier.fillMaxSize()
+				)
+			}
+		},
+		progress = data?.progress,
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerOverlay.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.Modifier
 import org.jellyfin.androidtv.ui.composable.rememberQueueEntry
 import org.jellyfin.androidtv.ui.player.base.PlayerOverlayLayout
 import org.jellyfin.androidtv.ui.player.base.rememberPlayerOverlayVisibility
+import org.jellyfin.androidtv.ui.player.base.toast.MediaToastRegistry
+import org.jellyfin.androidtv.ui.player.base.toast.MediaToasts
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.baseItemFlow
@@ -16,6 +18,7 @@ import org.koin.compose.koinInject
 fun VideoPlayerOverlay(
 	modifier: Modifier = Modifier,
 	playbackManager: PlaybackManager = koinInject(),
+	mediaToastRegistry: MediaToastRegistry,
 ) {
 	val visibilityState = rememberPlayerOverlayVisibility()
 
@@ -36,4 +39,6 @@ fun VideoPlayerOverlay(
 			)
 		},
 	)
+
+	MediaToasts(mediaToastRegistry)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -17,6 +18,8 @@ import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.ScreensaverLock
 import org.jellyfin.androidtv.ui.player.base.PlayerSubtitles
 import org.jellyfin.androidtv.ui.player.base.PlayerSurface
+import org.jellyfin.androidtv.ui.player.base.toast.MediaToastRegistry
+import org.jellyfin.androidtv.ui.player.video.toast.rememberPlaybackManagerMediaToastEmitter
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.koin.compose.koinInject
@@ -42,6 +45,10 @@ fun VideoPlayerScreen() {
 	val videoSize by playbackManager.state.videoSize.collectAsState()
 	val aspectRatio = videoSize.aspectRatio.takeIf { !it.isNaN() && it > 0f } ?: DefaultVideoAspectRatio
 
+	val coroutineScope = rememberCoroutineScope()
+	val mediaToastRegistry = remember { MediaToastRegistry(coroutineScope) }
+	rememberPlaybackManagerMediaToastEmitter(playbackManager, mediaToastRegistry)
+
 	Box(
 		modifier = Modifier
 			.background(Color.Black)
@@ -57,6 +64,7 @@ fun VideoPlayerScreen() {
 
 		VideoPlayerOverlay(
 			playbackManager = playbackManager,
+			mediaToastRegistry = mediaToastRegistry,
 		)
 
 		PlayerSubtitles(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/toast/rememberPlaybackManagerMediaToastEmitter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/toast/rememberPlaybackManagerMediaToastEmitter.kt
@@ -1,0 +1,44 @@
+package org.jellyfin.androidtv.ui.player.video.toast
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.player.base.toast.MediaToastRegistry
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.model.PlayState
+
+@Composable
+fun rememberPlaybackManagerMediaToastEmitter(
+	playbackManager: PlaybackManager,
+	mediaToastRegistry: MediaToastRegistry,
+) {
+	val coroutineScope = rememberCoroutineScope()
+
+	LaunchedEffect(playbackManager) {
+		var active = false
+
+		playbackManager.state.playState
+			.filter { playState ->
+				// Wait until we received our first "playing" state before emitting play/pause events
+				// this avoids an immediate toast from showing when the video player is opened
+				if (!active) {
+					active = playState == PlayState.PLAYING
+					false
+				} else {
+					active
+				}
+			}
+			.onEach { playState ->
+				when (playState) {
+					PlayState.PLAYING -> mediaToastRegistry.emit(R.drawable.ic_play)
+					PlayState.PAUSED -> mediaToastRegistry.emit(R.drawable.ic_pause)
+					else -> Unit
+				}
+			}
+			.launchIn(coroutineScope)
+	}
+}


### PR DESCRIPTION
Finishing old branches

**Changes**

Add media toasts to the video player. A media toast indicates an action confirmation. It is only implemented for play/pause actions for now.

![97200007a1](https://github.com/user-attachments/assets/b92872b6-1dcb-41f3-8de8-be2378062564)

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
