### PR TITLE
Align version handling with server and web logic

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -79,6 +79,7 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.androidtv.util.apiclient.Response;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
+import org.jellyfin.androidtv.util.sdk.MediaSourceVersionsKt;
 import org.jellyfin.androidtv.util.sdk.TrailerUtils;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.sdk.model.api.BaseItemDto;
@@ -140,6 +141,10 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     BaseItemDto mBaseItem;
 
     private ArrayList<MediaSourceInfo> versions;
+    // Whether the version to display was resolved for the item that is currently loaded
+    private boolean mVersionResolved;
+    // Whether focus should return to the versions button once the buttons are rebuilt
+    private boolean mFocusVersionsButton;
     private final Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private final Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
     private final Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
@@ -357,6 +362,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     }
 
     private void loadItem(UUID id) {
+        mVersionResolved = false;
+
         if (mChannelId != null && mProgramInfo == null) {
             // if we are displaying a live tv channel - we want to get whatever is showing now on that channel
             FullDetailsFragmentHelperKt.getLiveTvChannel(this, mChannelId, channel -> {
@@ -418,6 +425,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             posterHeight = aspect > 1 ? Utils.convertDpToPixel(requireContext(), 160) : Utils.convertDpToPixel(requireContext(), item.getType() == BaseItemKind.PERSON || item.getType() == BaseItemKind.MUSIC_ARTIST ? 300 : 200);
 
             mDetailsOverviewRow = new MyDetailsOverviewRow(item);
+            mDetailsOverviewRow.setSelectedMediaSourceIndex(MediaSourceVersionsKt.getOwnMediaSourceIndex(item));
 
             String primaryImageUrl = imageHelper.getValue().getLogoImageUrl(mBaseItem, 600);
             if (primaryImageUrl == null) {
@@ -487,6 +495,20 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
     public void setBaseItem(BaseItemDto item) {
         if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+
+        // Every version is a separate item with its own user data, so the version the server puts first
+        // is displayed instead of the queried item to show and resume the version that is played
+        if (item != null && !mVersionResolved) {
+            mVersionResolved = true;
+            UUID versionId = MediaSourceVersionsKt.getPrioritizedVersionId(item);
+            if (versionId != null) {
+                FullDetailsFragmentHelperKt.getItem(this, versionId, version -> {
+                    setBaseItem(version != null ? version : item);
+                    return null;
+                });
+                return;
+            }
+        }
 
         mBaseItem = item;
         backgroundService.getValue().setBackground(item);
@@ -675,6 +697,13 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             addButtons(BUTTON_SIZE);
         }
 
+        if (mFocusVersionsButton && mVersionsButton != null) {
+            mFocusVersionsButton = false;
+            // The button is not attached to the view hierarchy until the row is bound
+            TextUnderButton versionsButton = mVersionsButton;
+            versionsButton.post(versionsButton::requestFocus);
+        }
+
         mLastUpdated = Instant.now();
     }
 
@@ -845,12 +874,8 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
             mVersionsButton = TextUnderButton.create(requireContext(), R.drawable.ic_guide, buttonSize, 0, getString(R.string.select_version), new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (versions != null) {
-                        addVersionsMenu(v);
-                    } else {
-                        versions = new ArrayList<>(mBaseItem.getMediaSources());
-                        addVersionsMenu(v);
-                    }
+                    versions = new ArrayList<>(mBaseItem.getMediaSources());
+                    addVersionsMenu(v);
                 }
             });
             mDetailsOverviewRow.addAction(mVersionsButton);
@@ -1103,13 +1128,16 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         menu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem menuItem) {
-                mDetailsOverviewRow.setSelectedMediaSourceIndex(menuItem.getItemId());
-                FullDetailsFragmentHelperKt.getItem(FullDetailsFragment.this, UUIDSerializerKt.toUUID(versions.get(mDetailsOverviewRow.getSelectedMediaSourceIndex()).getId()), item -> {
+                String versionId = versions.get(menuItem.getItemId()).getId();
+                if (versionId == null) return true;
+
+                // Display the selected version itself: it owns the resume position, watched state and
+                // media streams that playback of this version uses
+                FullDetailsFragmentHelperKt.getItem(FullDetailsFragment.this, UUIDSerializerKt.toUUID(versionId), item -> {
                     if (item == null) return null;
 
-                    mBaseItem = item;
-                    mDorPresenter.getViewHolder().setItem(mDetailsOverviewRow);
-                    if (mVersionsButton != null) mVersionsButton.requestFocus();
+                    mFocusVersionsButton = true;
+                    setBaseItem(item);
                     return null;
                 });
                 return true;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -70,6 +70,7 @@ import org.jellyfin.androidtv.ui.presentation.MyDetailsOverviewRowPresenter;
 import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.DateTimeExtensionsKt;
 import org.jellyfin.androidtv.util.ImageHelper;
+import org.jellyfin.androidtv.util.ItemsToPlay;
 import org.jellyfin.androidtv.util.KeyProcessor;
 import org.jellyfin.androidtv.util.MarkdownRenderer;
 import org.jellyfin.androidtv.util.PlaybackHelper;
@@ -719,11 +720,11 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
         BaseItemDto baseItem = mBaseItem;
         if (baseItem.getType() == BaseItemKind.AUDIO || baseItem.getType() == BaseItemKind.MUSIC_ALBUM || baseItem.getType() == BaseItemKind.MUSIC_ARTIST) {
             if (baseItem.getType() == BaseItemKind.MUSIC_ALBUM || baseItem.getType() == BaseItemKind.MUSIC_ARTIST) {
-                playbackHelper.getValue().getItemsToPlay(getContext(), baseItem, false, false, new Response<List<BaseItemDto>>(getLifecycle()) {
+                playbackHelper.getValue().getItemsToPlay(getContext(), baseItem, false, false, new Response<ItemsToPlay>(getLifecycle()) {
                     @Override
-                    public void onResponse(List<BaseItemDto> response) {
+                    public void onResponse(ItemsToPlay response) {
                         if (!isActive()) return;
-                        mediaManager.getValue().addToAudioQueue(response);
+                        mediaManager.getValue().addToAudioQueue(response.getItems());
                     }
                 });
             } else {
@@ -1218,17 +1219,18 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     }
 
     void play(final BaseItemDto item, final int pos, final boolean shuffle) {
-        playbackHelper.getValue().getItemsToPlay(getContext(), item, pos == 0 && item.getType() == BaseItemKind.MOVIE, shuffle, new Response<List<BaseItemDto>>(getLifecycle()) {
+        playbackHelper.getValue().getItemsToPlay(getContext(), item, pos == 0 && item.getType() == BaseItemKind.MOVIE, shuffle, new Response<ItemsToPlay>(getLifecycle()) {
             @Override
-            public void onResponse(List<BaseItemDto> response) {
+            public void onResponse(ItemsToPlay response) {
                 if (!isActive()) return;
-                if (response.isEmpty()) {
+                List<BaseItemDto> items = response.getItems();
+                if (items.isEmpty()) {
                     Timber.e("No items to play - ignoring play request.");
                     return;
                 }
 
-                interactionTracker.getValue().notifyStartSession(item, response);
-                KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).launch(getContext(), response, pos, false, 0, shuffle);
+                interactionTracker.getValue().notifyStartSession(item, items);
+                KoinJavaComponent.<PlaybackLauncher>get(PlaybackLauncher.class).launch(getContext(), items, pos, false, 0, shuffle, response.getMediaSourceId());
             }
         });
     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -15,6 +15,7 @@ import org.jellyfin.androidtv.ui.navigation.NavigationRepository;
 import org.jellyfin.androidtv.ui.playback.MediaManager;
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher;
 import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
+import org.jellyfin.androidtv.util.ItemsToPlay;
 import org.jellyfin.androidtv.util.PlaybackHelper;
 import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.Response;
@@ -156,11 +157,11 @@ public class ItemLauncher {
                             break;
                         case Play:
                             //Just play it directly
-                            playbackHelper.getValue().getItemsToPlay(context, baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<List<BaseItemDto>>() {
+                            playbackHelper.getValue().getItemsToPlay(context, baseItem, baseItem.getType() == BaseItemKind.MOVIE, false, new Response<ItemsToPlay>() {
                                 @Override
-                                public void onResponse(List<BaseItemDto> response) {
+                                public void onResponse(ItemsToPlay response) {
                                     if (!isActive()) return;
-                                    playbackLauncher.getValue().launch(context, response);
+                                    playbackLauncher.getValue().launch(context, response.getItems(), null, false, 0, false, response.getMediaSourceId());
                                 }
                             });
                             break;
@@ -216,11 +217,11 @@ public class ItemLauncher {
                     @Override
                     public void onResponse(BaseItemDto response) {
                         if (!isActive()) return;
-                        playbackHelper.getValue().getItemsToPlay(context, response, false, false, new Response<List<BaseItemDto>>() {
+                        playbackHelper.getValue().getItemsToPlay(context, response, false, false, new Response<ItemsToPlay>() {
                             @Override
-                            public void onResponse(List<BaseItemDto> response) {
+                            public void onResponse(ItemsToPlay itemsToPlay) {
                                 if (!isActive()) return;
-                                playbackLauncher.getValue().launch(context, response);
+                                playbackLauncher.getValue().launch(context, itemsToPlay.getItems());
                             }
                         });
                     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -44,6 +44,7 @@ import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.DateTimeExtensionsKt;
 import org.jellyfin.androidtv.util.ImageHelper;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
+import org.jellyfin.androidtv.util.ItemsToPlay;
 import org.jellyfin.androidtv.util.PlaybackHelper;
 import org.jellyfin.androidtv.util.TextUtilsKt;
 import org.jellyfin.androidtv.util.TimeUtils;
@@ -335,11 +336,11 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
                     } else if (mSelectedProgramView instanceof GuideChannelHeader) {
                         // Tuning directly to a channel
                         GuideChannelHeader channelHeader = (GuideChannelHeader) mSelectedProgramView;
-                        playbackHelper.getValue().getItemsToPlay(requireContext(), channelHeader.getChannel(), false, false, new Response<List<BaseItemDto>>(getLifecycle()) {
+                        playbackHelper.getValue().getItemsToPlay(requireContext(), channelHeader.getChannel(), false, false, new Response<ItemsToPlay>(getLifecycle()) {
                             @Override
-                            public void onResponse(List<BaseItemDto> response) {
+                            public void onResponse(ItemsToPlay response) {
                                 if (!isActive()) return;
-                                playbackLauncher.getValue().launch(requireContext(), response);
+                                playbackLauncher.getValue().launch(requireContext(), response.getItems());
                             }
                         });
                     }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/ExternalPlayerActivity.kt
@@ -33,7 +33,6 @@ import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.PlaybackStopInfo
 import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.extensions.ticks
-import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import java.io.File
@@ -95,7 +94,8 @@ class ExternalPlayerActivity : FragmentActivity() {
 	private fun playNext(position: Duration = Duration.ZERO) {
 		val currentPosition = videoQueueManager.getCurrentMediaPosition()
 		val item = videoQueueManager.getCurrentVideoQueue().getOrNull(currentPosition) ?: return finish()
-		val mediaSource = item.mediaSources?.firstOrNull { it.id?.toUUIDOrNull() == item.id }
+		// The server orders the media sources so the version that should play comes first
+		val mediaSource = item.mediaSources?.firstOrNull()
 
 		if (mediaSource == null) {
 			Toast.makeText(this, R.string.msg_no_playable_items, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -30,6 +30,7 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.ReportingHelper;
 import org.jellyfin.androidtv.util.apiclient.Response;
 import org.jellyfin.androidtv.util.profile.DeviceProfileKt;
+import org.jellyfin.androidtv.util.sdk.MediaSourceVersionsKt;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.sdk.api.client.ApiClient;
 import org.jellyfin.sdk.model.ServerVersion;
@@ -930,10 +931,12 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     public void next() {
         Timber.d("Next called.");
         if (mCurrentIndex < mItems.size() - 1) {
+            String playedVersionName = getPlayedVersionName();
             stop();
             resetPlayerErrors();
             mCurrentIndex++;
             videoQueueManager.getValue().setCurrentMediaPosition(mCurrentIndex);
+            continueVersion(playedVersionName);
             Timber.i("Moving to index: %d out of %d total items.", mCurrentIndex, mItems.size());
             spinnerOff = false;
             play(0);
@@ -943,14 +946,37 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     public void prev() {
         Timber.d("Prev called.");
         if (mCurrentIndex > 0 && mItems.size() > 0) {
+            String playedVersionName = getPlayedVersionName();
             stop();
             resetPlayerErrors();
             mCurrentIndex--;
             videoQueueManager.getValue().setCurrentMediaPosition(mCurrentIndex);
+            continueVersion(playedVersionName);
             Timber.i("Moving to index: %d out of %d total items.", mCurrentIndex, mItems.size());
             spinnerOff = false;
             play(0);
         }
+    }
+
+    /**
+     * Name of the version that is playing, or null when the current item has no alternate versions.
+     */
+    private String getPlayedVersionName() {
+        BaseItemDto item = getCurrentlyPlayingItem();
+        if (item == null || !MediaSourceVersionsKt.getHasAlternateVersions(item)) return null;
+
+        MediaSourceInfo mediaSource = getCurrentMediaSource();
+        return mediaSource != null ? mediaSource.getName() : null;
+    }
+
+    /**
+     * Keep playing the version named {@code versionName} when the current item has a version with that
+     * name, so switching items does not switch versions.
+     */
+    private void continueVersion(String versionName) {
+        BaseItemDto item = getCurrentlyPlayingItem();
+        MediaSourceInfo version = item != null ? MediaSourceVersionsKt.findVersionByName(item, versionName) : null;
+        mCurrentMediaSourceId = version != null ? version.getId() : null;
     }
 
     public void fastForward() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -42,7 +42,6 @@ import org.jellyfin.sdk.model.api.MediaStream;
 import org.jellyfin.sdk.model.api.MediaStreamType;
 import org.jellyfin.sdk.model.api.PlayMethod;
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod;
-import org.jellyfin.sdk.model.serializer.UUIDSerializerKt;
 import org.koin.java.KoinJavaComponent;
 
 import java.time.Duration;
@@ -201,16 +200,10 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
             if (mediaSources == null || mediaSources.isEmpty()) {
                 return null;
-            } else {
-                // Prefer the media source with the same id as the item
-                for (MediaSourceInfo mediaSource : mediaSources) {
-                    if (item.getId().equals(UUIDSerializerKt.toUUIDOrNull(mediaSource.getId()))) {
-                        return mediaSource;
-                    }
-                }
-                // Or fallback to the first media source if none match
-                return mediaSources.get(0);
             }
+
+            // The server orders the media sources so the version that should play comes first
+            return mediaSources.get(0);
         }
     }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -70,6 +70,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     List<BaseItemDto> mItems;
     VideoManager mVideoManager;
     int mCurrentIndex;
+    // Id of the media source to play for the current item, or null to let the server pick one
+    private String mCurrentMediaSourceId;
     protected long mCurrentPosition = 0;
     private PlaybackState mPlaybackState = PlaybackState.IDLE;
 
@@ -134,6 +136,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (items != null && startIndex > 0 && startIndex < items.size()) {
             mCurrentIndex = startIndex;
         }
+        mCurrentMediaSourceId = videoQueueManager.getValue().getCurrentMediaSourceId();
         mFragment = fragment;
         mHandler = new Handler();
 
@@ -164,6 +167,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     public void setItems(List<BaseItemDto> items) {
         mItems = items;
         mCurrentIndex = 0;
+        mCurrentMediaSourceId = null;
     }
 
     public float getPlaybackSpeed() {
@@ -200,6 +204,15 @@ public class PlaybackController implements PlaybackControllerNotifiable {
 
             if (mediaSources == null || mediaSources.isEmpty()) {
                 return null;
+            }
+
+            // Prefer the version that was selected for this item
+            if (mCurrentMediaSourceId != null) {
+                for (MediaSourceInfo mediaSource : mediaSources) {
+                    if (mCurrentMediaSourceId.equals(mediaSource.getId())) {
+                        return mediaSource;
+                    }
+                }
             }
 
             // The server orders the media sources so the version that should play comes first

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -43,6 +43,7 @@ class PlaybackLauncher(
 		replace: Boolean = false,
 		itemsPosition: Int = 0,
 		shuffle: Boolean = false,
+		mediaSourceId: String? = null,
 	) {
 		val isAudio = items.any { it.mediaType == MediaType.AUDIO }
 
@@ -54,6 +55,7 @@ class PlaybackLauncher(
 
 			videoQueueManager.setCurrentVideoQueue(items.toList())
 			videoQueueManager.setCurrentMediaPosition(itemsPosition)
+			videoQueueManager.setCurrentMediaSourceId(mediaSourceId)
 
 			if (items.isEmpty()) return
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
@@ -5,6 +5,7 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 class VideoQueueManager {
 	private var _currentVideoQueue: List<BaseItemDto> = emptyList()
 	private var _currentMediaPosition = -1
+	private var _currentMediaSourceId: String? = null
 	private var _lastPlayedAudioLanguageIsoCode: String? = null
 	private var _lastPlayedSubtitleLanguageIsoCode: String? = null
 
@@ -25,6 +26,16 @@ class VideoQueueManager {
 
 	fun getCurrentMediaPosition() = _currentMediaPosition
 
+	/**
+	 * Set the id of the media source to play for the item at [getCurrentMediaPosition], or null to let
+	 * the server pick the media source.
+	 */
+	fun setCurrentMediaSourceId(mediaSourceId: String?) {
+		_currentMediaSourceId = mediaSourceId
+	}
+
+	fun getCurrentMediaSourceId(): String? = _currentMediaSourceId
+
 	fun getLastPlayedAudioLanguageIsoCode(): String? {
 		return _lastPlayedAudioLanguageIsoCode
 	}
@@ -44,6 +55,7 @@ class VideoQueueManager {
 	fun clearVideoQueue() {
 		_currentVideoQueue = emptyList()
 		_currentMediaPosition = -1
+		_currentMediaSourceId = null
 		_lastPlayedAudioLanguageIsoCode = null
 		_lastPlayedSubtitleLanguageIsoCode = null
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -23,6 +23,7 @@ import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.core.queue.supplier.QueueSupplier
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.createBaseItemQueueEntry
+import org.jellyfin.playback.jellyfin.queue.mediaSourceId
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MediaType
@@ -222,11 +223,16 @@ class RewriteMediaManager(
 	/**
 	 * A simple [QueueSupplier] implementation for compatibility with existing UI/playback code. It contains
 	 * a mutable BaseItemDto list that is used to retrieve items from.
+	 *
+	 * @param mediaSourceId Id of the media source to play for the item at [mediaSourceIndex], used to
+	 * play a specific version of that item.
 	 */
 	class BaseItemQueueSupplier(
 		private val api: ApiClient,
 		val items: List<BaseItemDto>,
 		val visibleInScreensaver: Boolean,
+		private val mediaSourceId: String? = null,
+		private val mediaSourceIndex: Int = 0,
 	) : QueueSupplier {
 		override val size: Int
 			get() = items.size
@@ -235,6 +241,7 @@ class RewriteMediaManager(
 			val item = items.getOrNull(index) ?: return null
 			return createBaseItemQueueEntry(api, item).also {
 				it.visibleInScreensaver = visibleInScreensaver
+				if (index == mediaSourceIndex) it.mediaSourceId = mediaSourceId
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
@@ -30,7 +30,13 @@ class VideoPlayerFragment : Fragment() {
 		super.onCreate(savedInstanceState)
 
 		// Create a queue from the items added to the legacy video queue
-		val queueSupplier = RewriteMediaManager.BaseItemQueueSupplier(api, videoQueueManager.getCurrentVideoQueue(), false)
+		val queueSupplier = RewriteMediaManager.BaseItemQueueSupplier(
+			api,
+			videoQueueManager.getCurrentVideoQueue(),
+			false,
+			videoQueueManager.getCurrentMediaSourceId(),
+			videoQueueManager.getCurrentMediaPosition().coerceAtLeast(0),
+		)
 		Timber.i("Created a queue with ${queueSupplier.items.size} items")
 		playbackManager.queue.clear()
 		playbackManager.queue.addSupplier(queueSupplier)

--- a/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
+++ b/app/src/main/java/org/jellyfin/androidtv/util/KeyProcessor.java
@@ -292,11 +292,11 @@ public class KeyProcessor {
                     playbackHelper.getValue().retrieveAndPlay(item.getId(), true, activity);
                     return true;
                 case MENU_ADD_QUEUE:
-                    playbackHelper.getValue().getItemsToPlay(activity, item, false, false, new Response<List<BaseItemDto>>(activity.getLifecycle()) {
+                    playbackHelper.getValue().getItemsToPlay(activity, item, false, false, new Response<ItemsToPlay>(activity.getLifecycle()) {
                         @Override
-                        public void onResponse(List<BaseItemDto> response) {
+                        public void onResponse(ItemsToPlay response) {
                             if (!isActive()) return;
-                            mediaManager.getValue().addToAudioQueue(response);
+                            mediaManager.getValue().addToAudioQueue(response.getItems());
                         }
 
                         @Override

--- a/app/src/main/java/org/jellyfin/androidtv/util/PlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/PlaybackHelper.kt
@@ -5,13 +5,29 @@ import org.jellyfin.androidtv.util.apiclient.Response
 import org.jellyfin.sdk.model.api.BaseItemDto
 import java.util.UUID
 
+/**
+ * The items to play and the media source to use for the item playback was started for.
+ *
+ * An alternate version is not always an item of the queue itself: it is not part of the episode
+ * listing of its series, so the queue contains its primary episode instead and [mediaSourceId]
+ * selects the version to play for it.
+ *
+ * @param items The items to play.
+ * @param mediaSourceId Id of the media source to play for the item playback was started for, or null
+ * to let the server pick the media source.
+ */
+data class ItemsToPlay(
+	val items: List<BaseItemDto>,
+	val mediaSourceId: String? = null,
+)
+
 interface PlaybackHelper {
 	fun getItemsToPlay(
 		context: Context,
 		mainItem: BaseItemDto,
 		allowIntros: Boolean,
 		shuffle: Boolean,
-		outerResponse: Response<List<BaseItemDto>>,
+		outerResponse: Response<ItemsToPlay>,
 	)
 
 	fun retrieveAndPlay(itemId: UUID, shuffle: Boolean, context: Context)

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/MediaSourceVersions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/MediaSourceVersions.kt
@@ -1,0 +1,37 @@
+package org.jellyfin.androidtv.util.sdk
+
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+
+/**
+ * Whether this item is part of a group of alternate versions. Every version is a separate item that
+ * is also exposed as a media source of the other versions in the group, so an item with multiple
+ * media sources always has alternate versions.
+ */
+val BaseItemDto.hasAlternateVersions: Boolean
+	get() = (mediaSources?.size ?: 0) > 1
+
+/**
+ * The media source of this item itself. The id of a media source is the id of the item owning it,
+ * although it is formatted without dashes and can therefore not be compared directly.
+ */
+val BaseItemDto.ownMediaSource: MediaSourceInfo?
+	get() = mediaSources?.firstOrNull { it.id?.toUUIDOrNull() == id }
+
+/**
+ * The id of the media source to play to get the version this item represents, or null when the item
+ * has no alternate versions and the server can pick the media source itself.
+ */
+val BaseItemDto.versionMediaSourceId: String?
+	get() = if (hasAlternateVersions) ownMediaSource?.id else null
+
+/**
+ * Find the version of this item named [name] to continue playing in the same version as another
+ * item. Returns null when this item has no alternate versions or when none of them match.
+ */
+fun BaseItemDto.findVersionByName(name: String?): MediaSourceInfo? {
+	if (name.isNullOrEmpty() || !hasAlternateVersions) return null
+
+	return mediaSources?.firstOrNull { it.name.equals(name, ignoreCase = true) }
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/MediaSourceVersions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/MediaSourceVersions.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.util.sdk
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import java.util.UUID
 
 /**
  * Whether this item is part of a group of alternate versions. Every version is a separate item that
@@ -25,6 +26,23 @@ val BaseItemDto.ownMediaSource: MediaSourceInfo?
  */
 val BaseItemDto.versionMediaSourceId: String?
 	get() = if (hasAlternateVersions) ownMediaSource?.id else null
+
+/**
+ * Index of [ownMediaSource] in the media sources of this item, or 0 when the item has none.
+ */
+val BaseItemDto.ownMediaSourceIndex: Int
+	get() = mediaSources?.indexOfFirst { it.id?.toUUIDOrNull() == id }?.takeIf { it >= 0 } ?: 0
+
+/**
+ * Id of the item owning the media source the server ordered first, or null when that is this item
+ * itself. The server puts the version that should play first, which is the version that was played
+ * most recently for an item with alternate versions.
+ */
+val BaseItemDto.prioritizedVersionId: UUID?
+	get() = when {
+		!hasAlternateVersions -> null
+		else -> mediaSources?.firstOrNull()?.id?.toUUIDOrNull()?.takeIf { it != id }
+	}
 
 /**
  * Find the version of this item named [name] to continue playing in the same version as another

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/SdkPlaybackHelper.kt
@@ -13,6 +13,7 @@ import org.jellyfin.androidtv.data.repository.ItemRepository
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.playback.PlaybackControllerContainer
 import org.jellyfin.androidtv.ui.playback.PlaybackLauncher
+import org.jellyfin.androidtv.util.ItemsToPlay
 import org.jellyfin.androidtv.util.PlaybackHelper
 import org.jellyfin.androidtv.util.apiclient.Response
 import org.jellyfin.sdk.api.client.ApiClient
@@ -47,15 +48,17 @@ class SdkPlaybackHelper(
 		mainItem: BaseItemDto,
 		allowIntros: Boolean,
 		shuffle: Boolean,
-		outerResponse: Response<List<BaseItemDto>>
+		outerResponse: Response<ItemsToPlay>
 	) {
 		getScope(context).launch {
 			runCatching {
 				val items = getItems(mainItem, allowIntros, shuffle)
-				if (items.isEmpty() && !mainItem.mediaSources.isNullOrEmpty()) listOf(mainItem)
+				val itemsToPlay = if (items.isEmpty() && !mainItem.mediaSources.isNullOrEmpty()) listOf(mainItem)
 				else items
+
+				ItemsToPlay(itemsToPlay, mainItem.versionMediaSourceId)
 			}.fold(
-				onSuccess = { items -> outerResponse.onResponse(items) },
+				onSuccess = { itemsToPlay -> outerResponse.onResponse(itemsToPlay) },
 				onFailure = { exception ->
 					when (exception) {
 						is Exception -> outerResponse.onError(exception)
@@ -281,6 +284,7 @@ class SdkPlaybackHelper(
 				playbackControllerContainer.playbackController?.hasFragment() == true,
 				0,
 				shuffle,
+				item.versionMediaSourceId,
 			)
 		}
 	}
@@ -309,6 +313,7 @@ class SdkPlaybackHelper(
 				playbackControllerContainer.playbackController?.hasFragment() == true,
 				index ?: 0,
 				shuffle,
+				items.getOrNull(index ?: 0)?.versionMediaSourceId,
 			)
 		}
 	}

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.playback.jellyfin
 
 import androidx.lifecycle.Lifecycle
+import org.jellyfin.playback.core.mediastream.MediaStreamResolver
+import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.plugin.playbackPlugin
 import org.jellyfin.playback.jellyfin.lyrics.LyricsPlayerService
 import org.jellyfin.playback.jellyfin.mediasegment.MediaSegmentService
@@ -17,7 +19,10 @@ fun jellyfinPlugin(
 	mediaSegmentSkipTypes: Set<MediaSegmentType> = emptySet(),
 	lifecycle: Lifecycle? = null,
 ) = playbackPlugin {
-	provide(JellyfinMediaStreamResolver(api, deviceProfileBuilder))
+	// Provided as service as well to be able to use the queue for version selection
+	val mediaStreamResolver = JellyfinMediaStreamResolver(api, deviceProfileBuilder)
+	provide(mediaStreamResolver as PlayerService)
+	provide(mediaStreamResolver as MediaStreamResolver)
 
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)

--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
@@ -3,7 +3,9 @@ package org.jellyfin.playback.jellyfin.mediastream
 import org.jellyfin.playback.core.mediastream.MediaConversionMethod
 import org.jellyfin.playback.core.mediastream.MediaStreamResolver
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
+import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.mediaSourceId
 import org.jellyfin.sdk.api.client.ApiClient
@@ -13,13 +15,14 @@ import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.MediaProtocol
+import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 
 class JellyfinMediaStreamResolver(
 	private val api: ApiClient,
 	private val deviceProfileBuilder: () -> DeviceProfile,
-) : MediaStreamResolver {
+) : PlayerService(), MediaStreamResolver {
 	companion object {
 		private val supportedMediaTypes = arrayOf(MediaType.VIDEO, MediaType.AUDIO)
 	}
@@ -28,9 +31,11 @@ class JellyfinMediaStreamResolver(
 		val baseItem = queueEntry.baseItem
 		if (baseItem == null || !supportedMediaTypes.contains(baseItem.mediaType)) return null
 
-		val mediaInfo = getPlaybackInfo(baseItem, queueEntry.mediaSourceId)
+		val mediaSourceId = queueEntry.mediaSourceId ?: getContinuedVersionId(queueEntry)
+		val mediaInfo = getPlaybackInfo(baseItem, mediaSourceId)
 
-		// Remember which version is actually played so it can be reported to the server
+		// Remember which version is actually played so it can be reported to the server and continued
+		// when playing the next entry
 		queueEntry.mediaSourceId = mediaInfo.mediaSource.id
 
 		return when {
@@ -79,6 +84,45 @@ class JellyfinMediaStreamResolver(
 			// No compatible stream found
 			else -> null
 		}
+	}
+
+	/**
+	 * Id of the media source of [queueEntry] that has the same name as the version played for the entry
+	 * before it, or null when it has no matching version. Keeps playback in the version that is being
+	 * watched when continuing with another item.
+	 */
+	private fun getContinuedVersionId(queueEntry: QueueEntry): String? {
+		val mediaSources = queueEntry.baseItem?.mediaSources
+		if (mediaSources == null || mediaSources.size < 2) return null
+
+		val playedVersion = getPlayedVersion(queueEntry) ?: return null
+
+		return mediaSources.firstOrNull { it.name.equals(playedVersion.name, ignoreCase = true) }?.id
+	}
+
+	/**
+	 * The media source played for the entry before [queueEntry]. That is the entry that is playing when
+	 * the next entry is preloaded, or the last entry with a played version before it in the queue when
+	 * playback of [queueEntry] already started.
+	 */
+	private fun getPlayedVersion(queueEntry: QueueEntry): MediaSourceInfo? {
+		val currentEntry = manager.queue.entry.value
+		val previousEntry = when {
+			currentEntry != null && currentEntry !== queueEntry -> currentEntry
+
+			else -> {
+				val entries = manager.queue.entries.value
+				val index = entries.indexOfFirst { it === queueEntry }
+				if (index < 0) null else entries.take(index).lastOrNull { it.mediaSourceId != null }
+			}
+		}
+
+		val playedId = previousEntry?.mediaSourceId ?: return null
+		val mediaSources = previousEntry.baseItem?.mediaSources
+		// Only continue a version when the previous entry had alternate versions to pick from
+		if (mediaSources == null || mediaSources.size < 2) return null
+
+		return mediaSources.firstOrNull { it.id == playedId }
 	}
 
 	private suspend fun getPlaybackInfo(

--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
@@ -30,6 +30,9 @@ class JellyfinMediaStreamResolver(
 
 		val mediaInfo = getPlaybackInfo(baseItem, queueEntry.mediaSourceId)
 
+		// Remember which version is actually played so it can be reported to the server
+		queueEntry.mediaSourceId = mediaInfo.mediaSource.id
+
 		return when {
 			// Direct play video
 			mediaInfo.mediaSource.supportsDirectPlay && baseItem.mediaType == MediaType.VIDEO -> mediaInfo.toStream(

--- a/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
+++ b/playback/jellyfin/src/main/kotlin/mediastream/JellyfinMediaStreamResolver.kt
@@ -104,11 +104,16 @@ class JellyfinMediaStreamResolver(
 			error("Failed to get media info for item ${item.id} source ${mediaSourceId}: ${response.errorCode}")
 		}
 
-		val mediaSource = response.mediaSources
-			// Filter out invalid streams (like strm files)
-			.filter { it.protocol == MediaProtocol.FILE && !it.isRemote }
-			// Select first media source
-			.firstOrNull { mediaSourceId == null || it.id == mediaSourceId }
+		val mediaSource = when (mediaSourceId) {
+			null -> response.mediaSources
+				// Filter out invalid streams (like strm files)
+				.filter { it.protocol == MediaProtocol.FILE && !it.isRemote }
+				// The server orders the media sources so the version that should play comes first
+				.firstOrNull()
+
+			// Always use the requested version, even when it needs to be transcoded
+			else -> response.mediaSources.firstOrNull { it.id == mediaSourceId }
+		}
 
 		requireNotNull(mediaSource) {
 			"Failed to get media info for item ${item.id} source ${mediaSourceId}: media source missing in response"

--- a/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
+++ b/playback/jellyfin/src/main/kotlin/playsession/PlaySessionService.kt
@@ -12,6 +12,7 @@ import org.jellyfin.playback.core.model.RepeatMode
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.playback.jellyfin.queue.mediaSourceId
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
 import org.jellyfin.sdk.model.api.PlayMethod
@@ -75,6 +76,7 @@ class PlaySessionService(
 			api.playStateApi.reportPlaybackStart(
 				PlaybackStartInfo(
 					itemId = item.id,
+					mediaSourceId = entry.mediaSourceId,
 					playSessionId = stream.identifier,
 					playlistItemId = item.playlistItemId,
 					canSeek = true,
@@ -105,6 +107,7 @@ class PlaySessionService(
 			api.playStateApi.reportPlaybackProgress(
 				PlaybackProgressInfo(
 					itemId = item.id,
+					mediaSourceId = entry.mediaSourceId,
 					playSessionId = stream.identifier,
 					playlistItemId = item.playlistItemId,
 					canSeek = true,
@@ -135,6 +138,7 @@ class PlaySessionService(
 			api.playStateApi.reportPlaybackStopped(
 				PlaybackStopInfo(
 					itemId = item.id,
+					mediaSourceId = entry.mediaSourceId,
 					playSessionId = stream.identifier,
 					playlistItemId = item.playlistItemId,
 					positionTicks = withContext(Dispatchers.Main) { state.positionInfo.active.inWholeTicks },


### PR DESCRIPTION
The playback logic for different versions doesn't really work as intended by the server right now.

**Changes**
* Report the played media source during playback and not just the main item
* Play the media source the server prioritizes (server does it for a reason and it is necessaary for version-aware resume
* Pass the selected version through the playback launch path (otherwise we won't play that version)
* Show and resume the selected version on the details page
* Continue playing the matching version of the next item

**Code assistance**
Opus 5 for exploration and some cross checking between the web logic and the one in atv.

**Issues**
