### PR TITLE
Fix by-letter filtering for names with transliterated sort names

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -364,6 +364,10 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
         return totalItems;
     }
 
+    public Instant getLastFullRetrieve() {
+        return lastFullRetrieve;
+    }
+
     public void setSortBy(BrowseGridFragment.SortOption option) {
         if (!option.value.equals(mSortBy) || !option.order.equals(sortOrder)) {
             mSortBy = option.value;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -558,34 +558,102 @@ fun ItemRowAdapter.retrieveArtists(
 	}
 }
 
+// The server transliterates non-Latin names when generating sort names (e.g. Hebrew
+// "בדרך" becomes "bdrk"), so a nameStartsWith query never matches these scripts.
+// Filter on the display name locally instead: look up all names in the view with a
+// lightweight query, then fetch only the matching items with the requested field set.
+private const val LOCAL_LETTER_FILTER_LOOKUP_LIMIT = 2500
+private const val LOCAL_LETTER_FILTER_MAX_RESULTS = 150 // ids are passed in the query string
+private val LOCAL_FILTER_LETTERS = 'א'..'ת' // Hebrew alphabet
+
+private fun localLetterFilterOrNull(nameStartsWith: String?): Char? =
+	nameStartsWith?.singleOrNull()?.takeIf { it in LOCAL_FILTER_LETTERS }
+
 fun ItemRowAdapter.retrieveItems(
 	api: ApiClient,
 	query: GetItemsRequest,
 	startIndex: Int,
 	batchSize: Int
 ) {
+	val localLetterFilter = localLetterFilterOrNull(query.nameStartsWith)
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response = withContext(Dispatchers.IO) {
-				api.itemsApi.getItems(
-					query.copy(
-						startIndex = startIndex,
-						limit = batchSize,
-					)
-				).content
-			}
+			if (localLetterFilter != null) {
+				// everything is loaded in the first batch when filtering locally
+				if (startIndex > 0) return@runCatching
+				val retrieveGeneration = lastFullRetrieve
 
-			totalItems = response.totalRecordCount
-			setItems(
-				items = response.items,
-				transform = { item, _ ->
-					BaseItemDtoBaseRowItem(
-						item,
-						preferParentThumb,
-						isStaticHeight,
-					)
-				},
-			)
+				val lookup = withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						query.copy(
+							nameStartsWith = null,
+							startIndex = 0,
+							limit = LOCAL_LETTER_FILTER_LOOKUP_LIMIT,
+							fields = null,
+							enableImages = false,
+							enableTotalRecordCount = false,
+						)
+					).content
+				}
+
+				if (lookup.items.size >= LOCAL_LETTER_FILTER_LOOKUP_LIMIT) {
+					Timber.w("Local letter filter lookup hit the %s item limit, results may be incomplete", LOCAL_LETTER_FILTER_LOOKUP_LIMIT)
+				}
+
+				val matchingIds = lookup.items
+					.filter { it.name?.startsWith(localLetterFilter) == true }
+					.map { it.id }
+				if (matchingIds.size > LOCAL_LETTER_FILTER_MAX_RESULTS) {
+					Timber.w("Local letter filter matched %s items, only showing the first %s", matchingIds.size, LOCAL_LETTER_FILTER_MAX_RESULTS)
+				}
+
+				val filteredItems = if (matchingIds.isEmpty()) emptyList() else withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						query.copy(
+							nameStartsWith = null,
+							startIndex = null,
+							limit = null,
+							ids = matchingIds.take(LOCAL_LETTER_FILTER_MAX_RESULTS),
+						)
+					).content.items
+				}
+
+				// a newer retrieve started while we were loading, discard these results
+				if (retrieveGeneration !== lastFullRetrieve) return@runCatching
+
+				totalItems = filteredItems.size
+				setItems(
+					items = filteredItems,
+					transform = { item, _ ->
+						BaseItemDtoBaseRowItem(
+							item,
+							preferParentThumb,
+							isStaticHeight,
+						)
+					},
+				)
+			} else {
+				val response = withContext(Dispatchers.IO) {
+					api.itemsApi.getItems(
+						query.copy(
+							startIndex = startIndex,
+							limit = batchSize,
+						)
+					).content
+				}
+
+				totalItems = response.totalRecordCount
+				setItems(
+					items = response.items,
+					transform = { item, _ ->
+						BaseItemDtoBaseRowItem(
+							item,
+							preferParentThumb,
+							isStaticHeight,
+						)
+					},
+				)
+			}
 
 			if (itemsLoaded == 0) removeRow()
 		}.fold(


### PR DESCRIPTION
  **Changes**

  On servers that transliterate non-Latin display names into sort names, the by-letter strip cannot filter Hebrew libraries because `nameStartsWith` matches the transliterated sort name rather than the displayed
  Hebrew name. Client-side transliteration is not reliable because it is lossy-some Hebrew letters are omitted, several map to the same Latin letter, and manually configured sort names retain their custom values.

  This PR handles Hebrew letter selections inside `ItemRowAdapter.retrieveItems`:

  - Perform a lightweight lookup without additional fields, images, or total-record counting to retrieve the view’s item names and IDs.
  - Filter items locally using `name.startsWith(letter)`.
  - Limit the lookup to 2,500 items and matches to 150 IDs, logging a warning if either limit is reached.
  - Fetch matching items by ID using the original fields and sorting so the grid behaves like a normal filtered page.
  - Set `totalItems` to the match count, marking the adapter as fully loaded and preventing unnecessary pagination.
  - Discard stale responses using an identity check against `lastFullRetrieve` when a newer selection has started.

  Verified using a Hebrew movie library on Jellyfin Server 10.11.11. Hebrew letter selections now return the correct titles in approximately 0.5 seconds, including items with English artwork or original titles but
  Hebrew display names. Latin letters and `#` remain unchanged, and other locales continue using the existing server-side filtering path.

  The Hebrew `byletter_letters` Weblate translation already provides the Hebrew strip. A separate translation follow-up can remove the five final letter forms because titles do not begin with them.

  **Issues**

  None.