### PR TITLE
Fix playback not resuming after seek/scrub operations

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -1223,6 +1223,18 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     @Override
+    public void onSeekComplete() {
+        Timber.d("Seek complete - resetting wasSeeking flag");
+        wasSeeking = false;
+
+        if (mPlaybackState == PlaybackState.PLAYING || mPlaybackState == PlaybackState.SEEKING) {
+            mPlaybackState = PlaybackState.PLAYING;
+            mVideoManager.play();
+            startReportLoop();
+        }
+    }
+
+    @Override
     public void onError() {
         if (mFragment == null) {
             playerErrorEncountered();

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerNotifiable.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerNotifiable.kt
@@ -6,4 +6,5 @@ interface PlaybackControllerNotifiable {
 	fun onPrepared()
 	fun onProgress()
 	fun onPlaybackSpeedChange(newSpeed: Float)
+	fun onSeekComplete() {}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -85,6 +85,7 @@ public class VideoManager {
     private long mMetaDuration = -1;
     private long lastExoPlayerPosition = -1;
     private boolean nightModeEnabled;
+    private boolean seekInProgress = false;
 
     public boolean isContracted = false;
 
@@ -160,6 +161,11 @@ public class VideoManager {
             public void onPlaybackStateChanged(int playbackState) {
                 if (playbackState == Player.STATE_BUFFERING) {
                     Timber.d("Player is buffering");
+                }
+
+                if (playbackState == Player.STATE_READY && seekInProgress) {
+                    seekInProgress = false;
+                    if (mPlaybackControllerNotifiable != null) mPlaybackControllerNotifiable.onSeekComplete();
                 }
 
                 if (playbackState == Player.STATE_ENDED) {
@@ -358,6 +364,7 @@ public class VideoManager {
             return -1;
 
         Timber.i("Exo length in seek is: %d", getDuration());
+        seekInProgress = true;
         mExoPlayer.seekTo(pos);
         return pos;
     }

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -66,6 +66,7 @@ class ExoPlayerBackend(
 	private val audioAttributeState = AudioAttributeState()
 	private val timedEventState = TimedEventState()
 	private var lastKnownDuration: Duration? = null
+	private var wasPlayingBeforeScrub = false
 
 	private val assHandler by lazy {
 		AssHandler(AssRenderType.OVERLAY_OPEN_GL)
@@ -305,7 +306,16 @@ class ExoPlayerBackend(
 	}
 
 	override fun setScrubbing(scrubbing: Boolean) {
+		if (scrubbing && !exoPlayer.isScrubbingModeEnabled) {
+			wasPlayingBeforeScrub = exoPlayer.isPlaying
+		}
+
 		exoPlayer.isScrubbingModeEnabled = scrubbing
+
+		if (!scrubbing && wasPlayingBeforeScrub) {
+			exoPlayer.play()
+			wasPlayingBeforeScrub = false
+		}
 	}
 
 	override fun setSpeed(speed: Float) {


### PR DESCRIPTION
  ** Changes **

  Fix video playback stopping after forward/rewind operations, requiring manual
  unpause to continue. Two separate bugs were identified and fixed:

  **New Compose player (ExoPlayerBackend):** When using D-pad left/right on the
  seekbar, `isScrubbingModeEnabled` pauses ExoPlayer but setting it back to
  `false` does not resume playback. The fix tracks the play state before scrubbing
  and restores it when scrubbing ends.

  **Legacy player (PlaybackController/VideoManager):** After a seek, ExoPlayer's
  async state transitions could leave the `wasSeeking` flag stuck and the progress
  loop stopped, with no callback to signal seek completion. The fix adds an
  `onSeekComplete` callback triggered when ExoPlayer reaches `STATE_READY` after a
  seek, which resets state and ensures playback continues.

  ## Code assistance

  An LLM was used to explore the codebase and trace the full code paths from key
  event handling through the seek/scrub pipeline to identify root causes.

  ## Issues

  Fixes video playback requiring manual unpause after using forward/rewind
  controls.