### PR TITLE
feat: add pin protection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
 	implementation(libs.androidx.fragment)
 	implementation(libs.androidx.fragment.compose)
 	implementation(libs.androidx.leanback.core)
+	implementation(libs.androidx.gridlayout)
 	implementation(libs.androidx.leanback.preference)
 	implementation(libs.androidx.navigation3.ui)
 	implementation(libs.androidx.preference)

--- a/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PreferenceModule.kt
@@ -6,10 +6,12 @@ import org.jellyfin.androidtv.preference.SystemPreferences
 import org.jellyfin.androidtv.preference.TelemetryPreferences
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
+import org.jellyfin.androidtv.preference.UserPinRepository
 import org.koin.dsl.module
 
 val preferenceModule = module {
 	single { PreferencesRepository(get(), get(), get()) }
+	single { UserPinRepository(get()) }
 
 	single { LiveTvPreferences(get()) }
 	single { UserSettingPreferences(get()) }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPinRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPinRepository.kt
@@ -1,0 +1,38 @@
+package org.jellyfin.androidtv.preference
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import java.security.MessageDigest
+import java.util.UUID
+import org.jellyfin.preference.store.SharedPreferenceStore
+import org.jellyfin.preference.stringPreference
+
+class UserPinRepository(context: Context) : SharedPreferenceStore(
+	sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+) {
+	private fun getPinPreference(userId: UUID) = stringPreference("user_pin_$userId", "")
+
+	fun setPin(userId: UUID, pin: String) {
+		val hash = hashPin(pin)
+		this[getPinPreference(userId)] = hash
+	}
+
+	fun removePin(userId: UUID) {
+		delete(getPinPreference(userId))
+	}
+
+	fun hasPin(userId: UUID): Boolean {
+		return sharedPreferences.contains("user_pin_$userId")
+	}
+
+	fun verifyPin(userId: UUID, pin: String): Boolean {
+		val storedHash = this[getPinPreference(userId)]
+		if (storedHash.isEmpty()) return false
+		return storedHash == hashPin(pin)
+	}
+
+	private fun hashPin(pin: String): String {
+		val bytes = MessageDigest.getInstance("SHA-256").digest(pin.toByteArray())
+		return bytes.joinToString("") { "%02x".format(it) }
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -36,7 +38,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.LocalTextStyle
 import org.jellyfin.androidtv.ui.base.ProfilePicture
@@ -50,6 +55,7 @@ import org.jellyfin.androidtv.util.showIfNotEmpty
 fun UserCard(
 	image: @Composable () -> Unit,
 	name: @Composable () -> Unit,
+	showLocked: Boolean,
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -82,15 +88,22 @@ fun UserCard(
 
 		Spacer(Modifier.height(8.dp))
 
-		Box(
+		Row(
 			modifier = Modifier
 				.fillMaxWidth()
 				.basicMarquee(
 					iterations = if (focused) Int.MAX_VALUE else 0,
 					initialDelayMillis = 0,
 				),
-			contentAlignment = Alignment.TopCenter,
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
 		) {
+			if(showLocked) {
+				Icon(painterResource(R.drawable.ic_lock_outline), contentDescription = null)
+
+                Spacer(modifier = Modifier.width(4.dp))
+			}
+
 			ProvideTextStyle(
 				LocalTextStyle.current.copy(
 					color = color.second,
@@ -109,6 +122,7 @@ class UserCardView @JvmOverloads constructor(
 ) : AbstractComposeView(context, attrs, defStyleAttr) {
 	var name by mutableStateOf<String?>(null)
 	var image by mutableStateOf<String?>(null)
+	var hasPin by mutableStateOf<Boolean>(false)
 	private var focused by mutableStateOf(false)
 
 	init {
@@ -163,6 +177,7 @@ class UserCardView @JvmOverloads constructor(
 					maxLines = 1
 				)
 			},
+			showLocked = hasPin,
 			modifier = Modifier
 				.padding(horizontal = 6.dp, vertical = 8.dp)
 				.width(110.dp),

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerUserScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerUserScreen.kt
@@ -1,12 +1,17 @@
 package org.jellyfin.androidtv.ui.settings.screen.authentication
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.map
@@ -15,22 +20,33 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.AuthenticationRepository
 import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.auth.repository.ServerUserRepository
+import org.jellyfin.androidtv.preference.UserPinRepository
 import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.jellyfin.androidtv.ui.startup.PinDialogFragment
 import org.koin.compose.koinInject
 import java.util.UUID
 
 @Composable
 fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 	val router = LocalRouter.current
-	val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+	val lifecycleOwner = LocalLifecycleOwner.current
+	val lifecycleScope = lifecycleOwner.lifecycleScope
 	val serverRepository = koinInject<ServerRepository>()
 	val serverUserRepository = koinInject<ServerUserRepository>()
 	val authenticationRepository = koinInject<AuthenticationRepository>()
+	val userPinRepository = koinInject<UserPinRepository>()
+
+	val context = LocalContext.current
+	val fragmentManager = remember(context) {
+		generateSequence(context) { (it as? android.content.ContextWrapper)?.baseContext }
+			.filterIsInstance<FragmentActivity>()
+			.firstOrNull()?.supportFragmentManager
+	}
 
 	LaunchedEffect(serverRepository) { serverRepository.loadStoredServers() }
 
@@ -40,12 +56,85 @@ fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 
 	val user = remember(server) { server?.let(serverUserRepository::getStoredServerUsers)?.find { user -> user.id == userId } }
 
+	var hasPin by remember(userId) { mutableStateOf(userPinRepository.hasPin(userId)) }
+
+	DisposableEffect(lifecycleOwner, fragmentManager) {
+		if (fragmentManager != null) {
+			// Result listener for Setting a PIN (Initial set or Change after verification)
+			fragmentManager.setFragmentResultListener("pin_set_request", lifecycleOwner) { _, _ ->
+				hasPin = userPinRepository.hasPin(userId)
+			}
+
+			// Result listener for Verifying before Changing a PIN
+			fragmentManager.setFragmentResultListener("pin_verify_change_request", lifecycleOwner) { _, result ->
+				if (result.getBoolean(PinDialogFragment.RESULT_EXTRA_SUCCESS)) {
+					// Verification successful, now show SET dialog
+					PinDialogFragment.newInstance(userId, "pin_set_request", PinDialogFragment.Companion.Mode.SET).show(fragmentManager, "pin_dialog_set")
+				}
+			}
+
+			// Result listener for Verifying before Removing a PIN
+			fragmentManager.setFragmentResultListener("pin_verify_remove_request", lifecycleOwner) { _, result ->
+				if (result.getBoolean(PinDialogFragment.RESULT_EXTRA_SUCCESS)) {
+					// Verification successful, remove PIN
+					userPinRepository.removePin(userId)
+					hasPin = false
+				}
+			}
+		}
+		onDispose {
+			fragmentManager?.clearFragmentResultListener("pin_set_request")
+			fragmentManager?.clearFragmentResultListener("pin_verify_change_request")
+			fragmentManager?.clearFragmentResultListener("pin_verify_remove_request")
+		}
+	}
+
 	SettingsColumn {
 		item {
 			ListSection(
 				overlineContent = { Text(server?.name?.uppercase().orEmpty()) },
 				headingContent = { Text(user?.name.orEmpty()) },
 			)
+		}
+
+		item {
+			if (hasPin) {
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_lock_outline), contentDescription = null) },
+					headingContent = { Text(stringResource(R.string.lbl_change_pin)) },
+					onClick = {
+						fragmentManager?.let {
+							// Verify first
+							PinDialogFragment.newInstance(userId, "pin_verify_change_request", PinDialogFragment.Companion.Mode.VERIFY).show(it, "pin_dialog_verify_change")
+						}
+					}
+				)
+			} else {
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_lock_outline), contentDescription = null) },
+					headingContent = { Text(stringResource(R.string.lbl_set_pin)) },
+					onClick = {
+						fragmentManager?.let {
+							PinDialogFragment.newInstance(userId, "pin_set_request", PinDialogFragment.Companion.Mode.SET).show(it, "pin_dialog_set")
+						}
+					}
+				)
+			}
+		}
+
+		if (hasPin) {
+			item {
+				ListButton(
+					leadingContent = { Icon(painterResource(R.drawable.ic_lock_open_outline), contentDescription = null) },
+					headingContent = { Text(stringResource(R.string.lbl_remove_pin)) },
+					onClick = {
+						fragmentManager?.let {
+							// Verify first
+							PinDialogFragment.newInstance(userId, "pin_verify_remove_request", PinDialogFragment.Companion.Mode.VERIFY).show(it, "pin_dialog_verify_remove")
+						}
+					}
+				)
+			}
 		}
 
 		item {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/PinDialogFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/PinDialogFragment.kt
@@ -1,0 +1,183 @@
+package org.jellyfin.androidtv.ui.startup
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.Button
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import java.util.UUID
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.databinding.FragmentPinDialogBinding
+import org.jellyfin.androidtv.preference.UserPinRepository
+import org.koin.android.ext.android.inject
+
+class PinDialogFragment : DialogFragment() {
+
+	companion object {
+		const val ARG_USER_ID = "user_id"
+		const val ARG_REQUEST_KEY = "request_key"
+		const val ARG_MODE = "mode"
+		const val RESULT_KEY_PIN_ENTERED = "result_pin_entered"
+		const val RESULT_EXTRA_SUCCESS = "success"
+
+		enum class Mode {
+			VERIFY,
+			SET
+		}
+
+		fun newInstance(userId: UUID, requestKey: String = RESULT_KEY_PIN_ENTERED, mode: Mode = Mode.VERIFY): PinDialogFragment {
+			return PinDialogFragment().apply {
+				arguments = bundleOf(
+					ARG_USER_ID to userId.toString(),
+					ARG_REQUEST_KEY to requestKey,
+					ARG_MODE to mode.name
+				)
+			}
+		}
+	}
+
+	private var _binding: FragmentPinDialogBinding? = null
+	private val binding get() = _binding!!
+	private val userPinRepository: UserPinRepository by inject()
+
+	private val userId: UUID by lazy { UUID.fromString(requireArguments().getString(ARG_USER_ID)) }
+	private val requestKey: String by lazy { requireArguments().getString(ARG_REQUEST_KEY)!! }
+	private val mode: Mode by lazy { Mode.valueOf(requireArguments().getString(ARG_MODE)!!) }
+
+	private var currentPin = ""
+
+	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+		_binding = FragmentPinDialogBinding.inflate(inflater, container, false)
+		return binding.root
+	}
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+		dialog?.window?.setDimAmount(0.8f)
+		super.onViewCreated(view, savedInstanceState)
+
+		binding.title.text = getString(
+			if (mode == Mode.SET) R.string.lbl_set_pin
+			else R.string.lbl_enter_pin
+		)
+		updatePinDisplay()
+
+		setupKeypad()
+	}
+
+	private fun setupKeypad() {
+		val grid = binding.keypadGrid
+		for (i in 0 until grid.childCount) {
+			val child = grid.getChildAt(i)
+			if (child is Button) {
+				val text = child.text.toString()
+				if (text.all { it.isDigit() }) {
+					child.setOnClickListener { onPinDigit(text) }
+				} else if (text == "⌫") {
+					child.setOnClickListener { onDelete() }
+				} else if (text == "OK") {
+					child.setOnClickListener { onEnter() }
+					// Request focus for OK button as default
+					child.post { child.requestFocus() }
+				}
+			}
+		}
+	}
+
+	private fun updatePinDisplay() {
+		binding.pinInput.setText(currentPin)
+	}
+
+	private fun onPinDigit(digit: String) {
+		currentPin += digit
+		updatePinDisplay()
+	}
+
+	private fun onDelete() {
+		if (currentPin.isNotEmpty()) {
+			currentPin = currentPin.dropLast(1)
+			updatePinDisplay()
+		}
+	}
+
+	private var firstAttemptPin: String? = null
+
+	private fun onEnter() {
+		when(mode) {
+			Mode.SET -> if (currentPin.isNotEmpty()) {
+				if (firstAttemptPin == null) {
+					// First entry
+					firstAttemptPin = currentPin
+					currentPin = ""
+					updatePinDisplay()
+					binding.title.text = getString(R.string.lbl_reenter_pin)
+				} else {
+					// Confirmation entry
+					if (currentPin == firstAttemptPin) {
+						userPinRepository.setPin(userId, currentPin)
+						Toast.makeText(context, R.string.lbl_pin_set, Toast.LENGTH_SHORT).show()
+						setFragmentResult(requestKey, bundleOf(RESULT_EXTRA_SUCCESS to true))
+						dismiss()
+					} else {
+						Toast.makeText(context, R.string.lbl_pin_mismatch, Toast.LENGTH_SHORT).show()
+						// Reset to start
+						firstAttemptPin = null
+						currentPin = ""
+						updatePinDisplay()
+						binding.title.text = getString(R.string.lbl_set_pin)
+					}
+				}
+			}
+			Mode.VERIFY ->
+				if (userPinRepository.verifyPin(userId, currentPin)) {
+					setFragmentResult(requestKey, bundleOf(RESULT_EXTRA_SUCCESS to true))
+					dismiss()
+				} else {
+					Toast.makeText(context, R.string.lbl_incorrect_pin, Toast.LENGTH_SHORT).show()
+					currentPin = ""
+					updatePinDisplay()
+				}
+		}
+	}
+
+	override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+		val dialog = super.onCreateDialog(savedInstanceState)
+		dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+
+		// Handle physical keyboard / remote number keys
+		dialog.setOnKeyListener { _, keyCode, event ->
+			if (event.action == KeyEvent.ACTION_DOWN) {
+				 when (keyCode) {
+					 in KeyEvent.KEYCODE_0..KeyEvent.KEYCODE_9 -> {
+						 onPinDigit((keyCode - KeyEvent.KEYCODE_0).toString())
+						 true
+					 }
+					 KeyEvent.KEYCODE_DEL -> {
+						 onDelete()
+						 true
+					 }
+					 KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER -> {
+						 // Let the focused view handle it (e.g. OK button)
+						 // But if focus is elsewhere (e.g. Input field which is not focusable?), we might want to handle it?
+						 // The grid buttons are focusable.
+						 false
+					 }
+					 else -> false
+				 }
+			} else false
+		}
+		return dialog
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+		_binding = null
+		dialog?.window?.setDimAmount(0.0f)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -36,8 +36,10 @@ import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.auth.repository.ServerUserRepository
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.databinding.FragmentServerBinding
+import org.jellyfin.androidtv.preference.UserPinRepository
 import org.jellyfin.androidtv.ui.ServerButtonView
 import org.jellyfin.androidtv.ui.card.UserCardView
+import org.jellyfin.androidtv.ui.startup.PinDialogFragment
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.util.ListAdapter
 import org.jellyfin.androidtv.util.MarkdownRenderer
@@ -55,8 +57,10 @@ class ServerFragment : Fragment() {
 	private val authenticationRepository: AuthenticationRepository by inject()
 	private val serverUserRepository: ServerUserRepository by inject()
 	private val backgroundService: BackgroundService by inject()
+	private val userPinRepository: UserPinRepository by inject()
 	private var _binding: FragmentServerBinding? = null
 	private val binding get() = _binding!!
+	private var pendingLoginUser: User? = null
 
 	private val serverIdArgument get() = arguments?.getString(ARG_SERVER_ID)?.ifBlank { null }?.toUUIDOrNull()
 
@@ -71,7 +75,8 @@ class ServerFragment : Fragment() {
 		_binding = FragmentServerBinding.inflate(inflater, container, false)
 
 		val userAdapter = UserAdapter(requireContext(), server, startupViewModel, authenticationRepository, serverUserRepository)
-		userAdapter.onItemPressed = { user ->
+
+		fun performLogin(server: Server, user: User) {
 			startupViewModel.authenticate(server, user).onEach { state ->
 				when (state) {
 					// Ignored states
@@ -97,6 +102,24 @@ class ServerFragment : Fragment() {
 					).show()
 				}
 			}.launchIn(lifecycleScope)
+		}
+
+		childFragmentManager.setFragmentResultListener(PinDialogFragment.RESULT_KEY_PIN_ENTERED, viewLifecycleOwner) { _, result ->
+			if (result.getBoolean(PinDialogFragment.RESULT_EXTRA_SUCCESS)) {
+				pendingLoginUser?.let { user ->
+					performLogin(server, user)
+				}
+				pendingLoginUser = null
+			}
+		}
+
+		userAdapter.onItemPressed = { user ->
+			if (userPinRepository.hasPin(user.id)) {
+				pendingLoginUser = user
+				PinDialogFragment.newInstance(user.id).show(childFragmentManager, "pin_dialog")
+			} else {
+				performLogin(server, user)
+			}
 		}
 		binding.users.adapter = userAdapter
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -74,7 +74,7 @@ class ServerFragment : Fragment() {
 
 		_binding = FragmentServerBinding.inflate(inflater, container, false)
 
-		val userAdapter = UserAdapter(requireContext(), server, startupViewModel, authenticationRepository, serverUserRepository)
+		val userAdapter = UserAdapter(requireContext(), server, startupViewModel, authenticationRepository, serverUserRepository, userPinRepository)
 
 		fun performLogin(server: Server, user: User) {
 			startupViewModel.authenticate(server, user).onEach { state ->
@@ -227,6 +227,7 @@ class ServerFragment : Fragment() {
 		private val startupViewModel: StartupViewModel,
 		private val authenticationRepository: AuthenticationRepository,
 		private val serverUserRepository: ServerUserRepository,
+		private val userPinRepository: UserPinRepository,
 	) : ListAdapter<User, UserAdapter.ViewHolder>() {
 		var onItemPressed: (User) -> Unit = {}
 
@@ -241,6 +242,7 @@ class ServerFragment : Fragment() {
 		override fun onBindViewHolder(holder: ViewHolder, user: User) {
 			holder.cardView.name = user.name
 			holder.cardView.image = startupViewModel.getUserImage(server, user)
+			holder.cardView.hasPin = userPinRepository.hasPin(user.id)
 
 			holder.cardView.setPopupMenu {
 				// Logout button

--- a/app/src/main/res/drawable/ic_lock_open_outline.xml
+++ b/app/src/main/res/drawable/ic_lock_open_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M18,8h-1V6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h2c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2H6c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2zM18,20H6V10h12v10zM12,13c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lock_outline.xml
+++ b/app/src/main/res/drawable/ic_lock_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1V6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2H6c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2zM8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2H8.9V6zM18,20H6V10h12v10z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_pin_dialog.xml
+++ b/app/src/main/res/layout/fragment_pin_dialog.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Leanback.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/lbl_enter_pin"
+        app:layout_constraintBottom_toTopOf="@+id/pin_input"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <EditText
+        android:id="@+id/pin_input"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:background="@null"
+        android:focusable="false"
+        android:gravity="center"
+        android:inputType="numberPassword"
+        android:textColor="@color/white"
+        android:textSize="24sp"
+        android:letterSpacing="0.2"
+        app:layout_constraintBottom_toTopOf="@+id/keypad_grid"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        tools:text="1234" />
+
+    <androidx.gridlayout.widget.GridLayout
+        android:id="@+id/keypad_grid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        app:columnCount="3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pin_input">
+
+        <!-- Buttons 1-9 generated programmatically or defined here -->
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="1"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="2"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="3"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="4"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="5"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="6"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="7"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="8"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="9"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/btn_delete"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="⌫"
+            android:textSize="20sp" />
+
+        <Button
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="0"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/btn_enter"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:text="OK"
+            android:textSize="16sp" />
+
+    </androidx.gridlayout.widget.GridLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -532,6 +532,15 @@
         <item quantity="many">%1$s álbumes</item>
         <item quantity="other">%1$s álbumes</item>
     </plurals>
+    <string name="lbl_enter_pin">Introducir PIN</string>
+    <string name="lbl_set_pin">Establecer PIN</string>
+    <string name="lbl_change_pin">Cambiar PIN</string>
+    <string name="lbl_remove_pin">Eliminar PIN</string>
+    <string name="lbl_pin_removed">PIN eliminado</string>
+    <string name="lbl_pin_set">PIN establecido</string>
+    <string name="lbl_incorrect_pin">PIN incorrecto</string>
+    <string name="lbl_pin_mismatch">PINs no coinciden</string>
+    <string name="lbl_reenter_pin">Reintroducir PIN</string>
     <string name="random">Aleatorio</string>
     <string name="pref_playback_advanced">Preferencias avanzadas de reproducción</string>
     <string name="unreleased">Sin estrenar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -619,4 +619,13 @@
         <item quantity="one">%1$s album</item>
         <item quantity="other">%1$s albums</item>
     </plurals>
+    <string name="lbl_enter_pin">Enter PIN</string>
+    <string name="lbl_set_pin">Set PIN</string>
+    <string name="lbl_change_pin">Change PIN</string>
+    <string name="lbl_remove_pin">Remove PIN</string>
+    <string name="lbl_pin_removed">PIN removed</string>
+    <string name="lbl_pin_set">PIN set</string>
+    <string name="lbl_incorrect_pin">Incorrect PIN</string>
+    <string name="lbl_pin_mismatch">PINs do not match</string>
+    <string name="lbl_reenter_pin">Re-enter PIN</string>
 </resources>

--- a/app/src/test/java/org/jellyfin/androidtv/preference/UserPinRepositoryTest.kt
+++ b/app/src/test/java/org/jellyfin/androidtv/preference/UserPinRepositoryTest.kt
@@ -1,0 +1,79 @@
+package org.jellyfin.preference
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import java.util.UUID
+import org.jellyfin.androidtv.preference.UserPinRepository
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UserPinRepositoryTest {
+
+	private val context = mockk<Context>()
+	private val sharedPreferences = mockk<SharedPreferences>()
+	private val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+
+	private lateinit var repository: UserPinRepository
+
+	@BeforeEach
+	fun setup() {
+		mockkStatic(PreferenceManager::class)
+		every { PreferenceManager.getDefaultSharedPreferences(context) } returns sharedPreferences
+		every { sharedPreferences.edit() } returns editor
+
+		repository = UserPinRepository(context)
+	}
+
+	@Test
+	fun `setPin stores hashed pin`() {
+		val userId = UUID.randomUUID()
+		val pin = "1234"
+		val key = "user_pin_$userId"
+		val slotKey = slot<String>()
+		val slotValue = slot<String>()
+
+		every { editor.putString(capture(slotKey), capture(slotValue)) } returns editor
+
+		repository.setPin(userId, pin)
+
+		verify { editor.putString(key, any()) }
+		assertTrue(slotValue.captured.isNotEmpty())
+		assertFalse(slotValue.captured == pin) // Should be hashed
+	}
+
+	@Test
+	fun `verifyPin returns true for correct pin`() {
+		val userId = UUID.randomUUID()
+		val pin = "1234"
+		val key = "user_pin_$userId"
+
+		// We need to capture what setPin stores to verify it against verifyPin logic which re-hashes
+		// Or we just test that verifyPin uses getString and hashes input.
+
+		// Let's implement setPin effectively in the mock
+		val storedHash = "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4" // SHA-256 for 1234
+		every { sharedPreferences.getString(key, "") } returns storedHash
+
+		assertTrue(repository.verifyPin(userId, pin))
+	}
+
+	@Test
+	fun `verifyPin returns false for incorrect pin`() {
+		val userId = UUID.randomUUID()
+		val pin = "1234"
+		val key = "user_pin_$userId"
+
+		val storedHash = "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4" // SHA-256 for 1234
+		every { sharedPreferences.getString(key, "") } returns storedHash
+
+		assertFalse(repository.verifyPin(userId, "0000"))
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-compose-ui = "1.10.6"
 androidx-constraintlayout = "2.2.1"
 androidx-core = "1.18.0"
 androidx-fragment = "1.8.9"
+androidx-gridlayout = "1.1.0"
 androidx-leanback = "1.2.0"
 androidx-lifecycle = "2.10.0"
 androidx-media3 = "1.10.0"
@@ -74,6 +75,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-fragment-compose = { module = "androidx.fragment:fragment-compose", version.ref = "androidx-fragment" }
+androidx-gridlayout = { module = "androidx.gridlayout:gridlayout", version.ref = "androidx-gridlayout" }
 androidx-leanback-core = { module = "androidx.leanback:leanback", version.ref = "androidx-leanback" }
 androidx-leanback-preference = { module = "androidx.leanback:leanback-preference", version.ref = "androidx-leanback" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
Most of this PR originates from #5352, however, that PR was rejected due to being AI generated. I've revised the code, changed a few things and essentially understood it; no longer being an AI dump and able to explain any detail of this. (I've co-authored the original commit author, which I think is proper attribution)

I don't really develop for Android, so the code is not of high quality, and there's potentially some bad design decisions which I'm willing to improve on. I've done only minor modifications over the original AI code because it seems simple and structured enough to not need any further complexity.

**Changes**

Add PIN protection for users. All PINs are hashed in new repository. 

The proper user settings have been added too (add, change and remove PIN), it has tests, lock SVGs and a visual indicator on the locked accounts in its selection screen.

There's new resource strings that will need translations from other languages, I've taken care of the default english ones and spanish.

**Code assistance**

The only use of AI was from the code already present in #5352 as well as questions to ChatGPT (GPT-5 mini) about Android design concepts and explaining small code snippets. No code was generated from it.

I've asked in https://github.com/jellyfin/jellyfin-androidtv/pull/5352#issuecomment-4034413508 about doing this and I understand this is still at the boundary of what's permitted. But I want to highlight I've put the effort of reviewing it and will change any low quality aspect of the PR as requested.

**Issues**

- closes #3509