### PR TITLE
Update progress styling in NowPlayingView

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalContext
@@ -33,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.button.ButtonBase
@@ -90,6 +92,7 @@ fun NowPlayingComposable(
 							.padding(3.dp)
 					) {
 						val image = item.itemImages[ImageType.PRIMARY] ?: item.albumPrimaryImage ?: item.parentImages[ImageType.PRIMARY]
+						val progressFillColor = JellyfinTheme.colorScheme.rangeControlFill
 
 						AsyncImage(
 							url = image?.getUrl(api),
@@ -102,16 +105,18 @@ fun NowPlayingComposable(
 								.drawWithContent {
 									drawContent()
 
+									val width = 3.dp.toPx()
+
 									// Background
 									drawCircle(
-										style = Stroke(width = 3.dp.toPx()),
+										style = Stroke(width),
 										color = Color.Black,
 										alpha = 0.4f,
 									)
 									// Foreground
 									drawArc(
-										style = Stroke(width = 3.dp.toPx()),
-										color = Color.White,
+										style = Stroke(width, cap = StrokeCap.Round),
+										color = progressFillColor,
 										useCenter = false,
 										startAngle = -90f,
 										sweepAngle = 360f * progress,


### PR DESCRIPTION
Make the NowPlayingView design more consistent with other UI like the RangeControl/RangeControl/MediaToast.

**Changes**

- Use rounded caps
- Use rangeControlFill color (blue) instead of white

<img width="469" height="165" alt="afbeelding" src="https://github.com/user-attachments/assets/54b44b61-875c-4093-9107-2938752b3c44" />


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
