### PR TITLE
Add Amazon Fire TV 4K (1st Gen) to modelsWithDoViHdr10PlusBug

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/KnownDefects.kt
@@ -9,6 +9,7 @@ private val modelsWithDoViHdr10PlusBug = listOf(
 	"AFTKRT", // Amazon Fire TV 4K Max (2nd Gen)
 	"AFTKA", // Amazon Fire TV 4K Max (1st Gen)
 	"AFTKM", // Amazon Fire TV 4K (2nd Gen)
+	"AFTMM", // Amazon Fire TV 4K (1st Gen)
 )
 
 object KnownDefects {


### PR DESCRIPTION
**Changes**
- Add **Amazon Fire TV 4K (1st Gen)** to modelsWithDoViHdr10PlusBug

```
Fire TV Stick 4K - 1st Gen (2018)	AFTMM	API Level 25 (Android 7.1)	Fire OS 6
```
https://developer.amazon.com/docs/device-specs/identify-fire-tv-devices.html

**Code assistance**


**Issues**
- https://old.reddit.com/r/jellyfin/comments/1ur7xr5/black_screen_with_audio_on_fire_tv_4k_same_file/
