### PR TITLE
Increase to default page size in Live TV guide

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -64,7 +64,7 @@ import timber.log.Timber;
 public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.OnKeyListener {
     public static final int GUIDE_ROW_HEIGHT_DP = 55;
     public static final int GUIDE_ROW_WIDTH_PER_MIN_DP = 7;
-    public static final int PAGE_SIZE = 75;
+    public static final int PAGE_SIZE = 150;
     public static final int NORMAL_HOURS = 9;
     public static final int FILTERED_HOURS = 4;
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -95,7 +95,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private PositionableListRowPresenter mPopupRowPresenter;
 
     //Live guide items
-    private static final int PAGE_SIZE = 75;
+    private static final int PAGE_SIZE = 150;
     private static final int GUIDE_HOURS = 9;
 
     BaseItemDto mSelectedProgram;


### PR DESCRIPTION
**Changes**
In lieu of a configurable item for the Live TV guide page size, this PR simply doubles the page size from 75 to 150 by modifying the hard-coded 'PAGE_SIZE' variable in both the Playback Overlay (CustomPlaybackOverlayFragment.java) and the Live TV UI (LiveTvGuideFragment.java).

This PR shouldn't have a performance impact for modern Android TV devices, and provides for a better user experience for people with larger channel lists.

**Code assistance**
No code assistance used.

**Issues**
n/a.