### PR TITLE
Return state from rememberPlayerProgress

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/dream/composable/DreamContentNowPlaying.kt
@@ -34,7 +34,7 @@ import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.blurHashPainter
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
 import org.jellyfin.androidtv.ui.composable.modifier.overscan
-import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
+import org.jellyfin.androidtv.ui.composable.rememberPlayerPositionInfo
 import org.jellyfin.androidtv.ui.player.base.PlayerSeekbar
 import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
 import org.jellyfin.androidtv.util.apiclient.getUrl
@@ -78,15 +78,12 @@ fun DreamContentNowPlaying(
 	// Lyrics overlay (on top of background)
 	if (lyrics != null) {
 		val playState by remember { playbackManager.state.playState }.collectAsState()
-
-		// Using the progress animation causes the layout to recompose, which we need for synced lyrics to work
-		// we don't actually use the animation value here
-		rememberPlayerProgress(playbackManager)
+		val positionInfo by rememberPlayerPositionInfo(playbackManager)
 
 		LyricsDtoBox(
 			lyricDto = lyrics,
-			currentTimestamp = playbackManager.state.positionInfo.active,
-			duration = playbackManager.state.positionInfo.duration,
+			currentTimestamp = positionInfo.active,
+			duration = positionInfo.duration,
 			paused = playState != PlayState.PLAYING,
 			fontSize = 22.sp,
 			color = Color.White,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -65,7 +65,7 @@ fun NowPlayingComposable(
 
 	val entry by rememberQueueEntry(playbackManager)
 	val item = entry?.run { baseItemFlow.collectAsState(baseItem) }?.value
-	val progress = rememberPlayerProgress(playbackManager)
+	val progress by rememberPlayerProgress(playbackManager)
 
 	LaunchedEffect(item == null) { onFocusableChange(item != null) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/LyricsBox.kt
@@ -163,7 +163,7 @@ fun LyricsBox(
 	color: Color = LocalTextStyle.current.color,
 ) = Box(modifier) {
 	var totalHeight by remember { mutableFloatStateOf(0f) }
-	val progress = rememberPlayerProgress(!paused, currentTimestamp, duration)
+	val progress by rememberPlayerProgress(!paused, currentTimestamp, duration)
 
 	LyricsBoxContent(
 		items = lines,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/item/ItemCardBaseItemOverlay.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/item/ItemCardBaseItemOverlay.kt
@@ -152,7 +152,7 @@ private fun ProgressIndicator(
 	val currentQueueEntry by rememberQueueEntry(playbackManager)
 
 	val playedPercentage = if (playState == PlayState.PLAYING && currentQueueEntry?.baseItem?.id == item.id) {
-		rememberPlayerProgress(playbackManager)
+		rememberPlayerProgress(playbackManager).value
 	} else {
 		item.userData?.playedPercentage?.toFloat()?.div(100f)?.coerceIn(0f, 1f)?.takeIf { it > 0f && it < 1f }
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/playback.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/playback.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,7 +55,7 @@ fun rememberPlayerPositionInfo(
 @Composable
 fun rememberPlayerProgress(
 	playbackManager: PlaybackManager = koinInject(),
-): Float {
+): State<Float> {
 	val playState by playbackManager.state.playState.collectAsState()
 	val active = playbackManager.state.positionInfo.active
 	val duration = playbackManager.state.positionInfo.duration
@@ -71,7 +72,7 @@ fun rememberPlayerProgress(
 	playing: Boolean,
 	active: Duration,
 	duration: Duration,
-): Float {
+): State<Float> {
 	val animatable = remember { Animatable(0f, 0f) }
 
 	LaunchedEffect(playing, duration) {
@@ -92,5 +93,5 @@ fun rememberPlayerProgress(
 		}
 	}
 
-	return animatable.value
+	return animatable.asState()
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/AudioNowPlayingFragmentHelper.kt
@@ -28,7 +28,7 @@ import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.LyricsDtoBox
 import org.jellyfin.androidtv.ui.composable.modifier.fadingEdges
-import org.jellyfin.androidtv.ui.composable.rememberPlayerProgress
+import org.jellyfin.androidtv.ui.composable.rememberPlayerPositionInfo
 import org.jellyfin.androidtv.ui.composable.rememberQueueEntry
 import org.jellyfin.androidtv.ui.player.base.PlayerSeekbar
 import org.jellyfin.androidtv.util.apiclient.albumPrimaryImage
@@ -107,15 +107,12 @@ fun initializePreviewView(
 		// Display lyrics overlay
 		if (lyrics != null) {
 			val playState by remember { playbackManager.state.playState }.collectAsState()
-
-			// Using the progress animation causes the layout to recompose, which we need for synced lyrics to work
-			// we don't actually use the animation value here
-			rememberPlayerProgress(playbackManager)
+			val positionInfo by rememberPlayerPositionInfo(playbackManager)
 
 			LyricsDtoBox(
 				lyricDto = lyrics,
-				currentTimestamp = playbackManager.state.positionInfo.active,
-				duration = playbackManager.state.positionInfo.duration,
+				currentTimestamp = positionInfo.active,
+				duration = positionInfo.duration,
 				paused = playState != PlayState.PLAYING,
 				fontSize = 12.sp,
 				color = Color.White,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerSeekbar.kt
@@ -23,7 +23,7 @@ fun PlayerSeekbar(
 ) {
 	val playState by playbackManager.state.playState.collectAsState()
 	val positionInfo = playbackManager.state.positionInfo
-	val progress = rememberPlayerProgress(
+	val progress by rememberPlayerProgress(
 		playing = playState == PlayState.PLAYING,
 		active = positionInfo.active,
 		duration = positionInfo.duration,


### PR DESCRIPTION
**Changes**

Return a `State<Float>` from the `rememberPlayerProgress()` helper function to avoid recomposition if the value isn't used. Additionally change the lyrics rendering to use `rememberPlayerPositionInfo` to avoid the previous hack and to get better performance.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
