### PR TITLE
Refactor: Extract HEVC and AV1 codec modules

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/MediaCodecCapabilitiesTest.kt
@@ -1,12 +1,11 @@
 package org.jellyfin.androidtv.util.profile
 
-import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
-import android.media.MediaFormat
-import android.os.Build
 import android.util.Size
 import androidx.media3.common.MimeTypes
+import org.jellyfin.androidtv.util.profile.codec.Av1CodecCapabilities
 import org.jellyfin.androidtv.util.profile.codec.AvcCodecCapabilities
+import org.jellyfin.androidtv.util.profile.codec.HevcCodecCapabilities
 import org.jellyfin.androidtv.util.profile.codec.MediaCodecQuery
 
 class MediaCodecCapabilitiesTest(
@@ -15,93 +14,18 @@ class MediaCodecCapabilitiesTest(
 	private val mediaCodecList by lazy { MediaCodecList(MediaCodecList.REGULAR_CODECS) }
 	private val codecQuery by lazy { MediaCodecQuery(mediaCodecList, softwareCodecsEnabled) }
 	private val avc by lazy { AvcCodecCapabilities(codecQuery) }
+	private val hevc by lazy { HevcCodecCapabilities(codecQuery) }
+	private val av1 by lazy { Av1CodecCapabilities(codecQuery) }
 
-	// Map common Dolby Vision Profiles to their corresponding CodecProfileLevel constant
-	private object DolbyVisionProfiles {
-		val Profile5: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-				CodecProfileLevel.DolbyVisionProfileDvheStn else -1
-		}
-		val Profile7: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-				CodecProfileLevel.DolbyVisionProfileDvheDtb else -1
-		}
-		val Profile8: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1)
-				CodecProfileLevel.DolbyVisionProfileDvheSt else -1
-		}
-	}
+	fun supportsAV1(): Boolean = av1.supportsAv1()
 
-	// Some devices (e.g., Fire OS) may support AV1 below the official API level
-	// Use the platform constant if the API level is met; otherwise fall back to the literal value
-	// Reference:
-	// https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/media/java/android/media/MediaCodecInfo.java
-	private object AV1ProfileLevel {
-		val ProfileMain10: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-				CodecProfileLevel.AV1ProfileMain10 else 0x2
-		}
-		val ProfileMain10HDR10: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-				CodecProfileLevel.AV1ProfileMain10HDR10 else 0x1000
-		}
-		val ProfileMain10HDR10Plus: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-				CodecProfileLevel.AV1ProfileMain10HDR10Plus else 0x2000
-		}
-		val DolbyVisionProfile10: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-				CodecProfileLevel.DolbyVisionProfileDvav110 else 0x400
-		}
-		val Level5: Int by lazy {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-				CodecProfileLevel.AV1Level5 else 0x1000
-		}
-	}
+	fun supportsAV1Main10(): Boolean = av1.supportsAv1Main10()
 
-	// HEVC levels as reported by ffprobe are multiplied by 30, e.g. level 4.1 is 123
-	private val hevcLevels = listOf(
-		CodecProfileLevel.HEVCMainTierLevel1 to 30,
-		CodecProfileLevel.HEVCMainTierLevel2 to 60,
-		CodecProfileLevel.HEVCMainTierLevel21 to 63,
-		CodecProfileLevel.HEVCMainTierLevel3 to 90,
-		CodecProfileLevel.HEVCMainTierLevel31 to 93,
-		CodecProfileLevel.HEVCMainTierLevel4 to 120,
-		CodecProfileLevel.HEVCMainTierLevel41 to 123,
-		CodecProfileLevel.HEVCMainTierLevel5 to 150,
-		CodecProfileLevel.HEVCMainTierLevel51 to 153,
-		CodecProfileLevel.HEVCMainTierLevel52 to 156,
-		CodecProfileLevel.HEVCMainTierLevel6 to 180,
-		CodecProfileLevel.HEVCMainTierLevel61 to 183,
-		CodecProfileLevel.HEVCMainTierLevel62 to 186,
-	)
+	fun supportsAV1DolbyVision(): Boolean = av1.supportsAv1DolbyVision()
 
-	fun supportsAV1(): Boolean = codecQuery.hasCodecForMime(MimeTypes.VIDEO_AV1)
+	fun supportsAV1HDR10(): Boolean = av1.supportsAv1HDR10()
 
-	fun supportsAV1Main10(): Boolean = codecQuery.hasDecoder(
-		MimeTypes.VIDEO_AV1,
-		AV1ProfileLevel.ProfileMain10,
-		AV1ProfileLevel.Level5
-	)
-
-	fun supportsAV1DolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-		codecQuery.hasDecoder(
-			MimeTypes.VIDEO_DOLBY_VISION,
-			AV1ProfileLevel.DolbyVisionProfile10,
-			CodecProfileLevel.DolbyVisionLevelHd24
-		)
-
-	fun supportsAV1HDR10(): Boolean = codecQuery.hasDecoder(
-		MimeTypes.VIDEO_AV1,
-		AV1ProfileLevel.ProfileMain10HDR10,
-		AV1ProfileLevel.Level5
-	)
-
-	fun supportsAV1HDR10Plus(): Boolean = codecQuery.hasDecoder(
-		MimeTypes.VIDEO_AV1,
-		AV1ProfileLevel.ProfileMain10HDR10Plus,
-		AV1ProfileLevel.Level5
-	)
+	fun supportsAV1HDR10Plus(): Boolean = av1.supportsAv1HDR10Plus()
 
 	fun supportsAVC(): Boolean = avc.supportsAvc()
 
@@ -111,57 +35,21 @@ class MediaCodecCapabilitiesTest(
 
 	fun getAVCHigh10Level(): Int = avc.getHigh10Level()
 
-	fun supportsHevc(): Boolean = codecQuery.hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_HEVC)
+	fun supportsHevc(): Boolean = hevc.supportsHevc()
 
-	fun supportsHevcMain10(): Boolean = codecQuery.hasDecoder(
-		MediaFormat.MIMETYPE_VIDEO_HEVC,
-		CodecProfileLevel.HEVCProfileMain10,
-		CodecProfileLevel.HEVCMainTierLevel4
-	)
+	fun supportsHevcMain10(): Boolean = hevc.supportsHevcMain10()
 
-	// Can safely assume Dolby Vision decoders support single-layer HEVC profiles
-	fun supportsHevcDolbyVision(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-		codecQuery.hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION)
+	fun supportsHevcDolbyVision(): Boolean = hevc.supportsHevcDolbyVision()
 
-	// Checks for Dolby Vision Profile 7 (Enhancement Layer) and multi-instance HEVC support
-	fun supportsHevcDolbyVisionEL(): Boolean =
-		Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-			codecQuery.hasDecoder(
-				MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION,
-				DolbyVisionProfiles.Profile7,
-				CodecProfileLevel.DolbyVisionLevelHd24
-			) &&
-			codecQuery.supportsMultiInstance(MediaFormat.MIMETYPE_VIDEO_HEVC)
+	fun supportsHevcDolbyVisionEL(): Boolean = hevc.supportsHevcDolbyVisionEL()
 
-	fun supportsHevcHDR10(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-		codecQuery.hasDecoder(
-			MediaFormat.MIMETYPE_VIDEO_HEVC,
-			CodecProfileLevel.HEVCProfileMain10HDR10,
-			CodecProfileLevel.HEVCMainTierLevel4
-		)
+	fun supportsHevcHDR10(): Boolean = hevc.supportsHevcHDR10()
 
-	fun supportsHevcHDR10Plus(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
-		codecQuery.hasDecoder(
-			MediaFormat.MIMETYPE_VIDEO_HEVC,
-			CodecProfileLevel.HEVCProfileMain10HDR10Plus,
-			CodecProfileLevel.HEVCMainTierLevel4
-		)
+	fun supportsHevcHDR10Plus(): Boolean = hevc.supportsHevcHDR10Plus()
 
-	fun getHevcMainLevel(): Int = getHevcLevel(
-		CodecProfileLevel.HEVCProfileMain
-	)
+	fun getHevcMainLevel(): Int = hevc.getMainLevel()
 
-	fun getHevcMain10Level(): Int = getHevcLevel(
-		CodecProfileLevel.HEVCProfileMain10
-	)
-
-	private fun getHevcLevel(profile: Int): Int {
-		val level = codecQuery.getDecoderLevel(MediaFormat.MIMETYPE_VIDEO_HEVC, profile)
-
-		return hevcLevels.asReversed().find { item ->
-			level >= item.first
-		}?.second ?: 0
-	}
+	fun getHevcMain10Level(): Int = hevc.getMain10Level()
 
 	fun supportsVc1(): Boolean = codecQuery.hasCodecForMime(MimeTypes.VIDEO_VC1)
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/Av1CodecCapabilities.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/Av1CodecCapabilities.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.util.profile.codec
+
+import android.media.MediaCodecInfo.CodecProfileLevel
+import androidx.media3.common.MimeTypes
+import org.jellyfin.androidtv.util.AndroidVersion
+
+class Av1CodecCapabilities(
+	private val query: MediaCodecQuery,
+) {
+	companion object {
+		private const val MIME_AV1 = MimeTypes.VIDEO_AV1
+		private const val MIME_DOLBY_VISION = MimeTypes.VIDEO_DOLBY_VISION
+
+		// Fallback values from AOSP MediaCodecInfo.java for pre-Q/R devices
+		// Some devices (e.g., Fire OS) support AV1 below the official API level
+		internal const val AV1_PROFILE_MAIN10 = 0x2
+		internal const val AV1_PROFILE_MAIN10_HDR10 = 0x1000
+		internal const val AV1_PROFILE_MAIN10_HDR10_PLUS = 0x2000
+		internal const val AV1_LEVEL5 = 0x1000
+		internal const val DV_PROFILE_DVAV1_10 = 0x400
+	}
+
+	private val profileMain10: Int
+		get() = if (AndroidVersion.isAtLeastQ) CodecProfileLevel.AV1ProfileMain10 else AV1_PROFILE_MAIN10
+
+	private val profileMain10HDR10: Int
+		get() = if (AndroidVersion.isAtLeastQ) CodecProfileLevel.AV1ProfileMain10HDR10 else AV1_PROFILE_MAIN10_HDR10
+
+	private val profileMain10HDR10Plus: Int
+		get() = if (AndroidVersion.isAtLeastQ) CodecProfileLevel.AV1ProfileMain10HDR10Plus else AV1_PROFILE_MAIN10_HDR10_PLUS
+
+	private val dolbyVisionProfile10: Int
+		get() = if (AndroidVersion.isAtLeastR) CodecProfileLevel.DolbyVisionProfileDvav110 else DV_PROFILE_DVAV1_10
+
+	private val level5: Int
+		get() = if (AndroidVersion.isAtLeastQ) CodecProfileLevel.AV1Level5 else AV1_LEVEL5
+
+	fun supportsAv1(): Boolean = query.hasCodecForMime(MIME_AV1)
+
+	fun supportsAv1Main10(): Boolean = query.hasDecoder(
+		MIME_AV1,
+		profileMain10,
+		level5,
+	)
+
+	fun supportsAv1DolbyVision(): Boolean =
+		AndroidVersion.isAtLeastN &&
+			query.hasDecoder(
+				MIME_DOLBY_VISION,
+				dolbyVisionProfile10,
+				CodecProfileLevel.DolbyVisionLevelHd24,
+			)
+
+	fun supportsAv1HDR10(): Boolean = query.hasDecoder(
+		MIME_AV1,
+		profileMain10HDR10,
+		level5,
+	)
+
+	fun supportsAv1HDR10Plus(): Boolean = query.hasDecoder(
+		MIME_AV1,
+		profileMain10HDR10Plus,
+		level5,
+	)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/HevcCodecCapabilities.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/HevcCodecCapabilities.kt
@@ -1,0 +1,80 @@
+package org.jellyfin.androidtv.util.profile.codec
+
+import android.media.MediaCodecInfo.CodecProfileLevel
+import android.media.MediaFormat
+import org.jellyfin.androidtv.util.AndroidVersion
+
+class HevcCodecCapabilities(
+	private val query: MediaCodecQuery,
+) {
+	companion object {
+		// HEVC levels as reported by ffprobe are multiplied by 30, e.g. level 4.1 is 123
+		internal val LEVEL_MAP: List<Pair<Int, Int>> = listOf(
+			CodecProfileLevel.HEVCMainTierLevel1 to 30,
+			CodecProfileLevel.HEVCMainTierLevel2 to 60,
+			CodecProfileLevel.HEVCMainTierLevel21 to 63,
+			CodecProfileLevel.HEVCMainTierLevel3 to 90,
+			CodecProfileLevel.HEVCMainTierLevel31 to 93,
+			CodecProfileLevel.HEVCMainTierLevel4 to 120,
+			CodecProfileLevel.HEVCMainTierLevel41 to 123,
+			CodecProfileLevel.HEVCMainTierLevel5 to 150,
+			CodecProfileLevel.HEVCMainTierLevel51 to 153,
+			CodecProfileLevel.HEVCMainTierLevel52 to 156,
+			CodecProfileLevel.HEVCMainTierLevel6 to 180,
+			CodecProfileLevel.HEVCMainTierLevel61 to 183,
+			CodecProfileLevel.HEVCMainTierLevel62 to 186,
+		)
+
+		private const val MIME_HEVC = MediaFormat.MIMETYPE_VIDEO_HEVC
+		private const val MIME_DOLBY_VISION = MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION
+	}
+
+	fun supportsHevc(): Boolean = query.hasCodecForMime(MIME_HEVC)
+
+	fun supportsHevcMain10(): Boolean = query.hasDecoder(
+		MIME_HEVC,
+		CodecProfileLevel.HEVCProfileMain10,
+		CodecProfileLevel.HEVCMainTierLevel4,
+	)
+
+	fun supportsHevcDolbyVision(): Boolean =
+		AndroidVersion.isAtLeastN &&
+			query.hasCodecForMime(MIME_DOLBY_VISION)
+
+	fun supportsHevcDolbyVisionEL(): Boolean =
+		AndroidVersion.isAtLeastN &&
+			query.hasDecoder(
+				MIME_DOLBY_VISION,
+				CodecProfileLevel.DolbyVisionProfileDvheDtb,
+				CodecProfileLevel.DolbyVisionLevelHd24,
+			) &&
+			query.supportsMultiInstance(MIME_HEVC)
+
+	fun supportsHevcHDR10(): Boolean =
+		AndroidVersion.isAtLeastN &&
+			query.hasDecoder(
+				MIME_HEVC,
+				CodecProfileLevel.HEVCProfileMain10HDR10,
+				CodecProfileLevel.HEVCMainTierLevel4,
+			)
+
+	fun supportsHevcHDR10Plus(): Boolean =
+		AndroidVersion.isAtLeastQ &&
+			query.hasDecoder(
+				MIME_HEVC,
+				CodecProfileLevel.HEVCProfileMain10HDR10Plus,
+				CodecProfileLevel.HEVCMainTierLevel4,
+			)
+
+	fun getMainLevel(): Int = getLevel(CodecProfileLevel.HEVCProfileMain)
+
+	fun getMain10Level(): Int = getLevel(CodecProfileLevel.HEVCProfileMain10)
+
+	private fun getLevel(profile: Int): Int {
+		val level = query.getDecoderLevel(MIME_HEVC, profile)
+
+		return LEVEL_MAP.asReversed().find { (codecLevel, _) ->
+			level >= codecLevel
+		}?.second ?: 0
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/HevcCodecCapabilities.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/HevcCodecCapabilities.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.androidtv.util.profile.codec
 
 import android.media.MediaCodecInfo.CodecProfileLevel
-import android.media.MediaFormat
+import androidx.media3.common.MimeTypes
 import org.jellyfin.androidtv.util.AndroidVersion
 
 class HevcCodecCapabilities(
@@ -25,8 +25,8 @@ class HevcCodecCapabilities(
 			CodecProfileLevel.HEVCMainTierLevel62 to 186,
 		)
 
-		private const val MIME_HEVC = MediaFormat.MIMETYPE_VIDEO_HEVC
-		private const val MIME_DOLBY_VISION = MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION
+		private const val MIME_HEVC = MimeTypes.VIDEO_H265
+		private const val MIME_DOLBY_VISION = MimeTypes.VIDEO_DOLBY_VISION
 	}
 
 	fun supportsHevc(): Boolean = query.hasCodecForMime(MIME_HEVC)

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/MediaCodecQuery.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/codec/MediaCodecQuery.kt
@@ -4,8 +4,8 @@ import android.media.MediaCodecInfo
 import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
 import android.media.MediaFormat
-import android.os.Build
 import android.util.Size
+import org.jellyfin.androidtv.util.AndroidVersion
 import timber.log.Timber
 
 /**
@@ -16,7 +16,7 @@ class MediaCodecQuery(
 	private val softwareCodecsEnabled: Boolean,
 ) {
 	private val MediaCodecInfo.isSoftwareCodec: Boolean
-		get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isSoftwareOnly
+		get() = AndroidVersion.isAtLeastQ && isSoftwareOnly
 
 	private fun decoderInfos(): Sequence<MediaCodecInfo> =
 		mediaCodecList.codecInfos.asSequence()

--- a/app/src/test/kotlin/util/profile/codec/Av1CodecCapabilitiesTest.kt
+++ b/app/src/test/kotlin/util/profile/codec/Av1CodecCapabilitiesTest.kt
@@ -1,0 +1,228 @@
+package org.jellyfin.androidtv.util.profile.codec
+
+import android.media.MediaCodecInfo.CodecProfileLevel
+import android.os.Build
+import androidx.media3.common.MimeTypes
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.jellyfin.androidtv.util.AndroidVersion
+
+class Av1CodecCapabilitiesTest : FunSpec({
+	val mimeAv1 = MimeTypes.VIDEO_AV1
+	val mimeDolbyVision = MimeTypes.VIDEO_DOLBY_VISION
+	val apiN = Build.VERSION_CODES.N
+	val apiQ = Build.VERSION_CODES.Q
+	val apiR = Build.VERSION_CODES.R
+
+	beforeEach {
+		mockkObject(AndroidVersion)
+	}
+
+	afterEach {
+		unmockkObject(AndroidVersion)
+	}
+
+	test("supportsAv1 returns true when device has AV1 decoder") {
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeAv1) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1() shouldBe true
+	}
+
+	test("supportsAv1 returns false when device has no AV1 decoder") {
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeAv1) } returns false
+		}
+		Av1CodecCapabilities(query).supportsAv1() shouldBe false
+	}
+
+	test("supportsAv1Main10 returns true when device supports Main10 at Level 5") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeAv1, any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1Main10() shouldBe true
+	}
+
+	test("supportsAv1Main10 returns false when device lacks Main10 support") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeAv1, any(), any()) } returns false
+		}
+		Av1CodecCapabilities(query).supportsAv1Main10() shouldBe false
+	}
+
+	test("supportsAv1Main10 uses fallback constants on pre-Q devices") {
+		every { AndroidVersion.sdkInt } returns apiQ - 1
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(any(), any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1Main10()
+
+		verify {
+			query.hasDecoder(
+				mimeAv1,
+				Av1CodecCapabilities.AV1_PROFILE_MAIN10,
+				Av1CodecCapabilities.AV1_LEVEL5,
+			)
+		}
+	}
+
+	test("supportsAv1DolbyVision returns false when sdkInt below API 24") {
+		every { AndroidVersion.sdkInt } returns apiN - 1
+		val query = mockk<MediaCodecQuery>()
+		Av1CodecCapabilities(query).supportsAv1DolbyVision() shouldBe false
+	}
+
+	test("supportsAv1DolbyVision returns true when sdkInt >= 24 and device has DV decoder") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeDolbyVision, any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1DolbyVision() shouldBe true
+	}
+
+	test("supportsAv1DolbyVision returns false when sdkInt >= 24 but no DV decoder") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeDolbyVision, any(), any()) } returns false
+		}
+		Av1CodecCapabilities(query).supportsAv1DolbyVision() shouldBe false
+	}
+
+	test("supportsAv1DolbyVision uses fallback DV constant on pre-R devices") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(any(), any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1DolbyVision()
+
+		verify {
+			query.hasDecoder(
+				mimeDolbyVision,
+				Av1CodecCapabilities.DV_PROFILE_DVAV1_10,
+				CodecProfileLevel.DolbyVisionLevelHd24,
+			)
+		}
+	}
+
+	test("supportsAv1HDR10 returns true when device supports Main10 HDR10") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeAv1, any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1HDR10() shouldBe true
+	}
+
+	test("supportsAv1HDR10 returns false when device lacks Main10 HDR10") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeAv1, any(), any()) } returns false
+		}
+		Av1CodecCapabilities(query).supportsAv1HDR10() shouldBe false
+	}
+
+	test("supportsAv1HDR10 uses fallback constants on pre-Q devices") {
+		every { AndroidVersion.sdkInt } returns apiQ - 1
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(any(), any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1HDR10()
+
+		verify {
+			query.hasDecoder(
+				mimeAv1,
+				Av1CodecCapabilities.AV1_PROFILE_MAIN10_HDR10,
+				Av1CodecCapabilities.AV1_LEVEL5,
+			)
+		}
+	}
+
+	test("supportsAv1HDR10Plus returns true when device supports Main10 HDR10Plus") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeAv1, any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1HDR10Plus() shouldBe true
+	}
+
+	test("supportsAv1HDR10Plus returns false when device lacks Main10 HDR10Plus") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeAv1, any(), any()) } returns false
+		}
+		Av1CodecCapabilities(query).supportsAv1HDR10Plus() shouldBe false
+	}
+
+	test("supportsAv1HDR10Plus uses fallback constants on pre-Q devices") {
+		every { AndroidVersion.sdkInt } returns apiQ - 1
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(any(), any(), any()) } returns true
+		}
+		Av1CodecCapabilities(query).supportsAv1HDR10Plus()
+
+		verify {
+			query.hasDecoder(
+				mimeAv1,
+				Av1CodecCapabilities.AV1_PROFILE_MAIN10_HDR10_PLUS,
+				Av1CodecCapabilities.AV1_LEVEL5,
+			)
+		}
+	}
+
+	// Simulated device profiles
+	test("Modern device profile: full AV1 + DolbyVision + HDR10+") {
+		every { AndroidVersion.sdkInt } returns apiR
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeAv1) } returns true
+			every { hasDecoder(mimeAv1, any(), any()) } returns true
+			every { hasDecoder(mimeDolbyVision, any(), any()) } returns true
+		}
+		val av1 = Av1CodecCapabilities(query)
+
+		av1.supportsAv1() shouldBe true
+		av1.supportsAv1Main10() shouldBe true
+		av1.supportsAv1DolbyVision() shouldBe true
+		av1.supportsAv1HDR10() shouldBe true
+		av1.supportsAv1HDR10Plus() shouldBe true
+	}
+
+	test("Fire TV profile: AV1 on older API with fallback constants, no DolbyVision") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeAv1) } returns true
+			every { hasDecoder(mimeAv1, Av1CodecCapabilities.AV1_PROFILE_MAIN10, Av1CodecCapabilities.AV1_LEVEL5) } returns true
+			every { hasDecoder(mimeAv1, Av1CodecCapabilities.AV1_PROFILE_MAIN10_HDR10, Av1CodecCapabilities.AV1_LEVEL5) } returns true
+			every { hasDecoder(mimeAv1, Av1CodecCapabilities.AV1_PROFILE_MAIN10_HDR10_PLUS, Av1CodecCapabilities.AV1_LEVEL5) } returns false
+			every { hasDecoder(mimeDolbyVision, any(), any()) } returns false
+		}
+		val av1 = Av1CodecCapabilities(query)
+
+		av1.supportsAv1() shouldBe true
+		av1.supportsAv1Main10() shouldBe true
+		av1.supportsAv1DolbyVision() shouldBe false
+		av1.supportsAv1HDR10() shouldBe true
+		av1.supportsAv1HDR10Plus() shouldBe false
+	}
+
+	test("No AV1 support at all") {
+		every { AndroidVersion.sdkInt } returns apiR
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeAv1) } returns false
+			every { hasDecoder(mimeAv1, any(), any()) } returns false
+			every { hasDecoder(mimeDolbyVision, any(), any()) } returns false
+		}
+		val av1 = Av1CodecCapabilities(query)
+
+		av1.supportsAv1() shouldBe false
+		av1.supportsAv1Main10() shouldBe false
+		av1.supportsAv1DolbyVision() shouldBe false
+		av1.supportsAv1HDR10() shouldBe false
+		av1.supportsAv1HDR10Plus() shouldBe false
+	}
+})

--- a/app/src/test/kotlin/util/profile/codec/HevcCodecCapabilitiesTest.kt
+++ b/app/src/test/kotlin/util/profile/codec/HevcCodecCapabilitiesTest.kt
@@ -1,0 +1,284 @@
+package org.jellyfin.androidtv.util.profile.codec
+
+import android.media.MediaCodecInfo.CodecProfileLevel
+import android.media.MediaFormat
+import android.os.Build
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.jellyfin.androidtv.util.AndroidVersion
+
+class HevcCodecCapabilitiesTest : FunSpec({
+	val mimeHevc = MediaFormat.MIMETYPE_VIDEO_HEVC
+	val mimeDolbyVision = MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION
+	val apiN = Build.VERSION_CODES.N
+	val apiQ = Build.VERSION_CODES.Q
+
+	beforeEach {
+		mockkObject(AndroidVersion)
+	}
+
+	afterEach {
+		unmockkObject(AndroidVersion)
+	}
+
+	test("supportsHevc returns true when device has HEVC decoder") {
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeHevc) } returns true
+		}
+		HevcCodecCapabilities(query).supportsHevc() shouldBe true
+	}
+
+	test("supportsHevc returns false when device has no HEVC decoder") {
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeHevc) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevc() shouldBe false
+	}
+
+	test("supportsHevcMain10 returns true when device supports Main10 at Level 4") {
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10, CodecProfileLevel.HEVCMainTierLevel4) } returns true
+		}
+		HevcCodecCapabilities(query).supportsHevcMain10() shouldBe true
+	}
+
+	test("supportsHevcMain10 returns false when device lacks Main10 support") {
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevcMain10() shouldBe false
+	}
+
+	test("supportsHevcDolbyVision returns false when sdkInt below API 24") {
+		every { AndroidVersion.sdkInt } returns apiN - 1
+		val query = mockk<MediaCodecQuery>()
+		HevcCodecCapabilities(query).supportsHevcDolbyVision() shouldBe false
+	}
+
+	test("supportsHevcDolbyVision returns true when sdkInt >= 24 and device has Dolby Vision codec") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeDolbyVision) } returns true
+		}
+		HevcCodecCapabilities(query).supportsHevcDolbyVision() shouldBe true
+	}
+
+	test("supportsHevcDolbyVision returns false when sdkInt >= 24 but no Dolby Vision codec") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeDolbyVision) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevcDolbyVision() shouldBe false
+	}
+
+	test("supportsHevcDolbyVisionEL returns false when sdkInt below API 24") {
+		every { AndroidVersion.sdkInt } returns apiN - 1
+		val query = mockk<MediaCodecQuery>()
+		HevcCodecCapabilities(query).supportsHevcDolbyVisionEL() shouldBe false
+	}
+
+	test("supportsHevcDolbyVisionEL returns true when device has Profile 7 decoder and multi-instance HEVC") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeDolbyVision, CodecProfileLevel.DolbyVisionProfileDvheDtb, CodecProfileLevel.DolbyVisionLevelHd24) } returns true
+			every { supportsMultiInstance(mimeHevc) } returns true
+		}
+		HevcCodecCapabilities(query).supportsHevcDolbyVisionEL() shouldBe true
+	}
+
+	test("supportsHevcDolbyVisionEL returns false when device has Profile 7 but no multi-instance") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeDolbyVision, CodecProfileLevel.DolbyVisionProfileDvheDtb, CodecProfileLevel.DolbyVisionLevelHd24) } returns true
+			every { supportsMultiInstance(mimeHevc) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevcDolbyVisionEL() shouldBe false
+	}
+
+	test("supportsHevcDolbyVisionEL returns false when device lacks Profile 7 decoder") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeDolbyVision, CodecProfileLevel.DolbyVisionProfileDvheDtb, CodecProfileLevel.DolbyVisionLevelHd24) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevcDolbyVisionEL() shouldBe false
+	}
+
+	test("supportsHevcHDR10 returns false when sdkInt below API 24") {
+		every { AndroidVersion.sdkInt } returns apiN - 1
+		val query = mockk<MediaCodecQuery>()
+		HevcCodecCapabilities(query).supportsHevcHDR10() shouldBe false
+	}
+
+	test("supportsHevcHDR10 returns true when sdkInt >= 24 and device supports Main10 HDR10") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10, CodecProfileLevel.HEVCMainTierLevel4) } returns true
+		}
+		HevcCodecCapabilities(query).supportsHevcHDR10() shouldBe true
+	}
+
+	test("supportsHevcHDR10 returns false when sdkInt >= 24 but device lacks Main10 HDR10") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevcHDR10() shouldBe false
+	}
+
+	test("supportsHevcHDR10Plus returns false when sdkInt below API 29") {
+		every { AndroidVersion.sdkInt } returns apiQ - 1
+		val query = mockk<MediaCodecQuery>()
+		HevcCodecCapabilities(query).supportsHevcHDR10Plus() shouldBe false
+	}
+
+	test("supportsHevcHDR10Plus returns true when sdkInt >= 29 and device supports Main10 HDR10Plus") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10Plus, CodecProfileLevel.HEVCMainTierLevel4) } returns true
+		}
+		HevcCodecCapabilities(query).supportsHevcHDR10Plus() shouldBe true
+	}
+
+	test("supportsHevcHDR10Plus returns false when sdkInt >= 29 but device lacks Main10 HDR10Plus") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10Plus, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+		}
+		HevcCodecCapabilities(query).supportsHevcHDR10Plus() shouldBe false
+	}
+
+	test("getMainLevel returns mapped level for device with Main Level 4.1") {
+		val query = mockk<MediaCodecQuery> {
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns CodecProfileLevel.HEVCMainTierLevel41
+		}
+		HevcCodecCapabilities(query).getMainLevel() shouldBe 123
+	}
+
+	test("getMainLevel returns mapped level for device with Main Level 5.1") {
+		val query = mockk<MediaCodecQuery> {
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns CodecProfileLevel.HEVCMainTierLevel51
+		}
+		HevcCodecCapabilities(query).getMainLevel() shouldBe 153
+	}
+
+	test("getMainLevel returns mapped level for device with Main Level 6.2") {
+		val query = mockk<MediaCodecQuery> {
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns CodecProfileLevel.HEVCMainTierLevel62
+		}
+		HevcCodecCapabilities(query).getMainLevel() shouldBe 186
+	}
+
+	test("getMainLevel returns 0 when device reports no HEVC Main support") {
+		val query = mockk<MediaCodecQuery> {
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns 0
+		}
+		HevcCodecCapabilities(query).getMainLevel() shouldBe 0
+	}
+
+	test("getMainLevel maps level between known values to the lower known level") {
+		val query = mockk<MediaCodecQuery> {
+			// Return a value between HEVCMainTierLevel4 and HEVCMainTierLevel41
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns (CodecProfileLevel.HEVCMainTierLevel4 + 1)
+		}
+		HevcCodecCapabilities(query).getMainLevel() shouldBe 120
+	}
+
+	test("getMain10Level returns mapped level for device with Main10 Level 5.1") {
+		val query = mockk<MediaCodecQuery> {
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain10) } returns CodecProfileLevel.HEVCMainTierLevel51
+		}
+		HevcCodecCapabilities(query).getMain10Level() shouldBe 153
+	}
+
+	test("getMain10Level returns 0 when device has no Main10 support") {
+		val query = mockk<MediaCodecQuery> {
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain10) } returns 0
+		}
+		HevcCodecCapabilities(query).getMain10Level() shouldBe 0
+	}
+
+	test("LEVEL_MAP contains all expected HEVC levels in ascending order") {
+		val expectedFfprobeLevels = listOf(30, 60, 63, 90, 93, 120, 123, 150, 153, 156, 180, 183, 186)
+		HevcCodecCapabilities.LEVEL_MAP.map { it.second } shouldBe expectedFfprobeLevels
+	}
+
+	test("LEVEL_MAP ffprobe level values are in ascending order") {
+		val ffprobeLevels = HevcCodecCapabilities.LEVEL_MAP.map { it.second }
+		ffprobeLevels shouldBe ffprobeLevels.sorted()
+	}
+
+	// Simulated device profiles
+	test("Shield TV profile: Main10 + HDR10 + Level 5.1") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeHevc) } returns true
+			every { hasCodecForMime(mimeDolbyVision) } returns true
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10, CodecProfileLevel.HEVCMainTierLevel4) } returns true
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10, CodecProfileLevel.HEVCMainTierLevel4) } returns true
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10Plus, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { hasDecoder(mimeDolbyVision, CodecProfileLevel.DolbyVisionProfileDvheDtb, CodecProfileLevel.DolbyVisionLevelHd24) } returns false
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns CodecProfileLevel.HEVCMainTierLevel51
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain10) } returns CodecProfileLevel.HEVCMainTierLevel51
+		}
+		val hevc = HevcCodecCapabilities(query)
+
+		hevc.supportsHevc() shouldBe true
+		hevc.supportsHevcMain10() shouldBe true
+		hevc.supportsHevcDolbyVision() shouldBe true
+		hevc.supportsHevcDolbyVisionEL() shouldBe false
+		hevc.supportsHevcHDR10() shouldBe true
+		hevc.supportsHevcHDR10Plus() shouldBe false
+		hevc.getMainLevel() shouldBe 153
+		hevc.getMain10Level() shouldBe 153
+	}
+
+	test("Budget device profile: basic HEVC only, no HDR") {
+		every { AndroidVersion.sdkInt } returns apiN
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeHevc) } returns true
+			every { hasCodecForMime(mimeDolbyVision) } returns false
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10Plus, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns CodecProfileLevel.HEVCMainTierLevel41
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain10) } returns 0
+		}
+		val hevc = HevcCodecCapabilities(query)
+
+		hevc.supportsHevc() shouldBe true
+		hevc.supportsHevcMain10() shouldBe false
+		hevc.supportsHevcDolbyVision() shouldBe false
+		hevc.supportsHevcHDR10() shouldBe false
+		hevc.supportsHevcHDR10Plus() shouldBe false
+		hevc.getMainLevel() shouldBe 123
+		hevc.getMain10Level() shouldBe 0
+	}
+
+	test("No HEVC support at all") {
+		every { AndroidVersion.sdkInt } returns apiQ
+		val query = mockk<MediaCodecQuery> {
+			every { hasCodecForMime(mimeHevc) } returns false
+			every { hasCodecForMime(mimeDolbyVision) } returns false
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { hasDecoder(mimeHevc, CodecProfileLevel.HEVCProfileMain10HDR10Plus, CodecProfileLevel.HEVCMainTierLevel4) } returns false
+			every { hasDecoder(mimeDolbyVision, CodecProfileLevel.DolbyVisionProfileDvheDtb, CodecProfileLevel.DolbyVisionLevelHd24) } returns false
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain) } returns 0
+			every { getDecoderLevel(mimeHevc, CodecProfileLevel.HEVCProfileMain10) } returns 0
+		}
+		val hevc = HevcCodecCapabilities(query)
+
+		hevc.supportsHevc() shouldBe false
+		hevc.supportsHevcMain10() shouldBe false
+		hevc.supportsHevcDolbyVision() shouldBe false
+		hevc.supportsHevcDolbyVisionEL() shouldBe false
+		hevc.supportsHevcHDR10() shouldBe false
+		hevc.supportsHevcHDR10Plus() shouldBe false
+		hevc.getMainLevel() shouldBe 0
+		hevc.getMain10Level() shouldBe 0
+	}
+})


### PR DESCRIPTION
**Changes**

This follows up on #5604 by extracting the HEVC and AV1 codec detection logic out of MediaCodecCapabilitiesTest into their own modules. After this change, MediaCodecCapabilitiesTest is just a thin delegation facade with no logic of its own.

**Code assistance**

Claude Code was used as an assistant during implementation, code review, and test authoring.

