### PR TITLE
Refactor PlayerBackendEventListener to abstract class

### DIFF
--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -84,7 +84,7 @@ class MutablePlayerState(
 		get() = backendService.backend?.getPositionInfo() ?: PositionInfo.EMPTY
 
 	init {
-		backendService.addListener(object : PlayerBackendEventListener {
+		backendService.addListener(object : PlayerBackendEventListener() {
 			override fun onPlayStateChange(state: PlayState) {
 				_playState.value = state
 			}

--- a/playback/core/src/main/kotlin/backend/BackendService.kt
+++ b/playback/core/src/main/kotlin/backend/BackendService.kt
@@ -78,7 +78,7 @@ class BackendService {
 		listeners.remove(listener)
 	}
 
-	inner class BackendEventListener : PlayerBackendEventListener {
+	inner class BackendEventListener : PlayerBackendEventListener() {
 		private fun <T> callListeners(
 			body: PlayerBackendEventListener.() -> T
 		): List<T> = listeners.map { listener -> listener.body() }

--- a/playback/core/src/main/kotlin/backend/PlayerBackendEventListener.kt
+++ b/playback/core/src/main/kotlin/backend/PlayerBackendEventListener.kt
@@ -3,8 +3,8 @@ package org.jellyfin.playback.core.backend
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
 
-interface PlayerBackendEventListener {
-	fun onPlayStateChange(state: PlayState)
-	fun onVideoSizeChange(width: Int, height: Int)
-	fun onMediaStreamEnd(mediaStream: PlayableMediaStream)
+abstract class PlayerBackendEventListener {
+	open fun onPlayStateChange(state: PlayState) = Unit
+	open fun onVideoSizeChange(width: Int, height: Int) = Unit
+	open fun onMediaStreamEnd(mediaStream: PlayableMediaStream) = Unit
 }

--- a/playback/core/src/main/kotlin/queue/QueueService.kt
+++ b/playback/core/src/main/kotlin/queue/QueueService.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.launch
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.backend.PlayerBackendEventListener
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
-import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PlaybackOrder
 import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.plugin.PlayerService
@@ -53,9 +52,7 @@ class QueueService internal constructor() : PlayerService(), Queue {
 		}.launchIn(coroutineScope)
 
 		// Automatically advance when current stream ends
-		manager.backendService.addListener(object : PlayerBackendEventListener {
-			override fun onPlayStateChange(state: PlayState) = Unit
-			override fun onVideoSizeChange(width: Int, height: Int) = Unit
+		manager.backendService.addListener(object : PlayerBackendEventListener() {
 			override fun onMediaStreamEnd(mediaStream: PlayableMediaStream) {
 				coroutineScope.launch {
 					val nextEntry = next(usePlaybackOrder = true, useRepeatMode = true)


### PR DESCRIPTION
**Changes**

Refactor the PlayerBackendEventListener to be an abstract class instead of an interface. This allows listeners to only implement the events they want to listen on and makes it easier to add new events in the future without modifying all listener implementations.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Part of #1057 
