### PR TITLE
Fix - Season cards always showing series poster instead of season image

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseItemDtoBaseRowItem.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/BaseItemDtoBaseRowItem.kt
@@ -109,7 +109,8 @@ open class BaseItemDtoBaseRowItem @JvmOverloads constructor(
 			preferParentThumb && baseItem?.type == BaseItemKind.EPISODE -> baseItem.parentImages[ImageType.THUMB]
 				?: baseItem.seriesThumbImage
 
-			baseItem?.type == BaseItemKind.SEASON -> baseItem.seriesPrimaryImage
+			baseItem?.type == BaseItemKind.SEASON -> baseItem.itemImages[ImageType.PRIMARY]
+				?: baseItem.seriesPrimaryImage
 			baseItem?.type == BaseItemKind.PROGRAM -> baseItem.itemImages[ImageType.THUMB]
 			baseItem?.type == BaseItemKind.AUDIO -> baseItem.albumPrimaryImage
 			else -> null

--- a/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ImageHelper.kt
@@ -56,7 +56,7 @@ class ImageHelper(
 	): String? {
 		val image = when {
 			preferParentThumb && item.type == BaseItemKind.EPISODE -> item.parentImages[ImageType.THUMB] ?: item.seriesThumbImage
-			item.type == BaseItemKind.SEASON -> item.seriesPrimaryImage
+			item.type == BaseItemKind.SEASON -> item.itemImages[ImageType.PRIMARY] ?: item.seriesPrimaryImage
 			item.type == BaseItemKind.PROGRAM && item.imageTags?.containsKey(ImageType.THUMB) == true -> item.itemImages[ImageType.THUMB]
 			item.type == BaseItemKind.AUDIO -> item.albumPrimaryImage
 			else -> null


### PR DESCRIPTION
Season cards unconditionally used the series primary image, ignoring the season's own primary image (if present). Now prefer the season's own image and fall back to the series poster only when no season image exists.

**Changes**
Use the season image if available, otherwise fallback the series image like the default/prior behavior.  Currently the web client behaves this way so this makes this consistent. 
This is a pretty straightforward change with addition of an ternary operator to decide.

**Code assistance**
Open 4.6 was used to identify where season poster was assigned and code reviewed the changes to ensure there were no other systemic impacts. 

**Issues**
I searched, but found none in this repo (which surprised me - but I may not of searched thoroughly enough). I found a similar issue in the web client repo that was resolved in a similar manner. 

Tested in emulator and fire cube/tv clients. 