### PR TITLE
Fix hls audio track restart loop

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -84,6 +84,9 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
     protected VideoOptions mCurrentOptions;
     private int mDefaultAudioIndex = -1;
+    // limit stop/replay attempts when an audio track switch cannot be applied to the player,
+    // otherwise a switch that fails identically after every restart loops forever
+    private int mAudioSwitchRestartCount = 0;
     protected boolean burningSubs = false;
 
     // The server does not update the subtitle delivery method when alwaysBurnInSubtitleWhenTranscoding
@@ -442,6 +445,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 // set mSeekPosition so the seekbar will not default to 0:00
                 mSeekPosition = position;
                 mCurrentPosition = 0;
+                mAudioSwitchRestartCount = 0;
 
                 mFragment.setFadingEnabled(false);
 
@@ -816,6 +820,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 Timber.i("setting mCurrentOptions audio stream index from %s to %s", mCurrentOptions.getAudioStreamIndex(), index);
                 mCurrentOptions.setAudioStreamIndex(index);
             }
+            mAudioSwitchRestartCount = 0;
             return;
         }
 
@@ -825,7 +830,13 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (!isTranscoding() && mVideoManager.setExoPlayerTrack(index, MediaStreamType.AUDIO, currentMediaSource.getMediaStreams())) {
             mCurrentOptions.setMediaSourceId(currentMediaSource.getId());
             mCurrentOptions.setAudioStreamIndex(index);
+            mAudioSwitchRestartCount = 0;
         } else {
+            if (mAudioSwitchRestartCount >= 2) {
+                Timber.w("unable to apply audio stream index %s after %s restarts, continuing playback with the current selection", index, mAudioSwitchRestartCount);
+                return;
+            }
+            mAudioSwitchRestartCount++;
             startSpinner();
             mCurrentOptions.setMediaSourceId(currentMediaSource.getId());
             mCurrentOptions.setAudioStreamIndex(index);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -455,8 +455,8 @@ public class VideoManager {
 
         int chosenTrackType = streamType == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE ? C.TRACK_TYPE_TEXT : C.TRACK_TYPE_AUDIO;
 
-
         int matchedIndex = -2;
+        int typeGroupPosition = -1;
         Tracks exoTracks = mExoPlayer.getCurrentTracks();
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {
             if (matchedIndex > -2)
@@ -464,6 +464,8 @@ public class VideoManager {
             // Group level information.
             @C.TrackType int trackType = groupInfo.getType();
             TrackGroup group = groupInfo.getMediaTrackGroup();
+            if (trackType == chosenTrackType)
+                typeGroupPosition++;
             for (int i = 0; i < group.length; i++) {
                 if (trackType == chosenTrackType) {
                     if (groupInfo.isTrackSelected(i)) {
@@ -477,6 +479,19 @@ public class VideoManager {
                                 id = Integer.parseInt(group.id);
                             }
                         } catch (NumberFormatException e) {
+                            // sources like HLS use non-numeric group ids (e.g. "audio:name") that
+                            // cannot be mapped back to a MediaStream by id - map the Nth audio
+                            // group to the Nth non-external audio MediaStream instead
+                            if (chosenTrackType == C.TRACK_TYPE_AUDIO) {
+                                int typePosition = 0;
+                                for (MediaStream stream : allStreams) {
+                                    if (stream.isExternal() || stream.getType() != streamType)
+                                        continue;
+                                    if (typePosition == typeGroupPosition)
+                                        return stream.getIndex();
+                                    typePosition++;
+                                }
+                            }
                             Timber.w("failed to parse group ID [%s]", group.id);
                             break;
                         }
@@ -522,12 +537,25 @@ public class VideoManager {
         //   if we want most formats to be handled by the external subtitle handler (which has adjustable size, background), we leave sub track selection disabled
         //   if we decide to use exoplayer to render a specific subtitle format, allow subtitle track selection and restrict selection to the chosen group
 
+        // position of the requested stream among non-external streams of the same type, used to
+        // match sources (e.g. HLS) whose player group ids are not numeric
+        int candidateTypePosition = 0;
+        for (MediaStream stream : allStreams) {
+            if (stream.getIndex() == index)
+                break;
+            if (!stream.isExternal() && stream.getType() == streamType)
+                candidateTypePosition++;
+        }
+
         Tracks exoTracks = mExoPlayer.getCurrentTracks();
         TrackGroup matchedGroup = null;
+        int typeGroupPosition = -1;
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {
             // Group level information.
             @C.TrackType int trackType = groupInfo.getType();
             TrackGroup group = groupInfo.getMediaTrackGroup();
+            if (trackType == chosenTrackType)
+                typeGroupPosition++;
             for (int i = 0; i < group.length; i++) {
                 // Individual track information.
                 boolean isSupported = groupInfo.isTrackSupported(i);
@@ -550,8 +578,12 @@ public class VideoManager {
                     if (id != exoTrackID)
                         continue;
                 } catch (NumberFormatException e) {
-                    Timber.w("failed to parse group ID [%s]", group.id);
-                    continue;
+                    // non-numeric group ids cannot be matched by id - for audio, fall back to
+                    // matching the Nth audio group to the Nth non-external audio MediaStream
+                    if (chosenTrackType != C.TRACK_TYPE_AUDIO || typeGroupPosition != candidateTypePosition) {
+                        Timber.w("failed to parse group ID [%s]", group.id);
+                        continue;
+                    }
                 }
 
                 if (!groupInfo.isTrackSupported(i)) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -455,6 +455,7 @@ public class VideoManager {
 
         int chosenTrackType = streamType == org.jellyfin.sdk.model.api.MediaStreamType.SUBTITLE ? C.TRACK_TYPE_TEXT : C.TRACK_TYPE_AUDIO;
 
+
         int matchedIndex = -2;
         Tracks exoTracks = mExoPlayer.getCurrentTracks();
         for (Tracks.Group groupInfo : exoTracks.getGroups()) {


### PR DESCRIPTION
Changes
.strm items (and anything else that resolves to HLS) would start playing, render one frame, then stop and restart in a loop about once a second, forever. Each restart also reported a play to the server, so the item's play count would balloon into the hundreds/thousands over a session.

Cause: ExoPlayer's track group ids for HLS sources are non-numeric strings (like audio:eng), but VideoManager.getExoPlayerTrack/setExoPlayerTrack parse them with Integer.parseInt to map back to a Jellyfin MediaStream index. That parse throws for HLS, so the app can never confirm the currently-selected audio track is already correct. PlaybackController.switchAudioStream then treats that as "the track isn't set" and calls stop() + playInternal() unconditionally - and since the audio index gets reset on every restart, it never settles.

Fix:

When the group id isn't numeric, fall back to matching audio tracks positionally (Nth ExoPlayer audio group to Nth non-external audio MediaStream) instead of failing outright.
Cap the stop/replay fallback in switchAudioStream at 2 attempts, so a switch that genuinely can't be applied just logs a warning instead of looping forever.
Tested on a real server against both a Hebrew-audio HLS .strm item (previously unplayable, confirmed looping in logcat before the fix) and normal direct-played MKV/MP4 files (unaffected either way).