### PR TITLE
Check for playAccess in BaseItemDto.canPlay extension

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemExtensions.kt
@@ -11,6 +11,7 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.LocationType
 import org.jellyfin.sdk.model.api.PersonKind
+import org.jellyfin.sdk.model.api.PlayAccess
 import java.time.LocalDateTime
 
 fun BaseItemDto.getSeasonEpisodeName(context: Context): String {
@@ -48,6 +49,7 @@ fun BaseItemDto.getDisplayName(context: Context): String {
 
 
 fun BaseItemDto?.canPlay() = this != null
+	&& playAccess != PlayAccess.NONE
 	&& isPlaceHolder != true
 	&& (type != BaseItemKind.EPISODE || locationType != LocationType.VIRTUAL)
 	&& type != BaseItemKind.PERSON


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

When the "PlayAccess" is set to "None" it means the user is not allowed to play the item. This doesn't mean they can't play it, just that we shouldn't let them. This check was accidentally removed years ago during one of many SDK migration changes.
Note that the server does not always set this property so there's still places where you can start playback from.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
