### PR TITLE
 InfoRow badges: differentiate between EAC3 and TrueHD Atmos, fix DTS-HD check

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -209,13 +209,20 @@ fun InfoRowMediaDetails(mediaSource: MediaSourceInfo) {
 	}
 	// Audio stream
 	val audioCodecName = when {
-		audioStream?.profile?.contains("Dolby Atmos", ignoreCase = true) == true -> stringResource(R.string.dolby_atmos)
+		audioStream?.profile?.contains("Dolby Atmos", ignoreCase = true) == true -> {
+			when (audioStream?.codec?.uppercase()) {
+				"EAC3" -> stringResource(R.string.eac3_atmos)
+				"TRUEHD" -> stringResource(R.string.truehd_atmos)
+				else -> stringResource(R.string.dolby_atmos)
+			}
+		}
 		audioStream?.profile?.contains("DTS:X", ignoreCase = true) == true -> stringResource(R.string.dts_x)
 		audioStream?.profile?.contains("DTS:HD", ignoreCase = true) == true -> stringResource(R.string.dts_hd)
 		else -> when (audioStream?.codec?.uppercase()) {
 			"DCA" -> stringResource(R.string.dca)
 			"AC3" -> stringResource(R.string.ac3)
 			"EAC3" -> stringResource(R.string.eac3)
+			"TRUEHD" -> stringResource(R.string.truehd)
 			else -> audioStream?.codec?.uppercase()
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -217,7 +217,7 @@ fun InfoRowMediaDetails(mediaSource: MediaSourceInfo) {
 			}
 		}
 		audioStream?.profile?.contains("DTS:X", ignoreCase = true) == true -> stringResource(R.string.dts_x)
-		audioStream?.profile?.contains("DTS:HD", ignoreCase = true) == true -> stringResource(R.string.dts_hd)
+		audioStream?.profile?.let { it.contains("DTS:HD", ignoreCase = true) || it.contains("DTS-HD", ignoreCase = true) } == true -> stringResource(R.string.dts_hd)
 		else -> when (audioStream?.codec?.uppercase()) {
 			"DCA" -> stringResource(R.string.dca)
 			"AC3" -> stringResource(R.string.ac3)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/composable/inforow/BaseItemInfoRow.kt
@@ -217,7 +217,10 @@ fun InfoRowMediaDetails(mediaSource: MediaSourceInfo) {
 			}
 		}
 		audioStream?.profile?.contains("DTS:X", ignoreCase = true) == true -> stringResource(R.string.dts_x)
-		audioStream?.profile?.let { it.contains("DTS:HD", ignoreCase = true) || it.contains("DTS-HD", ignoreCase = true) } == true -> stringResource(R.string.dts_hd)
+		audioStream?.profile?.let {
+		    it.contains("DTS:HD", ignoreCase = true) ||
+			    it.contains("DTS-HD", ignoreCase = true)
+		} == true -> stringResource(R.string.dts_hd)
 		else -> when (audioStream?.codec?.uppercase()) {
 			"DCA" -> stringResource(R.string.dca)
 			"AC3" -> stringResource(R.string.ac3)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -666,4 +666,7 @@
     <string name="hlg">HLG</string>
     <string name="pref_software_codecs_enabled">Use software codecs</string>
     <string name="pref_software_codecs_enabled_description">Some software-based implementations may degrade performance. Disabling this option makes transcoding more likely.</string>
+    <string name="truehd">TrueHD</string>
+    <string name="eac3_atmos">DD+ Atmos</string>
+    <string name="truehd_atmos">TrueHD Atmos</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -510,7 +510,7 @@
     <string name="indicator_subtitles_hearing_impaired">SDH</string>
     <string name="dolby_atmos">Dolby Atmos</string>
     <string name="dts_x">DTS:X</string>
-    <string name="dts_hd">DTS:HD</string>
+    <string name="dts_hd">DTS-HD</string>
     <string name="dca">DTS</string>
     <string name="ac3">DD</string>
     <string name="eac3">DD+</string>


### PR DESCRIPTION
**Changes**
This PR changes the InfoRow badges to differentiate between EAC3 and TrueHD when Dolby Atmos is present. Originally, it would just display "Dolby Atmos" in all cases, making it impossible to see the underlying audio codec. It adds the required strings for this, as well as a "TrueHD" string to allow for proper capitalisation. A fallback is present in the rare event of a different codec with Atmos.

For DTS-HD, the existing check looked for "DTS:HD" (with a colon), while the actual profile value is "DTS-HD" (with a hyphen), meaning the interface would always just display "DTS", even for DTS-HD files. This PR adds a check and fixes the user-facing string to use a hyphen instead.

In summary:
| Audio codec | Before | After |
|--------|--------|--------|
| DD+ with Atmos | Dolby Atmos | DD+ Atmos |
| TrueHD with Atmos | Dolby Atmos | TrueHD Atmos |
| Other codec with Atmos | Dolby Atmos | Dolby Atmos |
| TrueHD without Atmos | TRUEHD | TrueHD |
| DTS-HD | DTS | DTS-HD | 

I had GitHub build a debug apk, sideloaded it and successfully tested all changes.

**Code assistance**
Some use of Gemini for double checking and verification purposes

**Issues**
Fixes #5635 
