### PR TITLE
Fix presenter focus on old Android versions

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.kt
@@ -68,6 +68,7 @@ class CardPresenter(
 			setParentCompositionContext(parent.findViewTreeCompositionContext())
 			setViewTreeLifecycleOwner(parent.findViewTreeLifecycleOwner())
 			setViewTreeSavedStateRegistryOwner(parent.findViewTreeSavedStateRegistryOwner())
+			isFocusable = true
 		}
 
 		return CardViewHolder(view)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/GridButtonPresenter.kt
@@ -77,8 +77,13 @@ class GridButtonPresenter @JvmOverloads constructor(
 		}
 	}
 
-	override fun onCreateViewHolder(parent: ViewGroup): ViewHolder =
-		ViewHolder(ComposeView(parent.context))
+	override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
+		val view = ComposeView(parent.context).apply {
+			isFocusable = true
+		}
+
+		return ViewHolder(view)
+	}
 
 	override fun onBindViewHolder(viewHolder: Presenter.ViewHolder, item: Any?) {
 		if (viewHolder !is ViewHolder) return


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Older Android versions have a screwed up focus system that doesn't work nicely, these kinds of bugs only show up when testing with old (unstable) emulators.

Set focusable to presenter compose views so they correctly apply their effects.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
