### PR TITLE
Fix stale channel/program data in live TV playback overlay

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1129,7 +1129,21 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         }
     };
 
+    private boolean channelDataIsStale() {
+        List<BaseItemDto> channels = TvManager.getAllChannels();
+        if (channels == null || channels.isEmpty()) return true;
+        LocalDateTime now = LocalDateTime.now();
+        return channels.stream().anyMatch(channel ->
+            channel.getCurrentProgram() != null &&
+            channel.getCurrentProgram().getEndDate() != null &&
+            !channel.getCurrentProgram().getEndDate().isAfter(now)
+        );
+    }
+
     public void showQuickChannelChanger() {
+        if (channelDataIsStale()) {
+            prepareChannelAdapter();
+        }
         showChapterPanel();
         mHandler.postDelayed(() -> {
             if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;


### PR DESCRIPTION
Refresh the channel list when any program has ended before showing the quick channel changer, so program information stays current.  Shows program updates without requiring the user to navigate to the full guide.

User symptom is, when pressing the down D pad, the channel information doesn't update and is stale. Only seems to update when you exit and load the channel guide. 

**Changes**
The channel list (with embedded current program data) was loaded once when playback started via prepareChannelAdapter() and never refreshed. When the user pressed down to show the overlay again, it displayed the cached data regardless of how much time had passed. The full guide (showGuide()) already had time-based refresh logic, but the quick channel changer had none.

Fix: Added a channelDataIsStale() check inside showQuickChannelChanger() that inspects the cached channel list and returns true if any channel's current program end time has already passed. When stale data is detected, prepareChannelAdapter() is called to fetch fresh channel/program data from the server before displaying the overlay. This uses actual program boundaries as the refresh trigger rather than an arbitrary time interval.

I did consider a semaphore lock to guard on the scenario that a user could be hammering the down button but thought it overkill.

Tested/validated in androidTV device simulator (studio).

**Code assistance**
Almost all changes were coded by Opus 4.6. 

