### PR TITLE
Remember subtitle language between videos

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -507,18 +507,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (mCurrentOptions != null) {
             internalOptions.setSubtitleStreamIndex(mCurrentOptions.getSubtitleStreamIndex());
             internalOptions.setAudioStreamIndex(mCurrentOptions.getAudioStreamIndex());
-        } else {
-            // Restore last used subtitle language when starting fresh playback (e.g., from NextUp screen)
-            String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
-            MediaSourceInfo mediaSource = getCurrentMediaSource();
-            if (lastSubtitleLanguage != null && mediaSource != null && mediaSource.getMediaStreams() != null) {
-                for (MediaStream stream : mediaSource.getMediaStreams()) {
-                    if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
-                        internalOptions.setSubtitleStreamIndex(stream.getIndex());
-                        break;
-                    }
-                }
-            }
         }
         if (forcedSubtitleIndex != null) {
             internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
@@ -637,8 +625,27 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        // get subtitle info
-        mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex() != null ? response.getMediaSource().getDefaultSubtitleStreamIndex() : null);
+        // get subtitle info - prefer saved language preference over server default
+        String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
+        if (lastSubtitleLanguage != null) {
+            if (lastSubtitleLanguage.isEmpty()) {
+                // User explicitly disabled subtitles
+                mCurrentOptions.setSubtitleStreamIndex(null);
+            } else if (response.getMediaSource().getMediaStreams() != null) {
+                // Find subtitle stream matching saved language
+                Integer matchingIndex = null;
+                for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
+                    if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
+                        matchingIndex = stream.getIndex();
+                        break;
+                    }
+                }
+                mCurrentOptions.setSubtitleStreamIndex(matchingIndex);
+            }
+        } else {
+            // No saved preference, use server default
+            mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex());
+        }
         setDefaultAudioIndex(response);
         Timber.i("default audio index set to %s remote default %s", mDefaultAudioIndex, response.getMediaSource().getDefaultAudioStreamIndex());
         Timber.i("default sub index set to %s remote default %s", mCurrentOptions.getSubtitleStreamIndex(), response.getMediaSource().getDefaultSubtitleStreamIndex());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -507,6 +507,18 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (mCurrentOptions != null) {
             internalOptions.setSubtitleStreamIndex(mCurrentOptions.getSubtitleStreamIndex());
             internalOptions.setAudioStreamIndex(mCurrentOptions.getAudioStreamIndex());
+        } else {
+            // Restore last used subtitle language when starting fresh playback (e.g., from NextUp screen)
+            String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
+            MediaSourceInfo mediaSource = getCurrentMediaSource();
+            if (lastSubtitleLanguage != null && mediaSource != null && mediaSource.getMediaStreams() != null) {
+                for (MediaStream stream : mediaSource.getMediaStreams()) {
+                    if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
+                        internalOptions.setSubtitleStreamIndex(stream.getIndex());
+                        break;
+                    }
+                }
+            }
         }
         if (forcedSubtitleIndex != null) {
             internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -19,6 +19,7 @@ import org.jellyfin.sdk.model.api.MediaSegmentDto
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.koin.android.ext.android.inject
+import org.koin.java.KoinJavaComponent.get
 import timber.log.Timber
 import java.util.UUID
 
@@ -58,6 +59,15 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 
 	// Already using this subtitle index
 	if (mCurrentOptions.subtitleStreamIndex == index && !force) return
+
+	// Save subtitle language preference for restoration after NextUp screen
+	val videoQueueManager = get<VideoQueueManager>(VideoQueueManager::class.java)
+	if (index == -1) {
+		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(null)
+	} else {
+		val stream = currentMediaSource.mediaStreams?.firstOrNull { it.type == MediaStreamType.SUBTITLE && it.index == index }
+		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(stream?.language)
+	}
 
 	// Disable subtitles
 	if (index == -1) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -63,7 +63,8 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 	// Save subtitle language preference for restoration after NextUp screen
 	val videoQueueManager = get<VideoQueueManager>(VideoQueueManager::class.java)
 	if (index == -1) {
-		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(null)
+		// Use empty string to indicate "subtitles explicitly disabled" vs null meaning "no preference"
+		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode("")
 	} else {
 		val stream = currentMediaSource.mediaStreams?.firstOrNull { it.type == MediaStreamType.SUBTITLE && it.index == index }
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(stream?.language)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -19,7 +19,6 @@ import org.jellyfin.sdk.model.api.MediaSegmentDto
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.koin.android.ext.android.inject
-import org.koin.java.KoinJavaComponent.get
 import timber.log.Timber
 import java.util.UUID
 
@@ -61,7 +60,7 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 	if (mCurrentOptions.subtitleStreamIndex == index && !force) return
 
 	// Save subtitle language preference for restoration after NextUp screen
-	val videoQueueManager = get<VideoQueueManager>(VideoQueueManager::class.java)
+	val videoQueueManager by fragment.inject<VideoQueueManager>()
 	if (index == -1) {
 		// Use empty string to indicate "subtitles explicitly disabled" vs null meaning "no preference"
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode("")

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
@@ -6,6 +6,7 @@ class VideoQueueManager {
 	private var _currentVideoQueue: List<BaseItemDto> = emptyList()
 	private var _currentMediaPosition = -1
 	private var _lastPlayedAudioLanguageIsoCode: String? = null
+	private var _lastPlayedSubtitleLanguageIsoCode: String? = null
 
 	fun setCurrentVideoQueue(items: List<BaseItemDto>?) {
 		if (items.isNullOrEmpty()) return clearVideoQueue()
@@ -32,9 +33,18 @@ class VideoQueueManager {
 		_lastPlayedAudioLanguageIsoCode = isoCode
 	}
 
+	fun getLastPlayedSubtitleLanguageIsoCode(): String? {
+		return _lastPlayedSubtitleLanguageIsoCode
+	}
+
+	fun setLastPlayedSubtitleLanguageIsoCode(isoCode: String?) {
+		_lastPlayedSubtitleLanguageIsoCode = isoCode
+	}
+
 	fun clearVideoQueue() {
 		_currentVideoQueue = emptyList()
 		_currentMediaPosition = -1
 		_lastPlayedAudioLanguageIsoCode = null
+		_lastPlayedSubtitleLanguageIsoCode = null
 	}
 }


### PR DESCRIPTION
**Changes**

When the NextUp screen transitions to the next episode, subtitle settings that were manually changed during playback are lost. This happens because the NextUp screen creates a new PlaybackController instance, and the mCurrentOptions field (which holds the subtitle stream index) starts as null.

This fix mirrors the existing audio language persistence pattern. When the user changes subtitles, the language code is saved to VideoQueueManager. When a new PlaybackController starts fresh playback (such as from the NextUp screen), it checks for a saved subtitle language and finds the matching stream in the new episode.

**Issues**

Fixes #5436
Fixes #5509
Fixes #5402

**Testing**

**BEFORE**:
1. Chose a show, selected a random subtitle language
2. Finished the episode, waited for it to naturally proceed to the next episode
3. Subtitles reverted themselves to my previous subtitle preference from the server

**AFTER**:
1. Chose a show, selected a random subtitle language
2. Finished the episode, waited for it to naturally proceed to the next episode
3. Subtitles continued forward in the expected new language