### PR TITLE
Fix Google TV launcher channel thumbnails

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -283,11 +283,15 @@ class LeanbackChannelWorker(
 					listOf(
 						itemImages[ImageType.THUMB] to ImageType.THUMB,
 						itemImages[ImageType.PRIMARY] to ImageType.PRIMARY,
+						parentImages[ImageType.THUMB] to ImageType.THUMB,
+						parentImages[ImageType.PRIMARY] to ImageType.PRIMARY,
 					)
 				} else {
 					listOf(
 						itemImages[ImageType.PRIMARY] to ImageType.PRIMARY,
 						itemImages[ImageType.THUMB] to ImageType.THUMB,
+						parentImages[ImageType.THUMB] to ImageType.THUMB,
+						parentImages[ImageType.PRIMARY] to ImageType.PRIMARY,
 					)
 				}
 		}


### PR DESCRIPTION
**Changes**
Changed the behavior of thumbnail fetching in launcher channels when using Google TV launcher specifically.

1. When using Google TV launcher, `content://` URL of `ImageFetcher` cannot be used due to some breaking changes so use a direct HTTP URL instead.
2. In Google TV, the items are always displayed in 16:9 boxes so prefer fetching THUMB image first for all media types. Without this (and the ImageFetcher that handles aspect ratio conversions) the thumbnails are truncated.
3. Behavior on Android TV should not be affected.

**Issues**
Fixes #5350

**Screenshot**
Before (latest release) vs after (PR version)

<img width="1920" height="1080" alt="Screenshot_20260125_223150" src="https://github.com/user-attachments/assets/e72c16a0-472c-40e7-930f-c400e9680a93" />
