### PR TITLE
Add configChanges to manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,7 @@
         <!-- Main application -->
         <activity
             android:name=".ui.browsing.MainActivity"
+            android:configChanges="density|screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden|navigation|uiMode"
             android:launchMode="singleTask"
             android:windowSoftInputMode="adjustNothing" />
 


### PR DESCRIPTION
Ensures that the application is not destroyed and recreated when screen resolution (and layout, etc.) is changed so that media that just negotiated a video resolution and rate doesn't immediately crash the playing video.

**Changes**
Add `configChanges` to _AndroidManifest.xml_ to ensure that the application isn't recreated for mere config changes.

Note: This is already in the non-TV version.

**Code assistance**
No

**Issues**
Fixes #5682
