### PR TITLE
replace default UA with device's UA

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/JellyfinApplication.kt
@@ -2,24 +2,32 @@ package org.jellyfin.androidtv
 
 import android.app.Application
 import android.content.Context
+import android.webkit.WebSettings
 import androidx.work.BackoffPolicy
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.await
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okhttp3.OkHttp
+import okhttp3.OkHttpClient
 import org.acra.ACRA
 import org.jellyfin.androidtv.data.eventhandling.SocketHandler
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
 import org.jellyfin.androidtv.telemetry.TelemetryService
+import org.jellyfin.androidtv.util.WebUserAgentInterceptor
 import org.koin.android.ext.android.inject
 import java.util.concurrent.TimeUnit
 
 @Suppress("unused")
-class JellyfinApplication : Application() {
+class JellyfinApplication : Application(), SingletonImageLoader.Factory {
 	override fun onCreate() {
 		super.onCreate()
 
@@ -61,4 +69,12 @@ class JellyfinApplication : Application() {
 
 		TelemetryService.init(this)
 	}
+
+	override fun newImageLoader( context: PlatformContext ) =
+		ImageLoader.Builder( this )
+			.components {
+				val base by inject<OkHttpClient>()
+				add( OkHttpNetworkFetcherFactory(base) )
+			}
+			.build()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -12,6 +12,7 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.serviceLoaderEnabled
 import coil3.svg.SvgDecoder
 import coil3.util.Logger
+import okhttp3.OkHttpClient
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
@@ -51,6 +52,7 @@ import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
 import org.jellyfin.androidtv.util.KeyProcessor
 import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.androidtv.util.PlaybackHelper
+import org.jellyfin.androidtv.util.WebUserAgentInterceptor
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper
 import org.jellyfin.androidtv.util.coil.CoilTimberLogger
 import org.jellyfin.androidtv.util.coil.createCoilConnectivityChecker
@@ -60,7 +62,9 @@ import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.api.okhttp.OkHttpFactory
 import org.jellyfin.sdk.createJellyfin
 import org.jellyfin.sdk.model.ClientInfo
+import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -71,7 +75,13 @@ val defaultDeviceInfo = named("defaultDeviceInfo")
 val appModule = module {
 	// SDK
 	single(defaultDeviceInfo) { androidDevice(get()) }
-	single { OkHttpFactory() }
+	single {
+		val interceptor = WebUserAgentInterceptor(androidApplication())
+		OkHttpClient.Builder()
+					.addInterceptor( interceptor )
+					.build()
+	}
+	singleOf(::OkHttpFactory)
 	single { HttpClientOptions() }
 	single {
 		createJellyfin {

--- a/app/src/main/java/org/jellyfin/androidtv/util/WebUserAgentInterceptor.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/WebUserAgentInterceptor.kt
@@ -1,0 +1,20 @@
+package org.jellyfin.androidtv.util
+
+import android.content.Context
+import android.webkit.WebSettings
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class WebUserAgentInterceptor(
+	private val context: Context
+) : Interceptor, KoinComponent {
+
+	override fun intercept( chain: Interceptor.Chain ) =
+		chain.request()
+			 .newBuilder()
+			 .header( "User-Agent", WebSettings.getDefaultUserAgent(context) )
+			 .build()
+			 .let( chain::proceed )
+}


### PR DESCRIPTION
**Changes**

Current implementation uses default user agent from both JellyfinJDK and OkHttp. This inconsistence makes managing multiple devices a pain in the ass. On some stricter networks, presence of "okhttp" or default user agent will instantly get 403.

<img width="2083" height="180" alt="image" src="https://github.com/user-attachments/assets/26fa7a2d-4fd5-44b9-801b-a6f106af3288" />

This PR aims to bring device's user agent as the default, so that devices can be easily ID'd on the network

<img width="2094" height="241" alt="image" src="https://github.com/user-attachments/assets/4fc04367-a7a3-454e-895a-4be2dcb7c3d4" />

**Code assistance**

No AI model was used to generate code (I don't like them looking at what I'm working on). Though, I did use Gemini to pinpoint the problem. I asked it why I could access Jellyfin on Amazon Silk (FireTV's web browser) but not in the app, coupling with some Nginx configuration on my end, it was able to pinpoint exact problem. I blocked `okhttp` in UA, removing it did solve the issue, but I didn't want to compromise security for a streaming service.

**Issues**

None that I can find

---

If there's another component that also makes network request that isn't "patched", please let me know.