### PR TITLE
Add media type API to set proper content type in audio attributes

### DIFF
--- a/playback/core/src/main/kotlin/mediastream/mediatype/MediaType.kt
+++ b/playback/core/src/main/kotlin/mediastream/mediatype/MediaType.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.playback.core.mediastream.mediatype
+
+/**
+ * Definition of the type for a specific media.
+ */
+enum class MediaType {
+	/**
+	 * Media type for primarily video content like movies, tv shows and live tv.
+	 */
+	Video,
+
+	/**
+	 * Media type for primarily audio content like music, podcasts and audio books.
+	 */
+	Audio,
+
+	/**
+	 * Unknown media type.
+	 */
+	Unknown,
+}

--- a/playback/core/src/main/kotlin/mediastream/mediatype/mediaTypeElement.kt
+++ b/playback/core/src/main/kotlin/mediastream/mediatype/mediaTypeElement.kt
@@ -1,0 +1,20 @@
+package org.jellyfin.playback.core.mediastream.mediatype
+
+import org.jellyfin.playback.core.element.ElementKey
+import org.jellyfin.playback.core.element.elementFlow
+import org.jellyfin.playback.core.element.requiredElement
+import org.jellyfin.playback.core.queue.QueueEntry
+
+private val mediaTypeKey = ElementKey<MediaType>("MediaType")
+
+/**
+ * Get or set the media type this [QueueEntry]. A supported backend will use this to
+ * set correct audio attributes for the media.
+ */
+var QueueEntry.mediaType by requiredElement(mediaTypeKey) { MediaType.Unknown }
+
+/**
+ * Get the flow of [mediaType].
+ * @see mediaType
+ */
+val QueueEntry.mediaTypeFlow by elementFlow(mediaTypeKey)

--- a/playback/jellyfin/src/main/kotlin/queue/createBaseItemQueueEntry.kt
+++ b/playback/jellyfin/src/main/kotlin/queue/createBaseItemQueueEntry.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.playback.jellyfin.queue
 
+import org.jellyfin.playback.core.mediastream.mediatype.mediaType
 import org.jellyfin.playback.core.mediastream.normalizationGain
 import org.jellyfin.playback.core.queue.QueueEntry
 import org.jellyfin.playback.core.queue.QueueEntryMetadata
@@ -10,6 +11,8 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.extensions.ticks
 import java.util.UUID
+import org.jellyfin.playback.core.mediastream.mediatype.MediaType as PlayerMediaType
+import org.jellyfin.sdk.model.api.MediaType as SdkMediaType
 
 /**
  * Create a [QueueEntry] from a [BaseItemDto].
@@ -46,6 +49,13 @@ fun createBaseItemQueueEntry(api: ApiClient, baseItem: BaseItemDto): QueueEntry 
 	)
 	entry.baseItem = baseItem
 	entry.normalizationGain = baseItem.normalizationGain
+	entry.mediaType = when (baseItem.mediaType) {
+		SdkMediaType.VIDEO -> PlayerMediaType.Video
+		SdkMediaType.AUDIO -> PlayerMediaType.Audio
+		SdkMediaType.PHOTO,
+		SdkMediaType.BOOK,
+		SdkMediaType.UNKNOWN -> PlayerMediaType.Unknown
+	}
 	return entry
 }
 

--- a/playback/media3/exoplayer/src/main/kotlin/AudioAttributeState.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/AudioAttributeState.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.playback.media3.exoplayer
+
+import androidx.media3.common.AudioAttributes
+import timber.log.Timber
+
+class AudioAttributeState {
+	private var _audioAttributes: AudioAttributes? = null
+
+	fun updateAudioAttributes(
+		builder: AudioAttributes.Builder.() -> Unit,
+		onChange: (audioAttributes: AudioAttributes) -> Unit,
+	) {
+		val newAudioAttributes = AudioAttributes.Builder().apply {
+			builder()
+		}.build()
+
+		if (_audioAttributes != newAudioAttributes) {
+			Timber.d("Audio attributes changed")
+
+			onChange(newAudioAttributes)
+			_audioAttributes = newAudioAttributes
+		}
+	}
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Adds a new "media type" element to queue entries that can be set to video, audio or unknown (default). It is used to set the proper audio attributes in ExoPlayer and will eventually be used to determine which UI to show (music or video player).
Also fixed an issue where playItem would early return and not call `exoPlayer.play()` for the initial item.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
