### PR TITLE
Fix HEVC DV/HDR direct play capability detection

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -154,7 +154,7 @@ class MediaCodecCapabilitiesTest(
 		MediaFormat.MIMETYPE_VIDEO_HEVC,
 		CodecProfileLevel.HEVCProfileMain10,
 		CodecProfileLevel.HEVCMainTierLevel4
-	)
+	) || supportsHevcHDR10()
 
 	// Can safely assume Dolby Vision decoders support single-layer HEVC profiles
 	fun supportsHevcDolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
@@ -188,8 +188,9 @@ class MediaCodecCapabilitiesTest(
 		CodecProfileLevel.HEVCProfileMain
 	)
 
-	fun getHevcMain10Level(): Int = getHevcLevel(
-		CodecProfileLevel.HEVCProfileMain10
+	fun getHevcMain10Level(): Int = maxOf(
+		getHevcLevel(CodecProfileLevel.HEVCProfileMain10),
+		getHevcLevel(CodecProfileLevel.HEVCProfileMain10HDR10)
 	)
 
 	private fun getHevcLevel(profile: Int): Int {

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -425,12 +425,12 @@ fun createDeviceProfile(
 	/// HDR exclude list
 
 	val unsupportedRangeTypesAv1 = buildSet {
-		add(VideoRangeType.DOVI_INVALID)
+		if (!supportsAV1Main10) add(VideoRangeType.DOVI_INVALID)
 
 		if (!supportsAV1DolbyVision) {
 			add(VideoRangeType.DOVI)
 			if (!supportsAV1HDR10) add(VideoRangeType.DOVI_WITH_HDR10)
-			if (!supportsAV1HDR10Plus) add(VideoRangeType.DOVI_WITH_HDR10_PLUS)
+			if (!supportsAV1HDR10) add(VideoRangeType.DOVI_WITH_HDR10_PLUS)
 		}
 
 		if (!supportsAV1HDR10Plus) {
@@ -441,7 +441,7 @@ fun createDeviceProfile(
 	}
 
 	val unsupportedRangeTypesHevc = buildSet {
-		add(VideoRangeType.DOVI_INVALID)
+		if (!supportsHevcMain10) add(VideoRangeType.DOVI_INVALID)
 
 		if (!supportsHevcDolbyVisionEL) {
 			add(VideoRangeType.DOVI_WITH_EL)
@@ -450,7 +450,7 @@ fun createDeviceProfile(
 			if (!supportsHevcDolbyVision) {
 				add(VideoRangeType.DOVI)
 				if (!supportsHevcHDR10) add(VideoRangeType.DOVI_WITH_HDR10)
-				if (!supportsHevcHDR10Plus && !KnownDefects.hevcDoviHdr10PlusBug) add(VideoRangeType.DOVI_WITH_HDR10_PLUS)
+				if (!supportsHevcHDR10 && !KnownDefects.hevcDoviHdr10PlusBug) add(VideoRangeType.DOVI_WITH_HDR10_PLUS)
 			}
 		}
 


### PR DESCRIPTION
## Changes

Relaxes overly aggressive HDR exclusion conditions that prevent direct play on capable devices:

- **DOVIInvalid**: Only exclude when the device lacks 10-bit HEVC decode, rather than unconditionally. The base HEVC Main10 layer is playable on any device with Main10 support.
- **DOVIWithHDR10Plus**: Gate on HDR10 support (the actual fallback layer) instead of HDR10+ support. This follows the same logic already used for DOVIWithHDR10.
- **supportsHevcMain10**: Include HDR10 profile in the check, since devices that report HEVCProfileMain10HDR10 but not HEVCProfileMain10 still support 10-bit decode.
- **getHevcMain10Level**: Take the max of Main10 and Main10HDR10 reported levels for accurate level detection.

## Testing

**Confirmed working:**
- Nvidia Shield Pro 2019 — DV Profile 8.1 (DOVIWithHDR10Plus) direct plays correctly

**Reported affected by #5093 (not yet tested with this fix):**
- Google TV (TCL C855)
- UGOOS AM8
- Fire TV Cube
- Google TV Streamer
- Sony OLED TVs
- Panasonic TVs (Android 11)

**Risk assessment:**
- Changes only relax conditions for fallback layers (Main10, HDR10), not the DV decoder path — devices that falsely report DV support (#5210) are unaffected
- Logic mirrors the existing pattern used for DOVIWithHDR10 (which gates on HDR10 support)

## Code assistance

LLM used for debugging — analyzing Jellyfin server logs, tracing ExoPlayer errors via logcat, and identifying the root cause conditions in the device profile logic.

## Issues

Fixes #5093