### PR TITLE
Fix - stale recording overlay

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1097,6 +1097,13 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     refreshCurrentPosition();
                     long currentTime = isLiveTv ? getTimeShiftedProgress() : mCurrentPosition;
 
+                    // Detect live TV program transition and refresh channel/program data
+                    if (isLiveTv && mCurrentProgramEnd != null
+                            && LocalDateTime.now().isAfter(mCurrentProgramEnd)) {
+                        mCurrentProgramEnd = null;
+                        updateTvProgramInfo();
+                    }
+
                     reportingHelper.getValue().reportProgress(mFragment, PlaybackController.this, getCurrentlyPlayingItem(), getCurrentStreamInfo(), currentTime * 10000, false);
                 }
                 if (mPlaybackState != PlaybackState.UNDEFINED && mPlaybackState != PlaybackState.IDLE) {


### PR DESCRIPTION
When you press up on the remote (overlay) when watching livetv then press the record button, the button doesn't change state (e.g. doesn't change red). You have to leave the menu then come back to see if it's recording. Same is true if you cancel the recording. 

On a side note, there are psuedo related issues with https://github.com/jellyfin/jellyfin-androidtv/pull/5396 and https://github.com/jellyfin/jellyfin/pull/16191.... (which is why I keep peeling the onion :-) ).  You would need 16191 or live in a + UTC to even be able to press record in the first place from the overlay.  Once I could do that (-5 UTC here), I noticed all these other problems and started at least trying to fix them. 

**Changes**
Change to update the "items" list dynamically so the user doesn't have to exit and come back to get a refresh.
The "big" change was to making the items list mutable on the setter call.

Opus 4.6 was used to check potential impacts it the "ecosystem" and research tasks. There were none noted.

