### PR TITLE
Implement D-Pad Playback Skip UX Option

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [MajMongoose](https://github.com/majmongoose)
  - [Olaren15](https://github.com/Olaren15)
  - [dtrexler](https://github.com/dtrexler)
+ - [Blackney](https://github.com/Blackney)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -81,6 +81,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 */
 		var stillWatchingBehavior = enumPreference("enable_still_watching", StillWatchingBehavior.DISABLED)
 
+		/**
+		 * Use D-pad left/right to skip backward/forward instead of showing the seek bar
+		 */
+		var dpadSkipEnabled = booleanPreference("pref_dpad_skip_enabled", false)
+
 		/* Playback - Video */
 		/**
 		 * Whether to use an external playback application or not.

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -59,6 +59,8 @@ import org.jellyfin.androidtv.ui.livetv.LiveTvGuideFragmentHelperKt;
 import org.jellyfin.androidtv.ui.livetv.TvManager;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
+import org.jellyfin.androidtv.preference.UserPreferences;
+import org.jellyfin.androidtv.preference.UserSettingPreferences;
 import org.jellyfin.androidtv.ui.playback.overlay.LeanbackOverlayFragment;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.ChannelCardPresenter;
@@ -135,6 +137,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
+    private final Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
+    private final Lazy<UserSettingPreferences> userSettingPreferences = inject(UserSettingPreferences.class);
 
     private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
 
@@ -588,13 +592,29 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     if (!mIsVisible) {
                         if (!playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
+                            boolean dpadSkip = userPreferences.getValue().get(UserPreferences.Companion.getDpadSkipEnabled());
+
                             if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
-                                setFadingEnabled(true);
+                                if (dpadSkip) {
+                                    int forwardMs = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipForwardLength());
+                                    playbackControllerContainer.getValue().getPlaybackController().fastForward();
+                                    binding.skipIndicator.show(true, forwardMs / 1000);
+                                    leanbackOverlayFragment.setShouldShowOverlay(false);
+                                } else {
+                                    setFadingEnabled(true);
+                                }
                                 return true;
                             }
 
                             if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
-                                setFadingEnabled(true);
+                                if (dpadSkip) {
+                                    int backMs = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipBackLength());
+                                    playbackControllerContainer.getValue().getPlaybackController().rewind();
+                                    binding.skipIndicator.show(false, backMs / 1000);
+                                    leanbackOverlayFragment.setShouldShowOverlay(false);
+                                } else {
+                                    setFadingEnabled(true);
+                                }
                                 return true;
                             }
                         }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -9,6 +9,7 @@ import android.media.AudioManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -119,6 +120,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private Animation hidePopup;
     private final Handler mHandler = new Handler();
     private Runnable mHideTask;
+    private final Handler skipRepeatHandler = new Handler(Looper.getMainLooper());
+    private Runnable skipRepeatRunnable = null;
 
     private AudioManager mAudioManager;
 
@@ -596,10 +599,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                             if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                                 if (dpadSkip) {
-                                    int forwardMs = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipForwardLength());
-                                    playbackControllerContainer.getValue().getPlaybackController().fastForward();
-                                    binding.skipIndicator.show(true, forwardMs / 1000);
                                     leanbackOverlayFragment.setShouldShowOverlay(false);
+                                    if (skipRepeatRunnable == null) {
+                                        int forwardMs = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipForwardLength());
+                                        startDpadSkip(true, forwardMs);
+                                    }
                                 } else {
                                     setFadingEnabled(true);
                                 }
@@ -608,10 +612,11 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                             if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
                                 if (dpadSkip) {
-                                    int backMs = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipBackLength());
-                                    playbackControllerContainer.getValue().getPlaybackController().rewind();
-                                    binding.skipIndicator.show(false, backMs / 1000);
                                     leanbackOverlayFragment.setShouldShowOverlay(false);
+                                    if (skipRepeatRunnable == null) {
+                                        int backMs = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipBackLength());
+                                        startDpadSkip(false, backMs);
+                                    }
                                 } else {
                                     setFadingEnabled(true);
                                 }
@@ -630,6 +635,16 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     //and then manage our fade timer
                     if (mFadeEnabled) startFadeTimer();
+                }
+            }
+
+            if (event.getAction() == KeyEvent.ACTION_UP) {
+                if (!mGuideVisible && !playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
+                    boolean dpadSkip = userPreferences.getValue().get(UserPreferences.Companion.getDpadSkipEnabled());
+                    if (dpadSkip && (keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_RIGHT)) {
+                        stopSkipRepeat();
+                        return true;
+                    }
                 }
             }
 
@@ -718,6 +733,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     public void onStop() {
         super.onStop();
         Timber.i("Stopping!");
+
+        stopSkipRepeat();
 
         if (leanbackOverlayFragment != null)
             leanbackOverlayFragment.setOnKeyInterceptListener(null);
@@ -1362,5 +1379,31 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         WindowManager.LayoutParams params = getActivity().getWindow().getAttributes();
         params.preferredDisplayModeId = 0;
         getActivity().getWindow().setAttributes(params);
+    }
+
+    private void startDpadSkip(boolean forward, int skipMs) {
+        stopSkipRepeat();
+        if (forward) playbackControllerContainer.getValue().getPlaybackController().fastForward();
+        else playbackControllerContainer.getValue().getPlaybackController().rewind();
+        binding.skipIndicator.show(forward, skipMs / 1000);
+        leanbackOverlayFragment.setShouldShowOverlay(false);
+        skipRepeatRunnable = new Runnable() {
+            @Override
+            public void run() {
+                if (forward) playbackControllerContainer.getValue().getPlaybackController().fastForward();
+                else playbackControllerContainer.getValue().getPlaybackController().rewind();
+                binding.skipIndicator.show(forward, skipMs / 1000);
+                leanbackOverlayFragment.setShouldShowOverlay(false);
+                skipRepeatHandler.postDelayed(this, 1000);
+            }
+        };
+        skipRepeatHandler.postDelayed(skipRepeatRunnable, 1000);
+    }
+
+    private void stopSkipRepeat() {
+        if (skipRepeatRunnable != null) {
+            skipRepeatHandler.removeCallbacks(skipRepeatRunnable);
+            skipRepeatRunnable = null;
+        }
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipIndicatorView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipIndicatorView.kt
@@ -1,0 +1,81 @@
+package org.jellyfin.androidtv.ui.playback.overlay
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.player.base.toast.MediaToast
+
+class SkipIndicatorView @JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+	defStyle: Int = 0,
+) : AbstractComposeView(context, attrs, defStyle) {
+
+	data class SkipIndicatorState(val forward: Boolean, val seconds: Int)
+
+	private val _state = MutableStateFlow<SkipIndicatorState?>(null)
+	private val _showCount = MutableStateFlow(0)
+
+	fun show(forward: Boolean, seconds: Int) {
+		_state.value = SkipIndicatorState(forward, seconds)
+		_showCount.value++
+	}
+
+	@Composable
+	override fun Content() {
+		val state by _state.collectAsState()
+		val showCount by _showCount.collectAsState()
+
+		LaunchedEffect(showCount) {
+			if (showCount > 0) {
+				delay(700)
+				_state.value = null
+			}
+		}
+
+		Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+			MediaToast(
+				visible = state != null,
+				icon = {
+					val s = state ?: return@MediaToast
+					Column(
+						horizontalAlignment = Alignment.CenterHorizontally,
+						verticalArrangement = Arrangement.Center,
+					) {
+						Icon(
+							imageVector = ImageVector.vectorResource(
+								if (s.forward) R.drawable.ic_fast_forward else R.drawable.ic_rewind
+							),
+							contentDescription = null,
+							modifier = Modifier.size(32.dp),
+						)
+						Text(
+							text = "${s.seconds}s",
+							fontSize = 12.sp,
+						)
+					}
+				},
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -107,6 +107,53 @@ fun SettingsPlaybackAdvancedScreen() {
 			}
 		}
 
+		item {
+			var skipBackLength by rememberPreference(userSettingPreferences, UserSettingPreferences.skipBackLength)
+			val interactionSource = remember { MutableInteractionSource() }
+
+			ListControl(
+				headingContent = { Text(stringResource(R.string.skip_back_length)) },
+				interactionSource = interactionSource,
+			) {
+				Row(
+					verticalAlignment = Alignment.CenterVertically,
+				) {
+					RangeControl(
+						modifier = Modifier
+							.height(4.dp)
+							.weight(1f),
+						interactionSource = interactionSource,
+						// 5 - 30 seconds with 5 second increment
+						min = 5_000f,
+						max = 30_000f,
+						stepForward = 5_000f,
+						value = skipBackLength.toFloat(),
+						onValueChange = { skipBackLength = it.roundToInt() }
+					)
+
+					Spacer(Modifier.width(Tokens.Space.spaceSm))
+
+					Box(
+						modifier = Modifier.sizeIn(minWidth = 32.dp),
+						contentAlignment = Alignment.CenterEnd
+					) {
+						Text("${skipBackLength / 1000}s")
+					}
+				}
+			}
+		}
+
+		item {
+			var dpadSkipEnabled by rememberPreference(userPreferences, UserPreferences.dpadSkipEnabled)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_dpad_skip_enabled)) },
+				captionContent = { Text(stringResource(R.string.pref_dpad_skip_enabled_summary)) },
+				trailingContent = { Checkbox(checked = dpadSkipEnabled) },
+				onClick = { dpadSkipEnabled = !dpadSkipEnabled }
+			)
+		}
+
 		item { ListSection(headingContent = { Text(stringResource(R.string.pref_video)) }) }
 
 		item {

--- a/app/src/main/res/layout/vlc_player_interface.xml
+++ b/app/src/main/res/layout/vlc_player_interface.xml
@@ -120,4 +120,9 @@
         android:id="@+id/skip_overlay"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <org.jellyfin.androidtv.ui.playback.overlay.SkipIndicatorView
+        android:id="@+id/skip_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -532,6 +532,9 @@
     <string name="segment_type_recap">Recaps</string>
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
+    <string name="skip_back_length">Skip back length</string>
+    <string name="pref_dpad_skip_enabled">D-pad skip mode</string>
+    <string name="pref_dpad_skip_enabled_summary">Left/right skips backward/forward instead of showing the seek bar</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
     <string name="pref_subtitles_background_opacity">Subtitle background opacity</string>
     <string name="pref_troubleshooting">Troubleshooting</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
- Add a new optional toggle in Advanced Playback Preferences that when enabled, will make the right/left D-Pad buttons trigger a one off skip on press, or repeatedly skip if held down.
- Add a new "Skip back length" setting to match the existing "Skip forward length" setting, both of which are used as the skip amounts
- Make a new playback overlay to show when the skip occurs, show the direction with an icon and the number of seconds skipped

**Code assistance**
Claude Code used to better understand existing code base, align with existing patterns where possible, then generate code with heavy manual review/testing

**Issues**
Implements https://github.com/jellyfin/jellyfin-androidtv/issues/5510
