### PR TITLE
Disable dependency info inclusion in bundles and APKs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,11 @@ android {
 		}
 	}
 
+	dependenciesInfo {
+		includeInBundle = false
+		includeInApk = false
+	}
+
 	buildTypes {
 		release {
 			proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**

Disable dependency metadata from being included in our app releases. See linked issue for more context.

**Issues**

Fixes #5546