### PR TITLE
Fix by-letter filtering for names with transliterated sort names

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -364,6 +364,10 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
         return totalItems;
     }
 
+    public Instant getLastFullRetrieve() {
+        return lastFullRetrieve;
+    }
+
     public void setSortBy(BrowseGridFragment.SortOption option) {
         if (!option.value.equals(mSortBy) || !option.order.equals(sortOrder)) {
             mSortBy = option.value;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -558,34 +558,102 @@ fun ItemRowAdapter.retrieveArtists(
 	}
 }
 
+// The server transliterates non-Latin names when generating sort names (e.g. Hebrew
+// "בדרך" becomes "bdrk"), so a nameStartsWith query never matches these scripts.
+// Filter on the display name locally instead: look up all names in the view with a
+// lightweight query, then fetch only the matching items with the requested field set.
+private const val LOCAL_LETTER_FILTER_LOOKUP_LIMIT = 2500
+private const val LOCAL_LETTER_FILTER_MAX_RESULTS = 150 // ids are passed in the query string
+private val LOCAL_FILTER_LETTERS = 'א'..'ת' // Hebrew alphabet
+
+private fun localLetterFilterOrNull(nameStartsWith: String?): Char? =
+	nameStartsWith?.singleOrNull()?.takeIf { it in LOCAL_FILTER_LETTERS }
+
 fun ItemRowAdapter.retrieveItems(
 	api: ApiClient,
 	query: GetItemsRequest,
 	startIndex: Int,
 	batchSize: Int
 ) {
+	val localLetterFilter = localLetterFilterOrNull(query.nameStartsWith)
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response = withContext(Dispatchers.IO) {
-				api.itemsApi.getItems(
-					query.copy(
-						startIndex = startIndex,
-						limit = batchSize,
-					)
-				).content
-			}
+			if (localLetterFilter != null) {
+				// everything is loaded in the first batch when filtering locally
+				if (startIndex > 0) return@runCatching
+				val retrieveGeneration = lastFullRetrieve
 
-			totalItems = response.totalRecordCount
-			setItems(
-				items = response.items,
-				transform = { item, _ ->
-					BaseItemDtoBaseRowItem(
-						item,
-						preferParentThumb,
-						isStaticHeight,
-					)
-				},
-			)
+				val lookup = withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						query.copy(
+							nameStartsWith = null,
+							startIndex = 0,
+							limit = LOCAL_LETTER_FILTER_LOOKUP_LIMIT,
+							fields = null,
+							enableImages = false,
+							enableTotalRecordCount = false,
+						)
+					).content
+				}
+
+				if (lookup.items.size >= LOCAL_LETTER_FILTER_LOOKUP_LIMIT) {
+					Timber.w("Local letter filter lookup hit the %s item limit, results may be incomplete", LOCAL_LETTER_FILTER_LOOKUP_LIMIT)
+				}
+
+				val matchingIds = lookup.items
+					.filter { it.name?.startsWith(localLetterFilter) == true }
+					.map { it.id }
+				if (matchingIds.size > LOCAL_LETTER_FILTER_MAX_RESULTS) {
+					Timber.w("Local letter filter matched %s items, only showing the first %s", matchingIds.size, LOCAL_LETTER_FILTER_MAX_RESULTS)
+				}
+
+				val filteredItems = if (matchingIds.isEmpty()) emptyList() else withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						query.copy(
+							nameStartsWith = null,
+							startIndex = null,
+							limit = null,
+							ids = matchingIds.take(LOCAL_LETTER_FILTER_MAX_RESULTS),
+						)
+					).content.items
+				}
+
+				// a newer retrieve started while we were loading, discard these results
+				if (retrieveGeneration !== lastFullRetrieve) return@runCatching
+
+				totalItems = filteredItems.size
+				setItems(
+					items = filteredItems,
+					transform = { item, _ ->
+						BaseItemDtoBaseRowItem(
+							item,
+							preferParentThumb,
+							isStaticHeight,
+						)
+					},
+				)
+			} else {
+				val response = withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						query.copy(
+							startIndex = startIndex,
+							limit = batchSize,
+						)
+					).content
+				}
+
+				totalItems = response.totalRecordCount
+				setItems(
+					items = response.items,
+					transform = { item, _ ->
+						BaseItemDtoBaseRowItem(
+							item,
+							preferParentThumb,
+							isStaticHeight,
+						)
+					},
+				)
+			}
 
 			if (itemsLoaded == 0) removeRow()
 		}.fold(


### PR DESCRIPTION
**Changes**
On servers that transliterate non-Latin display names into sort names (a Hebrew title beginning with the letter bet gets a sort name beginning with the Latin letter "b"), the by-letter strip is broken for those libraries: `nameStartsWith` matches against the sort name, so selecting a Hebrew letter never returns anything. Mapping letters to their transliteration on the client is not reliable either - the transliteration is lossy (aleph and ayin are dropped entirely, several letters collide on the same Latin letter) and items with a forced sort name keep the forced value.

This PR resolves Hebrew letter selections on the client instead, inside `ItemRowAdapter.retrieveItems`:
1. A lightweight lookup of the view (same query without the heavy field set, without images and without total record count) fetches names and ids only.
2. The items are filtered on the display name (`name.startsWith(letter)`), capped at 150 matches because the ids are passed in the query string.
3. The matching items are then fetched by `ids` with the original field set and sorting, so the grid behaves like a normal filtered page (`totalItems` is set to the match count, which also marks the adapter fully loaded and disables further paging).

A staleness guard (identity comparison on `lastFullRetrieve`) discards responses from an older click when a newer retrieve has started, which previously interleaved results from two different letters.

Verified against a Hebrew movie library (server 10.11.11): selecting a Hebrew letter now filters correctly in ~0.5s, including titles whose posters/original names are English but whose display name is Hebrew. Latin letters and `#` behave exactly as before, and the range check (single char in the Hebrew block) means no behavior change for other locales. The Hebrew `byletter_letters` translation already exists on Weblate, so the strip itself shows Hebrew letters when the device locale is Hebrew (a small Weblate follow-up could drop the five final letterforms from that string, since no title starts with a final form).

**Code assistance**
Investigation (server sort-name transliteration behavior, API queries against a real library) and implementation were done with Claude Code; the change was human-directed and verified end-to-end on a real device and server before and after.

**Issues**
No existing open issue found for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)