### PR TITLE
Move around various settings

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsDeveloperScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsDeveloperScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import coil3.ImageLoader
-import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.SystemPreferences
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -28,12 +27,11 @@ fun SettingsDeveloperScreen() {
 	val systemPreferences = koinInject<SystemPreferences>()
 	val context = LocalContext.current
 	val isTvDevice = remember(context) { context.isTvDevice() }
-	val isDeveloperBuild = BuildConfig.DEVELOPMENT
 
 	SettingsColumn {
 		item {
 			ListSection(
-				overlineContent = { Text(stringResource(R.string.settings).uppercase()) },
+				overlineContent = { Text(stringResource(R.string.pref_about_title).uppercase()) },
 				headingContent = { Text(stringResource(R.string.pref_developer_link)) },
 			)
 		}
@@ -57,26 +55,6 @@ fun SettingsDeveloperScreen() {
 				headingContent = { Text(stringResource(R.string.disable_ui_mode_warning)) },
 				trailingContent = { Checkbox(checked = disableUiModeWarning) },
 				onClick = { disableUiModeWarning = !disableUiModeWarning }
-			)
-		}
-
-		// Playback rewrite - only show in debug mode
-		if (isDeveloperBuild) item {
-			var playbackRewriteVideoEnabled by rememberPreference(userPreferences, UserPreferences.playbackRewriteVideoEnabled)
-			ListButton(
-				// String is hardcoded because it's for development only
-				headingContent = { Text("Enable new playback module for video") },
-				trailingContent = { Checkbox(checked = playbackRewriteVideoEnabled) },
-				captionContent = { Text(stringResource(R.string.enable_playback_module_description)) },
-				onClick = { playbackRewriteVideoEnabled = !playbackRewriteVideoEnabled }
-			)
-
-			var assDirectPlay by rememberPreference(userPreferences, UserPreferences.assDirectPlay)
-			ListButton(
-				headingContent = { Text(stringResource(R.string.preference_enable_libass)) },
-				trailingContent = { Checkbox(checked = assDirectPlay) },
-				captionContent = { Text(stringResource(R.string.enable_playback_module_description)) },
-				onClick = { assDirectPlay = !assDirectPlay }
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -69,14 +69,6 @@ fun SettingsMainScreen() {
 
 		item {
 			ListButton(
-				leadingContent = { Icon(painterResource(R.drawable.ic_flask), contentDescription = null) },
-				headingContent = { Text(stringResource(R.string.pref_developer_link)) },
-				onClick = { router.push(Routes.DEVELOPER) }
-			)
-		}
-
-		item {
-			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_jellyfin), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_about_title)) },
 				onClick = { router.push(Routes.ABOUT) }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/about/SettingsAboutScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/about/SettingsAboutScreen.kt
@@ -62,5 +62,13 @@ fun SettingsAboutScreen(launchedFromLogin: Boolean = false) {
 				onClick = { router.push(Routes.LICENSES) },
 			)
 		}
+
+		if (!launchedFromLogin) item {
+			ListButton(
+				leadingContent = { Icon(painterResource(R.drawable.ic_flask), contentDescription = null) },
+				headingContent = { Text(stringResource(R.string.pref_developer_link)) },
+				onClick = { router.push(Routes.DEVELOPER) }
+			)
+		}
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -188,20 +188,34 @@ fun SettingsPlaybackAdvancedScreen() {
 		}
 
 		item {
+			ListButton(
+				headingContent = { Text(stringResource(R.string.preference_codecs)) },
+				captionContent = { Text(stringResource(R.string.preference_codecs_summary)) },
+				onClick = { router.push(Routes.PLAYBACK_CODEC) }
+			)
+		}
+
+		item { ListSection(headingContent = { Text(stringResource(R.string.pref_subtitles)) }) }
+
+		item {
 			var pgsDirectPlay by rememberPreference(userPreferences, UserPreferences.pgsDirectPlay)
 
 			ListButton(
 				headingContent = { Text(stringResource(R.string.preference_enable_pgs)) },
+				captionContent = { Text(stringResource(R.string.preference_enable_pgs_description)) },
 				trailingContent = { Checkbox(checked = pgsDirectPlay) },
 				onClick = { pgsDirectPlay = !pgsDirectPlay }
 			)
 		}
 
 		item {
+			var assDirectPlay by rememberPreference(userPreferences, UserPreferences.assDirectPlay)
+
 			ListButton(
-				headingContent = { Text(stringResource(R.string.preference_codecs)) },
-				captionContent = { Text(stringResource(R.string.preference_codecs_summary)) },
-				onClick = { router.push(Routes.PLAYBACK_CODEC) }
+				headingContent = { Text(stringResource(R.string.preference_enable_ass)) },
+				captionContent = { Text(stringResource(R.string.preference_enable_ass_description)) },
+				trailingContent = { Checkbox(checked = assDirectPlay) },
+				onClick = { assDirectPlay = !assDirectPlay }
 			)
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPlayerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPlayerScreen.kt
@@ -4,15 +4,19 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.rememberAsyncImagePainter
+import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.repository.ExternalAppRepository
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.LocalShapes
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.form.RadioButton
@@ -20,12 +24,14 @@ import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListMessage
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.util.componentName
 import org.koin.compose.koinInject
 
 @Composable
 fun SettingsPlaybackPlayerScreen() {
+	val userPreferences = koinInject<UserPreferences>()
 	val externalAppRepository = koinInject<ExternalAppRepository>()
 	val context = LocalContext.current
 	val router = LocalRouter.current
@@ -33,6 +39,9 @@ fun SettingsPlaybackPlayerScreen() {
 
 	val externalPlayerApps = remember(context) { externalAppRepository.getExternalPlayerApps(context) }
 	val currentExternalPlayer = remember(context) { externalAppRepository.getCurrentExternalPlayerApp(context) }
+
+	var playbackRewriteVideoEnabled by rememberPreference(userPreferences, UserPreferences.playbackRewriteVideoEnabled)
+	val showNewPlayer = playbackRewriteVideoEnabled || BuildConfig.DEVELOPMENT
 
 	SettingsColumn {
 		item {
@@ -54,9 +63,32 @@ fun SettingsPlaybackPlayerScreen() {
 					)
 				},
 				headingContent = { Text(stringResource(R.string.app_name)) },
-				trailingContent = { RadioButton(checked = currentExternalPlayer == null) },
+				trailingContent = { RadioButton(checked = currentExternalPlayer == null && !playbackRewriteVideoEnabled) },
 				captionContent = { Text(stringResource(R.string.video_player_internal)) },
 				onClick = {
+					playbackRewriteVideoEnabled = false
+					externalAppRepository.setExternalPlayerapp(null)
+					router.back()
+				}
+			)
+		}
+
+		if (showNewPlayer) item {
+			ListButton(
+				leadingContent = {
+					Image(
+						painter = rememberAsyncImagePainter(R.drawable.ic_flask),
+						contentDescription = null,
+						modifier = Modifier
+							.size(32.dp)
+							.clip(LocalShapes.current.small)
+					)
+				},
+				headingContent = { Text("New video player") },
+				trailingContent = { RadioButton(checked = currentExternalPlayer == null && playbackRewriteVideoEnabled) },
+				captionContent = { Text(stringResource(R.string.enable_playback_module_description)) },
+				onClick = {
+					playbackRewriteVideoEnabled = true
 					externalAppRepository.setExternalPlayerapp(null)
 					router.back()
 				}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -558,7 +558,6 @@
     <string name="pref_report_device_profile_failure">Failed to submit document. Your Jellyfin server may prohibit client logs.</string>
     <string name="fast_forward">Fast forward</string>
     <string name="rewind">Rewind</string>
-    <string name="preference_enable_libass">Enable Advanced SubStation Alpha subtitle client rendering</string>
     <string name="preference_enable_pgs">Direct play PGS subtitles</string>
     <string name="pref_burn_subtitles_when_transcoding">Burn in subtitles when transcoding</string>
     <string name="pref_burn_subtitles_when_transcoding_description">Always burn subtitles into the video during transcoding. This can fix subtitle sync issues but disables subtitle customization.</string>
@@ -614,6 +613,9 @@
     <string name="codec_level_4_2">Level 4.2</string>
     <string name="codec_level_4_1">Level 4.1</string>
     <string name="codec_level_4_0">Level 4.0</string>
+    <string name="preference_enable_ass">Direct play ASS subtitles</string>
+    <string name="preference_enable_pgs_description">Requires transcoding when disabled</string>
+    <string name="preference_enable_ass_description">Experimental feature, may not work reliably</string>
     <string name="auto">Auto</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>


### PR DESCRIPTION
**Changes**

- Move option for experimental video module to be part of the video player selection
  - Only shows in developer builds
- Move option to enable libass support to the advanced playback settings
  - Now also shows up in release builds (0.20)
- Add description to pgs option
- Add section for subtitle related options in advanced playback settings
- Move "developer settings" to the about screen instead of showing them on the main settings screen

**Screenshots**

<img width="542" height="785" alt="afbeelding" src="https://github.com/user-attachments/assets/e6ab26ec-a6ea-44bd-836c-267d44ae9c33" />

<img width="542" height="785" alt="afbeelding" src="https://github.com/user-attachments/assets/74c6a64d-5ca1-486b-b9a6-57e643055108" />

<img width="537" height="390" alt="afbeelding" src="https://github.com/user-attachments/assets/3508ebc9-af2b-4533-beb6-79b23e77a0ef" />


**Code assistance**
no<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
