### PR TITLE
Feature - Add paging to live tv channel guide

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -300,6 +300,11 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 event.startTracking();
                 return true;
+            case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+            case KeyEvent.KEYCODE_MEDIA_REWIND:
+            case KeyEvent.KEYCODE_MEDIA_NEXT:
+            case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                return true;
         }
         return false;
     }
@@ -323,6 +328,11 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
                 // bring up filter selection
                 showFilterOptions.setValue(true);
                 break;
+            case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+            case KeyEvent.KEYCODE_MEDIA_REWIND:
+            case KeyEvent.KEYCODE_MEDIA_NEXT:
+            case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                return handleChannelPageKey(keyCode);
             case KeyEvent.KEYCODE_ENTER:
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 if ((event.getFlags() & KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
@@ -374,6 +384,76 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
         }
 
         return false;
+    }
+
+    private boolean handleChannelPageKey(int keyCode) {
+        if (mDetailPopup != null && mDetailPopup.isShowing()) {
+            return true;
+        }
+        if (mSpinner.getVisibility() == View.VISIBLE || mAllChannels == null || mAllChannels.isEmpty()) {
+            return true;
+        }
+
+        // Calculate how many rows are visible on screen
+        int visibleRows = Math.max(1, mChannelScroller.getHeight() / guideRowHeightPx);
+
+        // Find which row currently has focus (check both program rows and channel headers)
+        int currentRowNdx = -1;
+        boolean focusOnChannelHeader = false;
+        View focused = requireActivity().getCurrentFocus();
+        for (int i = 0; i < mProgramRows.getChildCount(); i++) {
+            View row = mProgramRows.getChildAt(i);
+            if (row == focused || (focused != null && row instanceof ViewGroup && ((ViewGroup) row).indexOfChild(focused) >= 0)) {
+                currentRowNdx = i;
+                break;
+            }
+        }
+        if (currentRowNdx < 0) {
+            // Check if focus is on a channel header
+            for (int i = 0; i < mChannels.getChildCount(); i++) {
+                if (focused == mChannels.getChildAt(i)) {
+                    currentRowNdx = i;
+                    focusOnChannelHeader = true;
+                    break;
+                }
+            }
+        }
+        if (currentRowNdx < 0) return true;
+
+        // Calculate target row, clamped to valid range
+        int targetRowNdx;
+        if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
+            targetRowNdx = Math.min(currentRowNdx + visibleRows, mProgramRows.getChildCount() - 1);
+        } else {
+            targetRowNdx = Math.max(currentRowNdx - visibleRows, 0);
+        }
+
+        if (focusOnChannelHeader) {
+            // Stay on channel headers when paging
+            View targetHeader = mChannels.getChildAt(targetRowNdx);
+            if (targetHeader != null) {
+                targetHeader.requestFocus();
+            }
+        } else {
+            View targetRow = mProgramRows.getChildAt(targetRowNdx);
+            if (targetRow instanceof ViewGroup) {
+                // Find the child at the same horizontal position to preserve time scroll position
+                int focusedLeft = focused != null ? focused.getLeft() : 0;
+                ViewGroup targetGroup = (ViewGroup) targetRow;
+                View best = targetRow;
+                for (int i = 0; i < targetGroup.getChildCount(); i++) {
+                    View child = targetGroup.getChildAt(i);
+                    if (child.getLeft() <= focusedLeft && child.getRight() > focusedLeft) {
+                        best = child;
+                        break;
+                    }
+                }
+                best.requestFocus();
+            } else if (targetRow != null) {
+                targetRow.requestFocus();
+            }
+        }
+        return true;
     }
 
     View.OnClickListener datePickedListener = new View.OnClickListener() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -42,6 +42,7 @@ import org.jellyfin.androidtv.ui.ScrollViewListener;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.DateTimeExtensionsKt;
+import org.jellyfin.androidtv.util.KeyEventExtensionsKt;
 import org.jellyfin.androidtv.util.ImageHelper;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.PlaybackHelper;
@@ -400,7 +401,7 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
         }
         LiveTvGuideFragmentHelperKt.pageGuideChannels(
                 requireActivity(), mProgramRows, mChannels, guideVisibleRows,
-                LiveTvGuideFragmentHelperKt.isChannelPageForward(keyCode)
+                KeyEventExtensionsKt.isPageForward(keyCode)
         );
         return true;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragmentHelper.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.ui.livetv
 
 import android.app.Activity
 import android.content.Context
-import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.collectAsState
@@ -95,14 +94,6 @@ fun pageGuideChannels(
 
 	return true
 }
-
-fun isChannelPageKey(keyCode: Int): Boolean = keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
-	|| keyCode == KeyEvent.KEYCODE_MEDIA_REWIND
-	|| keyCode == KeyEvent.KEYCODE_MEDIA_NEXT
-	|| keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS
-
-fun isChannelPageForward(keyCode: Int): Boolean =
-	keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_MEDIA_NEXT
 
 fun createNoProgramDataBaseItem(
 	context: Context,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -107,6 +107,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private int mCurrentDisplayChannelEndNdx = 0;
     private List<BaseItemDto> mAllChannels;
     private UUID mFirstFocusChannelId;
+    private int guideRowHeightPx;
+    private int guideVisibleRows;
 
     private List<BaseItemDto> mItemsToPlay;
 
@@ -419,10 +421,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 event.startTracking();
                 return true;
             }
-            if (mGuideVisible && (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
-                    || keyCode == KeyEvent.KEYCODE_MEDIA_REWIND
-                    || keyCode == KeyEvent.KEYCODE_MEDIA_NEXT
-                    || keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS)) {
+            if (mGuideVisible && LiveTvGuideFragmentHelperKt.isChannelPageKey(keyCode)) {
                 return true;
             }
         } else if (event.getAction() == KeyEvent.ACTION_UP) {
@@ -473,12 +472,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
     private boolean handleGuideChannelPageKey(int keyCode) {
         if (!mGuideVisible) return false;
-        if (keyCode != KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
-                && keyCode != KeyEvent.KEYCODE_MEDIA_REWIND
-                && keyCode != KeyEvent.KEYCODE_MEDIA_NEXT
-                && keyCode != KeyEvent.KEYCODE_MEDIA_PREVIOUS) {
-            return false;
-        }
+        if (!LiveTvGuideFragmentHelperKt.isChannelPageKey(keyCode)) return false;
         if (mDetailPopup != null && mDetailPopup.isShowing()) {
             return true;
         }
@@ -486,66 +480,14 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             return true;
         }
 
-        // Calculate how many rows are visible on screen
-        int guideRowHeightPx = Utils.convertDpToPixel(requireContext(), LiveTvGuideFragment.GUIDE_ROW_HEIGHT_DP);
-        int visibleRows = Math.max(1, tvGuideBinding.channelScroller.getHeight() / guideRowHeightPx);
-
-        // Find which row currently has focus (check both program rows and channel headers)
-        int currentRowNdx = -1;
-        boolean focusOnChannelHeader = false;
-        View focused = requireActivity().getCurrentFocus();
-        for (int i = 0; i < tvGuideBinding.programRows.getChildCount(); i++) {
-            View row = tvGuideBinding.programRows.getChildAt(i);
-            if (row == focused || (focused != null && row instanceof ViewGroup && ((ViewGroup) row).indexOfChild(focused) >= 0)) {
-                currentRowNdx = i;
-                break;
-            }
+        if (guideVisibleRows == 0) {
+            guideRowHeightPx = Utils.convertDpToPixel(requireContext(), LiveTvGuideFragment.GUIDE_ROW_HEIGHT_DP);
+            guideVisibleRows = Math.max(1, tvGuideBinding.channelScroller.getHeight() / guideRowHeightPx);
         }
-        if (currentRowNdx < 0) {
-            // Check if focus is on a channel header
-            for (int i = 0; i < tvGuideBinding.channels.getChildCount(); i++) {
-                if (focused == tvGuideBinding.channels.getChildAt(i)) {
-                    currentRowNdx = i;
-                    focusOnChannelHeader = true;
-                    break;
-                }
-            }
-        }
-        if (currentRowNdx < 0) return true;
-
-        // Calculate target row, clamped to valid range
-        int targetRowNdx;
-        if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
-            targetRowNdx = Math.min(currentRowNdx + visibleRows, tvGuideBinding.programRows.getChildCount() - 1);
-        } else {
-            targetRowNdx = Math.max(currentRowNdx - visibleRows, 0);
-        }
-
-        if (focusOnChannelHeader) {
-            // Stay on channel headers when paging
-            View targetHeader = tvGuideBinding.channels.getChildAt(targetRowNdx);
-            if (targetHeader != null) {
-                targetHeader.requestFocus();
-            }
-        } else {
-            View targetRow = tvGuideBinding.programRows.getChildAt(targetRowNdx);
-            if (targetRow instanceof ViewGroup) {
-                // Find the child at the same horizontal position to preserve time scroll position
-                int focusedLeft = focused != null ? focused.getLeft() : 0;
-                ViewGroup targetGroup = (ViewGroup) targetRow;
-                View best = targetRow;
-                for (int i = 0; i < targetGroup.getChildCount(); i++) {
-                    View child = targetGroup.getChildAt(i);
-                    if (child.getLeft() <= focusedLeft && child.getRight() > focusedLeft) {
-                        best = child;
-                        break;
-                    }
-                }
-                best.requestFocus();
-            } else if (targetRow != null) {
-                targetRow.requestFocus();
-            }
-        }
+        LiveTvGuideFragmentHelperKt.pageGuideChannels(
+                requireActivity(), tvGuideBinding.programRows, tvGuideBinding.channels, guideVisibleRows,
+                LiveTvGuideFragmentHelperKt.isChannelPageForward(keyCode)
+        );
         return true;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -56,6 +56,7 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuide;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideFragment;
 import org.jellyfin.androidtv.ui.livetv.LiveTvGuideFragmentHelperKt;
+import org.jellyfin.androidtv.util.KeyEventExtensionsKt;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
@@ -421,7 +422,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                 event.startTracking();
                 return true;
             }
-            if (mGuideVisible && LiveTvGuideFragmentHelperKt.isChannelPageKey(keyCode)) {
+            if (mGuideVisible && KeyEventExtensionsKt.isPageKey(keyCode)) {
                 return true;
             }
         } else if (event.getAction() == KeyEvent.ACTION_UP) {
@@ -472,7 +473,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
     private boolean handleGuideChannelPageKey(int keyCode) {
         if (!mGuideVisible) return false;
-        if (!LiveTvGuideFragmentHelperKt.isChannelPageKey(keyCode)) return false;
+        if (!KeyEventExtensionsKt.isPageKey(keyCode)) return false;
         if (mDetailPopup != null && mDetailPopup.isShowing()) {
             return true;
         }
@@ -486,7 +487,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         }
         LiveTvGuideFragmentHelperKt.pageGuideChannels(
                 requireActivity(), tvGuideBinding.programRows, tvGuideBinding.channels, guideVisibleRows,
-                LiveTvGuideFragmentHelperKt.isChannelPageForward(keyCode)
+                KeyEventExtensionsKt.isPageForward(keyCode)
         );
         return true;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyEventExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyEventExtensions.kt
@@ -24,3 +24,18 @@ fun KeyEvent.isMediaSessionKeyEvent(): Boolean = when {
 		else -> false
 	}
 }
+
+/**
+ * Returns whether the given key code is a page key (FF/RW/Next/Previous).
+ * Used by grids and guides to page through items.
+ */
+fun isPageKey(keyCode: Int): Boolean = keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
+	|| keyCode == KeyEvent.KEYCODE_MEDIA_REWIND
+	|| keyCode == KeyEvent.KEYCODE_MEDIA_NEXT
+	|| keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS
+
+/**
+ * Returns whether the given page key code represents a forward direction.
+ */
+fun isPageForward(keyCode: Int): Boolean = keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
+	|| keyCode == KeyEvent.KEYCODE_MEDIA_NEXT


### PR DESCRIPTION
On the LiveTV channel guide AND the guide "popup" overlay display, allow the user to page up and down through the guide using the fast forward and rewind buttons. 

Not all devices/remotes will be able to utilize this. 

**Changes**
Added key handlers (trying to cover all variants) for FF/RW in the guide screens.  Need to "math" what was visible to the user to calculate the page size and use that to define a scroll port page window. Also covers the scenario of being full "left" in the guide on the channel column....i.e. you can page there. 

If user has scrolled right, do not scroll left/right when paging. 

**Code assistance**
LLM used to understand certain aspects of the guide/key handling architecture. Also code review and enhancements. 

** Testing **
Tested in an android studio emulator, on fire cube device and on an nvidia shield device. All function as expected. Given this is new, extra rigor should be applied and considered. 
