### PR TITLE
Add libass ASS subtitle direct play

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
 	// Jellyfin
 	implementation(projects.playback.core)
 	implementation(projects.playback.jellyfin)
+	implementation(projects.playback.libass)
 	implementation(projects.playback.media3.exoplayer)
 	implementation(projects.playback.media3.session)
 	implementation(projects.preference)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -249,7 +249,12 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var trickPlayEnabled = booleanPreference("trick_play_enabled", false)
 
 		/**
-  		 * Enable PGS subtitle direct-play.
+		 * Enable ASS/SSA subtitle direct-play using client-side libass rendering.
+		 */
+		var assDirectPlay = booleanPreference("ass_direct_play", true)
+
+		/**
+		 * Enable PGS subtitle direct-play.
 		 */
 		var pgsDirectPlay = booleanPreference("pgs_enabled", true)
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -42,6 +42,7 @@ fun PlaybackController.getLiveTvChannel(
 @OptIn(UnstableApi::class)
 fun PlaybackController.disableDefaultSubtitles() {
 	Timber.i("Disabling non-baked subtitles")
+	mVideoManager.clearLibassSubtitles()
 
 	with(mVideoManager.mExoPlayer.trackSelector!!) {
 		parameters = parameters.buildUpon()
@@ -102,6 +103,10 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 			SubtitleDeliveryMethod.EXTERNAL,
 			SubtitleDeliveryMethod.EMBED,
 			SubtitleDeliveryMethod.HLS -> {
+				if (stream.usesLibassSubtitleRendering()) {
+					Timber.i("Routing ASS/SSA subtitle stream $index through libass client renderer")
+				}
+
 				// External subtitles need to be resolved differently
 				val group = if (stream.deliveryMethod == SubtitleDeliveryMethod.EXTERNAL) {
 					mVideoManager.mExoPlayer.currentTracks.groups.firstOrNull { group ->

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -47,6 +47,7 @@ import org.jellyfin.androidtv.R;
 import org.jellyfin.androidtv.data.compat.StreamInfo;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.ZoomMode;
+import org.jellyfin.playback.libass.LibassSubtitleController;
 import org.jellyfin.sdk.api.client.ApiClient;
 import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
@@ -71,6 +72,7 @@ public class VideoManager {
     private PlaybackOverlayFragmentHelper _helper;
     public ExoPlayer mExoPlayer;
     private PlayerView mExoPlayerView;
+    private LibassSubtitleController mLibassSubtitleController;
     private Handler mHandler = new Handler();
 
     private long mMetaDuration = -1;
@@ -86,6 +88,9 @@ public class VideoManager {
         mActivity = activity;
         _helper = helper;
         nightModeEnabled = userPreferences.get(UserPreferences.Companion.getAudioNightMode());
+        mLibassSubtitleController = userPreferences.get(UserPreferences.Companion.getAssDirectPlay())
+                ? new LibassSubtitleController()
+                : null;
 
         mExoPlayer = configureExoplayerBuilder(activity).build();
 
@@ -118,6 +123,9 @@ public class VideoManager {
         mExoPlayerView.getSubtitleView().setFractionalTextSize(0.0533f * userPreferences.get(UserPreferences.Companion.getSubtitlesTextSize()));
         mExoPlayerView.getSubtitleView().setBottomPaddingFraction(userPreferences.get(UserPreferences.Companion.getSubtitlesOffsetPosition()));
         mExoPlayerView.getSubtitleView().setStyle(subtitleStyle);
+        if (mLibassSubtitleController != null) {
+            mLibassSubtitleController.attach(mExoPlayer, mExoPlayerView.getSubtitleView());
+        }
 
         mExoPlayer.addListener(new Player.Listener() {
             @Override
@@ -218,8 +226,17 @@ public class VideoManager {
         extractorsFactory.setConstantBitrateSeekingEnabled(true);
         extractorsFactory.setConstantBitrateSeekingAlwaysEnabled(true);
         DefaultDataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, exoPlayerHttpDataSourceFactory);
-        exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
-        exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory));
+        if (mLibassSubtitleController != null) {
+            mLibassSubtitleController.configure(
+                    exoPlayerBuilder,
+                    dataSourceFactory,
+                    extractorsFactory,
+                    defaultRendererFactory
+            );
+        } else {
+            exoPlayerBuilder.setRenderersFactory(defaultRendererFactory);
+            exoPlayerBuilder.setMediaSourceFactory(new DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory));
+        }
 
         exoPlayerBuilder.setAudioAttributes(new AudioAttributes.Builder()
                 .setUsage(C.USAGE_MEDIA)
@@ -354,8 +371,11 @@ public class VideoManager {
         try {
             // Add external subtitles
             List<MediaItem.SubtitleConfiguration> subtitleConfigurations = new ArrayList<>();
+            boolean hasLibassSubtitles = false;
             for (MediaStream mediaStream : streamInfo.getMediaSource().getMediaStreams()) {
                 if (mediaStream.getType() != MediaStreamType.SUBTITLE) continue;
+
+                hasLibassSubtitles = hasLibassSubtitles || VideoManagerHelperKt.usesLibassSubtitleRendering(mediaStream);
 
                 if (mediaStream.getDeliveryMethod() == SubtitleDeliveryMethod.EXTERNAL) {
                     Uri subtitleUri = Uri.parse(api.createUrl(mediaStream.getDeliveryUrl(), Collections.emptyMap(), Collections.emptyMap(), true));
@@ -369,6 +389,10 @@ public class VideoManager {
                     Timber.i("Adding subtitle track %s of type %s", subtitleConfiguration.uri, subtitleConfiguration.mimeType);
                     subtitleConfigurations.add(subtitleConfiguration);
                 }
+            }
+
+            if (mLibassSubtitleController != null && hasLibassSubtitles) {
+                mLibassSubtitleController.registerFallbackFonts(api);
             }
 
             MediaItem mediaItem = new MediaItem.Builder()
@@ -555,6 +579,12 @@ public class VideoManager {
         Timber.d("Setting playback speed: %f", speed);
 
         mExoPlayer.setPlaybackParameters(new PlaybackParameters(speed));
+    }
+
+    public void clearLibassSubtitles() {
+        if (mLibassSubtitleController != null) {
+            mLibassSubtitleController.clearSelectedTrack();
+        }
     }
 
     public void destroy() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
@@ -5,8 +5,11 @@ import android.media.audiofx.DynamicsProcessing
 import android.media.audiofx.Equalizer
 import android.os.Build
 import androidx.core.net.toUri
+import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.playback.media3.exoplayer.mapping.getFfmpegSubtitleMimeType
 import org.jellyfin.sdk.model.api.MediaStream
+import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import timber.log.Timber
 
 /**
@@ -22,6 +25,19 @@ fun getSubtitleMediaStreamCodec(stream: MediaStream): String {
 
 	return urlExtensionMediaType ?: codecMediaType ?: urlSubtitleExtension ?: codec
 }
+
+fun usesLibassSubtitleRendering(codec: String?, deliveryMethod: SubtitleDeliveryMethod?): Boolean {
+	val isAssCodec = codec.equals(Codec.Subtitle.ASS, ignoreCase = true) ||
+		codec.equals(Codec.Subtitle.SSA, ignoreCase = true)
+
+	return isAssCodec && (
+		deliveryMethod == SubtitleDeliveryMethod.EMBED ||
+			deliveryMethod == SubtitleDeliveryMethod.EXTERNAL
+		)
+}
+
+fun MediaStream.usesLibassSubtitleRendering(): Boolean =
+	type == MediaStreamType.SUBTITLE && usesLibassSubtitleRendering(codec, deliveryMethod)
 
 private var audioEffect: AudioEffect? = null
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/PlaybackAdvancedPreferencesScreen.kt
@@ -98,6 +98,11 @@ class PlaybackAdvancedPreferencesScreen : OptionsFragment() {
 			}
 
 			checkbox {
+				setTitle(R.string.preference_enable_libass)
+				bind(userPreferences, UserPreferences.assDirectPlay)
+			}
+
+			checkbox {
 				setTitle(R.string.preference_enable_pgs)
 				bind(userPreferences, UserPreferences.pgsDirectPlay)
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -6,14 +6,35 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.util.Size
-import androidx.core.content.ContextCompat
 import androidx.media3.common.MimeTypes
 import timber.log.Timber
 
+@Suppress("TooManyFunctions")
+interface DeviceProfileCapabilities {
+	fun supportsAV1(): Boolean
+	fun supportsAV1Main10(): Boolean
+	fun supportsAV1DolbyVision(): Boolean
+	fun supportsAV1HDR10(): Boolean
+	fun supportsAV1HDR10Plus(): Boolean
+	fun supportsAVC(): Boolean
+	fun supportsAVCHigh10(): Boolean
+	fun getAVCMainLevel(): Int
+	fun getAVCHigh10Level(): Int
+	fun supportsHevc(): Boolean
+	fun supportsHevcMain10(): Boolean
+	fun supportsHevcDolbyVision(): Boolean
+	fun supportsHevcDolbyVisionEL(): Boolean
+	fun supportsHevcHDR10(): Boolean
+	fun supportsHevcHDR10Plus(): Boolean
+	fun getHevcMainLevel(): Int
+	fun getHevcMain10Level(): Int
+	fun supportsVc1(): Boolean
+	fun getMaxResolution(mime: String): Size
+}
+
 class MediaCodecCapabilitiesTest(
 	private val context: Context,
-) {
-	private val display by lazy { ContextCompat.getDisplayOrDefault(context) }
+) : DeviceProfileCapabilities {
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
 
 	// Map common Dolby Vision Profiles to their corresponding CodecProfileLevel constant
@@ -97,46 +118,46 @@ class MediaCodecCapabilitiesTest(
 		CodecProfileLevel.HEVCMainTierLevel62 to 186,
 	)
 
-	fun supportsAV1(): Boolean = hasCodecForMime(MimeTypes.VIDEO_AV1)
+	override fun supportsAV1(): Boolean = hasCodecForMime(MimeTypes.VIDEO_AV1)
 
-	fun supportsAV1Main10(): Boolean = hasDecoder(
+	override fun supportsAV1Main10(): Boolean = hasDecoder(
 		MimeTypes.VIDEO_AV1,
 		AV1ProfileLevel.ProfileMain10,
 		AV1ProfileLevel.Level5
 	)
 
-	fun supportsAV1DolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+	override fun supportsAV1DolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
 		hasDecoder(
 			MimeTypes.VIDEO_DOLBY_VISION,
 			AV1ProfileLevel.DolbyVisionProfile10,
 			CodecProfileLevel.DolbyVisionLevelHd24
 		)
 
-	fun supportsAV1HDR10(): Boolean = hasDecoder(
+	override fun supportsAV1HDR10(): Boolean = hasDecoder(
 		MimeTypes.VIDEO_AV1,
 		AV1ProfileLevel.ProfileMain10HDR10,
 		AV1ProfileLevel.Level5
 	)
 
-	fun supportsAV1HDR10Plus(): Boolean = hasDecoder(
+	override fun supportsAV1HDR10Plus(): Boolean = hasDecoder(
 		MimeTypes.VIDEO_AV1,
 		AV1ProfileLevel.ProfileMain10HDR10Plus,
 		AV1ProfileLevel.Level5
 	)
 
-	fun supportsAVC(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AVC)
+	override fun supportsAVC(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AVC)
 
-	fun supportsAVCHigh10(): Boolean = hasDecoder(
+	override fun supportsAVCHigh10(): Boolean = hasDecoder(
 		MediaFormat.MIMETYPE_VIDEO_AVC,
 		CodecProfileLevel.AVCProfileHigh10,
 		CodecProfileLevel.AVCLevel4
 	)
 
-	fun getAVCMainLevel(): Int = getAVCLevel(
+	override fun getAVCMainLevel(): Int = getAVCLevel(
 		CodecProfileLevel.AVCProfileMain
 	)
 
-	fun getAVCHigh10Level(): Int = getAVCLevel(
+	override fun getAVCHigh10Level(): Int = getAVCLevel(
 		CodecProfileLevel.AVCProfileHigh10
 	)
 
@@ -148,20 +169,20 @@ class MediaCodecCapabilitiesTest(
 		}?.second ?: 0
 	}
 
-	fun supportsHevc(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_HEVC)
+	override fun supportsHevc(): Boolean = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_HEVC)
 
-	fun supportsHevcMain10(): Boolean = hasDecoder(
+	override fun supportsHevcMain10(): Boolean = hasDecoder(
 		MediaFormat.MIMETYPE_VIDEO_HEVC,
 		CodecProfileLevel.HEVCProfileMain10,
 		CodecProfileLevel.HEVCMainTierLevel4
 	)
 
 	// Can safely assume Dolby Vision decoders support single-layer HEVC profiles
-	fun supportsHevcDolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+	override fun supportsHevcDolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
 		hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION)
 
 	// Checks for Dolby Vision Profile 7 (Enhancement Layer) and multi-instance HEVC support
-	fun supportsHevcDolbyVisionEL(): Boolean =
+	override fun supportsHevcDolbyVisionEL(): Boolean =
 		Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
 			hasDecoder(
 				MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION,
@@ -170,25 +191,25 @@ class MediaCodecCapabilitiesTest(
 			) &&
 			supportsMultiInstance(MediaFormat.MIMETYPE_VIDEO_HEVC)
 
-	fun supportsHevcHDR10(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+	override fun supportsHevcHDR10(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
 		hasDecoder(
 			MediaFormat.MIMETYPE_VIDEO_HEVC,
 			CodecProfileLevel.HEVCProfileMain10HDR10,
 			CodecProfileLevel.HEVCMainTierLevel4
 		)
 
-	fun supportsHevcHDR10Plus(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+	override fun supportsHevcHDR10Plus(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
 		hasDecoder(
 			MediaFormat.MIMETYPE_VIDEO_HEVC,
 			CodecProfileLevel.HEVCProfileMain10HDR10Plus,
 			CodecProfileLevel.HEVCMainTierLevel4
 		)
 
-	fun getHevcMainLevel(): Int = getHevcLevel(
+	override fun getHevcMainLevel(): Int = getHevcLevel(
 		CodecProfileLevel.HEVCProfileMain
 	)
 
-	fun getHevcMain10Level(): Int = getHevcLevel(
+	override fun getHevcMain10Level(): Int = getHevcLevel(
 		CodecProfileLevel.HEVCProfileMain10
 	)
 
@@ -200,7 +221,7 @@ class MediaCodecCapabilitiesTest(
 		}?.second ?: 0
 	}
 
-	fun supportsVc1(): Boolean = hasCodecForMime(MimeTypes.VIDEO_VC1)
+	override fun supportsVc1(): Boolean = hasCodecForMime(MimeTypes.VIDEO_VC1)
 
 	private fun getDecoderLevel(mime: String, profile: Int): Int {
 		var maxLevel = 0
@@ -283,7 +304,7 @@ class MediaCodecCapabilitiesTest(
 		return false
 	}
 
-	fun getMaxResolution(mime: String): Size {
+	override fun getMaxResolution(mime: String): Size {
 		var maxWidth = 0
 		var maxHeight = 0
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -64,13 +64,13 @@ fun createDeviceProfile(
 	maxBitrate = userPreferences.getMaxBitrate(),
 	isAC3Enabled = userPreferences[UserPreferences.ac3Enabled],
 	downMixAudio = userPreferences[UserPreferences.audioBehaviour] == AudioBehavior.DOWNMIX_TO_STEREO,
-	assDirectPlay = false,
+	assDirectPlay = userPreferences[UserPreferences.assDirectPlay],
 	pgsDirectPlay = userPreferences[UserPreferences.pgsDirectPlay],
 	jellyfinTenEleven = serverVersion >= ServerVersion(10, 11, 0),
 )
 
 fun createDeviceProfile(
-	mediaTest: MediaCodecCapabilitiesTest,
+	mediaTest: DeviceProfileCapabilities,
 	maxBitrate: Int,
 	isAC3Enabled: Boolean,
 	downMixAudio: Boolean,

--- a/app/src/test/kotlin/ui/playback/SubtitleRoutingTests.kt
+++ b/app/src/test/kotlin/ui/playback/SubtitleRoutingTests.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.androidtv.ui.playback
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
+
+class SubtitleRoutingTests : FunSpec({
+	test("ASS and SSA direct subtitle tracks use libass routing") {
+		usesLibassSubtitleRendering("ass", SubtitleDeliveryMethod.EMBED) shouldBe true
+		usesLibassSubtitleRendering("ssa", SubtitleDeliveryMethod.EXTERNAL) shouldBe true
+		usesLibassSubtitleRendering("ASS", SubtitleDeliveryMethod.EXTERNAL) shouldBe true
+	}
+
+	test("non-ASS or baked subtitle tracks keep existing routing") {
+		usesLibassSubtitleRendering("srt", SubtitleDeliveryMethod.EXTERNAL) shouldBe false
+		usesLibassSubtitleRendering("vtt", SubtitleDeliveryMethod.HLS) shouldBe false
+		usesLibassSubtitleRendering("pgs", SubtitleDeliveryMethod.EMBED) shouldBe false
+		usesLibassSubtitleRendering("ass", SubtitleDeliveryMethod.ENCODE) shouldBe false
+		usesLibassSubtitleRendering(null, SubtitleDeliveryMethod.EXTERNAL) shouldBe false
+	}
+})

--- a/app/src/test/kotlin/util/profile/DeviceProfileSubtitleTests.kt
+++ b/app/src/test/kotlin/util/profile/DeviceProfileSubtitleTests.kt
@@ -1,0 +1,82 @@
+package org.jellyfin.androidtv.util.profile
+
+import android.util.Size
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.mockk.every
+import io.mockk.mockk
+import org.jellyfin.androidtv.constant.Codec
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
+
+class DeviceProfileSubtitleTests : FunSpec({
+	test("ASS and SSA profiles direct play when libass is enabled") {
+		val profile = createDeviceProfile(
+			mediaTest = testCapabilities(),
+			maxBitrate = 100_000_000,
+			isAC3Enabled = true,
+			downMixAudio = false,
+			assDirectPlay = true,
+			pgsDirectPlay = false,
+			jellyfinTenEleven = true,
+		)
+
+		profile.methodsFor(Codec.Subtitle.ASS) shouldContainExactlyInAnyOrder listOf(
+			SubtitleDeliveryMethod.EMBED,
+			SubtitleDeliveryMethod.EXTERNAL,
+			SubtitleDeliveryMethod.ENCODE,
+		)
+		profile.methodsFor(Codec.Subtitle.SSA) shouldContainExactlyInAnyOrder listOf(
+			SubtitleDeliveryMethod.EMBED,
+			SubtitleDeliveryMethod.EXTERNAL,
+			SubtitleDeliveryMethod.ENCODE,
+		)
+	}
+
+	test("ASS and SSA profiles only encode when libass is disabled") {
+		val profile = createDeviceProfile(
+			mediaTest = testCapabilities(),
+			maxBitrate = 100_000_000,
+			isAC3Enabled = true,
+			downMixAudio = false,
+			assDirectPlay = false,
+			pgsDirectPlay = false,
+			jellyfinTenEleven = true,
+		)
+
+		profile.methodsFor(Codec.Subtitle.ASS) shouldContainExactlyInAnyOrder listOf(SubtitleDeliveryMethod.ENCODE)
+		profile.methodsFor(Codec.Subtitle.SSA) shouldContainExactlyInAnyOrder listOf(SubtitleDeliveryMethod.ENCODE)
+	}
+})
+
+private fun org.jellyfin.sdk.model.api.DeviceProfile.methodsFor(format: String) = subtitleProfiles
+	.filter { it.format == format }
+	.map { it.method }
+
+private fun testCapabilities(): DeviceProfileCapabilities {
+	val zeroSize = mockk<Size> {
+		every { width } returns 0
+		every { height } returns 0
+	}
+
+	return object : DeviceProfileCapabilities {
+		override fun supportsAV1() = false
+		override fun supportsAV1Main10() = false
+		override fun supportsAV1DolbyVision() = false
+		override fun supportsAV1HDR10() = false
+		override fun supportsAV1HDR10Plus() = false
+		override fun supportsAVC() = false
+		override fun supportsAVCHigh10() = false
+		override fun getAVCMainLevel() = 0
+		override fun getAVCHigh10Level() = 0
+		override fun supportsHevc() = false
+		override fun supportsHevcMain10() = false
+		override fun supportsHevcDolbyVision() = false
+		override fun supportsHevcDolbyVisionEL() = false
+		override fun supportsHevcHDR10() = false
+		override fun supportsHevcHDR10Plus() = false
+		override fun getHevcMainLevel() = 0
+		override fun getHevcMain10Level() = 0
+		override fun supportsVc1() = false
+		override fun getMaxResolution(mime: String) = zeroSize
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ kotest = "6.0.4"
 kotlin = "2.2.21"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
+libass-android = "0.4.0"
 markwon = "4.6.2"
 mockk = "1.14.6"
 slf4j-timber = "0.0.4"
@@ -95,6 +96,8 @@ androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "androidx-media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 jellyfin-androidx-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-decoder", version.ref = "jellyfin-androidx-media" }
+libass-android-kt = { module = "io.github.peerless2012:ass-kt", version.ref = "libass-android" }
+libass-android-media = { module = "io.github.peerless2012:ass-media", version.ref = "libass-android" }
 
 # Markwon
 markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }

--- a/playback/libass/build.gradle.kts
+++ b/playback/libass/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+	id("com.android.library")
+	kotlin("android")
+}
+
+android {
+	namespace = "org.jellyfin.playback.libass"
+	compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+	defaultConfig {
+		minSdk = libs.versions.android.minSdk.get().toInt()
+	}
+
+	lint {
+		lintConfig = file("$rootDir/android-lint.xml")
+		abortOnError = false
+	}
+
+	testOptions.unitTests.all {
+		it.useJUnitPlatform()
+	}
+}
+
+dependencies {
+	// Jellyfin
+	implementation(libs.jellyfin.sdk)
+
+	// Kotlin
+	implementation(libs.kotlinx.coroutines)
+
+	// Media3
+	implementation(libs.androidx.media3.exoplayer)
+	implementation(libs.androidx.media3.ui)
+	implementation(libs.libass.android.kt)
+	implementation(libs.libass.android.media)
+
+	// Logging
+	implementation(libs.timber)
+
+	// Compatibility (desugaring)
+	coreLibraryDesugaring(libs.android.desugar)
+
+	// Testing
+	testImplementation(libs.kotest.runner.junit5)
+	testImplementation(libs.kotest.assertions)
+}

--- a/playback/libass/src/main/AndroidManifest.xml
+++ b/playback/libass/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/playback/libass/src/main/kotlin/org/jellyfin/playback/libass/LibassSubtitleController.kt
+++ b/playback/libass/src/main/kotlin/org/jellyfin/playback/libass/LibassSubtitleController.kt
@@ -1,0 +1,116 @@
+package org.jellyfin.playback.libass
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.RenderersFactory
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.extractor.ExtractorsFactory
+import androidx.media3.ui.SubtitleView
+import io.github.peerless2012.ass.media.AssHandler
+import io.github.peerless2012.ass.media.kt.withAssMkvSupport
+import io.github.peerless2012.ass.media.kt.withAssSupport
+import io.github.peerless2012.ass.media.parser.AssSubtitleParserFactory
+import io.github.peerless2012.ass.media.type.AssRenderType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.subtitleApi
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+
+@OptIn(UnstableApi::class)
+class LibassSubtitleController(
+	private val renderType: AssRenderType = AssRenderType.OVERLAY_CANVAS,
+) {
+	private val assHandler = AssHandler(renderType)
+	private var attachedPlayer: ExoPlayer? = null
+	private var attachedSubtitleView: SubtitleView? = null
+
+	fun configure(
+		builder: ExoPlayer.Builder,
+		dataSourceFactory: DataSource.Factory,
+		extractorsFactory: ExtractorsFactory,
+		renderersFactory: RenderersFactory,
+	) {
+		val subtitleParserFactory = AssSubtitleParserFactory(assHandler)
+		val mediaSourceFactory = DefaultMediaSourceFactory(
+			dataSourceFactory,
+			extractorsFactory.withAssMkvSupport(subtitleParserFactory, assHandler),
+		)
+
+		mediaSourceFactory.setSubtitleParserFactory(subtitleParserFactory)
+
+		builder
+			.setMediaSourceFactory(mediaSourceFactory)
+			.setRenderersFactory(renderersFactory.withAssSupport(assHandler))
+	}
+
+	fun attach(player: ExoPlayer, subtitleView: SubtitleView?) {
+		if (attachedPlayer !== player) {
+			assHandler.init(player)
+			attachedPlayer = player
+		}
+
+		if (renderType == AssRenderType.OVERLAY_CANVAS || renderType == AssRenderType.OVERLAY_OPEN_GL) {
+			if (subtitleView != null && attachedSubtitleView !== subtitleView) {
+				subtitleView.withAssSupport(assHandler)
+				attachedSubtitleView = subtitleView
+			}
+		}
+	}
+
+	fun clearSelectedTrack() {
+		assHandler.render?.setTrack(null)
+	}
+
+	fun registerFallbackFonts(api: ApiClient) {
+		val cacheKey = api.hashCode()
+		val deferred = fallbackFontCache.computeIfAbsent(cacheKey) {
+			fontScope.async {
+				loadFallbackFonts(api)
+			}
+		}
+
+		fontScope.launch {
+			runCatching {
+				deferred.await()
+			}.onSuccess { fonts ->
+				fonts.forEach { font ->
+					assHandler.addFont(font.name, font.data)
+				}
+			}.onFailure { error ->
+				fallbackFontCache.remove(cacheKey, deferred)
+				Timber.w(error, "Unable to load Jellyfin fallback subtitle fonts for libass")
+			}
+		}
+	}
+
+	private suspend fun loadFallbackFonts(api: ApiClient): List<FallbackFont> {
+		val fonts = api.subtitleApi.getFallbackFontList().content
+
+		return fonts.mapNotNull { font ->
+			val name = font.name ?: return@mapNotNull null
+			runCatching {
+				FallbackFont(name, api.subtitleApi.getFallbackFont(name).content)
+			}.onFailure { error ->
+				Timber.w(error, "Unable to load Jellyfin fallback subtitle font %s", name)
+			}.getOrNull()
+		}
+	}
+
+	private class FallbackFont(
+		val name: String,
+		val data: ByteArray,
+	)
+
+	companion object {
+		private val fontScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+		private val fallbackFontCache = ConcurrentHashMap<Int, Deferred<List<FallbackFont>>>()
+	}
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(":app")
 // Modules
 include(":playback:core")
 include(":playback:jellyfin")
+include(":playback:libass")
 include(":playback:media3:exoplayer")
 include(":playback:media3:session")
 include(":preference")


### PR DESCRIPTION
**Changes**
- Add a new `:playback:libass` module that wires libass subtitle parsing/rendering into Media3 playback.
- Add an advanced playback preference for ASS/SSA direct play, and only advertise direct ASS/SSA subtitle delivery when that preference is enabled.
- Route ASS/SSA subtitle selection through libass rendering while preserving encoded subtitle fallback behavior.
- Add subtitle routing and device profile tests for direct ASS/SSA behavior.

**Code assistance**
Codex helped stage this pull request from the local branch, summarize the changes, and prepare the PR description.

**Issues**
None linked.