### PR TITLE
fix: skip image load when aspect ratio is negative (corrupt image)

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/AsyncImageView.kt
@@ -76,7 +76,7 @@ class AsyncImageView @JvmOverloads constructor(
 
 			// Only show blurhash if an image is going to be loaded from the network
 			val isLowRamDevice = context.getSystemService<ActivityManager>()?.isLowRamDevice == true
-			if (url != null && blurHash != null && !isLowRamDevice) withContext(Dispatchers.IO) {
+			if (url != null && blurHash != null && !isLowRamDevice && aspectRatio > 0) withContext(Dispatchers.IO) {
 				val blurHashBitmap = BlurHashDecoder.decode(
 					blurHash,
 					if (aspectRatio > 1) round(blurHashResolution * aspectRatio).toInt() else blurHashResolution,

--- a/app/src/main/java/org/jellyfin/androidtv/util/BlurHashDecoder.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/BlurHashDecoder.kt
@@ -15,7 +15,7 @@ object BlurHashDecoder {
 	 * Decode a blur hash into a new bitmap.
 	 */
 	fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
-		if (blurHash == null || blurHash.length < 6) return null
+		if (blurHash == null || blurHash.length < 6 || width <= 0 || height <= 0) return null
 
 		val numCompEnc = decode83(blurHash, 0, 1)
 		val numCompX = (numCompEnc % 9) + 1


### PR DESCRIPTION
**Changes:**

Skip image loading entirely when PrimaryImageAspectRatio is negative or zero, as this indicates corrupt/unprocessable image data from the server (e.g. SkiaSharp codec returning -1 for dimensions). Instead of attempting to decode a BlurHash with invalid dimensions and crashing with NegativeArraySizeException, the placeholder is shown. Additionally, BlurHashDecoder.decode() now validates that width and height are positive before proceeding as a defensive guard.

**Code assistance:**

GitHub Copilot assisted with implementing the fix and structuring the defensive checks.

**Issues:**

Fixes #5567
