### PR TITLE
Use FixedMotionDurationScale for playback and timer animations

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/FixedMotionDurationScale.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/FixedMotionDurationScale.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.androidtv.ui.composable
+
+import androidx.compose.ui.MotionDurationScale
+
+/**
+ * A [MotionDurationScale] implementation that always returns a fixed scale factor of 1f. To be used for animations that should ignore the
+ * system animator duration scale.
+ */
+object FixedMotionDurationScale : MotionDurationScale {
+	override val scaleFactor: Float = 1f
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/playback.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PositionInfo
@@ -80,7 +81,7 @@ fun rememberPlayerProgress(
 		if (active == Duration.ZERO) animatable.snapTo(0f)
 		else animatable.snapTo((activeMs / durationMs).coerceIn(0f, 1f))
 
-		if (playing) {
+		if (playing) withContext(FixedMotionDurationScale) {
 			animatable.animateTo(
 				targetValue = 1f,
 				animationSpec = tween(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/nextup/NextUpFragment.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -49,6 +50,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.button.Button
 import org.jellyfin.androidtv.ui.base.button.ProgressButton
 import org.jellyfin.androidtv.ui.composable.AsyncImage
+import org.jellyfin.androidtv.ui.composable.FixedMotionDurationScale
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
@@ -142,13 +144,15 @@ fun NextUpOverlay(
 			// Make sure to cancel any running timer
 			confirmTimer.snapTo(0f)
 		} else {
-			confirmTimer.animateTo(
-				targetValue = 1f,
-				animationSpec = tween(
-					durationMillis = durationMillis,
-					easing = LinearEasing,
-				),
-			)
+			withContext(FixedMotionDurationScale) {
+				confirmTimer.animateTo(
+					targetValue = 1f,
+					animationSpec = tween(
+						durationMillis = durationMillis,
+						easing = LinearEasing,
+					),
+				)
+			}
 			onConfirm()
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/stillwatching/StillWatchingFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/stillwatching/StillWatchingFragment.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.background.AppBackground
@@ -47,6 +48,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.button.Button
 import org.jellyfin.androidtv.ui.base.button.ProgressButton
 import org.jellyfin.androidtv.ui.composable.AsyncImage
+import org.jellyfin.androidtv.ui.composable.FixedMotionDurationScale
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
@@ -137,13 +139,15 @@ fun StillWatchingOverlay(
 	val api = koinInject<ApiClient>()
 	val endWatchingTimer = remember { Animatable(0f) }
 	LaunchedEffect(item) {
-		endWatchingTimer.animateTo(
-			targetValue = 1f,
-			animationSpec = tween(
-				durationMillis = TIMEOUT_IN_MS,
-				easing = LinearEasing,
-			),
-		)
+		withContext(FixedMotionDurationScale) {
+			endWatchingTimer.animateTo(
+				targetValue = 1f,
+				animationSpec = tween(
+					durationMillis = TIMEOUT_IN_MS,
+					easing = LinearEasing,
+				),
+			)
+		}
 		onCancel()
 	}
 


### PR DESCRIPTION
**Changes**

The duration of Animations in Android can be changes using the ANIMATOR_DURATION_SCALE setting. By default compose uses this for all animations, which is perfectly fine for most animations we use.

However, we also use animations in a few places where the timing we use must be exact. Like the "next up" countdown button and more importantly, the playback progress timer.

Some people tweaked their animation scale and this caused weird issues. This PR adds a new `FixedMotionDurationScale` co-routine context element that forced the scale factor to be 1 and uses it for the player progress & nextup/still-watching timer buttons. This fixes the displayed time, progress bar and lyrics progress animations among others.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5110