### PR TITLE
Feature - Enhancements to the quick channel changer/chapter popup overlay

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/ChannelCardView.java
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui.card;
 
 import android.content.Context;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.FrameLayout;
 
 import org.jellyfin.androidtv.R;
@@ -20,16 +21,35 @@ public class ChannelCardView extends FrameLayout {
     }
 
     public void setItem(final BaseItemDto channel) {
+        if (channel == null) return;
         if (channel.getNumber() != null) binding.name.setText(channel.getNumber() + " " + channel.getName());
         else binding.name.setText(channel.getName());
+
+        boolean isFavorite = channel.getUserData() != null && channel.getUserData().isFavorite();
+        binding.favImage.setVisibility(isFavorite ? View.VISIBLE : View.GONE);
 
         BaseItemDto program = channel.getCurrentProgram();
         if (program != null) {
             updateDisplay(program);
+            updateRecordingIndicator(program);
         } else {
             binding.program.setText(R.string.no_program_data);
             binding.time.setText("");
             binding.progress.setProgress(0);
+            binding.recIndicator.setVisibility(View.GONE);
+        }
+    }
+
+    private void updateRecordingIndicator(BaseItemDto program) {
+        if (program.getSeriesTimerId() != null) {
+            binding.recIndicator.setImageResource(program.getTimerId() != null
+                    ? R.drawable.ic_record_series_red : R.drawable.ic_record_series);
+            binding.recIndicator.setVisibility(View.VISIBLE);
+        } else if (program.getTimerId() != null) {
+            binding.recIndicator.setImageResource(R.drawable.ic_record_red);
+            binding.recIndicator.setVisibility(View.VISIBLE);
+        } else {
+            binding.recIndicator.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManagerHelper.kt
@@ -10,6 +10,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.LocationType
 import org.jellyfin.sdk.model.api.MediaType
@@ -40,6 +41,7 @@ fun loadLiveTvChannels(fragment: Fragment, callback: (channels: Collection<BaseI
 			withContext(Dispatchers.IO) {
 				api.liveTvApi.getLiveTvChannels(
 					addCurrentProgram = true,
+					fields = setOf(ItemFields.OVERVIEW),
 					enableFavoriteSorting = liveTvPreferences[LiveTvPreferences.favsAtTop],
 					sortBy = if (sortDatePlayed) setOf(ItemSortBy.DATE_PLAYED) else setOf(ItemSortBy.SORT_NAME),
 					sortOrder = if (sortDatePlayed) SortOrder.DESCENDING else SortOrder.ASCENDING,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -29,7 +29,6 @@ import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.fragment.app.Fragment;
 import androidx.leanback.app.RowsSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
-import androidx.leanback.widget.HeaderItem;
 import androidx.leanback.widget.ListRow;
 import androidx.leanback.widget.OnItemViewClickedListener;
 import androidx.leanback.widget.Presenter;
@@ -62,6 +61,7 @@ import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.ChannelCardPresenter;
+import org.jellyfin.androidtv.ui.presentation.CircularObjectAdapter;
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.util.CoroutineUtils;
@@ -93,6 +93,13 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private ListRow mChapterRow;
     private ArrayObjectAdapter mPopupRowAdapter;
     private PositionableListRowPresenter mPopupRowPresenter;
+    private CircularObjectAdapter mCircularChannelAdapter;
+    private CircularObjectAdapter mCircularChapterAdapter;
+    private Runnable mProgramInfoUpdateTask;
+    private boolean mQuickChannelChangerVisible = false;
+
+    private static final int OVERLAY_GUIDE_TEXT_DEBOUNCE_MS = 200;
+    private static final long TICKS_PER_MS = 10_000;
 
     //Live guide items
     private static final int PAGE_SIZE = 75;
@@ -187,10 +194,33 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     .findFragmentById(R.id.rows_area);
         }
 
-        mPopupRowPresenter = new PositionableListRowPresenter();
+        mPopupRowPresenter = new PositionableListRowPresenter(null, /* trapFocus */ true);
         mPopupRowAdapter = new ArrayObjectAdapter(mPopupRowPresenter);
         mPopupRowsFragment.setAdapter(mPopupRowAdapter);
         mPopupRowsFragment.setOnItemViewClickedListener(itemViewClickedListener);
+        mPopupRowsFragment.setOnItemViewSelectedListener((itemViewHolder, item, rowViewHolder, row) -> {
+            if (!mQuickChannelChangerVisible) return;
+
+            if (mProgramInfoUpdateTask != null) {
+                mHandler.removeCallbacks(mProgramInfoUpdateTask);
+            }
+            binding.popupDescription.setText("");
+            binding.popupHeader.setText("");
+
+            if (item instanceof BaseItemDto) {
+                BaseItemDto channel = (BaseItemDto) item;
+                BaseItemDto program = channel.getCurrentProgram();
+                String overview = (program != null) ? program.getOverview() : null;
+                String headerText = getProgramHeaderText(program);
+
+                mProgramInfoUpdateTask = () -> {
+                    if (binding == null) return;
+                    binding.popupHeader.setText(headerText);
+                    binding.popupDescription.setText(overview != null ? overview : "");
+                };
+                mHandler.postDelayed(mProgramInfoUpdateTask, OVERLAY_GUIDE_TEXT_DEBOUNCE_MS);
+            }
+        });
 
         // And the Live Guide element
         tvGuideBinding = OverlayTvGuideBinding.inflate(inflater, container, false);
@@ -229,6 +259,10 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     public void onDestroyView() {
         super.onDestroyView();
 
+        if (mProgramInfoUpdateTask != null) {
+            mHandler.removeCallbacks(mProgramInfoUpdateTask);
+            mProgramInfoUpdateTask = null;
+        }
         binding = null;
         // To fix race condition in hide timer
         mIsVisible = false;
@@ -344,6 +378,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
             @Override
             public void onAnimationEnd(Animation animation) {
+                if (binding == null || mPopupPanelVisible) return;
+                binding.popupHeader.setVisibility(View.GONE);
+                binding.popupHeader.setText("");
+                binding.popupDescription.setVisibility(View.GONE);
+                binding.popupDescription.setText("");
                 binding.popupArea.setVisibility(View.GONE);
             }
 
@@ -376,7 +415,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
             if (item instanceof ChapterItemInfoBaseRowItem) {
                 ChapterItemInfoBaseRowItem rowItem = (ChapterItemInfoBaseRowItem) item;
-                Long start = rowItem.getChapterInfo().getStartPositionTicks() / 10000;
+                Long start = rowItem.getChapterInfo().getStartPositionTicks() / TICKS_PER_MS;
                 playbackControllerContainer.getValue().getPlaybackController().seek(start);
                 hidePopupPanel();
             } else if (item instanceof BaseItemDto) {
@@ -475,7 +514,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
             if (event.getAction() == KeyEvent.ACTION_DOWN) {
-                if (!mGuideVisible)
+                if (!mGuideVisible && !mPopupPanelVisible)
                     leanbackOverlayFragment.setShouldShowOverlay(true);
                 else {
                     leanbackOverlayFragment.setShouldShowOverlay(false);
@@ -527,11 +566,6 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
                     }
                 }
 
-                if (mPopupPanelVisible && !mGuideVisible && keyCode == KeyEvent.KEYCODE_DPAD_LEFT && mPopupRowPresenter.getPosition() == 0) {
-                    mPopupRowsFragment.requireView().requestFocus();
-                    mPopupRowPresenter.setPosition(0);
-                    return true;
-                }
                 if (mGuideVisible) {
                     if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_ESCAPE) {
                         // go back to normal
@@ -732,14 +766,21 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
     private void showChapterPanel() {
         setFadingEnabled(false);
+        binding.popupArea.clearAnimation();
         binding.popupArea.startAnimation(showPopup);
         binding.skipOverlay.setSkipUiEnabled(!mIsVisible && !mGuideVisible && !mPopupPanelVisible);
     }
 
     private void hidePopupPanel() {
         startFadeTimer();
+        if (mProgramInfoUpdateTask != null) {
+            mHandler.removeCallbacks(mProgramInfoUpdateTask);
+        }
+        // Don't change visibility before the animation — let the whole panel fade out together.
+        // Header/description are reset in hidePopup's onAnimationEnd (which sets popupArea GONE).
         binding.popupArea.startAnimation(hidePopup);
         mPopupPanelVisible = false;
+        mQuickChannelChangerVisible = false;
         binding.skipOverlay.setSkipUiEnabled(!mIsVisible && !mGuideVisible && !mPopupPanelVisible);
     }
 
@@ -1130,37 +1171,101 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     };
 
     public void showQuickChannelChanger() {
-        showChapterPanel();
-        mHandler.postDelayed(() -> {
-            if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+        mQuickChannelChangerVisible = true;
+        // Show header and reserve description space for channels
+        binding.popupHeader.setText("");
+        binding.popupHeader.setVisibility(View.VISIBLE);
+        binding.popupDescription.setText("");
+        binding.popupDescription.setVisibility(View.VISIBLE);
 
-            int ndx = TvManager.getAllChannelsIndex(TvManager.getLastLiveTvChannel());
-            if (ndx > 0) {
-                mPopupRowPresenter.setPosition(ndx);
-            }
-            mPopupPanelVisible = true;
-        }, 500);
+        // Pre-position if the adapter is already loaded. If it isn't ready yet
+        // (async load in prepareChannelAdapter), that callback will set position
+        // when it completes — the presenter queues it until the row is bound.
+        positionQuickChannelIfReady();
+
+        mPopupPanelVisible = true;
+        showChapterPanel();
+    }
+
+    private void positionQuickChannelIfReady() {
+        if (binding == null || mCircularChannelAdapter == null) return;
+
+        int idx = TvManager.getAllChannelsIndex(TvManager.getLastLiveTvChannel());
+        // If the "last channel" index is temporarily stale (for example after tuning
+        // to a brand-new channel from guide), keep circular behavior by centering on
+        // the first item instead of leaving selection at position 0 (hard left edge).
+        if (idx < 0) idx = 0;
+
+        int centeredPosition = mCircularChannelAdapter.centerPosition(idx);
+        if (centeredPosition < 0) return;
+
+        mPopupRowPresenter.setPosition(centeredPosition);
+
+        // Populate description for initially focused channel in case selection callback
+        // does not fire when the popup first appears.
+        Object focusedItem = mCircularChannelAdapter.get(centeredPosition);
+        if (!(focusedItem instanceof BaseItemDto)) return;
+
+        BaseItemDto program = ((BaseItemDto) focusedItem).getCurrentProgram();
+        String overview = (program != null) ? program.getOverview() : null;
+        if (overview != null && !overview.isEmpty()) {
+            binding.popupDescription.setText(overview);
+        }
+        binding.popupHeader.setText(getProgramHeaderText(program));
+    }
+
+    private String getProgramHeaderText(BaseItemDto program) {
+        if (program == null) return "";
+
+        Integer season = program.getParentIndexNumber();
+        Integer episode = program.getIndexNumber();
+        Integer episodeEnd = program.getIndexNumberEnd();
+
+        String seFragment = null;
+        if (episode != null) {
+            String ePart = (episodeEnd != null)
+                    ? getString(R.string.lbl_episode_range, episode, episodeEnd)
+                    : getString(R.string.lbl_episode_number, episode);
+            seFragment = (season != null)
+                    ? getString(R.string.lbl_season_number, season) + ":" + ePart
+                    : ePart;
+        }
+
+        String episodeTitle = program.getEpisodeTitle();
+        String title = (episodeTitle != null && !episodeTitle.isEmpty()) ? episodeTitle : program.getName();
+        if (title == null) title = "";
+
+        if (seFragment == null) return title;
+        if (title.isEmpty()) return seFragment;
+        return title + " (" + seFragment + ")";
     }
 
     public void showChapterSelector() {
+        mQuickChannelChangerVisible = false;
+        // Show header for chapters (no description area needed)
+        binding.popupHeader.setText(R.string.chapters);
+        binding.popupHeader.setVisibility(View.VISIBLE);
+        binding.popupDescription.setVisibility(View.GONE);
+        // Position before the panel animates in. If the row isn't bound yet,
+        // the presenter queues the position until onBindRowViewHolder fires.
+        PlaybackController controller =
+            playbackControllerContainer.getValue().getPlaybackController();
+        if (controller == null) return;
+        BaseItemDto currentItem = controller.getCurrentlyPlayingItem();
+        if (currentItem == null) return;
+        int ndx = getCurrentChapterIndex(currentItem,
+            controller.getCurrentPosition() * TICKS_PER_MS);
+        if (ndx >= 0 && mCircularChapterAdapter != null) {
+            mPopupRowPresenter.setPosition(mCircularChapterAdapter.centerPosition(ndx));
+        }
+        mPopupPanelVisible = true;
         showChapterPanel();
-        mHandler.postDelayed(() -> {
-            if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
-
-            int ndx = getCurrentChapterIndex(playbackControllerContainer.getValue().getPlaybackController().getCurrentlyPlayingItem(), playbackControllerContainer.getValue().getPlaybackController().getCurrentPosition() * 10000);
-            if (ndx > 0) {
-                mPopupRowPresenter.setPosition(ndx);
-            }
-            mPopupPanelVisible = true;
-        }, 500);
     }
 
     private int getCurrentChapterIndex(BaseItemDto item, long pos) {
         int ndx = 0;
-        Timber.d("*** looking for chapter at pos: %d", pos);
         if (item.getChapters() != null) {
             for (ChapterInfo chapter : item.getChapters()) {
-                Timber.d("*** chapter %d has pos: %d", ndx, chapter.getStartPositionTicks());
                 if (chapter.getStartPositionTicks() > pos) return ndx - 1;
                 ndx++;
             }
@@ -1281,26 +1386,73 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         List<ChapterInfo> chapters = item.getChapters();
 
         if (chapters != null && !chapters.isEmpty()) {
-            // create chapter row for later use
+            // create chapter row with circular scrolling
             ItemRowAdapter chapterAdapter = new ItemRowAdapter(requireContext(), BaseItemExtensionsKt.buildChapterItems(item), new CardPresenter(true, 110), new MutableObjectAdapter<Row>());
             chapterAdapter.Retrieve();
+            mCircularChapterAdapter = new CircularObjectAdapter(chapterAdapter);
             if (mChapterRow != null) mPopupRowAdapter.remove(mChapterRow);
-            mChapterRow = new ListRow(new HeaderItem(requireContext().getString(R.string.chapters)), chapterAdapter);
+            mPopupRowPresenter.invalidate();
+            mChapterRow = new ListRow(mCircularChapterAdapter);
             mPopupRowAdapter.add(mChapterRow);
         }
 
     }
 
     private void prepareChannelAdapter() {
-        // create quick channel change row
+        UUID focusedChannelId = null;
+        if (mQuickChannelChangerVisible && mCircularChannelAdapter != null) {
+            int focusedPosition = mPopupRowPresenter.getPosition();
+            if (focusedPosition > 0 && mCircularChannelAdapter.getRealSize() > 0) {
+                Object focusedItem = mCircularChannelAdapter.get(focusedPosition);
+                if (focusedItem instanceof BaseItemDto) {
+                    focusedChannelId = ((BaseItemDto) focusedItem).getId();
+                }
+            }
+        }
+
+        // create quick channel change row with circular scrolling
+        UUID finalFocusedChannelId = focusedChannelId;
         TvManager.loadAllChannels(this, response -> {
+            if (binding == null) return null;
             List<BaseItemDto> channels = TvManager.getAllChannels();
             if (channels == null) return null;
-            ArrayObjectAdapter channelAdapter = new ArrayObjectAdapter(new ChannelCardPresenter());
-            channelAdapter.addAll(0, channels);
+            ArrayObjectAdapter innerAdapter = new ArrayObjectAdapter(new ChannelCardPresenter());
+            innerAdapter.addAll(0, channels);
+            mCircularChannelAdapter = new CircularObjectAdapter(innerAdapter);
             if (mChapterRow != null) mPopupRowAdapter.remove(mChapterRow);
-            mChapterRow = new ListRow(new HeaderItem(requireContext().getString(R.string.channels)), channelAdapter);
+            // The invalidate here deals with a very annoying problem.
+            // It's pseudo-better "work around" to a prior attempt to deal with this.
+            // As best as I can tell, RecyclerView defers unbind until its next layout pass,
+            // so the presenter still holds a stale viewHolder.
+            // Explictly invalidate it so the position set below goes to pendingPosition
+            // and is applied when the new row is bound in onBindRowViewHolder.
+            // This also applies to chapters.
+            mPopupRowPresenter.invalidate();
+            mChapterRow = new ListRow(mCircularChannelAdapter);
             mPopupRowAdapter.add(mChapterRow);
+
+            if (mQuickChannelChangerVisible) {
+                int focusIndex = -1;
+                if (finalFocusedChannelId != null) {
+                    focusIndex = TvManager.getAllChannelsIndex(finalFocusedChannelId);
+                }
+                if (focusIndex < 0) {
+                    focusIndex = TvManager.getAllChannelsIndex(TvManager.getLastLiveTvChannel());
+                }
+                // Fall back to first channel if the target wasn't found.
+                if (focusIndex < 0) focusIndex = 0;
+                int pos = mCircularChannelAdapter.centerPosition(focusIndex);
+                if (pos >= 0) {
+                    mPopupRowPresenter.setPosition(pos);
+                    Object focusedItem = mCircularChannelAdapter.get(pos);
+                    if (focusedItem instanceof BaseItemDto) {
+                        BaseItemDto program = ((BaseItemDto) focusedItem).getCurrentProgram();
+                        String overview = (program != null) ? program.getOverview() : null;
+                        binding.popupDescription.setText(overview != null ? overview : "");
+                        binding.popupHeader.setText(getProgramHeaderText(program));
+                    }
+                }
+            }
             return null;
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CircularObjectAdapter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CircularObjectAdapter.kt
@@ -1,0 +1,30 @@
+package org.jellyfin.androidtv.ui.presentation
+
+import androidx.leanback.widget.ObjectAdapter
+
+class CircularObjectAdapter(
+	private val delegate: ObjectAdapter,
+) : ObjectAdapter(delegate.presenterSelector) {
+	companion object {
+		private const val MULTIPLIER = 1_000
+	}
+
+	val realSize: Int get() = delegate.size()
+
+	override fun size(): Int = if (realSize == 0) 0 else realSize * MULTIPLIER
+
+	override fun get(position: Int): Any {
+		val size = realSize
+		if (size == 0) {
+			throw IndexOutOfBoundsException("CircularObjectAdapter is empty")
+		}
+
+		return delegate.get(Math.floorMod(position, size))!!
+	}
+
+	fun centerPosition(realIndex: Int): Int {
+		val size = realSize
+		if (size == 0 || realIndex < 0 || realIndex >= size) return -1
+		return (MULTIPLIER / 2) * size + realIndex
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
@@ -1,13 +1,19 @@
 package org.jellyfin.androidtv.ui.presentation
 
+import android.view.KeyEvent
+import androidx.leanback.widget.ObjectAdapter
 import androidx.leanback.widget.RowPresenter
-import timber.log.Timber
 
 class PositionableListRowPresenter : CustomListRowPresenter {
 	private var viewHolder: ViewHolder? = null
+	private var pendingPosition: Int = -1
+	private val trapFocus: Boolean
 
-	constructor() : super()
-	constructor(padding: Int?) : super(padding)
+	constructor() : this(padding = null, trapFocus = false)
+	constructor(padding: Int?) : this(padding, trapFocus = false)
+	constructor(padding: Int? = null, trapFocus: Boolean = false) : super(padding) {
+		this.trapFocus = trapFocus
+	}
 
 	init {
 		shadowEnabled = false
@@ -22,12 +28,64 @@ class PositionableListRowPresenter : CustomListRowPresenter {
 		if (holder !is ViewHolder) return
 
 		viewHolder = holder
+		val grid = holder.gridView
+		if (trapFocus) {
+			// Prevent focus from escaping the grid at either boundary so the user
+			// stays inside the popup (channel changer / chapter selector).
+			// Uses the adapter size to detect boundaries rather than hard-coding
+			// position 0, so this works regardless of the adapter's centering strategy.
+			grid.setOnKeyInterceptListener { event ->
+				val adapter = grid.adapter as? ObjectAdapter
+				val pos = grid.selectedPosition
+				val size = adapter?.size() ?: 0
+				when (event.keyCode) {
+					KeyEvent.KEYCODE_DPAD_LEFT -> pos <= 0
+					KeyEvent.KEYCODE_DPAD_RIGHT -> size > 0 && pos >= size - 1
+					else -> false
+				}
+			}
+		}
+
+		if (pendingPosition >= 0) {
+			val pos = pendingPosition
+			pendingPosition = -1
+			// Defer until after layout so the grid has items to scroll to.
+			grid.post {
+				grid.selectedPosition = pos
+			}
+		}
+	}
+
+	override fun onUnbindRowViewHolder(holder: RowPresenter.ViewHolder) {
+		if (holder === viewHolder) viewHolder = null
+		super.onUnbindRowViewHolder(holder)
+	}
+
+	/**
+	 * Clear the cached viewHolder so the next [position] set falls through
+	 * to [pendingPosition]. Call this after removing a row from the adapter
+	 * when RecyclerView defers the actual unbind to the next layout pass.
+	 */
+	fun invalidate() {
+		viewHolder = null
 	}
 
 	var position: Int
-		get() = viewHolder?.gridView?.selectedPosition ?: -1
+		get() = viewHolder?.gridView?.selectedPosition ?: pendingPosition
 		set(value) {
-			Timber.d("Setting position to $value")
-			viewHolder?.gridView?.selectedPosition = value
+			val grid = viewHolder?.gridView
+			if (grid != null && grid.isAttachedToWindow) {
+				grid.selectedPosition = value
+				pendingPosition = -1
+			} else if (grid != null) {
+				// Grid is bound but not yet attached to the window (e.g. the
+				// row was just added to the adapter and layout hasn't run).
+				// Post so the position is applied once the grid is laid out.
+				pendingPosition = -1
+				grid.post { grid.selectedPosition = value }
+			} else {
+				// Grid not bound yet — store for onBindRowViewHolder.
+				pendingPosition = value
+			}
 		}
 }

--- a/app/src/main/res/drawable/channel_card_background.xml
+++ b/app/src/main/res/drawable/channel_card_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/lb_basic_card_info_bg_color" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/white" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/lb_basic_card_info_bg_color" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/view_card_channel.xml
+++ b/app/src/main/res/layout/view_card_channel.xml
@@ -3,9 +3,32 @@
     android:layout_width="200dp"
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@color/lb_basic_card_info_bg_color"
+    android:background="@drawable/channel_card_background"
+    android:duplicateParentState="true"
     android:padding="14dp"
     android:gravity="center">
+
+    <ImageView
+        android:id="@+id/favImage"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:layout_marginEnd="4dp"
+        android:layout_centerVertical="false"
+        android:src="@drawable/ic_heart_red"
+        android:visibility="gone" />
+
+    <ImageView
+        android:id="@+id/recIndicator"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="4dp"
+        android:scaleType="fitCenter"
+        android:visibility="gone"
+        tools:src="@drawable/ic_record_series_red" />
 
     <TextView
         android:layout_width="match_parent"
@@ -14,7 +37,8 @@
         tools:text="WBTV 3.1"
         android:id="@+id/name"
         android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true"
+        android:layout_toEndOf="@+id/favImage"
+        android:layout_toStartOf="@+id/recIndicator"
         android:maxLines="1"
         android:ellipsize="end" />
 

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -40,22 +40,46 @@
 
     </FrameLayout>
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/popupArea"
         android:layout_width="fill_parent"
-        android:layout_height="225dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:background="@color/black_transparent"
+        android:layout_marginBottom="16dp"
+        android:background="@color/black_opaque"
+        android:orientation="vertical"
         android:visibility="gone">
+
+        <TextView
+            android:id="@+id/popupHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="48dp"
+            android:paddingTop="8dp"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/popupDescription"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:paddingHorizontal="48dp"
+            android:paddingTop="4dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:visibility="gone" />
 
         <LinearLayout
             android:id="@+id/rows_area"
             android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_gravity="start|bottom"
-            android:layout_marginTop="16dp"
+            android:layout_height="130dp"
+            android:layout_marginBottom="8dp"
             android:orientation="horizontal" />
-    </FrameLayout>
+    </LinearLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topPanel"


### PR DESCRIPTION
### Enhancements to the quick channel changer popup overlay and to chapter overlay for library content (movies etc) to a lesser degree.

  1. Left D-Pad focus boundary fix
Pressing left on the first channel/chapter card no longer lets focus escape the overlay (though improbable to encounter with the circular scrolling). This is also addressed separately in PR that fixes this issue without these changes/circular scrolling: https://github.com/jellyfin/jellyfin-androidtv/pull/5413
  
  2. Favorite heart icon on channel cards
A red heart icon now appears in the top-left corner of any channel card where the user has marked the channel as a favorite.

  3. Add recording indicators in upper right of the channel cards.

  4. Circular (carousel) scrolling
The channel list wraps around — scrolling past the last channel loops back to the first, and vice versa. 
Implemented via a new CircularObjectAdapter that reports a "virtual item" count (realSize × 1,000).  This is probably much larger than needs to be but there's no harm that I can see (it's not "preloaded" etc - per se). The overlay pre-positions to the correct virtual index when opening.

  5. Program description above channel cards
When the quick channel overlay is open, the currently-focused channel's program title and description (overview) appears in a reserved 2-line text area above the cards. 
The text updates with a 200ms debounce while scrolling to avoid distracting text "flicker". 
_Required adding ItemFields.OVERVIEW to the getLiveTvChannels API call to actually fetch the data._

  6. Focus border on channel cards
The currently-focused channel card gets a thin white border so it's clearly visible. Implemented as a channel_card_background.xml. _If this UI element were to be used in other places (chapter cards etc), I would probably implement this differently._

Tested in emulator, fire cube and nvidia shield.  There are some "complimentary" changes in various other PRs that I didn't cherry pick into this but I have, and always have, merged all my branches/PRs together into an integration branch to test they will all co-exist. However, depending on merge order (if any), it's possible merge conflicts may arise.  This one should be last if merged.


**Code assistance**
Claude Opus/Sonnet and Codex used mostly for code reviews but also investigating ideas/approaches. Used in some places for coding (agent mode) when issues arose.

