### PR TITLE
Correct video start delay setting not showing decimal values in settings

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -39,6 +39,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.clientLogApi
 import org.jellyfin.sdk.model.ServerVersion
 import org.koin.compose.koinInject
+import java.text.DecimalFormat
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
@@ -156,10 +157,11 @@ fun SettingsPlaybackAdvancedScreen() {
 					Spacer(Modifier.width(Tokens.Space.spaceSm))
 
 					Box(
-						modifier = Modifier.sizeIn(minWidth = 32.dp),
+						modifier = Modifier.sizeIn(minWidth = 48.dp),
 						contentAlignment = Alignment.CenterEnd
 					) {
-						Text("${(videoStartDelay / 1000.0).toString().removeSuffix(".0")}s")
+						val formatter = remember { DecimalFormat("0.##") }
+						Text("${formatter.format(videoStartDelay / 1000f)}s")
 					}
 				}
 			}


### PR DESCRIPTION
**Changes**
Video start delay setting was not showing decimal values and was truncating the display to a whole number in the settings. For example a value of 1.75 would show as 1. This change sets the text value to a double for displaying in the settings menu to ensure the decimal part of the number is not lost.

**Code assistance**
None, this is a small one line change.

**Issues**
None that I could find.