### PR TITLE
Fix recording from playback overlay, passing programId to default gettimer

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
@@ -159,12 +159,12 @@ fun CustomPlaybackOverlayFragment.recordProgram(program: BaseItemDto, isSeries: 
 	lifecycleScope.launch {
 		runCatching {
 			withContext(Dispatchers.IO) {
-				val defaultTimer by api.liveTvApi.getDefaultTimer()
+				val defaultTimer by api.liveTvApi.getDefaultTimer(program.id.toString())
 
 				if (isSeries) {
-					api.liveTvApi.createSeriesTimer(defaultTimer.copy(programId = program.id.toString()))
+					api.liveTvApi.createSeriesTimer(defaultTimer)
 				} else {
-					api.liveTvApi.createTimer(defaultTimer.asTimerInfoDto().copy(programId = program.id.toString()))
+					api.liveTvApi.createTimer(defaultTimer.asTimerInfoDto())
 				}
 			}
 		}.fold(


### PR DESCRIPTION
The playback overlay's recordProgram() calls getDefaultTimer() without passing the programId, causing the server to return DateTime.MinValue for StartDate/EndDate. The Kotlin SDK then mangled these into year-0000 dates that the server rejected with HTTP 400 (separate issue).

Pass program.id to getDefaultTimer() so the server returns real dates from the EPG program data. This matches how LiveProgramDetailPopupHelper already does it correctly [https://github.com/jellyfin/jellyfin-androidtv/blob/master/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopupHelper.kt#L95-L100
](url)

**Changes**
Added the programid to the getDefaultTImer call. Remove the unnecessary copy in the subsequent isSeries block. 

**Code assistance**
Opus 4.6 was used to aide in researching/debugging and making some of these changes.  Extra scrutiny suggested.

**Issues**
https://github.com/jellyfin/jellyfin/issues/16190
https://github.com/jellyfin/jellyfin-androidtv/issues/4371

