### PR TITLE
Fix back button only working once

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/compat/AppNavigationHost.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/compat/AppNavigationHost.kt
@@ -24,7 +24,6 @@ fun AppNavigationHost(
 ) {
 	val factory = remember { AppNavigationHostViewFactory() }
 
-	val currentAction by navigationRepository.currentAction.collectAsState(NavigationAction.Nothing)
 	val canGoBack by remember {
 		navigationRepository.currentAction.map { navigationRepository.canGoBack }.distinctUntilChanged()
 	}.collectAsState(navigationRepository.canGoBack)
@@ -36,12 +35,13 @@ fun AppNavigationHost(
 		modifier = modifier,
 	)
 
-	LaunchedEffect(currentAction) {
-		when (val currentAction = currentAction) {
-			is NavigationAction.NavigateFragment -> factory.view.navigate(currentAction)
-			NavigationAction.GoBack -> factory.view.goBack()
-
-			NavigationAction.Nothing -> Unit
+	LaunchedEffect(Unit) {
+		navigationRepository.currentAction.collect { action ->
+			when (action) {
+				is NavigationAction.NavigateFragment -> factory.view.navigate(action)
+				NavigationAction.GoBack -> factory.view.goBack()
+				NavigationAction.Nothing -> Unit
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Changes**

**Problem:** After the MainActivity compose refactor (https://github.com/jellyfin/jellyfin-androidtv/pull/5495), the back button only works once then stops responding entirely (silently swallows all subsequent back presses).


`AppNavigationHost` used `LaunchedEffect(currentAction)` to react to navigation changes, but
  `LaunchedEffect` only re-runs when its key changes. Since `GoBack` is a singleton
  object, pressing back multiple times emits the same value, and the effect ran the first
  time but ignored every subsequent back press.

**Solution:**

Switched from `LaunchedEffect(currentAction)` to collecting the flow directly with
  `LaunchedEffect(Unit) { flow.collect {} }`, which runs on every emission even when the
  value is the same object.

**Testing:**

Steps to reproduce (before fix):
1. Launch app, land on Home
2. Select a show library -> select a show -> select an episode -> select an actor (5 screens deep)
3. Press back, notice it navigates back once (yay!)
4. Press back again, notice nothing happens, app appears frozen (boooo. This is the bug).

After fix:
1. Same navigation path (Home -> Shows -> Show -> Episode -> Actor)
2. Pressed back 4 times, notice each press navigated to the previous screen (yay! bug is fixed!)

**Code assistance**

I worked with Claude Code while debugging, analyzing logs and root causing the issue. It also helped me author the fix.

**Issues**

<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

No open issues. This is a recently introduced bug that hasn't made it to public builds yet.