### PR TITLE
Catch errors when applying gain in ExoPlayerAudioPipeline

### DIFF
--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerAudioPipeline.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerAudioPipeline.kt
@@ -36,9 +36,17 @@ class ExoPlayerAudioPipeline {
 			?.times(100f)
 			// Round to integer
 			?.toInt()
+			// Ignore if zero (so the enhancer will be disabled)
+			?.takeIf { it != 0 }
 
 		Timber.d("Applying gain (targetGain=$targetGain)")
-		loudnessEnhancer?.setEnabled(targetGain != null)
-		loudnessEnhancer?.setTargetGain(targetGain ?: 0)
+		runCatching {
+			loudnessEnhancer?.setTargetGain(targetGain ?: 0)
+		}.onSuccess {
+			loudnessEnhancer?.setEnabled(targetGain != null)
+		}.onFailure { error ->
+			Timber.e(error, "Failed to apply gain of $targetGain")
+			loudnessEnhancer?.setEnabled(false)
+		}
 	}
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

- Disable loudness enhancer if target gain is 0
- Disable loudness enhancer if we fail to set the target gain
- Catch errors while applying the loudness gain

**Code assistance**
no<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5528