### PR TITLE
Fix left D-Pad focus "escape" on channel and chapter display overlay

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -475,7 +475,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
             if (event.getAction() == KeyEvent.ACTION_DOWN) {
-                if (!mGuideVisible)
+                if (!mGuideVisible && !mPopupPanelVisible)
                     leanbackOverlayFragment.setShouldShowOverlay(true);
                 else {
                     leanbackOverlayFragment.setShouldShowOverlay(false);
@@ -527,11 +527,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     }
                 }
 
-                if (mPopupPanelVisible && !mGuideVisible && keyCode == KeyEvent.KEYCODE_DPAD_LEFT && mPopupRowPresenter.getPosition() == 0) {
-                    mPopupRowsFragment.requireView().requestFocus();
-                    mPopupRowPresenter.setPosition(0);
-                    return true;
-                }
                 if (mGuideVisible) {
                     if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_ESCAPE) {
                         // go back to normal

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -187,7 +187,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     .findFragmentById(R.id.rows_area);
         }
 
-        mPopupRowPresenter = new PositionableListRowPresenter();
+        mPopupRowPresenter = new PositionableListRowPresenter(null, true);
         mPopupRowAdapter = new ArrayObjectAdapter(mPopupRowPresenter);
         mPopupRowsFragment.setAdapter(mPopupRowAdapter);
         mPopupRowsFragment.setOnItemViewClickedListener(itemViewClickedListener);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1142,7 +1142,9 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         mHandler.postDelayed(() -> {
             if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
 
-            int ndx = getCurrentChapterIndex(playbackControllerContainer.getValue().getPlaybackController().getCurrentlyPlayingItem(), playbackControllerContainer.getValue().getPlaybackController().getCurrentPosition() * 10000);
+            PlaybackController controller = playbackControllerContainer.getValue().getPlaybackController();
+            int ndx = getCurrentChapterIndex(controller.getCurrentlyPlayingItem(),
+                controller.getCurrentPosition() * 10000);
             if (ndx > 0) {
                 mPopupRowPresenter.setPosition(ndx);
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
@@ -6,9 +6,13 @@ import timber.log.Timber
 
 class PositionableListRowPresenter : CustomListRowPresenter {
 	private var viewHolder: ViewHolder? = null
+	private val trapFocusAtStart: Boolean
 
-	constructor() : super()
-	constructor(padding: Int?) : super(padding)
+	constructor() : this(padding = null, trapFocusAtStart = false)
+	constructor(padding: Int?) : this(padding, trapFocusAtStart = false)
+	constructor(padding: Int? = null, trapFocusAtStart: Boolean = false) : super(padding) {
+		this.trapFocusAtStart = trapFocusAtStart
+	}
 
 	init {
 		shadowEnabled = false
@@ -23,11 +27,13 @@ class PositionableListRowPresenter : CustomListRowPresenter {
 		if (holder !is ViewHolder) return
 
 		viewHolder = holder
-		// Prevent focus from escaping the grid at the left boundary so the user
-		// stays inside the popup (channel changer / chapter selector).
-		holder.gridView?.setOnKeyInterceptListener { event ->
-			event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT &&
-				(holder.gridView?.selectedPosition ?: -1) <= 0
+		if (trapFocusAtStart) {
+			// Prevent focus from escaping the grid at the left boundary so the user
+			// stays inside the popup (channel changer / chapter selector).
+			holder.gridView?.setOnKeyInterceptListener { event ->
+				event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT &&
+					(holder.gridView?.selectedPosition ?: -1) <= 0
+			}
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.androidtv.ui.presentation
 
+import android.view.KeyEvent
 import androidx.leanback.widget.RowPresenter
 import timber.log.Timber
 
@@ -22,6 +23,12 @@ class PositionableListRowPresenter : CustomListRowPresenter {
 		if (holder !is ViewHolder) return
 
 		viewHolder = holder
+		// Prevent focus from escaping the grid at the left boundary so the user
+		// stays inside the popup (channel changer / chapter selector).
+		holder.gridView?.setOnKeyInterceptListener { event ->
+			event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT &&
+				(holder.gridView?.selectedPosition ?: -1) <= 0
+		}
 	}
 
 	var position: Int


### PR DESCRIPTION
When a user presses down on the D Pad, a channel (or chapter) overlay display is loaded. If you scroll all the way to the right, you stop. You can either select that channel/chapter or not - as you would expect.
When you do the same scrolling all the way to the left boundary, a strange thing happens.  The "up" overlay displays in the background and the user is left in a strange state. Only "fix" is to go back and press down again. 

**Changes**
An effective focus trap was implemented/refactored to make the left boundary the same at the right boundary... and to remove  showing the "other" overlay in the background which was a mess.

Branch built and tested on a real firetv device. 

**Code assistance**
After several false starts by myself, Opus 4.6 was used to help to trace down the correct method to make this work and identify other areas that may be affected. Assisted with creation of a basic test and regression test plan. 

**Testing Steps**
Validated this functionality on firetv device:
 
 Live TV — Channel Changer
  1. While watching live TV, press DOWN to open the quick channel changer
  2. Scroll LEFT to the first channel — should stop at the boundary
  3. Keep pressing LEFT — nothing should happen, no focus loss, no overlay appearing behind
  4. Press RIGHT — should scroll right through channels normally
  5. Press DPAD_CENTER/ENTER — should tune to the selected channel
  6. Press UP or DOWN — should dismiss the popup

  Movie/Episode — Chapter Selector
  7.  While watching content with chapters, open the chapter selector
  8.  Scroll LEFT to the first chapter — should stop at the boundary
  9.  Keep pressing LEFT — nothing should happen
  10. Press RIGHT — should scroll right through chapters normally
  11. Press DPAD_CENTER/ENTER — should jump to the selected chapter  
  12. Press BACK — should dismiss the popup
  

  Misc regression checks ("just because" sanity checks, should be unaffected. May not be complete):

  Playback Transport Controls
  13. While watching any content (not live TV), press a key to show transport overlay — should still appear normally
  14. While live TV channel changer is open, transport controls should NOT appear behind it
  
  Home Screen
  15. Navigate a content row and scroll LEFT to the first item. Keep pressing LEFT — behavior identical to master version
  16. Check settings, login page scrolling behavior.

  Browse/Folder Screens
  17. Browse a library (movies, shows, etc.) — full LEFT at position 0 should be the same — behavior identical to master version



