### PR TITLE
Fix video player not unlocking screensaver when playback ends

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -607,6 +607,7 @@ public class VideoManager {
     }
 
     private void releasePlayer() {
+        _helper.setScreensaverLock(false);
         if (mExoPlayer != null) {
             mExoPlayerView.setPlayer(null);
             mExoPlayer.release();


### PR DESCRIPTION
**Changes**

The video player uses a dynamic screensaver lock that activates only when the media is playing. However, when the video player is closed automatically because playback of the final queue item ends it would never unlock, causing the screensaver to not show up until the app is restarted.

Add an additional, explicit, unlock when the player is released to avoid this problem.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #5097