### PR TITLE
Queue home videos from the same folder

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -156,11 +156,15 @@ public class ItemLauncher {
                             break;
                         case Play:
                             //Just play it directly
-                            playbackHelper.getValue().getItemsToPlay(context, baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
+                            final BaseItemDto itemToPlay = baseItem;
+                            playbackHelper.getValue().getItemsToPlay(context, itemToPlay, itemToPlay.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
                                 @Override
                                 public void onResponse(List<BaseItemDto> response) {
                                     if (!isActive()) return;
-                                    playbackLauncher.getValue().launch(context, response);
+                                    int itemPosition = itemToPlay.getType() == BaseItemKind.VIDEO
+                                            ? findItemPosition(response, itemToPlay)
+                                            : 0;
+                                    playbackLauncher.getValue().launch(context, response, null, false, itemPosition);
                                 }
                             });
                             break;
@@ -273,5 +277,15 @@ public class ItemLauncher {
                 }
                 break;
         }
+    }
+
+    private int findItemPosition(List<BaseItemDto> items, BaseItemDto selectedItem) {
+        for (int index = 0; index < items.size(); index++) {
+            if (items.get(index).getId().equals(selectedItem.getId())) {
+                return index;
+            }
+        }
+
+        return 0;
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -235,7 +235,7 @@ class SdkPlaybackHelper(
 				if (parentId == null) {
 					getParts(mainItem)
 				} else {
-					val siblingVideos = getVideosInFolder(parentId)
+					val siblingVideos = getVideosInFolder(parentId, mainItem)
 					if (siblingVideos.any { it.id == mainItem.id } && siblingVideos.size > 1) {
 						siblingVideos
 					} else {
@@ -262,27 +262,18 @@ class SdkPlaybackHelper(
 		}
 	}
 
-	private suspend fun getVideosInFolder(parentId: UUID): List<BaseItemDto> {
-		val videos = mutableListOf<BaseItemDto>()
-		var totalRecordCount: Int
+	private suspend fun getVideosInFolder(parentId: UUID, item: BaseItemDto): List<BaseItemDto> {
+		val response by api.itemsApi.getItems(
+			parentId = parentId,
+			isMissing = false,
+			includeItemTypes = listOf(BaseItemKind.VIDEO),
+			sortBy = listOf(ItemSortBy.SORT_NAME),
+			nameStartsWithOrGreater = item.sortName ?: item.name,
+			limit = ITEM_QUERY_LIMIT,
+			fields = ItemRepository.itemFields,
+		)
 
-		do {
-			val response by api.itemsApi.getItems(
-				parentId = parentId,
-				isMissing = false,
-				includeItemTypes = listOf(BaseItemKind.VIDEO),
-				sortBy = listOf(ItemSortBy.SORT_NAME),
-				startIndex = videos.size,
-				limit = ITEM_QUERY_LIMIT,
-				fields = ItemRepository.itemFields,
-			)
-
-			totalRecordCount = response.totalRecordCount
-			if (response.items.isEmpty()) break
-			videos += response.items
-		} while (videos.size < totalRecordCount)
-
-		return videos
+		return response.items
 	}
 
 	private suspend fun getParts(item: BaseItemDto): List<BaseItemDto> = buildList {

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -230,6 +230,20 @@ class SdkPlaybackHelper(
 				}
 			}
 
+			BaseItemKind.VIDEO -> {
+				val parentId = mainItem.parentId
+				if (parentId == null) {
+					getParts(mainItem)
+				} else {
+					val siblingVideos = getVideosInFolder(parentId)
+					if (siblingVideos.any { it.id == mainItem.id } && siblingVideos.size > 1) {
+						siblingVideos
+					} else {
+						getParts(mainItem)
+					}
+				}
+			}
+
 			else -> {
 				val parts = getParts(mainItem)
 				val addIntros = allowIntros && userPreferences[UserPreferences.cinemaModeEnabled]
@@ -246,6 +260,29 @@ class SdkPlaybackHelper(
 				}
 			}
 		}
+	}
+
+	private suspend fun getVideosInFolder(parentId: UUID): List<BaseItemDto> {
+		val videos = mutableListOf<BaseItemDto>()
+		var totalRecordCount: Int
+
+		do {
+			val response by api.itemsApi.getItems(
+				parentId = parentId,
+				isMissing = false,
+				includeItemTypes = listOf(BaseItemKind.VIDEO),
+				sortBy = listOf(ItemSortBy.SORT_NAME),
+				startIndex = videos.size,
+				limit = ITEM_QUERY_LIMIT,
+				fields = ItemRepository.itemFields,
+			)
+
+			totalRecordCount = response.totalRecordCount
+			if (response.items.isEmpty()) break
+			videos += response.items
+		} while (videos.size < totalRecordCount)
+
+		return videos
 	}
 
 	private suspend fun getParts(item: BaseItemDto): List<BaseItemDto> = buildList {


### PR DESCRIPTION
**Changes**

When playing a standalone home video item, load sibling videos from the same parent folder and start playback at the selected item. This lets home videos in the same folder play as a queue instead of only playing the selected video.

**Code assistance**

No code assistance, all natural.