### PR TITLE
Fix non-enum preferences not persisting to server

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/compat/rememberPreference.kt
@@ -17,7 +17,10 @@ import org.jellyfin.preference.store.PreferenceStore
 fun <ME, MV, T : Any> rememberPreference(store: PreferenceStore<ME, MV>, preference: Preference<T>): MutableState<T> {
 	val mutableState = remember { mutableStateOf(store[preference]) }
 	LaunchedEffect(mutableState.value) {
-		if (store[preference] != mutableState.value) store[preference] = mutableState.value
+		if (store[preference] != mutableState.value) {
+			store[preference] = mutableState.value
+			if (store is AsyncPreferenceStore) store.commit()
+		}
 	}
 	return mutableState
 }


### PR DESCRIPTION
**Changes**

The generic `rememberPreference()` overload for non-enum types (Int, String, etc.) updates the local in-memory cache but never calls `commit()` on the `AsyncPreferenceStore`, so preferences like `skipForwardLength` and `skipBackLength` silently revert on app restart. This adds the same `commit()` call the enum overload already has.

**Code assistance**

None.

**Issues**

Fixes #5405