### PR TITLE
Fix playback retry position

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -67,6 +67,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     private Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
     private Lazy<ReportingHelper> reportingHelper = inject(ReportingHelper.class);
     private final Lazy<InteractionTrackerViewModel> lazyInteractionTracker = inject(InteractionTrackerViewModel.class);
+    private final PlaybackPositionTracker playbackPositionTracker = new PlaybackPositionTracker();
 
     List<BaseItemDto> mItems;
     VideoManager mVideoManager;
@@ -266,9 +267,10 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (playbackRetries < 3) {
             if (mFragment != null)
                 Utils.showToast(mFragment.getContext(), mFragment.getString(R.string.player_error));
-            Timber.i("Player error encountered - retrying");
-            stop();
-            play(mCurrentPosition);
+            long retryPosition = getRecoverablePlaybackPosition();
+            Timber.i("Player error encountered - retrying at %s", retryPosition);
+            stopForRetry(retryPosition);
+            play(retryPosition);
         } else {
             mPlaybackState = PlaybackState.ERROR;
             if (mFragment != null) {
@@ -386,6 +388,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                     // playback has started following initial seek for direct play and hls
                     // get current position and reset seekPosition
                     newPos = mVideoManager.getCurrentPosition();
+                    playbackPositionTracker.updateFromPlayerPosition(newPos);
                     mSeekPosition = -1;
                 } else if (wasSeeking) {
                     // the initial seek for direct play and hls completed
@@ -442,6 +445,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 // set mSeekPosition so the seekbar will not default to 0:00
                 mSeekPosition = position;
                 mCurrentPosition = 0;
+                playbackPositionTracker.reset(position);
 
                 mFragment.setFadingEnabled(false);
 
@@ -876,11 +880,29 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             mPlaybackState = PlaybackState.IDLE;
 
             if (mVideoManager != null && mVideoManager.isPlaying()) mVideoManager.stopPlayback();
-            if (getCurrentlyPlayingItem() != null && mCurrentStreamInfo != null) {
-                Long mbPos = mCurrentPosition * 10000;
-                reportingHelper.getValue().reportStopped(mFragment, getCurrentlyPlayingItem(), mCurrentStreamInfo, mbPos);
-            }
+            reportStopped(mCurrentPosition);
             clearPlaybackSessionOptions();
+        }
+    }
+
+    private void stopForRetry(long retryPosition) {
+        Timber.i("stop for retry called at %s", retryPosition);
+        stopReportLoop();
+        if (mPlaybackState != PlaybackState.IDLE && mPlaybackState != PlaybackState.UNDEFINED) {
+            mPlaybackState = PlaybackState.IDLE;
+
+            if (mVideoManager != null) mVideoManager.stopPlayback();
+            reportStopped(retryPosition);
+            clearPlaybackSessionOptions();
+        }
+        mCurrentPosition = retryPosition;
+        playbackPositionTracker.reset(retryPosition);
+    }
+
+    private void reportStopped(long position) {
+        if (getCurrentlyPlayingItem() != null && mCurrentStreamInfo != null) {
+            Long mbPos = position * 10000;
+            reportingHelper.getValue().reportStopped(mFragment, getCurrentlyPlayingItem(), mCurrentStreamInfo, mbPos);
         }
     }
 
@@ -988,6 +1010,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             // Make sure we also set the seek positions so mCurrentPosition won't get overwritten in refreshCurrentPosition()
             currentSkipPos = mCurrentPosition;
             mSeekPosition = mCurrentPosition;
+            playbackPositionTracker.updateFromSeekPosition(mSeekPosition);
             // Finalize item playback
             itemComplete();
             return;
@@ -997,6 +1020,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
         // set seekPosition so real position isn't used until playback starts again
         mSeekPosition = pos;
+        playbackPositionTracker.updateFromSeekPosition(pos);
 
         if (mCurrentStreamInfo == null) return;
 
@@ -1070,8 +1094,18 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             Timber.i("Duration reported as: %s current pos: %s", getDuration(), mCurrentPosition);
 
             mSeekPosition = currentSkipPos;
+            playbackPositionTracker.updateFromSeekPosition(currentSkipPos);
             mHandler.postDelayed(skipRunnable, 800);
         }
+    }
+
+    private long getRecoverablePlaybackPosition() {
+        boolean preferPendingSeek = mSeekPosition != -1 && (wasSeeking || currentSkipPos != 0 || !finishedInitialSeek);
+        if (!preferPendingSeek && hasInitializedVideoManager()) {
+            playbackPositionTracker.updateFromPlayerPosition(mVideoManager.getCurrentPosition());
+        }
+
+        return playbackPositionTracker.getRecoverablePosition(mCurrentPosition, mSeekPosition, preferPendingSeek);
     }
 
     public void updateTvProgramInfo() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackPositionTracker.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackPositionTracker.java
@@ -1,0 +1,48 @@
+package org.jellyfin.androidtv.ui.playback;
+
+public final class PlaybackPositionTracker {
+    private long lastStablePosition = -1;
+
+    public void reset(long position) {
+        lastStablePosition = normalizePosition(position);
+    }
+
+    public void updateFromPlayerPosition(long position) {
+        if (position >= 0 && (position > 0 || lastStablePosition <= 0)) {
+            lastStablePosition = position;
+        }
+    }
+
+    public void updateFromSeekPosition(long position) {
+        if (position >= 0) {
+            lastStablePosition = position;
+        }
+    }
+
+    public long getRecoverablePosition(long currentPosition, long pendingSeekPosition, boolean preferPendingSeek) {
+        long normalizedCurrentPosition = normalizePosition(currentPosition);
+        long normalizedPendingSeekPosition = normalizePosition(pendingSeekPosition);
+
+        if (preferPendingSeek && normalizedPendingSeekPosition >= 0) {
+            return normalizedPendingSeekPosition;
+        }
+
+        if (lastStablePosition > 0) {
+            return lastStablePosition;
+        }
+
+        if (normalizedCurrentPosition > 0) {
+            return normalizedCurrentPosition;
+        }
+
+        if (normalizedPendingSeekPosition >= 0) {
+            return normalizedPendingSeekPosition;
+        }
+
+        return 0;
+    }
+
+    private long normalizePosition(long position) {
+        return position >= 0 ? position : -1;
+    }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -142,6 +142,7 @@ public class VideoManager {
             @Override
             public void onPlayerError(@NonNull PlaybackException error) {
                 Timber.e("***** Got error from player");
+                rememberCurrentExoPlayerPosition();
                 if (mPlaybackControllerNotifiable != null) mPlaybackControllerNotifiable.onError();
                 stopProgressLoop();
             }
@@ -181,6 +182,7 @@ public class VideoManager {
             public void onPositionDiscontinuity(@NonNull Player.PositionInfo oldPosition, @NonNull Player.PositionInfo newPosition, int reason) {
                 // discontinuity for reason internal usually indicates an error, and that the player will reset to its default timestamp
                 if (reason == Player.DISCONTINUITY_REASON_INTERNAL) {
+                    rememberExoPlayerPosition(oldPosition.positionMs);
                     Timber.i("Caught player discontinuity (reason internal) - oldPos: %s newPos: %s", oldPosition.positionMs, newPosition.positionMs);
                 }
             }
@@ -319,9 +321,8 @@ public class VideoManager {
         if (mExoPlayer == null || !isPlaying()) {
             return lastExoPlayerPosition == -1 ? 0 : lastExoPlayerPosition;
         } else {
-            long mExoPlayerCurrentPosition = mExoPlayer.getCurrentPosition();
-            lastExoPlayerPosition = mExoPlayerCurrentPosition;
-            return mExoPlayerCurrentPosition;
+            rememberCurrentExoPlayerPosition();
+            return lastExoPlayerPosition == -1 ? 0 : lastExoPlayerPosition;
         }
     }
 
@@ -375,8 +376,28 @@ public class VideoManager {
             return -1;
 
         Timber.i("Exo length in seek is: %d", getDuration());
+        rememberSeekPosition(pos);
         mExoPlayer.seekTo(pos);
         return pos;
+    }
+
+    private void rememberCurrentExoPlayerPosition() {
+        if (mExoPlayer != null) {
+            rememberExoPlayerPosition(mExoPlayer.getCurrentPosition());
+        }
+    }
+
+    private void rememberExoPlayerPosition(long position) {
+        // Keep the previous positive position when ExoPlayer reports 0 during an error reset.
+        if (position >= 0 && (position > 0 || lastExoPlayerPosition <= 0)) {
+            lastExoPlayerPosition = position;
+        }
+    }
+
+    private void rememberSeekPosition(long position) {
+        if (position >= 0) {
+            lastExoPlayerPosition = position;
+        }
     }
 
     private int getSubtitleSelectionFlags(MediaStream mediaStream) {
@@ -393,6 +414,7 @@ public class VideoManager {
             return;
         }
         Timber.i("Video path set to: %s", path);
+        lastExoPlayerPosition = -1;
 
         try {
             // Add external subtitles

--- a/app/src/test/kotlin/ui/playback/PlaybackPositionTrackerTests.kt
+++ b/app/src/test/kotlin/ui/playback/PlaybackPositionTrackerTests.kt
@@ -1,0 +1,52 @@
+package org.jellyfin.androidtv.ui.playback
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PlaybackPositionTrackerTests : FunSpec({
+	test("recoverable position uses last stable player position instead of stale session resume seek") {
+		val tracker = PlaybackPositionTracker()
+
+		tracker.reset(600_000)
+		tracker.updateFromPlayerPosition(1_860_000)
+
+		tracker.getRecoverablePosition(600_000, 600_000, false) shouldBe 1_860_000
+	}
+
+	test("pending seek position wins while a seek is in flight") {
+		val tracker = PlaybackPositionTracker()
+
+		tracker.reset(1_860_000)
+
+		tracker.getRecoverablePosition(1_860_000, 100_000, true) shouldBe 100_000
+	}
+
+	test("pending seek to zero is recoverable while a seek is in flight") {
+		val tracker = PlaybackPositionTracker()
+
+		tracker.reset(1_860_000)
+		tracker.updateFromSeekPosition(0)
+
+		tracker.getRecoverablePosition(1_860_000, 0, true) shouldBe 0
+	}
+
+	test("player reported zero does not replace a positive stable position") {
+		val tracker = PlaybackPositionTracker()
+
+		tracker.reset(600_000)
+		tracker.updateFromPlayerPosition(1_860_000)
+		tracker.updateFromPlayerPosition(0)
+
+		tracker.getRecoverablePosition(0, 600_000, false) shouldBe 1_860_000
+	}
+
+	test("recoverable position falls back to current then pending seek") {
+		val tracker = PlaybackPositionTracker()
+
+		tracker.reset(0)
+		tracker.getRecoverablePosition(42_000, -1, false) shouldBe 42_000
+
+		val newTracker = PlaybackPositionTracker()
+		newTracker.getRecoverablePosition(0, 600_000, false) shouldBe 600_000
+	}
+})


### PR DESCRIPTION
**Changes**

- Preserve a stable ExoPlayer playback position before error/reset paths can report `0` or the original resume seek.
- Retry internal playback from the recovered in-session position and report the previous stream stop at that same position.
- Add unit coverage for retry-position selection, pending seeks, seek-to-zero, and player reset-to-zero behavior.

Validation:

- PASS: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew detekt lint`
- PASS: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew test`
- PASS: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew assembleDebug`
- PASS: Android TV emulator proof against disposable Jellyfin Server 10.11.11. Seeded a 10-minute MP4 fixture with a 0:30 server resume point, started internal playback through a local proxy, injected a media-stream HTTP 503 after playback advanced, and observed Android TV retry from the current in-session position (`Player error encountered - retrying at 39774`, then `Play called from state: IDLE with pos: 39774`) instead of the original 0:30 resume point. Playback continued after retry and the server session advanced past 1:08. Local proof artifacts are under `/tmp/jellyfin-androidtv-proof/artifacts/long-*`.

Review log: https://gist.github.com/anagnorisis2peripeteia/b1aca3b1f17dbc9c85c4abcb54e3a9de

**Code assistance**

Used OpenAI Codex to investigate the playback retry behavior, draft the patch, and run local validation. The changes and review findings were checked before submission.

**Issues**

Related reports: #400, #1239, jellyfin/jellyfin#14689
