### PR TITLE
Fix next episode row showing wrong episode when episodes are missing

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -618,10 +618,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                     addItemRow(adapter, additionalPartsAdapter, 0, getString(R.string.lbl_additional_parts));
                 }
 
-                if (mBaseItem.getSeasonId() != null && mBaseItem.getIndexNumber() != null) {
-                    // query index is zero-based but episode no is not
-                    ItemRowAdapter nextAdapter = new ItemRowAdapter(requireContext(), BrowsingUtils.createNextEpisodesRequest(mBaseItem.getSeasonId(), mBaseItem.getIndexNumber()), 0, false, true, new CardPresenter(true, 120), adapter);
-                    addItemRow(adapter, nextAdapter, 5, getString(R.string.lbl_next_episode));
+                if (mBaseItem.getSeriesId() != null && mBaseItem.getSeasonId() != null) {
+                    FullDetailsFragmentHelperKt.loadNextEpisodes(this, adapter);
                 }
 
                 //Guest stars

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragmentHelper.kt
@@ -21,6 +21,8 @@ import org.jellyfin.androidtv.util.sdk.TrailerUtils.getExternalTrailerIntent
 import org.jellyfin.androidtv.util.sdk.compat.canResume
 import org.jellyfin.androidtv.util.sdk.compat.copyWithUserData
 import org.jellyfin.androidtv.util.showIfNotEmpty
+import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
+import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.extensions.libraryApi
@@ -226,6 +228,34 @@ fun FullDetailsFragment.populatePreviousButton() {
 		mPrevButton.isVisible = previousItem != null
 
 		showMoreButtonIfNeeded()
+	}
+}
+
+fun FullDetailsFragment.loadNextEpisodes(adapter: org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter<androidx.leanback.widget.Row>) {
+	val api by inject<ApiClient>()
+
+	lifecycleScope.launch {
+		try {
+			val episodes = withContext(Dispatchers.IO) {
+				api.tvShowsApi.getEpisodes(
+					seriesId = requireNotNull(mBaseItem.seriesId),
+					seasonId = mBaseItem.seasonId,
+					startItemId = mBaseItem.id,
+					isMissing = false,
+					fields = ItemRepository.itemFields,
+					limit = 21,
+				).content
+			}
+
+			// Remove the first item (current episode)
+			val nextEpisodes = episodes.items.drop(1)
+			if (nextEpisodes.isNotEmpty()) {
+				val nextAdapter = ItemRowAdapter(requireContext(), nextEpisodes, CardPresenter(true, 120), adapter, true)
+				addItemRow(adapter, nextAdapter, 5, getString(R.string.lbl_next_episode))
+			}
+		} catch (err: ApiClientException) {
+			Timber.w(err, "Failed to load next episodes")
+		}
 	}
 }
 


### PR DESCRIPTION
## The Problem

The "Next Episodes" row on the episode detail screen uses `startIndex` (a pagination offset) set to the episode's `indexNumber`. This only works when all episodes from 1 onward exist sequentially. When episodes are deleted or multi-part episodes shift the numbering, the offset lands on the wrong position in the list, showing an incorrect next episode.

For example: if episodes 1-12 are deleted, viewing episode 27 would show episode 39 as "next" because offset 27 in a list starting at episode 13 skips ahead.

## The Fix

Replace the generic `GetItemsRequest` with `startIndex` approach with `tvShowsApi.getEpisodes` using `startItemId`. This correctly asks the server for episodes starting from the current episode's ID, regardless of gaps in numbering.

## Changes

- `FullDetailsFragment.java`: Replace inline `ItemRowAdapter` creation with a call to `loadNextEpisodes()`
- `FullDetailsFragmentHelper.kt`: Add `loadNextEpisodes()` that uses `tvShowsApi.getEpisodes(startItemId = currentEpisodeId)` and creates a static `ItemRowAdapter` from the results

Fixes #1297