### PR TITLE
Add theme audio playback support

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/repository/ThemeAudioRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/repository/ThemeAudioRepository.kt
@@ -1,0 +1,34 @@
+package org.jellyfin.androidtv.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.libraryApi
+import org.jellyfin.sdk.api.client.extensions.userApi
+import timber.log.Timber
+import java.util.UUID
+
+interface ThemeAudioRepository {
+	suspend fun getThemeAudioUrl(itemId: UUID): String?
+}
+
+class ThemeAudioRepositoryImpl(private val api: ApiClient) : ThemeAudioRepository {
+
+	override suspend fun getThemeAudioUrl(itemId: UUID): String? = withContext(Dispatchers.IO) {
+		runCatching {
+			val response = api.libraryApi.getThemeSongs(
+				itemId = itemId,
+				userId = api.userApi.getCurrentUser().content.id,
+				inheritFromParent = true
+			)
+
+			val firstSongId = response.content.items.firstOrNull()?.id
+				?: return@runCatching null
+
+			val deviceId = api.deviceInfo.id
+			"${api.baseUrl}/Audio/$firstSongId/stream?static=true&deviceId=$deviceId"
+		}.onFailure { e ->
+			Timber.e(e, "ThemeMediaRepository: Exception in getThemeAudioUrl for $itemId")
+		}.getOrNull()
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -24,6 +24,8 @@ import org.jellyfin.androidtv.data.repository.ItemMutationRepository
 import org.jellyfin.androidtv.data.repository.ItemMutationRepositoryImpl
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.data.repository.NotificationsRepositoryImpl
+import org.jellyfin.androidtv.data.repository.ThemeAudioRepository
+import org.jellyfin.androidtv.data.repository.ThemeAudioRepositoryImpl
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.data.repository.UserViewsRepositoryImpl
 import org.jellyfin.androidtv.data.service.BackgroundService
@@ -44,6 +46,8 @@ import org.jellyfin.androidtv.ui.playback.nextup.NextUpViewModel
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepositoryImpl
 import org.jellyfin.androidtv.ui.playback.stillwatching.StillWatchingViewModel
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioPlayer
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModel
 import org.jellyfin.androidtv.ui.player.photo.PhotoPlayerViewModel
 import org.jellyfin.androidtv.ui.search.SearchFragmentDelegate
 import org.jellyfin.androidtv.ui.search.SearchRepository
@@ -150,6 +154,7 @@ val appModule = module {
 	single<SearchRepository> { SearchRepositoryImpl(get()) }
 	single<MediaSegmentRepository> { MediaSegmentRepositoryImpl(get(), get()) }
 	single<ExternalAppRepository> { ExternalAppRepository(get(), getAll(), get<DefaultExternalPlayerApi>()) }
+	single<ThemeAudioRepository> { ThemeAudioRepositoryImpl(get()) }
 
 	// External player APIs
 	single { VlcExternalPlayerApi() } bind ExternalPlayerApi::class
@@ -167,6 +172,7 @@ val appModule = module {
 	viewModel { SearchViewModel(get()) }
 	viewModel { DreamViewModel(get(), get(), get(), get(), get()) }
 	viewModel { SettingsViewModel() }
+	viewModel { ThemeAudioViewModel(get(), get(), get(), get()) }
 	viewModel { SettingsLibrariesScreenViewModel(get()) }
 
 	single { BackgroundService(get(), get(), get(), get(), get()) }
@@ -176,6 +182,7 @@ val appModule = module {
 	single { KeyProcessor() }
 	single { ReportingHelper(get(), get()) }
 	single<PlaybackHelper> { SdkPlaybackHelper(get(), get(), get(), get()) }
+	single { ThemeAudioPlayer(androidContext()) }
 
 	factory { (context: Context) -> SearchFragmentDelegate(context, get(), get()) }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -60,6 +60,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var mediaQueuingEnabled = booleanPreference("pref_enable_tv_queuing", true)
 
 		/**
+		 * Play audio theme background when a media is selected
+		 */
+		var playThemeAudio = booleanPreference("play_theme_audio", true)
+
+		/**
 		 * Enable the next up screen or not
 		 */
 		var nextUpBehavior = enumPreference("next_up_behavior", NextUpBehavior.EXTENDED)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
@@ -19,11 +19,13 @@ import org.jellyfin.androidtv.data.service.BackgroundService
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModel
 import org.jellyfin.androidtv.ui.presentation.CardPresenter
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 	protected var folder: BaseItemDto? = null
@@ -33,9 +35,11 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 
 	private val backgroundService by inject<BackgroundService>()
 	private val itemLauncher by inject<ItemLauncher>()
+	private val themeAudioViewModel: ThemeAudioViewModel by activityViewModel()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
+
 
 		// Parse intent
 		folder = Json.decodeFromString<BaseItemDto>(arguments?.getString(Extras.Folder)!!)
@@ -46,25 +50,29 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 		headersState = HEADERS_DISABLED
 
 		// Add event listeners
-		onItemViewClickedListener = OnItemViewClickedListener { _: Presenter.ViewHolder?, item: Any?, _: RowPresenter.ViewHolder?, row: Row ->
-			if (item is BaseRowItem) {
-				itemLauncher.launch(
-					item,
-					(row as ListRow).adapter as ItemRowAdapter,
-					requireContext()
-				)
+		onItemViewClickedListener =
+			OnItemViewClickedListener { _: Presenter.ViewHolder?, item: Any?, _: RowPresenter.ViewHolder?, row: Row ->
+				if (item is BaseRowItem) {
+					itemLauncher.launch(
+						item,
+						(row as ListRow).adapter as ItemRowAdapter,
+						requireContext()
+					)
+				}
 			}
-		}
-		onItemViewSelectedListener = OnItemViewSelectedListener { _: Presenter.ViewHolder?, item: Any?, _: RowPresenter.ViewHolder?, row: Row ->
-			if (item !is BaseRowItem) {
-				backgroundService.clearBackgrounds()
-			} else {
-				val adapter = (row as? ListRow)?.adapter
-				if (adapter is ItemRowAdapter) adapter.loadMoreItemsIfNeeded(adapter.indexOf(item))
+		onItemViewSelectedListener =
+			OnItemViewSelectedListener { _: Presenter.ViewHolder?, item: Any?, _: RowPresenter.ViewHolder?, row: Row ->
+				if (item !is BaseRowItem) {
+					backgroundService.clearBackgrounds()
+					themeAudioViewModel.onItemFocused(null)
+				} else {
+					val adapter = (row as? ListRow)?.adapter
+					if (adapter is ItemRowAdapter) adapter.loadMoreItemsIfNeeded(adapter.indexOf(item))
 
-				backgroundService.setBackground(item.baseItem)
+					backgroundService.setBackground(item.baseItem)
+					themeAudioViewModel.onItemFocused(item.baseItem?.id)
+				}
 			}
-		}
 
 		// Initialize
 		lifecycleScope.launch {
@@ -73,6 +81,7 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 			}
 		}
 	}
+
 
 	protected abstract suspend fun setupQueries(rowLoader: RowLoader)
 
@@ -101,5 +110,10 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 				mutableAdapter.add(row)
 			}
 		}
+	}
+
+	override fun onPause() {
+		super.onPause()
+		themeAudioViewModel.onItemUnfocused()
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -50,6 +50,8 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapterHelperKt;
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModel;
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModelHelperKt;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.HorizontalGridPresenter;
 import org.jellyfin.androidtv.util.CoroutineUtils;
@@ -129,6 +131,8 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
 
     private boolean mDirty = true; // CardHeight, RowDef or GridSize changed
 
+    private ThemeAudioViewModel themeAudioViewModel;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -192,6 +196,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         binding = HorizontalGridBrowseBinding.inflate(inflater, container, false);
+        themeAudioViewModel = ThemeAudioViewModelHelperKt.getThemeAudioViewModel(this);
         return binding.getRoot();
     }
 
@@ -623,7 +628,7 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
             chunkSize = Math.min(mCardsScreenEst + mCardsScreenStride, 150); // cap at 150
             Timber.d("buildAdapter adjusting chunkSize to <%s> screenEst <%s>", chunkSize, mCardsScreenEst);
         }
-        chunkSize=100;
+        chunkSize = 100;
 
         switch (mRowDef.getQueryType()) {
             case NextUp:
@@ -930,15 +935,25 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                 binding.title.setText(mainTitle);
                 //fill in default background
                 backgroundService.getValue().clearBackgrounds();
+                if (themeAudioViewModel != null) themeAudioViewModel.onItemFocused(null);
             } else {
                 mCurrentItem = (BaseRowItem) item;
                 binding.title.setText(mCurrentItem.getName(requireContext()));
                 binding.infoRow.removeAllViews();
                 mHandler.postDelayed(mDelayedSetItem, VIEW_SELECT_UPDATE_DELAY);
+                themeAudioViewModel.onItemFocused(((BaseRowItem) item).getBaseItem().getId());
 
                 if (!determiningPosterSize)
                     mAdapter.loadMoreItemsIfNeeded(mAdapter.indexOf(mCurrentItem));
             }
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (themeAudioViewModel != null) {
+            themeAudioViewModel.onItemUnfocused();
         }
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -46,6 +46,8 @@ import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter;
 import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapterHelperKt;
 import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModel;
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModelHelperKt;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.GridButtonPresenter;
@@ -106,6 +108,8 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     private final Lazy<ItemLauncher> itemLauncher = inject(ItemLauncher.class);
     private final Lazy<KeyProcessor> keyProcessor = inject(KeyProcessor.class);
     private final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
+
+    private ThemeAudioViewModel themeAudioViewModel;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -62,6 +62,8 @@ import org.jellyfin.androidtv.ui.navigation.Destinations;
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModel;
+import org.jellyfin.androidtv.ui.playback.theme.ThemeAudioViewModelHelperKt;
 import org.jellyfin.androidtv.ui.presentation.CardPresenter;
 import org.jellyfin.androidtv.ui.presentation.CustomListRowPresenter;
 import org.jellyfin.androidtv.ui.presentation.InfoCardPresenter;
@@ -153,6 +155,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
     private final Lazy<InteractionTrackerViewModel> interactionTracker = inject(InteractionTrackerViewModel.class);
 
+    private ThemeAudioViewModel themeAudioViewModel;
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -181,6 +185,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         if (timerJson != null) {
             mSeriesTimerInfo = Json.Default.decodeFromString(SeriesTimerInfoDto.Companion.serializer(), timerJson);
         }
+
+        themeAudioViewModel = ThemeAudioViewModelHelperKt.getThemeAudioViewModel(this);
 
         CoroutineUtils.readCustomMessagesOnLifecycle(getLifecycle(), customMessageRepository.getValue(), message -> {
             if (message.equals(CustomMessage.ActionComplete.INSTANCE) && mSeriesTimerInfo != null) {
@@ -282,6 +288,9 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     public void onPause() {
         super.onPause();
         stopClock();
+        if (themeAudioViewModel != null) {
+            themeAudioViewModel.onItemUnfocused();
+        }
     }
 
     @Override
@@ -583,7 +592,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 break;
             case MUSIC_ARTIST:
-                ItemRowAdapter artistAlbumsAdapter = new ItemRowAdapter(requireContext(),  BrowsingUtils.createArtistItemsRequest(mBaseItem.getId(), BaseItemKind.MUSIC_ALBUM), 100, false, new CardPresenter(), adapter);
+                ItemRowAdapter artistAlbumsAdapter = new ItemRowAdapter(requireContext(), BrowsingUtils.createArtistItemsRequest(mBaseItem.getId(), BaseItemKind.MUSIC_ALBUM), 100, false, new CardPresenter(), adapter);
                 addItemRow(adapter, artistAlbumsAdapter, 0, getString(R.string.lbl_albums));
 
                 break;
@@ -1200,8 +1209,30 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                                    RowPresenter.ViewHolder rowViewHolder, Row row) {
             if (!(item instanceof BaseRowItem)) {
                 mCurrentItem = null;
+                if (themeAudioViewModel != null) {
+                    if (mBaseItem != null) {
+                        // we look for an episode in a media item so we play theme based on the main media item instead
+                        themeAudioViewModel.onItemFocused(mBaseItem.getId());
+                    } else {
+                        themeAudioViewModel.onItemFocused(null);
+                    }
+                }
             } else {
                 mCurrentItem = (BaseRowItem) item;
+                if (themeAudioViewModel != null) {
+                    BaseItemDto rowBaseItem = mCurrentItem.getBaseItem();
+
+                    // something that doesn't have a base item will just use the main media item for theme music
+                    if (rowBaseItem != null) {
+                        themeAudioViewModel.onItemFocused(rowBaseItem.getId());
+                    } else {
+                        if (mBaseItem != null) {
+                            themeAudioViewModel.onItemFocused(mBaseItem.getId());
+                        } else {
+                            themeAudioViewModel.onItemFocused(null);
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/theme/ThemeAudioPlayer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/theme/ThemeAudioPlayer.kt
@@ -1,0 +1,35 @@
+package org.jellyfin.androidtv.ui.playback.theme
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+
+class ThemeAudioPlayer(private val context: Context) {
+	private var exoPlayer: ExoPlayer? = null
+
+	fun play(url: String) {
+		if (exoPlayer == null) {
+			exoPlayer = ExoPlayer.Builder(context).build().apply {
+				volume = 0.25f // Not too loud + Maybe a setting later
+				repeatMode = Player.REPEAT_MODE_ONE
+			}
+		}
+
+		exoPlayer?.apply {
+			setMediaItem(MediaItem.fromUri(url))
+			prepare()
+			playWhenReady = true
+		}
+	}
+
+	fun stop() {
+		exoPlayer?.stop()
+		exoPlayer?.clearMediaItems()
+	}
+
+	fun release() {
+		exoPlayer?.release()
+		exoPlayer = null
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/theme/ThemeAudioViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/theme/ThemeAudioViewModel.kt
@@ -1,0 +1,89 @@
+package org.jellyfin.androidtv.ui.playback.theme
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.data.repository.ThemeAudioRepository
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.playback.AudioEventListener
+import org.jellyfin.androidtv.ui.playback.MediaManager
+import org.jellyfin.androidtv.ui.playback.PlaybackController
+import org.jellyfin.sdk.model.api.BaseItemDto
+import timber.log.Timber
+import java.util.UUID
+
+class ThemeAudioViewModel(
+    private val repository: ThemeAudioRepository,
+    private val player: ThemeAudioPlayer,
+    private val userPreferences: UserPreferences,
+    private val mediaManager: MediaManager
+) : ViewModel(), AudioEventListener {
+
+	private var currentJob: Job? = null
+	private var lastFocusedItemId: UUID? = null
+	private var currentPlayingUrl: String? = null
+
+	init {
+		mediaManager.addAudioEventListener(this)
+	}
+
+	fun onItemFocused(itemId: UUID?) {
+
+		val isThemeAudioEnabled = userPreferences.get(UserPreferences.playThemeAudio)
+		if (itemId == lastFocusedItemId) return
+		if (mediaManager.isPlayingAudio) return
+
+		lastFocusedItemId = itemId
+
+		currentJob?.cancel()
+
+		if (itemId == null || !isThemeAudioEnabled) {
+			stopThemeAudio()
+			return
+		}
+
+		currentJob = viewModelScope.launch {
+			delay(800) // Debounce
+
+			val url = repository.getThemeAudioUrl(itemId)
+
+			if (url == currentPlayingUrl && currentPlayingUrl != null) {
+				return@launch
+			}
+
+			player.stop()
+			currentPlayingUrl = url
+
+			if (url != null && !mediaManager.isPlayingAudio) {
+				Timber.v("ThemeAudioViewModel: theme media started")
+				player.play(url)
+			}
+		}
+	}
+
+	private fun stopThemeAudio() {
+		player.stop()
+		currentPlayingUrl = null
+	}
+
+	fun onItemUnfocused() {
+		currentJob?.cancel()
+		stopThemeAudio()
+		lastFocusedItemId = null
+	}
+
+	// Stop theme if media is starting
+	override fun onPlaybackStateChange(newState: PlaybackController.PlaybackState, currentItem: BaseItemDto?) {
+		if (newState == PlaybackController.PlaybackState.PLAYING) {
+			onItemUnfocused()
+		}
+	}
+
+	override fun onCleared() {
+		super.onCleared()
+		mediaManager.removeAudioEventListener(this)
+		player.release()
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/theme/ThemeAudioViewModelHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/theme/ThemeAudioViewModelHelper.kt
@@ -1,0 +1,9 @@
+package org.jellyfin.androidtv.ui.playback.theme
+
+import androidx.fragment.app.Fragment
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
+
+fun getThemeAudioViewModel(fragment: Fragment): ThemeAudioViewModel {
+	val lazyViewModel: ThemeAudioViewModel by fragment.activityViewModel()
+	return lazyViewModel
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationScreen.kt
@@ -89,6 +89,17 @@ fun SettingsCustomizationScreen() {
 			)
 		}
 
+		item {
+			var themeAudioEnabled by rememberPreference(userPreferences, UserPreferences.playThemeAudio)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.preference_theme_audio)) },
+				trailingContent = { Checkbox(checked = themeAudioEnabled) },
+				captionContent = { Text(stringResource(R.string.preference_theme_audio_summary)) },
+				onClick = { themeAudioEnabled = !themeAudioEnabled }
+			)
+		}
+
 		item { ListSection(headingContent = { Text(stringResource(R.string.pref_browsing)) }) }
 
 		item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -618,6 +618,8 @@
     <string name="preference_enable_ass">Direct play ASS subtitles</string>
     <string name="preference_enable_pgs_description">Requires transcoding when disabled</string>
     <string name="preference_enable_ass_description">Experimental feature, may not work reliably</string>
+    <string name="preference_theme_audio">Play audio themes</string>
+    <string name="preference_theme_audio_summary">Play audio theme when browsing media</string>
     <string name="auto">Auto</string>
     <plurals name="seconds">
         <item quantity="one">%1$s second</item>


### PR DESCRIPTION
**Why?**
Theme audio is a nice feature in the Jellyfin Server and Web client, but it was currently missing in the Android TV app. This PR introduces theme audio playback support.

**Changes**
Implemented a `ThemeAudioRepository` to fetch theme audio data from the Jellyfin API, adhering to the project's repository conventions. Created a `ThemeAudioPlayer` powered by `ExoPlayer` for reliable background audio playback. The core logic is managed by a new `ThemeAudioViewModel`, which seamlessly handles focus/unfocus events and is integrated across the relevant browse and detail fragments. Finally, added a toggle in Settings -> Customization to enable/disable the feature, complete with localized strings for all supported languages.
All modified files have been reformatted to ensure code consistency, using Android Studio's built-in formatter.

**Code assistance**
An LLM was used to help navigate the codebase at first, but all code in this PR was written manually, no AI generated code is included.
AI was only used for: translating the new setting strings across all localized strings.xml files, and translating this PR description from French to English.

**Testing**
Tested on the built-in emulator in Android Studio and a Mi TV Box 4K 1st Gen (Android 11) with adb

**Issues**
Fixes #1150 partially (only Theme)
