### PR TITLE
Fix item names not showing when showCardInfoOverlay is set

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/item/ItemCardBaseItemOverlay.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/item/ItemCardBaseItemOverlay.kt
@@ -36,7 +36,10 @@ import org.koin.compose.koinInject
 
 @Composable
 @Stable
-fun ItemCardBaseItemOverlay(item: BaseItemDto) = Box(
+fun ItemCardBaseItemOverlay(
+	item: BaseItemDto,
+	footer: (@Composable () -> Unit)? = null,
+) = Box(
 	modifier = Modifier
 		.fillMaxSize()
 		.padding(Tokens.Space.spaceXs)
@@ -51,10 +54,16 @@ fun ItemCardBaseItemOverlay(item: BaseItemDto) = Box(
 		modifier = Modifier.align(Alignment.TopEnd)
 	)
 
-	ProgressIndicator(
-		item = item,
-		modifier = Modifier.align(Alignment.BottomCenter)
-	)
+	Column(
+		modifier = Modifier.align(Alignment.BottomCenter),
+		verticalArrangement = Arrangement.spacedBy(Tokens.Space.spaceXs)
+	) {
+		ProgressIndicator(
+			item = item,
+		)
+
+		if (footer != null) footer()
+	}
 }
 
 @Composable

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.kt
@@ -3,8 +3,12 @@ package org.jellyfin.androidtv.ui.presentation
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -30,6 +34,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.ImageType
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.item.ItemCard
@@ -42,6 +47,7 @@ import org.jellyfin.androidtv.ui.itemhandling.GridButtonBaseRowItem
 import org.jellyfin.androidtv.util.ImageHelper
 import org.jellyfin.androidtv.util.apiclient.JellyfinImage
 import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.design.Tokens
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.koin.compose.koinInject
@@ -290,6 +296,8 @@ private fun CardViewHolderContent(
 		else -> DpSize(150.dp * aspectRatio, 150.dp)
 	}
 
+	val usePreview = displayConfig.overrideShowInfo ?: showInfo
+
 	val card = @Composable {
 		ItemCard(
 			image = {
@@ -325,8 +333,36 @@ private fun CardViewHolderContent(
 				}
 			},
 			overlay = {
+				val showInfo = !usePreview && item.showCardInfoOverlay
 				item.baseItem?.let { baseItem ->
-					ItemCardBaseItemOverlay(baseItem)
+					ItemCardBaseItemOverlay(
+						item = baseItem,
+						footer = {
+							if (showInfo && title != null) {
+								val focusModifier = if (focused) Modifier.basicMarquee(
+									iterations = Int.MAX_VALUE,
+									initialDelayMillis = 0,
+								) else Modifier
+
+								Box(
+									modifier = Modifier
+										.fillMaxWidth()
+										.background(Tokens.Color.colorBluegrey900.copy(alpha = 0.6f), JellyfinTheme.shapes.extraSmall),
+								) {
+									Text(
+										text = title,
+										maxLines = 1,
+										overflow = TextOverflow.Ellipsis,
+										textAlign = TextAlign.Center,
+										color = Tokens.Color.colorWhite,
+										modifier = Modifier
+											.then(focusModifier)
+											.padding(Tokens.Space.spaceXs),
+									)
+								}
+							}
+						}
+					)
 				}
 			},
 			modifier = Modifier
@@ -334,7 +370,7 @@ private fun CardViewHolderContent(
 		)
 	}
 
-	if (displayConfig.overrideShowInfo ?: showInfo) {
+	if (usePreview) {
 		val focusModifier = if (focused) Modifier.basicMarquee(
 			iterations = Int.MAX_VALUE,
 			initialDelayMillis = 0,


### PR DESCRIPTION

**Changes**

Some library types (like photos, playlists and mixed media) are shown as a grid and need to display their titles within the card overlay. This wasn't re-implemented in #5343 making these libraries basically unusable.

This change re-adds this support, with a nicer design. This is still for legacy UI only. We're going to redo the browsing UI at some point....

<img width="1494" height="840" alt="afbeelding" src="https://github.com/user-attachments/assets/9dd42efc-29b8-4521-9451-b5c505d3be2a" />
_Demo server playlist library, ignore the inconsistent item sizes 🫠_

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
