### PR TITLE
Add UserId intent extra for user switching on startup

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/StartupActivity.kt
@@ -54,6 +54,7 @@ class StartupActivity : FragmentActivity() {
 		const val EXTRA_ITEM_ID = "ItemId"
 		const val EXTRA_ITEM_IS_USER_VIEW = "ItemIsUserView"
 		const val EXTRA_HIDE_SPLASH = "HideSplash"
+		const val EXTRA_USER_ID = "UserId"
 	}
 
 	private val startupViewModel: StartupViewModel by viewModel()
@@ -63,6 +64,7 @@ class StartupActivity : FragmentActivity() {
 	private val userRepository: UserRepository by inject()
 	private val navigationRepository: NavigationRepository by inject()
 	private val itemLauncher: ItemLauncher by inject()
+
 
 	private lateinit var binding: ActivityStartupBinding
 
@@ -109,6 +111,18 @@ class StartupActivity : FragmentActivity() {
 		.distinctUntilChanged()
 		.onEach { session ->
 			if (session != null) {
+				// Check if a specific user was requested via intent
+				val requestedUserId = intent.getStringExtra(EXTRA_USER_ID)?.toUUIDOrNull()
+				if (requestedUserId != null && requestedUserId != session.userId) {
+					Timber.i("User switch requested via intent to user $requestedUserId")
+					val switched = sessionRepository.switchCurrentSession(session.serverId, requestedUserId)
+					if (!switched) {
+						Timber.w("Failed to switch to requested user $requestedUserId")
+					}
+					// Clear the extra to prevent repeated switches
+					intent.removeExtra(EXTRA_USER_ID)
+				}
+
 				Timber.i("Found a session in the session repository, waiting for the currentUser in the application class.")
 
 				showSplash()
@@ -120,6 +134,21 @@ class StartupActivity : FragmentActivity() {
 					openNextActivity()
 				}
 			} else {
+				// Check if a specific user was requested via intent without an active session
+				val requestedUserId = intent.getStringExtra(EXTRA_USER_ID)?.toUUIDOrNull()
+				if (requestedUserId != null) {
+					Timber.i("User switch requested via intent to user $requestedUserId (no active session)")
+					val server = startupViewModel.getLastServer()
+					if (server != null) {
+						val switched = sessionRepository.switchCurrentSession(server.id, requestedUserId)
+						if (switched) {
+							intent.removeExtra(EXTRA_USER_ID)
+							return@onEach // Session change will re-trigger this flow
+						}
+						Timber.w("Failed to switch to requested user $requestedUserId on server ${server.id}")
+					}
+				}
+
 				// Clear audio queue in case left over from last run
 				mediaManager.clearAudioQueue()
 


### PR DESCRIPTION
## Summary

Allow external applications to launch Jellyfin Android TV and automatically switch to a specific user by passing a `UserId` intent extra containing the user's UUID.

This enables home automation scenarios (e.g. Home Assistant via ADB) where different household members can have dedicated buttons that launch Jellyfin directly into their profile without manual user selection.

### Usage

```bash
am start -n org.jellyfin.androidtv/.ui.startup.StartupActivity \
  --es UserId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
```

### How it works

- On startup, `StartupActivity` checks for the `UserId` intent extra
- If present and different from the current session user, it calls `SessionRepository.switchCurrentSession()` to switch to the requested user
- The user must already be authenticated (have a stored access token) for the switch to succeed
- If the switch fails, the app falls back to normal startup behavior
- The extra is cleared after processing to prevent repeated switches

### Related issues

- Closes #3170 (Deep Link Support - partial)
- Related to discussion #3452 (Deeplink to Jellyfin Android TV app)
- Related to discussion #11194 (Quick switch between users)

## Changes

- **`StartupActivity.kt`**: Added `EXTRA_USER_ID` constant and user switching logic in `onPermissionsGranted()` for both active session and no-session scenarios