### PR TITLE
Add playback completion verification in external players

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -232,7 +232,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 						PlaybackStopInfo(
 							itemId = item.id,
 							mediaSourceId = mediaSource.id,
-							positionTicks = if (playbackCompleted) runtime?.inWholeTicks else endPosition?.inWholeTicks,
+							positionTicks = if (endPosition == null && playbackCompleted) runtime?.inWholeTicks else endPosition?.inWholeTicks,
 							failed = false,
 						)
 					)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -56,6 +56,12 @@ class ExternalPlayerActivity : FragmentActivity() {
 		private const val API_MX_SUBS = "subs"
 		private const val API_MX_SUBS_NAME = "subs.name"
 		private const val API_MX_SUBS_FILENAME = "subs.filename"
+		private const val API_MX_RESULT_ID = "com.mxtech.intent.result.VIEW"
+		private const val API_MX_RESULT_END_BY = "end_by"
+		private const val API_MX_RESULT_END_BY_PLAYBACK_COMPLETION = "playback_completion"
+
+		// https://mpv-android.github.io/mpv-android/intent.html
+		private const val API_MPV_RESULT_ID = "is.xyz.mpv.MPVActivity.result"
 
 		// https://wiki.videolan.org/Android_Player_Intents/
 		private const val API_VLC_SUBTITLES = "subtitles_location"
@@ -67,6 +73,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 		private const val API_VIMU_RESUME = "forceresume"
 		private const val API_VIMU_RESULT_ID = "net.gtvbox.videoplayer.result"
 		private const val API_VIMU_RESULT_ERROR = 4
+		private const val API_VIMU_RESULT_PLAYBACK_COMPLETED = 1
 
 		// The extra keys used by various video players to read the end position
 		private val resultPositionExtras = arrayOf(API_MX_RESULT_POSITION, API_VLC_RESULT_POSITION)
@@ -85,7 +92,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 			Toast.makeText(this, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()
 			finish()
 		} else {
-			onItemFinished(result.data)
+			onItemFinished(result.data, result.resultCode)
 		}
 	}
 
@@ -192,7 +199,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 	}
 
 
-	private fun onItemFinished(result: Intent?) {
+	private fun onItemFinished(result: Intent?, resultCode: Int) {
 		if (currentItem == null) {
 			Toast.makeText(this@ExternalPlayerActivity, R.string.video_error_unknown_error, Toast.LENGTH_LONG).show()
 			finish()
@@ -208,8 +215,15 @@ class ExternalPlayerActivity : FragmentActivity() {
 			else null
 		}
 
+		val playbackCompleted = when (result?.action) {
+			API_MX_RESULT_ID -> extras?.getString(API_MX_RESULT_END_BY) == API_MX_RESULT_END_BY_PLAYBACK_COMPLETION
+			API_MPV_RESULT_ID -> endPosition == null
+			API_VIMU_RESULT_ID -> resultCode == API_VIMU_RESULT_PLAYBACK_COMPLETED
+			else -> false
+		}
+
 		val runtime = (mediaSource.runTimeTicks ?: item.runTimeTicks)?.ticks
-		val shouldPlayNext = runtime != null && endPosition != null && endPosition >= (runtime * 0.9)
+		val shouldPlayNext = playbackCompleted || (runtime != null && endPosition != null && endPosition >= (runtime * 0.9))
 
 		lifecycleScope.launch {
 			runCatching {
@@ -218,7 +232,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 						PlaybackStopInfo(
 							itemId = item.id,
 							mediaSourceId = mediaSource.id,
-							positionTicks = endPosition?.inWholeTicks,
+							positionTicks = if (playbackCompleted) runtime?.inWholeTicks else endPosition?.inWholeTicks,
 							failed = false,
 						)
 					)


### PR DESCRIPTION
**Changes**

Fix a regression introduced in v0.19 that broke the "play next episode" feature for external players that do not return a standard playback position on completion.

Adds a `playbackCompleted` flag resolved via a `when` expression on the result intent action, using each player's documented result contract:

- **MX Player**: completed when the `end_by` extra equals `playback_completion` (per the [MX Player intent documentation](https://mx.j2inter.com/api#title10))
- **MPV**: completed when the position extra is absent (per the [MPV Android intent documentation](https://mpv-android.github.io/mpv-android/intent.html#result-intent))
- **VIMU**: completed when `resultCode` equals `1` (per the [VIMU intent documentation](https://vimu.tv/player-api/#activity-result))
- **VLC**: completion not reliably detectable per [VLC intent documentation](https://wiki.videolan.org/Android_Player_Intents/); falls through to the existing time-elapsed heuristic

When `playbackCompleted = true`, `shouldPlayNext` is set accordingly and `positionTicks` in `PlaybackStopInfo` is reported as the full runtime, ensuring the server correctly marks the episode as watched.
To support the **VIMU** check, a `resultCode` parameter was added to the `onItemFinished` function.

Tested locally with **MX Player**, **MPV Android**, and **VLC** on `Fire TV Stick 4K Max 2nd gen (Fire OS 8)`.
**VIMU** logic follows the documented result contract (`resultCode == 1`) but could not be verified locally as the player is not available for free.

**Code assistance**

Used an LLM to cross-check Kotlin syntax and review the intent-handling logic against each player's documentation.

**Issues**

Fixes #5293
