### PR TITLE
FIX - Playback of recorded Live TV (MPEG-TS) causing player to stop/start in a loop.

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -73,7 +73,12 @@ public class StreamInfo {
     public final org.jellyfin.sdk.model.api.SubtitleDeliveryMethod getSubtitleDeliveryMethod() {
         Integer subtitleStreamIndex = MediaSource.getDefaultSubtitleStreamIndex();
         if (subtitleStreamIndex == null || subtitleStreamIndex == -1) return SubtitleDeliveryMethod.DROP;
-        return MediaSource.getMediaStreams().get(subtitleStreamIndex).getDeliveryMethod();
+        for (MediaStream stream : MediaSource.getMediaStreams()) {
+            if (stream.getType() == MediaStreamType.SUBTITLE && stream.getIndex() == subtitleStreamIndex) {
+                return stream.getDeliveryMethod();
+            }
+        }
+        return SubtitleDeliveryMethod.DROP;
     }
 
     private String PlaySessionId;

--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -9,6 +9,8 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod;
 import java.util.ArrayList;
 import java.util.UUID;
 
+import timber.log.Timber;
+
 public class StreamInfo {
     private UUID ItemId;
 
@@ -78,6 +80,7 @@ public class StreamInfo {
                 return stream.getDeliveryMethod();
             }
         }
+        Timber.w("Subtitle stream index %d not found in media streams", subtitleStreamIndex);
         return SubtitleDeliveryMethod.DROP;
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -690,10 +690,14 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         // Otherwise, query the players
         if (mCurrentOptions.getAudioStreamIndex() != null) {
             currIndex = mCurrentOptions.getAudioStreamIndex();
-        } else if (isTranscoding() && getCurrentMediaSource().getDefaultAudioStreamIndex() != null) {
-            currIndex = getCurrentMediaSource().getDefaultAudioStreamIndex();
-        } else if (hasInitializedVideoManager() && !isTranscoding()) {
-            currIndex = mVideoManager.getExoPlayerTrack(MediaStreamType.AUDIO, getCurrentlyPlayingItem().getMediaStreams());
+        } else if (isTranscoding()) {
+            MediaSourceInfo mediaSource = getCurrentMediaSource();
+            if (mediaSource != null && mediaSource.getDefaultAudioStreamIndex() != null)
+                currIndex = mediaSource.getDefaultAudioStreamIndex();
+        } else if (hasInitializedVideoManager()) {
+            MediaSourceInfo mediaSource = getCurrentMediaSource();
+            if (mediaSource != null && mediaSource.getMediaStreams() != null)
+                currIndex = mVideoManager.getExoPlayerTrack(MediaStreamType.AUDIO, mediaSource.getMediaStreams());
         }
         return currIndex;
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -84,6 +84,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     protected VideoOptions mCurrentOptions;
     private int mDefaultAudioIndex = -1;
+    private int mAudioSwitchRestartIndex = -1;
     protected boolean burningSubs = false;
     private float mRequestedPlaybackSpeed = -1.0f;
 
@@ -784,6 +785,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         Timber.i("trying to switch audio stream from %s to %s", currAudioIndex, index);
         if (currAudioIndex == index) {
             Timber.d("skipping setting audio stream, already set to requested index %s", index);
+            mAudioSwitchRestartIndex = -1;
             if (mCurrentOptions.getAudioStreamIndex() == null || mCurrentOptions.getAudioStreamIndex() != index) {
                 Timber.i("setting mCurrentOptions audio stream index from %s to %s", mCurrentOptions.getAudioStreamIndex(), index);
                 mCurrentOptions.setAudioStreamIndex(index);
@@ -797,13 +799,26 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (!isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.AUDIO, currentMediaSource.getMediaStreams())) {
             mCurrentOptions.setMediaSourceId(currentMediaSource.getId());
             mCurrentOptions.setAudioStreamIndex(index);
-        } else {
+            mAudioSwitchRestartIndex = -1;
+        } else if (index != mAudioSwitchRestartIndex) {
+            // In-player switch failed or we are transcoding — restart playback so the server
+            // can provide a stream with the requested audio track.
+            // Circuit breaker: allow only one automatic restart per requested index to prevent
+            // an infinite restart loop. If the restarted attempt still fails, the "give-up" else
+            // clears the guard so the user can try again manually.
+            Timber.i("restarting playback for audio stream index %d", index);
+            mAudioSwitchRestartIndex = index;
             startSpinner();
             mCurrentOptions.setMediaSourceId(currentMediaSource.getId());
             mCurrentOptions.setAudioStreamIndex(index);
             stop();
             playInternal(getCurrentlyPlayingItem(), mCurrentPosition, mCurrentOptions);
             mPlaybackState = PlaybackState.BUFFERING;
+        } else {
+            Timber.w("audio track switch to index %d failed after restart, not retrying", index);
+            mAudioSwitchRestartIndex = -1;
+            if (mFragment != null && mFragment.getContext() != null)
+                Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.msg_audio_track_switch_failed));
         }
     }
 
@@ -882,6 +897,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     private void resetPlayerErrors() {
         playbackRetries = 0;
+        mAudioSwitchRestartIndex = -1;
     }
 
     private void clearPlaybackSessionOptions() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -759,14 +759,19 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
 
         MediaSourceInfo currentMediaSource = getCurrentMediaSource();
-        if (currentMediaSource == null
-                || currentMediaSource.getMediaStreams() == null
-                || index >= currentMediaSource.getMediaStreams().size()) {
+        if (currentMediaSource == null || currentMediaSource.getMediaStreams() == null) {
+            return;
+        }
+
+        // Look up the requested stream by its Index key, not by list position
+        MediaStream requestedStream = findStreamByIndex(currentMediaSource.getMediaStreams(), MediaStreamType.AUDIO, index);
+        if (requestedStream == null) {
+            Timber.w("requested audio stream index %s not found in media source", index);
             return;
         }
 
         String lastAudioIsoCode = videoQueueManager.getValue().getLastPlayedAudioLanguageIsoCode();
-        String currentAudioIsoCode = currentMediaSource.getMediaStreams().get(index).getLanguage();
+        String currentAudioIsoCode = requestedStream.getLanguage();
 
         if (currentAudioIsoCode != null
                 && (lastAudioIsoCode == null || !lastAudioIsoCode.equals(currentAudioIsoCode))) {
@@ -1308,6 +1313,15 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     public void setZoom(@NonNull ZoomMode mode) {
         if (hasInitializedVideoManager())
             mVideoManager.setZoom(mode);
+    }
+
+    private static @Nullable MediaStream findStreamByIndex(@NonNull List<MediaStream> streams, @NonNull MediaStreamType type, int index) {
+        for (MediaStream stream : streams) {
+            if (stream.getType() == type && stream.getIndex() == index) {
+                return stream;
+            }
+        }
+        return null;
     }
 
     /**

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -444,15 +444,21 @@ public class VideoManager {
         // offset the stream index to account for external streams
         int exoTrackID = offsetStreamIndex(parsedGroupId, true, allStreams);
         if (exoTrackID >= 0) {
-            Timber.d("re-retrieved exoplayer track index %s", exoTrackID);
-            return exoTrackID;
+            MediaStream directMatch = findStreamByIndex(allStreams, streamType, exoTrackID);
+            if (directMatch != null) {
+                Timber.d("re-retrieved exoplayer track index %s", exoTrackID);
+                return directMatch.getIndex();
+            }
+            Timber.w("translated exoplayer track index %s does not map to a non-external %s stream", exoTrackID, streamType);
         }
 
         if (selectedGroupInfo == null)
             return -1;
 
-        // Ordinal fallback for containers with non-sequential track IDs (e.g., MPEG-TS with PIDs).
-        // Find the ordinal of the selected ExoPlayer group, return the Jellyfin stream at that position.
+        // Best-effort fallback when we cannot map the selected ExoPlayer group back to a
+        // Jellyfin stream index directly. Match by ordinal position among nonexternal
+        // tracks of the same type. This covers cases such as composite group IDs like "0x65"
+        // as well as other ID mismatches.
         int selectedOrdinal = 0;
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {
             if (groupInfo.getType() != chosenTrackType) continue;
@@ -545,9 +551,11 @@ public class VideoManager {
         }
 
         if (matchedGroup == null) {
-            // Ordinal fallback for containers with non-sequential track IDs (e.g., MPEG-TS with PIDs).
-            // Find the ordinal of the target Jellyfin stream, select the ExoPlayer group at that position.
-            // Stream existence is guaranteed by the candidateOptional check above.
+            // Best-effort fallback when direct ExoPlayer-group matching does not find the
+            // requested Jellyfin stream. Match by ordnial position among non-external
+            // tracks of the same type. This covers cases such as composite group IDs like
+            // "0x61" as well as other ID mismatches. Stream existence is guaranteed by the
+            // candidateOptional check above.
             int targetOrdinal = 0;
             for (MediaStream stream : allStreams) {
                 if (stream.isExternal() || stream.getType() != streamType) continue;
@@ -613,6 +621,19 @@ public class VideoManager {
                 return true;
         }
         return false;
+    }
+
+    private static @Nullable MediaStream findStreamByIndex(
+            @NonNull List<MediaStream> streams,
+            @NonNull MediaStreamType type,
+            int index
+    ) {
+        for (MediaStream stream : streams) {
+            if (!stream.isExternal() && stream.getType() == type && stream.getIndex() == index) {
+                return stream;
+            }
+        }
+        return null;
     }
 
     private static boolean isTrackGroupSelected(Tracks.Group groupInfo) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -413,69 +413,57 @@ public class VideoManager {
 
         int chosenTrackType = streamType == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE ? C.TRACK_TYPE_TEXT : C.TRACK_TYPE_AUDIO;
 
-        int matchedIndex = -2;
+        boolean selectedGroupFound = false;
+        int parsedGroupId = -1;
+        Tracks.Group selectedGroupInfo = null;
         Tracks exoTracks = mExoPlayer.getCurrentTracks();
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {
-            if (matchedIndex > -2)
+            if (selectedGroupFound)
                 break;
-            // Group level information.
-            @C.TrackType int trackType = groupInfo.getType();
+            if (groupInfo.getType() != chosenTrackType)
+                continue;
             TrackGroup group = groupInfo.getMediaTrackGroup();
             for (int i = 0; i < group.length; i++) {
-                if (trackType == chosenTrackType) {
-                    if (groupInfo.isTrackSelected(i)) {
-                        // we found the track, set to -1 first to handle failed int parsing
-                        matchedIndex = -1;
-                        int id;
-                        try {
-                            if (group.id.contains(":")) {
-                                id = Integer.parseInt(group.id.split(":")[1]);
-                            } else {
-                                id = Integer.parseInt(group.id);
-                            }
-                        } catch (NumberFormatException e) {
-                            Timber.w("failed to parse group ID [%s]", group.id);
-                            break;
+                if (groupInfo.isTrackSelected(i)) {
+                    selectedGroupFound = true;
+                    selectedGroupInfo = groupInfo;
+                    try {
+                        if (group.id.contains(":")) {
+                            parsedGroupId = Integer.parseInt(group.id.split(":")[1]);
+                        } else {
+                            parsedGroupId = Integer.parseInt(group.id);
                         }
-                        matchedIndex = id;
-                        break;
+                    } catch (NumberFormatException e) {
+                        Timber.w("failed to parse group ID [%s]", group.id);
                     }
+                    break;
                 }
             }
         }
 
         // offset the stream index to account for external streams
-        int exoTrackID = offsetStreamIndex(matchedIndex, true, allStreams);
+        int exoTrackID = offsetStreamIndex(parsedGroupId, true, allStreams);
         if (exoTrackID >= 0) {
             Timber.d("re-retrieved exoplayer track index %s", exoTrackID);
             return exoTrackID;
         }
 
-        // Fallback for containers with non-sequential track IDs (e.g., MPEG-TS uses PIDs).
-        // Match by ordinal position: find which Nth track of this type is selected in ExoPlayer,
-        // then return the index of the Nth non-external stream of that type in the Jellyfin list.
-        Timber.d("offset-based track lookup failed for matched index %s, falling back to ordinal matching", matchedIndex);
+        if (selectedGroupInfo == null)
+            return -1;
+
+        // Ordinal fallback for containers with non-sequential track IDs (e.g., MPEG-TS with PIDs).
+        // Find the ordinal of the selected ExoPlayer group, return the Jellyfin stream at that position.
         int selectedOrdinal = 0;
-        boolean found = false;
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {
             if (groupInfo.getType() != chosenTrackType) continue;
-            TrackGroup group = groupInfo.getMediaTrackGroup();
-            for (int i = 0; i < group.length; i++) {
-                if (groupInfo.isTrackSelected(i)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (found) break;
+            if (groupInfo == selectedGroupInfo) break;
             selectedOrdinal++;
         }
-        if (!found) return -1;
-
         int ordinal = 0;
-        for (org.jellyfin.sdk.model.api.MediaStream stream : allStreams) {
+        for (MediaStream stream : allStreams) {
             if (stream.isExternal() || stream.getType() != streamType) continue;
             if (ordinal == selectedOrdinal) {
-                Timber.d("ordinal fallback matched exoplayer ordinal %s to jellyfin stream index %s", selectedOrdinal, stream.getIndex());
+                Timber.d("ordinal fallback matched exoplayer group ordinal %s to jellyfin stream index %s", selectedOrdinal, stream.getIndex());
                 return stream.getIndex();
             }
             ordinal++;
@@ -512,82 +500,73 @@ public class VideoManager {
         Tracks exoTracks = mExoPlayer.getCurrentTracks();
         TrackGroup matchedGroup = null;
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {
-            // Group level information.
+            if (matchedGroup != null)
+                break;
+
+            // Group level information — filter and parse before entering the per-track loop.
             @C.TrackType int trackType = groupInfo.getType();
+            if (trackType != chosenTrackType)
+                continue;
+
             TrackGroup group = groupInfo.getMediaTrackGroup();
-            for (int i = 0; i < group.length; i++) {
-                // Individual track information.
-                boolean isSupported = groupInfo.isTrackSupported(i);
-                boolean isSelected = groupInfo.isTrackSelected(i);
-                Format trackFormat = group.getFormat(i);
-
-                Timber.i("track %s group %s/%s trackType %s label %s mime %s isSelected %s isSupported %s",
-                        trackFormat.id, i + 1, group.length, trackType, trackFormat.label, trackFormat.sampleMimeType, isSelected, isSupported);
-
-                if (trackType != chosenTrackType)
-                    continue;
-
-                int id;
-                try {
-                    if (group.id.contains(":")) {
-                        id = Integer.parseInt(group.id.split(":")[1]);
-                    } else {
-                        id = Integer.parseInt(group.id);
-                    }
-                    if (id != exoTrackID)
-                        continue;
-                } catch (NumberFormatException e) {
-                    Timber.w("failed to parse group ID [%s]", group.id);
-                    continue;
+            int id;
+            try {
+                if (group.id.contains(":")) {
+                    id = Integer.parseInt(group.id.split(":")[1]);
+                } else {
+                    id = Integer.parseInt(group.id);
                 }
-
-                if (!groupInfo.isTrackSupported(i)) {
-                    Timber.d("track is not compatible");
-                    return false;
-                }
-
-                if (groupInfo.isTrackSelected(i)) {
-                    Timber.d("track is already selected");
-                    return true;
-                }
-
-                Timber.i("matched exoplayer track %s to mediaStream track %s", trackFormat.id, index);
-                matchedGroup = group;
+            } catch (NumberFormatException e) {
+                Timber.w("failed to parse group ID [%s]", group.id);
+                continue;
             }
+            if (id != exoTrackID)
+                continue;
+
+            for (int i = 0; i < group.length; i++) {
+                Format trackFormat = group.getFormat(i);
+                Timber.i("track %s group %s/%s trackType %s label %s mime %s isSelected %s isSupported %s",
+                        trackFormat.id, i + 1, group.length, trackType, trackFormat.label, trackFormat.sampleMimeType,
+                        groupInfo.isTrackSelected(i), groupInfo.isTrackSupported(i));
+            }
+
+            if (!hasSupportedTrack(groupInfo)) {
+                Timber.d("track group is not compatible");
+                return false;
+            }
+
+            if (isTrackGroupSelected(groupInfo)) {
+                Timber.d("track group is already selected");
+                return true;
+            }
+
+            Timber.i("matched exoplayer group %s to mediaStream track %s", group.id, index);
+            matchedGroup = group;
         }
 
-        // Fallback for containers with non-sequential track IDs (e.g., MPEG-TS uses PIDs).
-        // Match by ordinal position: find the Nth ExoPlayer track group of this type,
-        // where N is the ordinal position of the target stream among non-external streams of that type.
         if (matchedGroup == null) {
-            Timber.d("offset-based track matching failed for index %s (exoTrackID %s), falling back to ordinal matching", index, exoTrackID);
+            // Ordinal fallback for containers with non-sequential track IDs (e.g., MPEG-TS with PIDs).
+            // Find the ordinal of the target Jellyfin stream, select the ExoPlayer group at that position.
+            // Stream existence is guaranteed by the candidateOptional check above.
             int targetOrdinal = 0;
-            boolean targetFound = false;
             for (MediaStream stream : allStreams) {
                 if (stream.isExternal() || stream.getType() != streamType) continue;
-                if (stream.getIndex() == index) {
-                    targetFound = true;
-                    break;
-                }
+                if (stream.getIndex() == index) break;
                 targetOrdinal++;
             }
-            if (!targetFound) return false;
-
             int currentOrdinal = 0;
             for (Tracks.Group groupInfo : exoTracks.getGroups()) {
                 if (groupInfo.getType() != chosenTrackType) continue;
                 if (currentOrdinal == targetOrdinal) {
-                    for (int i = 0; i < groupInfo.getMediaTrackGroup().length; i++) {
-                        if (!groupInfo.isTrackSupported(i)) {
-                            Timber.d("track is not compatible (ordinal match)");
-                            return false;
-                        }
-                        if (groupInfo.isTrackSelected(i)) {
-                            Timber.d("track is already selected (ordinal match)");
-                            return true;
-                        }
+                    if (!hasSupportedTrack(groupInfo)) {
+                        Timber.d("track group is not compatible (ordinal match)");
+                        return false;
                     }
-                    Timber.i("ordinal fallback matched jellyfin stream index %s to exoplayer ordinal %s", index, targetOrdinal);
+                    if (isTrackGroupSelected(groupInfo)) {
+                        Timber.d("track group is already selected (ordinal match)");
+                        return true;
+                    }
+                    Timber.i("ordinal fallback matched jellyfin stream index %s to exoplayer group ordinal %s", index, targetOrdinal);
                     matchedGroup = groupInfo.getMediaTrackGroup();
                     break;
                 }
@@ -625,6 +604,24 @@ public class VideoManager {
         Timber.d("Setting playback speed: %f", speed);
 
         mExoPlayer.setPlaybackParameters(new PlaybackParameters(speed));
+    }
+
+    private static boolean hasSupportedTrack(Tracks.Group groupInfo) {
+        TrackGroup group = groupInfo.getMediaTrackGroup();
+        for (int i = 0; i < group.length; i++) {
+            if (groupInfo.isTrackSupported(i))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean isTrackGroupSelected(Tracks.Group groupInfo) {
+        TrackGroup group = groupInfo.getMediaTrackGroup();
+        for (int i = 0; i < group.length; i++) {
+            if (groupInfo.isTrackSelected(i))
+                return true;
+        }
+        return false;
     }
 
     public void destroy() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,6 +287,7 @@
     <string name="subtitle_error">Unable to select subtitle</string>
     <string name="msg_no_items">No items to play</string>
     <string name="audio_error">Unable to play audio %1$s</string>
+    <string name="msg_audio_track_switch_failed">Unable to switch audio track</string>
     <string name="turn_off">Turn this option off</string>
     <string name="just_one">Just this one</string>
     <string name="lbl_sign_in">Please sign in</string>


### PR DESCRIPTION
MPEG-TS files (recordings) use PID-based track IDs (e.g. 0x41, 0x44) rather than sequential integers. The internal player's ID-based matching logic assumes   ExoPlayer track IDs map cleanly to Jellyfin stream indices — for TS files this always fails, triggering the restart fallback                                                                                                                                                                              

**Common/Severe case (what created this):  playback never starts (no user interaction required)**
Every time playback begins, switchAudioStream is called automatically to apply the default audio track. On an MPEG-TS recording, with even a single audio track, immediately enters a loop:

  1. Playback starts → switchAudioStream(defaultIndex) fires automatically
  2. getAudioStreamIndex() → ID match fails → returns -1
  3. -1 ≠ defaultIndex → tries setExoPlayerTrack → ID match fails → restarts
  4. Restart triggers onPrepared → back to step 1

The recording never plays. Every MPEG-TS recording was affected  - as least ones with the ATSC PID track scheme. 


**Rare multiple audio tracks case:  user switches audio tracks**
On recordings with multiple audio tracks (e.g. SAP dual-language), successfully getting past the above still left audio switching broken: the in-player switch would always fail and restart playback, and on return the read-back of the current track would again return -1, causing the loop to repeat on every switch attempt. I'm not entirely clear if this would happen in real world usage.

Tested in emulator, FireTV and NVIDIA Shield. Resolved this issue for me.  More regression testing recommended.

**Changes**
Added ordinal-based fallback matching to both getExoPlayerTrack and setExoPlayerTrack in VideoManager.java. When the offset/ID-based matching fails, the fallback matches by ordinal position among tracks of the same type — 
e.g., "the 1st audio stream in Jellyfin's list = the 1st audio track group in ExoPlayer." This works regardless of whether track IDs are sequential (MP4, MKV) or PID-based (MPEG-TS).

The existing ID-based matching is preserved as the primary path; the ordinal fallback only activates when it fails, so non-TS containers are unaffected.

**Code assistance**
Used Opus 4.6 to track down and assist in research of issue. Used agent mode to make initial code changes.  
Need more through review. 

**Issues**
[5421](https://github.com/jellyfin/jellyfin-androidtv/issues/5421)

**Related**
https://github.com/jellyfin/jellyfin/issues/11060