### PR TITLE
Fix dismissing in-app screensaver with remote

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/screensaver/InAppScreensaver.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/screensaver/InAppScreensaver.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onKeyEvent
 import org.jellyfin.androidtv.integration.dream.composable.DreamHost
 import org.jellyfin.androidtv.ui.InteractionTrackerViewModel
 import org.jellyfin.androidtv.ui.base.dialog.DialogBase
@@ -37,6 +38,10 @@ fun InAppScreensaver() {
 				indication = null,
 			) {
 				interactionTrackerViewModel.notifyInteraction(canCancel = true, userInitiated = false)
+			}
+			.onKeyEvent {
+				interactionTrackerViewModel.notifyInteraction(canCancel = true, userInitiated = true)
+				false
 			}
 	) {
 		DreamHost()


### PR DESCRIPTION
**Changes**

Not exactly sure when this issue was introduced, I suspect it's a compose dependency update, but it caused keypresses to no longer dismiss the in app screensaver because the key events where not forwarded to the activity anymore. Adding a key handler to the composable works around this.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
