### PR TITLE
Add TV show sort by latest episode

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -158,15 +158,19 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
 
         sortOptions = new HashMap<>();
         {
+            boolean isTvShows = mFolder.getCollectionType() == CollectionType.TVSHOWS;
+            int dateAddedLabelRes = isTvShows ? R.string.lbl_date_show_added : R.string.lbl_date_added;
+
             sortOptions.put(0, new SortOption(getString(R.string.lbl_name), ItemSortBy.SORT_NAME, SortOrder.ASCENDING));
-            sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), ItemSortBy.DATE_CREATED, SortOrder.DESCENDING));
+            sortOptions.put(1, new SortOption(getString(dateAddedLabelRes), ItemSortBy.DATE_CREATED, SortOrder.DESCENDING));
             sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), ItemSortBy.PREMIERE_DATE, SortOrder.DESCENDING));
             sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), ItemSortBy.OFFICIAL_RATING, SortOrder.ASCENDING));
             sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), ItemSortBy.COMMUNITY_RATING, SortOrder.DESCENDING));
             sortOptions.put(5, new SortOption(getString(R.string.lbl_critic_rating), ItemSortBy.CRITIC_RATING, SortOrder.DESCENDING));
 
-            if (mFolder.getCollectionType() == CollectionType.TVSHOWS) {
+            if (isTvShows) {
                 sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), ItemSortBy.SERIES_DATE_PLAYED, SortOrder.DESCENDING));
+                sortOptions.put(7, new SortOption(getString(R.string.lbl_date_episode_added), ItemSortBy.DATE_LAST_CONTENT_ADDED, SortOrder.DESCENDING));
             } else {
                 sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), ItemSortBy.DATE_PLAYED, SortOrder.DESCENDING));
             }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -159,10 +159,13 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
         sortOptions = new HashMap<>();
         {
             boolean isTvShows = mFolder.getCollectionType() == CollectionType.TVSHOWS;
-            int dateAddedLabelRes = isTvShows ? R.string.lbl_date_show_added : R.string.lbl_date_added;
 
             sortOptions.put(0, new SortOption(getString(R.string.lbl_name), ItemSortBy.SORT_NAME, SortOrder.ASCENDING));
-            sortOptions.put(1, new SortOption(getString(dateAddedLabelRes), ItemSortBy.DATE_CREATED, SortOrder.DESCENDING));
+            if (isTvShows) {
+                sortOptions.put(1, new SortOption(getString(R.string.lbl_date_show_added), ItemSortBy.DATE_CREATED, SortOrder.DESCENDING));
+            } else {
+                sortOptions.put(1, new SortOption(getString(R.string.lbl_date_added), ItemSortBy.DATE_CREATED, SortOrder.DESCENDING));
+            }
             sortOptions.put(2, new SortOption(getString(R.string.lbl_premier_date), ItemSortBy.PREMIERE_DATE, SortOrder.DESCENDING));
             sortOptions.put(3, new SortOption(getString(R.string.lbl_rating), ItemSortBy.OFFICIAL_RATING, SortOrder.ASCENDING));
             sortOptions.put(4, new SortOption(getString(R.string.lbl_community_rating), ItemSortBy.COMMUNITY_RATING, SortOrder.DESCENDING));
@@ -173,10 +176,9 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
                 sortOptions.put(7, new SortOption(getString(R.string.lbl_date_episode_added), ItemSortBy.DATE_LAST_CONTENT_ADDED, SortOrder.DESCENDING));
             } else {
                 sortOptions.put(6, new SortOption(getString(R.string.lbl_last_played), ItemSortBy.DATE_PLAYED, SortOrder.DESCENDING));
-            }
-
-            if (mFolder.getCollectionType() != null && mFolder.getCollectionType() == CollectionType.MOVIES) {
-                sortOptions.put(7, new SortOption(getString(R.string.lbl_runtime), ItemSortBy.RUNTIME, SortOrder.ASCENDING));
+                if (mFolder.getCollectionType() == CollectionType.MOVIES) {
+                    sortOptions.put(7, new SortOption(getString(R.string.lbl_runtime), ItemSortBy.RUNTIME, SortOrder.ASCENDING));
+                }
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,8 @@
     <string name="lbl_from">from</string>
     <string name="lbl_name">Name</string>
     <string name="lbl_date_added">Date added</string>
+    <string name="lbl_date_show_added">Date show added</string>
+    <string name="lbl_date_episode_added">Date episode added</string>
     <string name="lbl_premier_date">Premier date</string>
     <string name="lbl_critic_rating">Critic rating</string>
     <string name="lbl_community_rating">Community rating</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Adds a "Date episode added" sort option to TV show libraries using `DateLastContentAdded` in descending order. Renames the existing TV show creation-date label to "Date show added" for clarity. Movie and other library sort menus are unchanged.

**Code assistance**
OpenAI Codex was used to inspect the codebase, implement the sort option and string changes, compare the mapping with Jellyfin Web, and run local test, lint, build, and APK validation.

**Issues**
Fixes #1392
