### PR TITLE
Use lighter field set for home screen API requests

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/ItemRepository.kt
@@ -22,4 +22,16 @@ object ItemRepository {
 		ItemFields.TAGLINES,
 		ItemFields.TRICKPLAY,
 	)
+
+	// Lighter field set for home screen rows - excludes heavy fields like
+	// MediaSources, MediaStreams, Chapters, Trickplay that aren't needed for display.
+	// Full item data is fetched when user selects an item.
+	val browseFields = setOf(
+		ItemFields.CAN_DELETE,
+		ItemFields.CHILD_COUNT,
+		ItemFields.DATE_CREATED,
+		ItemFields.GENRES,
+		ItemFields.OVERVIEW,
+		ItemFields.PRIMARY_IMAGE_ASPECT_RATIO,
+	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -25,7 +25,7 @@ class HomeFragmentHelper(
 	fun loadResume(title: String, includeMediaTypes: Collection<MediaType>): HomeFragmentRow {
 		val query = GetResumeItemsRequest(
 			limit = ITEM_LIMIT_RESUME,
-			fields = ItemRepository.itemFields,
+			fields = ItemRepository.browseFields,
 			imageTypeLimit = 1,
 			enableTotalRecordCount = false,
 			mediaTypes = includeMediaTypes,
@@ -58,7 +58,7 @@ class HomeFragmentHelper(
 			imageTypeLimit = 1,
 			limit = ITEM_LIMIT_NEXT_UP,
 			enableResumable = false,
-			fields = ItemRepository.itemFields
+			fields = ItemRepository.browseFields
 		)
 
 		return HomeFragmentBrowseRowDefRow(BrowseRowDef(context.getString(R.string.lbl_next_up), query, arrayOf(ChangeTriggerType.TvPlayback)))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentLatestRow.kt
@@ -28,7 +28,7 @@ class HomeFragmentLatestRow(
 			.map { item ->
 				// Create query and add it to a new row
 				val request = GetLatestMediaRequest(
-					fields = ItemRepository.itemFields,
+					fields = ItemRepository.browseFields,
 					imageTypeLimit = 1,
 					parentId = item.id,
 					groupItems = true,


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This change excludes heavy fields from media items when rendering the Home Screen (eg MediaSources, MediaStreams, Chapters, Trickplay). **THIS IS SAFE!** Full item data is fetched when user selects an item detail page or initiates playback.

This makes the app launch/readiness feel noticeably faster.

I benchmarked on my own library / app startup. Without this change, it's 5+ seconds between launch and all the home rows being ready - the home rows sit empty for a considerable amount of time before the rows populate. With this change, it's 3s, which is noticeably faster. Most of that time is during the launch before the home rows appear at all. 

Combined with https://github.com/jellyfin/jellyfin-androidtv/pull/5544 the performance improvement on app launch is very significant for my library. 

**Code assistance**

I used Claude code to help me add logging and generate the benchmarks to confirm the magnitude of the improvement (~25-50%).

Measurement methodology: Time from MainActivity START to last 'Creating items' log entry (debug timing added by me), averaged over 3 runs per configuration.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

None
