### PR TITLE
Actually enable R8 minification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,8 @@ android {
 
 	buildTypes {
 		release {
+			isMinifyEnabled = true
+			isShrinkResources = true
 			proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
 
 			// Set package names used in various XML files


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Change from https://github.com/jellyfin/jellyfin-androidtv/pull/5053 added `proguardFiles(...)` to the release build but never set `isMinifyEnabled = true`. R8 has been a no-op in every release build since.

Two release APKs from identical source — only difference is presence of the `proguardFiles(...)` line. Neither sets `isMinifyEnabled`.

Byte-identical-DEX proof (on `master` HEAD):

```bash
./gradlew :app:clean :app:assembleRelease
cp app/build/outputs/apk/release/jellyfin-androidtv-v*.apk /tmp/A.apk

# Remove the proguardFiles(...) line from app/build.gradle.kts, then:
./gradlew :app:clean :app:assembleRelease
cp app/build/outputs/apk/release/jellyfin-androidtv-v*.apk /tmp/B.apk

for d in classes.dex classes2.dex classes3.dex classes4.dex classes5.dex classes6.dex; do
  printf "%s: A=%s B=%s\n" "$d" \
    "$(unzip -p /tmp/A.apk $d | shasum -a 256 | awk '{print $1}')" \
    "$(unzip -p /tmp/B.apk $d | shasum -a 256 | awk '{print $1}')"
done
```

Both APKs are `41,923,101` bytes. SHA-256 of every DEX matches:

| File         | Variant A (`proguardFiles` set) | Variant B (line removed) |
|--------------|---------------------------------|--------------------------|
| classes.dex  | `c71feedb…0954f3ff5`            | `c71feedb…0954f3ff5`     |
| classes2.dex | `d29ba356…3bdc74ee45`           | `d29ba356…3bdc74ee45`    |
| classes3.dex | `05a79ef1…1611870876`           | `05a79ef1…1611870876`    |
| classes4.dex | `a7e63222…6ffc7e21`             | `a7e63222…6ffc7e21`      |
| classes5.dex | `c0f68e08…d0e66c98`             | `c0f68e08…d0e66c98`      |
| classes6.dex | `8bf53951…0d7383f3`             | `8bf53951…0d7383f3`      |

Identical SHA-256 across all six DEX. The line contributes zero bytes to the shipped artifact.

APK shrinks 40 MB to 29 MB.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

Claude Code, help with debugging on remote device and scripts to compare builds.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

https://github.com/jellyfin/jellyfin-androidtv/pull/5053
