### PR TITLE
Add AndroidVersion helper for readable, mockable SDK version checks

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.di
 
 import android.content.Context
-import android.os.Build
 import androidx.lifecycle.ProcessLifecycleOwner
 import coil3.ImageLoader
 import coil3.annotation.ExperimentalCoilApi
@@ -54,6 +53,7 @@ import org.jellyfin.androidtv.ui.settings.compat.SettingsViewModel
 import org.jellyfin.androidtv.ui.startup.ServerAddViewModel
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.KeyProcessor
 import org.jellyfin.androidtv.util.MarkdownRenderer
 import org.jellyfin.androidtv.util.PlaybackHelper
@@ -128,7 +128,7 @@ val appModule = module {
 			components {
 				add(get<NetworkFetcher.Factory>())
 
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) add(AnimatedImageDecoder.Factory())
+				if (AndroidVersion.isAtLeastP) add(AnimatedImageDecoder.Factory())
 				else add(GifDecoder.Factory())
 				add(SvgDecoder.Factory())
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -4,7 +4,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
-import android.os.Build
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.media3.datasource.HttpDataSource
@@ -18,6 +17,7 @@ import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.profile.createDeviceProfile
 import org.jellyfin.playback.core.playbackManager
 import org.jellyfin.playback.jellyfin.jellyfinPlugin
@@ -60,7 +60,7 @@ fun Scope.createPlaybackManager() = playbackManager(androidContext()) {
 	val pendingIntent = PendingIntent.getActivity(get(), 0, activityIntent, PendingIntent.FLAG_IMMUTABLE)
 
 	val notificationChannelId = "session"
-	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+	if (AndroidVersion.isAtLeastO) {
 		val channel = NotificationChannel(
 			notificationChannelId,
 			notificationChannelId,

--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -6,7 +6,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import androidx.core.content.edit
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
@@ -28,6 +27,7 @@ import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.integration.provider.ImageProvider
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.startup.StartupActivity
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.ImageHelper
 import org.jellyfin.androidtv.util.apiclient.getUrl
 import org.jellyfin.androidtv.util.apiclient.itemImages
@@ -76,7 +76,7 @@ class LeanbackChannelWorker(
 	/**
 	 * Check if the app can use Leanback features and is API level 26 or higher.
 	 */
-	private val isSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+	private val isSupported = AndroidVersion.isAtLeastO &&
 		// Check for leanback support
 		context.packageManager.hasSystemFeature("android.software.leanback")
 		// Check for "android.media.tv" provider to workaround a false-positive in the previous check

--- a/app/src/main/java/org/jellyfin/androidtv/integration/provider/ImageProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/provider/ImageProvider.kt
@@ -5,7 +5,6 @@ import android.content.ContentValues
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.os.Build
 import android.os.ParcelFileDescriptor
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
@@ -15,6 +14,7 @@ import coil3.request.ImageRequest
 import coil3.request.error
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.koin.android.ext.android.inject
 import java.io.IOException
 
@@ -53,7 +53,7 @@ class ImageProvider : ContentProvider() {
 	) {
 		@Suppress("DEPRECATION")
 		val format = when {
-			Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> Bitmap.CompressFormat.WEBP_LOSSY
+			AndroidVersion.isAtLeastR -> Bitmap.CompressFormat.WEBP_LOSSY
 			else -> Bitmap.CompressFormat.WEBP
 		}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/ServerButtonView.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.ui
 
 import android.content.Context
 import android.graphics.Rect
-import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
 import androidx.compose.foundation.interaction.FocusInteraction
@@ -41,6 +40,7 @@ import org.jellyfin.androidtv.ui.base.button.ButtonBase
 import org.jellyfin.androidtv.ui.base.button.ButtonDefaults
 import org.jellyfin.androidtv.util.MenuBuilder
 import org.jellyfin.androidtv.util.popupMenu
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.showIfNotEmpty
 
 @Composable
@@ -107,7 +107,7 @@ class ServerButtonView @JvmOverloads constructor(
 	init {
 		isFocusable = true
 		descendantFocusability = FOCUS_BLOCK_DESCENDANTS
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) defaultFocusHighlightEnabled = false
+		if (AndroidVersion.isAtLeastO) defaultFocusHighlightEnabled = false
 	}
 
 	fun setPopupMenu(init: MenuBuilder.() -> Unit) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/TextUnderButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/TextUnderButton.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.ui
 
 import android.content.Context
-import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -9,6 +8,7 @@ import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import org.jellyfin.androidtv.databinding.TextUnderButtonBinding
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.dp
 
 class TextUnderButton @JvmOverloads constructor(
@@ -23,7 +23,7 @@ class TextUnderButton @JvmOverloads constructor(
 		isFocusable = true
 		isFocusableInTouchMode = true
 		descendantFocusability = FOCUS_BLOCK_DESCENDANTS
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) defaultFocusHighlightEnabled = false
+		if (AndroidVersion.isAtLeastO) defaultFocusHighlightEnabled = false
 	}
 
 	fun setLabel(text: String?) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/card/UserCardView.kt
@@ -2,7 +2,6 @@ package org.jellyfin.androidtv.ui.card
 
 import android.content.Context
 import android.graphics.Rect
-import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
 import androidx.compose.animation.core.animateFloatAsState
@@ -44,6 +43,7 @@ import org.jellyfin.androidtv.ui.base.ProvideTextStyle
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.util.MenuBuilder
 import org.jellyfin.androidtv.util.popupMenu
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.showIfNotEmpty
 
 @Composable
@@ -114,7 +114,7 @@ class UserCardView @JvmOverloads constructor(
 	init {
 		isFocusable = true
 		descendantFocusability = FOCUS_BLOCK_DESCENDANTS
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) defaultFocusHighlightEnabled = false
+		if (AndroidVersion.isAtLeastO) defaultFocusHighlightEnabled = false
 	}
 
 	fun setPopupMenu(init: MenuBuilder.() -> Unit) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManagerHelper.kt
@@ -3,8 +3,8 @@ package org.jellyfin.androidtv.ui.playback
 import android.media.audiofx.AudioEffect
 import android.media.audiofx.DynamicsProcessing
 import android.media.audiofx.Equalizer
-import android.os.Build
 import androidx.core.net.toUri
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.playback.media3.exoplayer.mapping.getFfmpegSubtitleMimeType
 import org.jellyfin.sdk.model.api.MediaStream
 import timber.log.Timber
@@ -32,7 +32,7 @@ fun applyAudioNightmode(audioSessionId: Int) {
 
 	audioEffect = when {
 		// Use dynamics processinc on Android 9 (API 28) and newer
-		Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> DynamicsProcessing(0, audioSessionId, null).apply {
+		AndroidVersion.isAtLeastP -> DynamicsProcessing(0, audioSessionId, null).apply {
 			setLimiterAllChannelsTo(
 				DynamicsProcessing.Limiter(
 					true,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackCodecScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackCodecScreen.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.androidtv.ui.settings.screen.playback
 
-import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -15,6 +14,7 @@ import org.jellyfin.androidtv.ui.navigation.LocalRouter
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.koin.compose.koinInject
 
 @Composable
@@ -51,7 +51,7 @@ fun SettingsPlaybackCodecScreen() {
 			)
 		}
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+		if (AndroidVersion.isAtLeastQ) {
 			item {
 				var softwareCodecsEnabled by rememberPreference(userPreferences, UserPreferences.softwareCodecsEnabled)
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/util/copyAction.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/util/copyAction.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.ui.settings.util
 
 import android.content.ClipData
-import android.os.Build
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ClipEntry
@@ -11,6 +10,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.util.AndroidVersion
 
 @Composable
 fun copyAction(data: ClipData): () -> Unit {
@@ -22,7 +22,7 @@ fun copyAction(data: ClipData): () -> Unit {
 		lifecycleScope.launch {
 			clipboard.setClipEntry(ClipEntry(data))
 
-			if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+			if (!AndroidVersion.isAtLeastT) {
 				Toast.makeText(context, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show()
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/util/AndroidVersion.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/AndroidVersion.kt
@@ -1,0 +1,51 @@
+package org.jellyfin.androidtv.util
+
+import android.os.Build
+
+/**
+ * Helper to check the current Android version.
+ *
+ * Comparisons are made against the device's Android SDK version in [Build.VERSION.SDK_INT]. Using the named
+ * properties below reads better at the call site than an inline `Build.VERSION.SDK_INT >= Build.VERSION_CODES.X`
+ * comparison.
+ *
+ * The [sdkInt] getter is the single seam that reads the system value. The version checks build on it, so tests can
+ * mock the SDK version by mocking [sdkInt] alone (`mockkObject(AndroidVersion)` + `every { AndroidVersion.sdkInt }`).
+ * This indirection exists because [Build.VERSION.SDK_INT] is a static final field that can't be set reflectively on
+ * JDK 17+.
+ *
+ * @see Build.VERSION.SDK_INT
+ */
+object AndroidVersion {
+	/**
+	 * The device's Android SDK version. Wraps [Build.VERSION.SDK_INT] so it can be mocked in tests.
+	 */
+	val sdkInt: Int get() = Build.VERSION.SDK_INT
+
+	/** At least Android 7 Nougat, API 24. @see Build.VERSION_CODES.N */
+	val isAtLeastN: Boolean get() = sdkInt >= Build.VERSION_CODES.N
+
+	/** At least Android 8 Oreo, API 26. @see Build.VERSION_CODES.O */
+	val isAtLeastO: Boolean get() = sdkInt >= Build.VERSION_CODES.O
+
+	/** At least Android 9 Pie, API 28. @see Build.VERSION_CODES.P */
+	val isAtLeastP: Boolean get() = sdkInt >= Build.VERSION_CODES.P
+
+	/** At least Android 10 Q, API 29. @see Build.VERSION_CODES.Q */
+	val isAtLeastQ: Boolean get() = sdkInt >= Build.VERSION_CODES.Q
+
+	/** At least Android 11 R, API 30. @see Build.VERSION_CODES.R */
+	val isAtLeastR: Boolean get() = sdkInt >= Build.VERSION_CODES.R
+
+	/** At least Android 12 S, API 31. @see Build.VERSION_CODES.S */
+	val isAtLeastS: Boolean get() = sdkInt >= Build.VERSION_CODES.S
+
+	/** At least Android 13 Tiramisu, API 33. @see Build.VERSION_CODES.TIRAMISU */
+	val isAtLeastT: Boolean get() = sdkInt >= Build.VERSION_CODES.TIRAMISU
+
+	/** At least Android 14 Upside Down Cake, API 34. @see Build.VERSION_CODES.UPSIDE_DOWN_CAKE */
+	val isAtLeastUpsideDownCake: Boolean get() = sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+	/** At least Android 16 Baklava, API 36. @see Build.VERSION_CODES.BAKLAVA */
+	val isAtLeastBaklava: Boolean get() = sdkInt >= Build.VERSION_CODES.BAKLAVA
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/BundleExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/BundleExtensions.kt
@@ -1,11 +1,10 @@
 package org.jellyfin.androidtv.util
 
-import android.os.Build
 import android.os.Bundle
 
 @Suppress("DEPRECATION")
 inline fun <reified T> Bundle.getValue(key: String): T? = when {
-	Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelable(key, T::class.java)
+	AndroidVersion.isAtLeastT -> getParcelable(key, T::class.java)
 	else -> get(key) as T?
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/DateTimeExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/DateTimeExtensions.kt
@@ -1,7 +1,6 @@
 package org.jellyfin.androidtv.util
 
 import android.content.Context
-import android.os.Build
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
@@ -9,7 +8,7 @@ import java.util.Locale
 @Suppress("DEPRECATION")
 val Context.locale: Locale
 	get() = when {
-		Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> resources.configuration.getLocales().get(0)
+		AndroidVersion.isAtLeastN -> resources.configuration.getLocales().get(0)
 		else -> resources.configuration.locale
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyEventExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyEventExtensions.kt
@@ -1,13 +1,12 @@
 package org.jellyfin.androidtv.util
 
-import android.os.Build
 import android.view.KeyEvent
 
 /**
  * Returns whether this key event is a media key event or not.
  */
 fun KeyEvent.isMediaSessionKeyEvent(): Boolean = when {
-	Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> KeyEvent.isMediaSessionKey(keyCode)
+	AndroidVersion.isAtLeastS -> KeyEvent.isMediaSessionKey(keyCode)
 
 	else -> when (keyCode) {
 		KeyEvent.KEYCODE_MEDIA_PLAY,

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -251,7 +251,9 @@ fun createDeviceProfileReport(
 				appendLine()
 				appendLine("- ${HdrFormats.DOLBY_VISION.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)}")
 				appendLine("- ${HdrFormats.HDR10}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10)}")
-				if (AndroidVersion.isAtLeastQ) appendLine("- ${HdrFormats.HDR10_PLUS.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)}")
+				if (AndroidVersion.isAtLeastQ) {
+					appendLine("- ${HdrFormats.HDR10_PLUS.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)}")
+				}
 				appendLine("- ${HdrFormats.HLG.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HLG)}")
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -47,15 +47,6 @@ private val featureNames = setOf(
 	"tunneled-playback",
 )
 
-// API levels
-private val isN = AndroidVersion.isAtLeastN // API 24
-private val isO = AndroidVersion.isAtLeastO // API 26
-private val isQ = AndroidVersion.isAtLeastQ // API 29
-private val isR = AndroidVersion.isAtLeastR // API 30
-private val isS = AndroidVersion.isAtLeastS // API 31
-private val isUpsideDownCake = AndroidVersion.isAtLeastUpsideDownCake // API 34
-private val isBaklava = AndroidVersion.isAtLeastBaklava // API 36
-
 // HDR formats to label strings
 enum class HdrFormats(val label: String) {
 	DOLBY_VISION("Dolby Vision"),
@@ -94,17 +85,17 @@ fun createDeviceProfileReport(
 	// Device capabilities used to generate profile
 	val codecs = MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
 		.filter { !it.isEncoder }
-		.sortedBy { if (isQ) it.canonicalName else it.name }
+		.sortedBy { if (AndroidVersion.isAtLeastQ) it.canonicalName else it.name }
 
 	appendDetails("Device codec decoders") {
 		for (codec in codecs) {
-			if (isQ) appendLine("- **${codec.canonicalName} (${codec.name})**")
+			if (AndroidVersion.isAtLeastQ) appendLine("- **${codec.canonicalName} (${codec.name})**")
 			else appendLine("- **${codec.name}**")
 
-			if (isQ) appendLine("  - isVendor: ${codec.isVendor}")
-			if (isQ) appendLine("  - isHardwareAccelerated: ${codec.isHardwareAccelerated}")
-			if (isQ) appendLine("  - isSoftwareOnly: ${codec.isSoftwareOnly}")
-			if (isQ) appendLine("  - isAlias: ${codec.isAlias}")
+			if (AndroidVersion.isAtLeastQ) appendLine("  - isVendor: ${codec.isVendor}")
+			if (AndroidVersion.isAtLeastQ) appendLine("  - isHardwareAccelerated: ${codec.isHardwareAccelerated}")
+			if (AndroidVersion.isAtLeastQ) appendLine("  - isSoftwareOnly: ${codec.isSoftwareOnly}")
+			if (AndroidVersion.isAtLeastQ) appendLine("  - isAlias: ${codec.isAlias}")
 
 			for (type in codec.supportedTypes) {
 				val capabilities = codec.getCapabilitiesForType(type)
@@ -112,9 +103,9 @@ fun createDeviceProfileReport(
 				appendLine("  - **$type**")
 
 				capabilities.audioCapabilities?.let { audio ->
-					if (isS) appendLine("    - minInputChannelCount: ${audio.minInputChannelCount}")
+					if (AndroidVersion.isAtLeastS) appendLine("    - minInputChannelCount: ${audio.minInputChannelCount}")
 					appendLine("    - maxInputChannelCount: ${audio.maxInputChannelCount}")
-					if (isS) audio.inputChannelCountRanges.takeIf { it.isNotEmpty() }?.let {
+					if (AndroidVersion.isAtLeastS) audio.inputChannelCountRanges.takeIf { it.isNotEmpty() }?.let {
 						appendLine("    - inputChannelCountRanges: ${it.joinToString(", ") { it.prettyFormat() }}")
 					}
 					audio.bitrateRange?.let { appendLine("    - bitrateRange: ${it.prettyFormat()}") }
@@ -138,7 +129,7 @@ fun createDeviceProfileReport(
 					video.supportedHeights?.let {
 						appendLine("    - supportedHeights: ${it.prettyFormat()}")
 					}
-					if (isQ) video.supportedPerformancePoints?.takeIf { it.isNotEmpty() }?.let {
+					if (AndroidVersion.isAtLeastQ) video.supportedPerformancePoints?.takeIf { it.isNotEmpty() }?.let {
 						appendLine("    - supportedPerformancePoints: ${it.joinToString(", ")}")
 					}
 				}
@@ -221,7 +212,7 @@ fun createDeviceProfileReport(
 		// Basic information
 		appendItem("Id") { appendValue(display.displayId.toString()) }
 		appendItem("Name") { appendValue(display.name) }
-		if (isS && display.deviceProductInfo != null) {
+		if (AndroidVersion.isAtLeastS && display.deviceProductInfo != null) {
 			val productInfo = requireNotNull(display.deviceProductInfo)
 			appendItem("Display product id") { appendValue(productInfo.productId) }
 			appendItem("Display bame") { appendValue(productInfo.name) }
@@ -242,34 +233,34 @@ fun createDeviceProfileReport(
 
 		// Refresh rate and timing
 		appendItem("Refresh rate") { appendValue(display.refreshRate.toString()) }
-		if (isBaklava) appendItem("Adaptive refresh rate") { appendValue(display.hasArrSupport().toString()) }
+		if (AndroidVersion.isAtLeastBaklava) appendItem("Adaptive refresh rate") { appendValue(display.hasArrSupport().toString()) }
 		appendItem("VSYNC offset") { appendValue(display.appVsyncOffsetNanos.nanoseconds.toString()) }
 		appendItem("Presentation deadline") { appendValue(display.presentationDeadlineNanos.nanoseconds.toString()) }
-		if (isR) appendItem("Minimal post processing") { appendValue(display.isMinimalPostProcessingSupported.toString()) }
+		if (AndroidVersion.isAtLeastR) appendItem("Minimal post processing") { appendValue(display.isMinimalPostProcessingSupported.toString()) }
 
 		// HDR
-		if (isO) appendItem("Any HDR") { appendValue(display.isHdr.toString()) }
-		if (isO) appendItem("Wide color gamut") { appendValue(display.isWideColorGamut.toString()) }
-		if (isQ) appendItem("Preferred wide color space") { appendValue(display.preferredWideGamutColorSpace.toString()) }
-		if (isN) {
+		if (AndroidVersion.isAtLeastO) appendItem("Any HDR") { appendValue(display.isHdr.toString()) }
+		if (AndroidVersion.isAtLeastO) appendItem("Wide color gamut") { appendValue(display.isWideColorGamut.toString()) }
+		if (AndroidVersion.isAtLeastQ) appendItem("Preferred wide color space") { appendValue(display.preferredWideGamutColorSpace.toString()) }
+		if (AndroidVersion.isAtLeastN) {
 			@Suppress("DEPRECATION")
-			val supportedHdrTypes = if (isUpsideDownCake) display.mode.supportedHdrTypes.toList()
+			val supportedHdrTypes = if (AndroidVersion.isAtLeastUpsideDownCake) display.mode.supportedHdrTypes.toList()
 			else display.hdrCapabilities.supportedHdrTypes.toList()
 
 			appendItem("HDR capabilities") {
 				appendLine()
 				appendLine("- ${HdrFormats.DOLBY_VISION.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)}")
 				appendLine("- ${HdrFormats.HDR10}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10)}")
-				if (isQ) appendLine("- ${HdrFormats.HDR10_PLUS.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)}")
+				if (AndroidVersion.isAtLeastQ) appendLine("- ${HdrFormats.HDR10_PLUS.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)}")
 				appendLine("- ${HdrFormats.HLG.label}: ${supportedHdrTypes.contains(Display.HdrCapabilities.HDR_TYPE_HLG)}")
 			}
 		}
 
-		if (isUpsideDownCake) appendItem("HDR/SDR ratio") {
+		if (AndroidVersion.isAtLeastUpsideDownCake) appendItem("HDR/SDR ratio") {
 			appendLine()
 			appendItem("Available") { appendValue(display.isHdrSdrRatioAvailable.toString()) }
 			appendItem("Ratio") { appendValue(display.hdrSdrRatio.toString()) }
-			if (isBaklava) {
+			if (AndroidVersion.isAtLeastBaklava) {
 				appendItem("Highest ratio") { appendValue(display.highestHdrSdrRatio.toString()) }
 			}
 		}
@@ -292,7 +283,7 @@ fun createDeviceProfileReport(
 		appendItem("Device model") { appendValue(Build.MODEL) }
 		appendItem("Device manufacturer") { appendValue(Build.MANUFACTURER) }
 		appendItem("Device codename") { appendValue(Build.DEVICE) }
-		if (isS) appendItem("Device SKU") { appendValue(Build.SKU) }
-		if (isS) appendItem("Device SOC") { appendValue(Build.SOC_MODEL) }
+		if (AndroidVersion.isAtLeastS) appendItem("Device SKU") { appendValue(Build.SKU) }
+		if (AndroidVersion.isAtLeastS) appendItem("Device SOC") { appendValue(Build.SOC_MODEL) }
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfileReport.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.BuildConfig
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.util.AndroidVersion
 import org.jellyfin.androidtv.util.appendCodeBlock
 import org.jellyfin.androidtv.util.appendDetails
 import org.jellyfin.androidtv.util.appendItem
@@ -47,13 +48,13 @@ private val featureNames = setOf(
 )
 
 // API levels
-private val isN = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N // API 24
-private val isO = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O // API 26
-private val isQ = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q // API 29
-private val isR = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R // API 30
-private val isS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S // API 31
-private val isUpsideDownCake = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE // API 34
-private val isBaklava = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA // API 36
+private val isN = AndroidVersion.isAtLeastN // API 24
+private val isO = AndroidVersion.isAtLeastO // API 26
+private val isQ = AndroidVersion.isAtLeastQ // API 29
+private val isR = AndroidVersion.isAtLeastR // API 30
+private val isS = AndroidVersion.isAtLeastS // API 31
+private val isUpsideDownCake = AndroidVersion.isAtLeastUpsideDownCake // API 34
+private val isBaklava = AndroidVersion.isAtLeastBaklava // API 36
 
 // HDR formats to label strings
 enum class HdrFormats(val label: String) {

--- a/app/src/test/kotlin/util/AndroidVersionTest.kt
+++ b/app/src/test/kotlin/util/AndroidVersionTest.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.util
+
+import android.os.Build
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+
+class AndroidVersionTest : FunSpec({
+	beforeEach {
+		mockkObject(AndroidVersion)
+	}
+
+	afterEach {
+		unmockkObject(AndroidVersion)
+	}
+
+	test("version checks return true when sdkInt is at the threshold") {
+		every { AndroidVersion.sdkInt } returns Build.VERSION_CODES.Q
+
+		AndroidVersion.isAtLeastN shouldBe true
+		AndroidVersion.isAtLeastO shouldBe true
+		AndroidVersion.isAtLeastP shouldBe true
+		AndroidVersion.isAtLeastQ shouldBe true
+		AndroidVersion.isAtLeastR shouldBe false
+		AndroidVersion.isAtLeastS shouldBe false
+		AndroidVersion.isAtLeastT shouldBe false
+	}
+
+	test("version checks return false when sdkInt is one below the threshold") {
+		every { AndroidVersion.sdkInt } returns Build.VERSION_CODES.R - 1
+
+		AndroidVersion.isAtLeastR shouldBe false
+		AndroidVersion.isAtLeastQ shouldBe true
+	}
+
+	test("all checks are true on the newest mocked version") {
+		every { AndroidVersion.sdkInt } returns Build.VERSION_CODES.BAKLAVA
+
+		AndroidVersion.isAtLeastN shouldBe true
+		AndroidVersion.isAtLeastO shouldBe true
+		AndroidVersion.isAtLeastP shouldBe true
+		AndroidVersion.isAtLeastQ shouldBe true
+		AndroidVersion.isAtLeastR shouldBe true
+		AndroidVersion.isAtLeastS shouldBe true
+		AndroidVersion.isAtLeastT shouldBe true
+		AndroidVersion.isAtLeastUpsideDownCake shouldBe true
+		AndroidVersion.isAtLeastBaklava shouldBe true
+	}
+
+	test("all checks are false on a version below every threshold") {
+		every { AndroidVersion.sdkInt } returns Build.VERSION_CODES.M
+
+		AndroidVersion.isAtLeastN shouldBe false
+		AndroidVersion.isAtLeastO shouldBe false
+		AndroidVersion.isAtLeastP shouldBe false
+		AndroidVersion.isAtLeastQ shouldBe false
+		AndroidVersion.isAtLeastR shouldBe false
+		AndroidVersion.isAtLeastS shouldBe false
+		AndroidVersion.isAtLeastT shouldBe false
+		AndroidVersion.isAtLeastUpsideDownCake shouldBe false
+		AndroidVersion.isAtLeastBaklava shouldBe false
+	}
+})


### PR DESCRIPTION
**Changes**

Introduces a shared `AndroidVersion` object with named `isAtLeastX` properties, mirroring the [pattern in jellyfin-android](https://github.com/jellyfin/jellyfin-android/blob/master/app/src/main/java/org/jellyfin/mobile/utils/AndroidVersion.kt). A single `sdkInt` getter is the only place `Build.VERSION.SDK_INT` is read, so tests can mock the SDK version by mocking that one property (the static final field can't be set reflectively on JDK 17+). Existing inline `SDK_INT >= VERSION_CODES.X` comparisons across the app are migrated to use it.

This unblocks #5646, which can then be rebased to consume `AndroidVersion` and drop its `DeviceSdk` shim (see [this comment](https://github.com/jellyfin/jellyfin-androidtv/pull/5646#discussion_r3485893997)).

**Code assistance**

Claude Code was used as an assistant during implementation and test authoring.
