### PR TITLE
Fix play next episode for MX and MPV external players

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -89,7 +89,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 			Toast.makeText(this, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()
 			finish()
 		} else {
-			onItemFinished(result.data)
+			onItemFinished(result)
 		}
 	}
 
@@ -190,7 +190,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 	}
 
 
-	private fun onItemFinished(result: Intent?) {
+	private fun onItemFinished(activityResult: ActivityResult) {
 		if (currentItem == null) {
 			Toast.makeText(this@ExternalPlayerActivity, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()
 			finish()
@@ -198,6 +198,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 		}
 
 		val (item, mediaSource) = currentItem!!
+		val result = activityResult.data
 		val extras = result?.extras ?: Bundle.EMPTY
 
 		val endPosition = resultPositionExtras.firstNotNullOfOrNull { key ->
@@ -209,13 +210,13 @@ class ExternalPlayerActivity : FragmentActivity() {
 		val playbackCompleted = when (result?.action) {
 			API_MX_RESULT_ID -> extras.getString(API_MX_RESULT_END_BY) == API_MX_RESULT_END_BY_PLAYBACK_COMPLETION
 			API_MPV_RESULT_ID -> endPosition == null // in MPV playback is completed when 'position' extra is absent
-			API_VIMU_RESULT_ID -> result?.resultCode == API_VIMU_RESULT_PLAYBACK_COMPLETED
+			API_VIMU_RESULT_ID -> activityResult.resultCode == API_VIMU_RESULT_PLAYBACK_COMPLETED
 			// in VLC is not possible to understand if playback is completed from resulting Intent
-			else -> null
+			else -> false
 		}
 
 		val runtime = (mediaSource.runTimeTicks ?: item.runTimeTicks)?.ticks
-		val shouldPlayNext = (playbackCompleted) || (runtime != null && endPosition != null && endPosition >= (runtime * 0.9))
+		val shouldPlayNext = playbackCompleted || (runtime != null && endPosition != null && endPosition >= (runtime * 0.9))
 
 		lifecycleScope.launch {
 			runCatching {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Fixes a regression where the "play next episode" feature failed for external players (specifically MX Player and MPV) because they do not return a standard playback position upon completion.

- **MX Player**: Re-implemented specific intent handling from v0.18 (checking the `end_by` flag).
- **MPV**: Added specific handling for MPV's result intent. Since MPV does not return a position extra when playback finishes, the code now correctly interprets this as completion based on the official MPV intent spec.

This restores functionality that was previously covered by the "time elapsed" fallback check, which was removed in v0.19.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
Used LLM to verify Kotlin syntax and validate the Intent handling logic for specific players.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #5293
