### PR TITLE
Fix improper behavior when using external player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
@@ -57,6 +57,11 @@ interface NavigationRepository {
 	 * Reset navigation to the initial destination or a specific [Destination.Fragment] without clearing history.
 	 */
 	fun reset(destination: Destination.Fragment? = null) = reset(destination, false)
+	
+	/**
+	 * Dummy navigation required for fragment activites without their own UI.
+	 */
+	fun goNowhere(required: Boolean): Boolean
 }
 
 class NavigationRepositoryImpl(
@@ -96,5 +101,12 @@ class NavigationRepositoryImpl(
 		_currentAction.tryEmit(NavigationAction.NavigateFragment(actualDestination, true, false, clearHistory))
 		Timber.i("Navigating to $actualDestination (via reset, clearHistory=$clearHistory)")
 	}
+	
+	override fun goNowhere(required: Boolean): Boolean {
+		if (!required) return false
+		Timber.i("Navigating to nowhere.")
+		_currentAction.tryEmit(NavigationAction.Nothing)
+		return true
+		}
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -228,6 +228,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 				Toast.makeText(this@ExternalPlayerActivity, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()
 			}
 
+			dataRefreshService.lastPlayedItem = item
 			dataRefreshService.lastPlayback = Instant.now()
 			when (item.type) {
 				BaseItemKind.MOVIE -> dataRefreshService.lastMoviePlayback = Instant.now()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -59,6 +59,7 @@ class PlaybackLauncher(
 
 			if (userPreferences[UserPreferences.useExternalPlayer] && items.all { it.supportsExternalPlayer }) {
 				context.startActivity(ActivityDestinations.externalPlayer(context, position?.milliseconds ?: Duration.ZERO))
+				navigationRepository.goNowhere(true)
 			} else if (userPreferences[UserPreferences.playbackRewriteVideoEnabled]) {
 				val destination = Destinations.videoPlayerNew(position)
 				navigationRepository.navigate(destination, replace)


### PR DESCRIPTION
This is a stopgap patch that regresses the external player launching behavior to its last known working state.

**Changes**
Re-implemented the call for `NavigationAction.Nothing` that was present before https://github.com/jellyfin/jellyfin-androidtv/pull/4591

**Code assistance**
None

**Issues**
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/5010
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/5148