### PR TITLE
Feature - add buffering spinner to the player when tuning a  live TV channel

### DIFF
--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -38,6 +38,15 @@
             android:layout_height="match_parent"
             android:layout_gravity="center" />
 
+        <ProgressBar
+            android:id="@+id/bufferingSpinner"
+            style="?android:attr/progressBarStyleLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:indeterminateTint="?android:attr/colorAccent"
+            android:visibility="gone" />
+
     </FrameLayout>
 
     <FrameLayout


### PR DESCRIPTION
When tuning a livetv channel that needs re-muxing/transcoding, the user can wait 5-10 seconds for the channel to tune/start. 
Show a theme-colored loading spinner during ExoPlayer buffering state, improving visual feedback when tuning to live TV channels while they wait.

**Changes**
Added a standard spinner for buffering livetv.

**Code assistance**
Heavy, nearly exclusive, reliance on Opus 4.6 to research and code the changes (agent mode). 