### PR TITLE
Add optional enhanced home screen with hero section

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -30,6 +30,7 @@ import org.jellyfin.androidtv.data.repository.UserViewsRepositoryImpl
 import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.integration.dream.DreamViewModel
 import org.jellyfin.androidtv.ui.InteractionTrackerViewModel
+import org.jellyfin.androidtv.ui.home.HomeViewModel
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
@@ -166,6 +167,7 @@ val appModule = module {
 	viewModel { SearchViewModel(get()) }
 	viewModel { DreamViewModel(get(), get(), get(), get(), get()) }
 	viewModel { SettingsViewModel() }
+	viewModel { HomeViewModel() }
 
 	single { BackgroundService(get(), get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -170,6 +170,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var seriesThumbnailsEnabled = booleanPreference("pref_enable_series_thumbnails", true)
 
 		/**
+		 * Enable enhanced home screen with hero section
+		 */
+		var enhancedHomeScreen = booleanPreference("pref_enhanced_home_screen", false)
+
+		/**
 		 * Subtitles foreground color
 		 */
 		var subtitlesBackgroundColor = longPreference("subtitles_background_color", 0x00FFFFFF)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragment.kt
@@ -5,8 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,6 +22,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.AndroidFragment
 import androidx.fragment.compose.content
@@ -29,14 +35,20 @@ import kotlinx.coroutines.flow.onEach
 import org.jellyfin.androidtv.auth.repository.ServerRepository
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
+import org.jellyfin.androidtv.data.service.BackgroundService
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.shared.toolbar.MainToolbar
 import org.jellyfin.androidtv.ui.shared.toolbar.MainToolbarActiveButton
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class HomeFragment : Fragment() {
 	private val sessionRepository by inject<SessionRepository>()
 	private val serverRepository by inject<ServerRepository>()
 	private val notificationRepository by inject<NotificationsRepository>()
+	private val backgroundService by inject<BackgroundService>()
+	private val homeViewModel by activityViewModel<HomeViewModel>()
+	private val userPreferences by inject<UserPreferences>()
 
 	override fun onCreateView(
 		inflater: LayoutInflater,
@@ -46,33 +58,101 @@ class HomeFragment : Fragment() {
 		val rowsFocusRequester = remember { FocusRequester() }
 		LaunchedEffect(rowsFocusRequester) { rowsFocusRequester.requestFocus() }
 
-		Column {
-			MainToolbar(MainToolbarActiveButton.Home)
+		// Observe preference changes
+		var enhancedHomeEnabled by remember { mutableStateOf(userPreferences[UserPreferences.enhancedHomeScreen]) }
 
-			// The leanback code has its own awful focus handling that doesn't work properly with Compose view inteop to workaround this
-			// issue we add custom behavior that only allows focus exit when the current selected row is the first one. Additionally when
-			// we do switch the focus, we reset the leanback state so it won't cause weird behavior when focus is regained
-			var rowsSupportFragment by remember { mutableStateOf<HomeRowsFragment?>(null) }
-			AndroidFragment<HomeRowsFragment>(
-				modifier = Modifier
-					.focusGroup()
-					.focusRequester(rowsFocusRequester)
-					.focusProperties {
-						onExit = {
-							val isFirstRowSelected = rowsSupportFragment?.selectedPosition?.let { it <= 0 } ?: false
-							if (requestedFocusDirection != FocusDirection.Up || !isFirstRowSelected) {
-								cancelFocusChange()
-							} else {
-								rowsSupportFragment?.selectedPosition = 0
-								rowsSupportFragment?.verticalGridView?.clearFocus()
+		DisposableEffect(Unit) {
+			val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+				if (key == UserPreferences.enhancedHomeScreen.key) {
+					enhancedHomeEnabled = userPreferences[UserPreferences.enhancedHomeScreen]
+					// Update background service based on preference
+					if (enhancedHomeEnabled) {
+						backgroundService.disable()
+					} else {
+						backgroundService.clearBackgrounds()
+					}
+				}
+			}
+
+			// Access SharedPreferences directly from the preference store
+			val sharedPrefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(requireContext())
+			sharedPrefs.registerOnSharedPreferenceChangeListener(listener)
+
+			onDispose {
+				sharedPrefs.unregisterOnSharedPreferenceChangeListener(listener)
+			}
+		}
+
+		if (enhancedHomeEnabled) {
+			// Enhanced home screen with hero section
+			Box(modifier = Modifier.fillMaxSize()) {
+				// Hero backdrop - extends down behind the rows
+				HomeHeroSection(
+					viewModel = homeViewModel,
+					modifier = Modifier.fillMaxSize()
+				)
+
+				// Foreground content
+				Column(modifier = Modifier.fillMaxSize()) {
+					MainToolbar(MainToolbarActiveButton.Home)
+
+					// Spacer to position rows over lower part of backdrop
+					Spacer(modifier = Modifier.height(160.dp))
+
+					// The leanback code has its own awful focus handling that doesn't work properly with Compose view inteop to workaround this
+					// issue we add custom behavior that only allows focus exit when the current selected row is the first one. Additionally when
+					// we do switch the focus, we reset the leanback state so it won't cause weird behavior when focus is regained
+					var rowsSupportFragment by remember { mutableStateOf<HomeRowsFragment?>(null) }
+					AndroidFragment<HomeRowsFragment>(
+						modifier = Modifier
+							.fillMaxWidth()
+							.weight(1f) // Take remaining space after toolbar and spacer
+							.focusGroup()
+							.focusRequester(rowsFocusRequester)
+							.focusProperties {
+								onExit = {
+									val isFirstRowSelected = rowsSupportFragment?.selectedPosition?.let { it <= 0 } ?: false
+									if (requestedFocusDirection != FocusDirection.Up || !isFirstRowSelected) {
+										cancelFocusChange()
+									} else {
+										rowsSupportFragment?.selectedPosition = 0
+										rowsSupportFragment?.verticalGridView?.clearFocus()
+									}
+								}
+							},
+						onUpdate = { fragment ->
+							rowsSupportFragment = fragment
+						}
+					)
+				}
+			}
+		} else {
+			// Original home screen without hero section
+			Column(modifier = Modifier.fillMaxSize()) {
+				MainToolbar(MainToolbarActiveButton.Home)
+
+				var rowsSupportFragment by remember { mutableStateOf<HomeRowsFragment?>(null) }
+				AndroidFragment<HomeRowsFragment>(
+					modifier = Modifier
+						.focusGroup()
+						.focusRequester(rowsFocusRequester)
+						.focusProperties {
+							onExit = {
+								val isFirstRowSelected = rowsSupportFragment?.selectedPosition?.let { it <= 0 } ?: false
+								if (requestedFocusDirection != FocusDirection.Up || !isFirstRowSelected) {
+									cancelFocusChange()
+								} else {
+									rowsSupportFragment?.selectedPosition = 0
+									rowsSupportFragment?.verticalGridView?.clearFocus()
+								}
 							}
 						}
+						.fillMaxSize(),
+					onUpdate = { fragment ->
+						rowsSupportFragment = fragment
 					}
-					.fillMaxSize(),
-				onUpdate = { fragment ->
-					rowsSupportFragment = fragment
-				}
-			)
+				)
+			}
 		}
 	}
 
@@ -89,5 +169,11 @@ class HomeFragment : Fragment() {
 				notificationRepository.updateServerNotifications(server)
 			}
 			.launchIn(viewLifecycleOwner.lifecycleScope)
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+		// Re-enable background service when leaving home screen
+		backgroundService.clearBackgrounds()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeHeroSection.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeHeroSection.kt
@@ -1,0 +1,180 @@
+package org.jellyfin.androidtv.ui.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem
+import org.jellyfin.androidtv.util.apiclient.getUrl
+import org.jellyfin.androidtv.util.apiclient.itemBackdropImages
+import org.jellyfin.sdk.api.client.ApiClient
+import org.koin.compose.koinInject
+
+@Composable
+fun HomeHeroSection(
+	viewModel: HomeViewModel,
+	modifier: Modifier = Modifier,
+) {
+	val focusedItem by viewModel.focusedItem.collectAsState()
+	val api = koinInject<ApiClient>()
+
+	Box(
+		modifier = modifier
+			.background(Color.Black) // Solid background as fallback
+	) {
+		// Background image
+		focusedItem?.let { item ->
+			val backdropUrl = item.baseItem?.itemBackdropImages?.firstOrNull()?.getUrl(api)
+
+			if (backdropUrl != null) {
+				AsyncImage(
+					model = ImageRequest.Builder(LocalContext.current)
+						.data(backdropUrl)
+						.crossfade(300)
+						.build(),
+					contentDescription = null,
+					modifier = Modifier.matchParentSize(),
+					contentScale = ContentScale.Crop
+				)
+			}
+		}
+
+		// Gradient overlay - strong gradient to make rows visible
+		Box(
+			modifier = Modifier
+				.matchParentSize()
+				.background(
+					brush = Brush.verticalGradient(
+						colors = listOf(
+							Color.Black.copy(alpha = 0.3f),
+							Color.Black.copy(alpha = 0.6f),
+							Color.Black.copy(alpha = 0.95f)
+						),
+						startY = 0f,
+						endY = 2000f
+					)
+				)
+		)
+
+		// Content - positioned at top
+		Column(
+			modifier = Modifier
+				.align(Alignment.TopStart)
+				.padding(start = 48.dp, top = 120.dp, end = 48.dp)
+				.fillMaxWidth(0.6f)
+		) {
+			// Show placeholder when no item is focused
+			if (focusedItem == null) {
+				Text(
+					text = "Select an item to see details",
+					fontSize = 24.sp,
+					color = Color.White.copy(alpha = 0.6f)
+				)
+			}
+
+			focusedItem?.let { item ->
+				// Title
+				Text(
+					text = item.getFullName(LocalContext.current) ?: "",
+					fontSize = 36.sp,
+					fontWeight = FontWeight.Bold,
+					color = Color.White,
+					maxLines = 2,
+					overflow = TextOverflow.Ellipsis
+				)
+
+				Spacer(modifier = Modifier.height(8.dp))
+
+				// Metadata row
+				Row(
+					verticalAlignment = Alignment.CenterVertically
+				) {
+					item.baseItem?.let { baseItem ->
+						// Community rating
+						baseItem.communityRating?.let { rating ->
+							Text(
+								text = "★ %.1f".format(rating),
+								fontSize = 18.sp,
+								color = Color.White.copy(alpha = 0.9f)
+							)
+							Spacer(modifier = Modifier.width(16.dp))
+						}
+
+						// Year
+						baseItem.productionYear?.let { year ->
+							Text(
+								text = year.toString(),
+								fontSize = 18.sp,
+								color = Color.White.copy(alpha = 0.9f)
+							)
+							Spacer(modifier = Modifier.width(16.dp))
+						}
+
+						// Runtime
+						baseItem.runTimeTicks?.let { ticks ->
+							val minutes = (ticks / 600000000).toInt()
+							val hours = minutes / 60
+							val mins = minutes % 60
+							val runtimeText = if (hours > 0) "${hours}h ${mins}m" else "${mins}m"
+
+							Text(
+								text = runtimeText,
+								fontSize = 18.sp,
+								color = Color.White.copy(alpha = 0.9f)
+							)
+							Spacer(modifier = Modifier.width(16.dp))
+						}
+
+						// Content rating
+						baseItem.officialRating?.let { rating ->
+							Text(
+								text = rating,
+								fontSize = 16.sp,
+								color = Color.White.copy(alpha = 0.8f),
+								modifier = Modifier
+									.background(Color.White.copy(alpha = 0.2f))
+									.padding(horizontal = 8.dp, vertical = 4.dp)
+							)
+						}
+					}
+				}
+
+				Spacer(modifier = Modifier.height(12.dp))
+
+				// Description
+				item.baseItem?.overview?.let { overview ->
+					Text(
+						text = overview,
+						fontSize = 14.sp,
+						color = Color.White.copy(alpha = 0.85f),
+						maxLines = 2,
+						overflow = TextOverflow.Ellipsis,
+						lineHeight = 20.sp
+					)
+				}
+			}
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -56,11 +56,13 @@ import org.jellyfin.sdk.api.sockets.subscribe
 import org.jellyfin.sdk.model.api.LibraryChangedMessage
 import org.jellyfin.sdk.model.api.UserDataChangedMessage
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
 
 class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyListener {
 	private val api by inject<ApiClient>()
+	private val homeViewModel by activityViewModel<HomeViewModel>()
 	private val backgroundService by inject<BackgroundService>()
 	private val playbackManager by inject<PlaybackManager>()
 	private val mediaManager by inject<MediaManager>()
@@ -88,7 +90,9 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
-		adapter = MutableObjectAdapter<Row>(PositionableListRowPresenter())
+		// Add horizontal spacing to prevent card overlap on focus (12dp)
+		val horizontalSpacing = (12 * resources.displayMetrics.density).toInt()
+		adapter = MutableObjectAdapter<Row>(PositionableListRowPresenter(null, horizontalSpacing))
 
 		lifecycleScope.launch(Dispatchers.IO) {
 			val currentUser = withTimeout(30.seconds) {
@@ -272,16 +276,14 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 		) {
 			if (item !is BaseRowItem) {
 				currentItem = null
-				//fill in default background
-				backgroundService.clearBackgrounds()
+				homeViewModel.updateFocusedItem(null)
 			} else {
 				currentItem = item
 				currentRow = row as ListRow
+				homeViewModel.updateFocusedItem(item)
 
 				val itemRowAdapter = row.adapter as? ItemRowAdapter
 				itemRowAdapter?.loadMoreItemsIfNeeded(itemRowAdapter.indexOf(item))
-
-				backgroundService.setBackground(item.baseItem)
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeViewModel.kt
@@ -1,0 +1,15 @@
+package org.jellyfin.androidtv.ui.home
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem
+
+class HomeViewModel : ViewModel() {
+	private val _focusedItem = MutableStateFlow<BaseRowItem?>(null)
+	val focusedItem = _focusedItem.asStateFlow()
+
+	fun updateFocusedItem(item: BaseRowItem?) {
+		_focusedItem.value = item
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.kt
@@ -2,12 +2,14 @@ package org.jellyfin.androidtv.ui.presentation
 
 import android.view.View
 import androidx.core.view.isVisible
+import androidx.leanback.widget.HorizontalGridView
 import androidx.leanback.widget.ListRow
 import androidx.leanback.widget.ListRowPresenter
 import androidx.leanback.widget.RowPresenter
 
 open class CustomListRowPresenter @JvmOverloads constructor(
-	private val topPadding: Int? = null
+	private val topPadding: Int? = null,
+	private val horizontalSpacing: Int? = null
 ) : ListRowPresenter() {
 	init {
 		headerPresenter = CustomRowHeaderPresenter()
@@ -22,6 +24,14 @@ open class CustomListRowPresenter @JvmOverloads constructor(
 
 		val view = holder.view?.parent as? View ?: return
 		if (topPadding != null) view.setPadding(view.paddingLeft, topPadding, view.paddingRight, view.paddingBottom)
+
+		// Set horizontal spacing on the grid view if specified
+		if (horizontalSpacing != null && holder is ViewHolder) {
+			val gridView = holder.gridView
+			if (gridView is HorizontalGridView) {
+				gridView.horizontalSpacing = horizontalSpacing
+			}
+		}
 
 		// Hide header view when the item doesn't have one
 		holder.headerViewHolder.view.isVisible = !(item is ListRow && item.headerItem == null)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/PositionableListRowPresenter.kt
@@ -8,6 +8,7 @@ class PositionableListRowPresenter : CustomListRowPresenter {
 
 	constructor() : super()
 	constructor(padding: Int?) : super(padding)
+	constructor(padding: Int?, horizontalSpacing: Int?) : super(padding, horizontalSpacing)
 
 	init {
 		shadowEnabled = false

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationScreen.kt
@@ -82,6 +82,17 @@ fun SettingsCustomizationScreen() {
 			)
 		}
 
+		item {
+			var enhancedHomeScreen by rememberPreference(userPreferences, UserPreferences.enhancedHomeScreen)
+
+			ListButton(
+				headingContent = { Text("Enhanced home screen") },
+				trailingContent = { Checkbox(checked = enhancedHomeScreen) },
+				captionContent = { Text("Show hero section with backdrop on home screen") },
+				onClick = { enhancedHomeScreen = !enhancedHomeScreen }
+			)
+		}
+
 		item { ListSection(headingContent = { Text(stringResource(R.string.pref_browsing)) }) }
 
 		item {


### PR DESCRIPTION
## Description

Adds an optional enhanced home screen feature inspired by Emby's home layout, featuring a hero section with backdrop image, title, and metadata that updates dynamically as users navigate through content.

## Features

- **Hero Section**: Displays focused item's backdrop image with title, rating, year, runtime, content rating, and description
- **Layered Design**: Backdrop extends behind content rows with gradient overlay for readability
- **Dynamic Updates**: Hero section updates in real-time as focus changes between items
- **Optional & Opt-in**: Disabled by default, can be enabled in Settings → Customization → "Enhanced home screen"
- **Reactive Settings**: Takes effect immediately without requiring app restart

## Implementation Details

- New `HomeViewModel` for sharing focused item state between `HomeFragment` and `HomeRowsFragment`
- New `HomeHeroSection` Composable for rendering the hero UI
- Conditional rendering in `HomeFragment` based on user preference
- Automatic `BackgroundService` management (disabled when enhanced mode is active)
- Added 12dp horizontal card spacing to prevent overlap on focus
- Uses Compose-View interop with proper lifecycle handling

## Screenshots
<img width="1920" height="1080" alt="Screenshot_20260607_144745" src="https://github.com/user-attachments/assets/7a13ba19-3641-4114-9186-3b5e9508c287" />
<img width="1920" height="1080" alt="Screenshot_20260607_144703" src="https://github.com/user-attachments/assets/0f3383aa-3607-44b2-afa2-610beda7c8af" />

## Testing

1. Enable the feature: Settings → Customization → Enable "Enhanced home screen"
2. Return to home screen - hero section should appear with backdrop
3. Navigate through content rows - hero updates as focus changes
4. Disable the feature - should revert to original home screen immediately
5. Verify card spacing prevents overlap when focusing items

## Code Assistance
Claude Sonnet 4.5