### PR TITLE
Add support for separate skip ahead and skip back lengths

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [MajMongoose](https://github.com/majmongoose)
  - [Olaren15](https://github.com/Olaren15)
  - [dtrexler](https://github.com/dtrexler)
+ - [Kyle Ferguson](https://github.com/kferguson42)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/LeanbackOverlayFragment.java
@@ -103,7 +103,9 @@ public class LeanbackOverlayFragment extends PlaybackSupportFragment {
         playerGlue.setSeekEnabled(playerAdapter.canSeek());
 
         long skipForwardLength = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipForwardLength()).longValue();
+        long skipBackLength = userSettingPreferences.getValue().get(UserSettingPreferences.Companion.getSkipBackLength()).longValue();
         playerGlue.setSeekProvider(playerAdapter.canSeek() ? new CustomSeekProvider(playerAdapter, imageLoader.getValue(), api.getValue(), requireContext(), skipForwardLength) : null);
+        playerGlue.setSeekProvider(playerAdapter.canSeek() ? new CustomSeekProvider(playerAdapter, imageLoader.getValue(), api.getValue(), requireContext(), skipBackLength) : null);
         recordingStateChanged();
         playerAdapter.updateDuration();
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -108,6 +108,42 @@ fun SettingsPlaybackAdvancedScreen() {
 		}
 
 		item {
+			var skipBackLength by rememberPreference(userSettingPreferences, UserSettingPreferences.skipBackLength)
+			val interactionSource = remember { MutableInteractionSource() }
+
+			ListControl(
+				headingContent = { Text(stringResource(R.string.skip_back_length)) },
+				interactionSource = interactionSource,
+			) {
+				Row(
+					verticalAlignment = Alignment.CenterVertically,
+				) {
+					RangeControl(
+						modifier = Modifier
+							.height(4.dp)
+							.weight(1f),
+						interactionSource = interactionSource,
+						// 5 - 30 seconds with 5 second increment
+						min = 5_000f,
+						max = 30_000f,
+						stepBack = 5_000f,
+						value = skipBackLength.toFloat(),
+						onValueChange = { skipBackLength = it.roundToInt() }
+					)
+
+					Spacer(Modifier.width(Tokens.Space.spaceSm))
+
+					Box(
+						modifier = Modifier.sizeIn(minWidth = 32.dp),
+						contentAlignment = Alignment.CenterEnd
+					) {
+						Text("${skipBackLength / 1000}s")
+					}
+				}
+			}
+		}
+
+		item {
 			var bufferLength by rememberPreference(userPreferences, UserPreferences.bufferLength)
 
 			ListButton(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -126,7 +126,7 @@ fun SettingsPlaybackAdvancedScreen() {
 						// 5 - 30 seconds with 5 second increment
 						min = 5_000f,
 						max = 30_000f,
-						stepBack = 5_000f,
+						stepBackward = 5_000f,
 						value = skipBackLength.toFloat(),
 						onValueChange = { skipBackLength = it.roundToInt() }
 					)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,6 +549,7 @@
     <string name="segment_type_recap">Recaps</string>
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
+    <string name="skip_back_length">Skip back length</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
     <string name="pref_subtitles_background_opacity">Subtitle background opacity</string>
     <string name="pref_troubleshooting">Troubleshooting</string>


### PR DESCRIPTION
**Changes**
* Allow existing `skipBackLength` variables to be visible and changed in the Settings, and to be used during video seeking.

**Code assistance**
No AI agents were used to write this code.  However, cards on the table, I have no real background in software/web development; the vast majority of my programming experience is in data science.  The changes made here are just the result of me looking for places where `skipForwardLength` or a similarly named variable already existed in the codebase, but had no corresponding `skipBackLength`.

**Issues**
Partially addresses #5510 
