### PR TITLE
Fix #5509: restore untagged subtitles by stream index

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -643,23 +643,33 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        // get subtitle info - prefer saved language preference over server default
+        // get subtitle info - prefer saved preference over server default
         String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
-        if (lastSubtitleLanguage != null) {
-            if (lastSubtitleLanguage.isEmpty()) {
-                // User explicitly disabled subtitles
-                mCurrentOptions.setSubtitleStreamIndex(null);
-            } else if (response.getMediaSource().getMediaStreams() != null) {
-                // Find subtitle stream matching saved language
-                Integer matchingIndex = null;
+        Integer lastSubtitleIndex = videoQueueManager.getValue().getLastPlayedSubtitleStreamIndex();
+        if (lastSubtitleLanguage != null && lastSubtitleLanguage.isEmpty()) {
+            // User explicitly disabled subtitles
+            mCurrentOptions.setSubtitleStreamIndex(null);
+        } else if ((lastSubtitleLanguage != null || lastSubtitleIndex != null) && response.getMediaSource().getMediaStreams() != null) {
+            // Find subtitle stream matching saved language
+            Integer matchingIndex = null;
+            if (lastSubtitleLanguage != null) {
                 for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
                     if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
                         matchingIndex = stream.getIndex();
                         break;
                     }
                 }
-                mCurrentOptions.setSubtitleStreamIndex(matchingIndex);
             }
+            // Fall back to matching by stream index for untagged subtitle tracks (language == null)
+            if (matchingIndex == null && lastSubtitleIndex != null && lastSubtitleIndex >= 0) {
+                for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
+                    if (stream.getType() == MediaStreamType.SUBTITLE && stream.getIndex() == lastSubtitleIndex) {
+                        matchingIndex = stream.getIndex();
+                        break;
+                    }
+                }
+            }
+            mCurrentOptions.setSubtitleStreamIndex(matchingIndex);
         } else {
             // No saved preference, use server default
             mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -64,9 +64,11 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 	if (index == -1) {
 		// Use empty string to indicate "subtitles explicitly disabled" vs null meaning "no preference"
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode("")
+		videoQueueManager.setLastPlayedSubtitleStreamIndex(-1)
 	} else {
 		val stream = currentMediaSource.mediaStreams?.firstOrNull { it.type == MediaStreamType.SUBTITLE && it.index == index }
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(stream?.language)
+		videoQueueManager.setLastPlayedSubtitleStreamIndex(index)
 	}
 
 	// Disable subtitles

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
@@ -7,6 +7,7 @@ class VideoQueueManager {
 	private var _currentMediaPosition = -1
 	private var _lastPlayedAudioLanguageIsoCode: String? = null
 	private var _lastPlayedSubtitleLanguageIsoCode: String? = null
+	private var _lastPlayedSubtitleStreamIndex: Int? = null
 
 	fun setCurrentVideoQueue(items: List<BaseItemDto>?) {
 		if (items.isNullOrEmpty()) return clearVideoQueue()
@@ -41,10 +42,17 @@ class VideoQueueManager {
 		_lastPlayedSubtitleLanguageIsoCode = isoCode
 	}
 
+	fun getLastPlayedSubtitleStreamIndex(): Int? = _lastPlayedSubtitleStreamIndex
+
+	fun setLastPlayedSubtitleStreamIndex(index: Int?) {
+		_lastPlayedSubtitleStreamIndex = index
+	}
+
 	fun clearVideoQueue() {
 		_currentVideoQueue = emptyList()
 		_currentMediaPosition = -1
 		_lastPlayedAudioLanguageIsoCode = null
 		_lastPlayedSubtitleLanguageIsoCode = null
+		_lastPlayedSubtitleStreamIndex = null
 	}
 }


### PR DESCRIPTION
Subtitle restoration across episodes only remembered the language ISO code of the last played subtitles. Tracks without a language tag (language == null) could not be matched and fell back to "None" on every NextUp transition.

Remember the subtitle stream index as a fallback: match by language first, then by stream index for untagged tracks.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
