### PR TITLE
Fix external subtitles not showing on external player

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -56,6 +56,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 		private const val API_MX_SUBS = "subs"
 		private const val API_MX_SUBS_NAME = "subs.name"
 		private const val API_MX_SUBS_FILENAME = "subs.filename"
+		private const val API_MX_SUBS_ENABLE = "subs.enable"
 		private const val API_MX_RESULT_ID = "com.mxtech.intent.result.VIEW"
 		private const val API_MX_RESULT_END_BY = "end_by"
 		private const val API_MX_RESULT_END_BY_PLAYBACK_COMPLETION = "playback_completion"
@@ -149,6 +150,7 @@ class ExternalPlayerActivity : FragmentActivity() {
 				routeFormat = format,
 			)
 		}.toTypedArray()
+		var subtitleUrlsToUris = subtitleUrls.map { it.toUri() }.toTypedArray();
 		val subtitleNames = externalSubtitles.map { it.displayTitle ?: it.title.orEmpty() }.toTypedArray()
 		val subtitleLanguages = externalSubtitles.map { it.language.orEmpty() }.toTypedArray()
 
@@ -178,9 +180,10 @@ class ExternalPlayerActivity : FragmentActivity() {
 			putExtra(API_MX_TITLE, title)
 			putExtra(API_MX_FILENAME, fileName)
 			putExtra(API_MX_SECURE_URI, true)
-			putExtra(API_MX_SUBS, subtitleUrls)
+			putExtra(API_MX_SUBS, subtitleUrlsToUris)
 			putExtra(API_MX_SUBS_NAME, subtitleNames)
 			putExtra(API_MX_SUBS_FILENAME, subtitleLanguages)
+			if (subtitleUrlsToUris.isNotEmpty()) putExtra(API_MX_SUBS_ENABLE, arrayOf(subtitleUrlsToUris.first()))
 
 			if (subtitleUrls.isNotEmpty()) putExtra(API_VLC_SUBTITLES, subtitleUrls.first().toString())
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
As of [mpv intent spec](https://mpv-android.github.io/mpv-android/intent.html), `subs` and `subs.enable` should be `ParcelableArray of Uri`.

0.18 [respects this](https://github.com/jellyfin/jellyfin-androidtv/blob/675ae7c391841c87ce1df8ed5dc5555c59f5c612/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java#L399). 0.19 passed [`Array<String>`](https://github.com/jellyfin/jellyfin-androidtv/blob/f76083e809504c546402aec73cbe12d40b3fb5de/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt#L140) instead.
This pr fixes this regression, by introducing another var `subtitleUrlsToUris`, in case of breaking other code.
Please let me know if you think `subtitleUrls` itself should be `Array<String>`.

0.18 passed [`subs.enable`](https://github.com/jellyfin/jellyfin-androidtv/blob/675ae7c391841c87ce1df8ed5dc5555c59f5c612/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.java#L422) but 0.19 removed it. This pr adds it back.


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
No AI is used.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #5095 