### PR TITLE
Add focus restoration to router

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -50,6 +50,7 @@ import org.jellyfin.androidtv.ui.search.SearchRepository
 import org.jellyfin.androidtv.ui.search.SearchRepositoryImpl
 import org.jellyfin.androidtv.ui.search.SearchViewModel
 import org.jellyfin.androidtv.ui.settings.compat.SettingsViewModel
+import org.jellyfin.androidtv.ui.settings.screen.library.SettingsLibrariesScreenViewModel
 import org.jellyfin.androidtv.ui.startup.ServerAddViewModel
 import org.jellyfin.androidtv.ui.startup.StartupViewModel
 import org.jellyfin.androidtv.ui.startup.UserLoginViewModel
@@ -166,6 +167,7 @@ val appModule = module {
 	viewModel { SearchViewModel(get()) }
 	viewModel { DreamViewModel(get(), get(), get(), get(), get()) }
 	viewModel { SettingsViewModel() }
+	viewModel { SettingsLibrariesScreenViewModel(get()) }
 
 	single { BackgroundService(get(), get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/focus/FocusPersistManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/focus/FocusPersistManager.kt
@@ -1,0 +1,35 @@
+package org.jellyfin.androidtv.ui.navigation.focus
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.focus.FocusRequester
+
+@Stable
+class FocusPersistManager {
+	private val requesters = mutableMapOf<String, FocusRequester>()
+	private var lastFocusedKey: String? = null
+
+	fun register(key: String, requester: FocusRequester) {
+		requesters[key] = requester
+	}
+
+	fun unregister(key: String) {
+		requesters.remove(key)
+	}
+
+	fun onFocusChanged(key: String, isFocused: Boolean) {
+		if (isFocused) lastFocusedKey = key
+	}
+
+	fun save(): String? = lastFocusedKey
+
+	fun restore(key: String?) {
+		if (key == null) return
+
+		requesters[key]?.requestFocus()
+	}
+}
+
+val LocalFocusPersistManager = compositionLocalOf<FocusPersistManager> {
+	error("No FocusPersistManager provided")
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/focus/FocusRestorationNavEntryDecorator.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/focus/FocusRestorationNavEntryDecorator.kt
@@ -1,0 +1,41 @@
+package org.jellyfin.androidtv.ui.navigation.focus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.navigation3.runtime.NavEntryDecorator
+import org.jellyfin.androidtv.ui.navigation.RouteContext
+
+@Composable
+fun rememberFocusRestorationNavEntryDecorator(): NavEntryDecorator<RouteContext> {
+	val savedFocusKeys = rememberSaveable { mutableMapOf<Any, String?>() }
+
+	return remember {
+		NavEntryDecorator(
+			onPop = { key -> savedFocusKeys.remove(key) },
+			decorate = { entry ->
+				val key = entry.contentKey
+				val focusPersistManager = remember(key) { FocusPersistManager() }
+
+				CompositionLocalProvider(
+					LocalFocusPersistManager provides focusPersistManager
+				) {
+					entry.Content()
+				}
+
+				LaunchedEffect(key) {
+					focusPersistManager.restore(savedFocusKeys[key])
+				}
+
+				DisposableEffect(key) {
+					onDispose {
+						savedFocusKeys[key] = focusPersistManager.save()
+					}
+				}
+			}
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/focus/focusKey.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/focus/focusKey.kt
@@ -1,0 +1,130 @@
+package org.jellyfin.androidtv.ui.navigation.focus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusEventModifierNode
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.TraversableNode
+import androidx.compose.ui.node.TraversableNode.Companion.TraverseDescendantsAction
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.findNearestAncestor
+import androidx.compose.ui.node.traverseDescendants
+import androidx.compose.ui.platform.InspectorInfo
+
+/**
+ * Add a unique identifier to this composable to automatically restore focus. Most commonly when navigating back a page within a router or
+ * on activity recreation. The focus keys automatically use their parent keys as suffix.
+ */
+@Composable
+fun Modifier.focusKey(
+	key: String,
+	focusRequester: FocusRequester = remember { FocusRequester() },
+): Modifier = this
+	.focusRequester(focusRequester)
+	.then(FocusKeyElement(key, focusRequester))
+
+private data class FocusKeyElement(
+	val key: String,
+	val focusRequester: FocusRequester
+) : ModifierNodeElement<FocusKeyNode>() {
+	override fun create() = FocusKeyNode(key, focusRequester)
+
+	override fun update(node: FocusKeyNode) {
+		node.update(key, focusRequester)
+	}
+
+	override fun InspectorInfo.inspectableProperties() {
+		name = "focusKey"
+		properties["key"] = key
+		properties["focusRequester"] = focusRequester
+	}
+}
+
+private class FocusKeyNode(
+	var key: String,
+	var focusRequester: FocusRequester
+) : Modifier.Node(),
+	TraversableNode,
+	FocusEventModifierNode,
+	CompositionLocalConsumerModifierNode {
+
+	override val traverseKey: Any = FocusKeyNode::class
+
+	private var cachedKey: String? = null
+
+	private val fullKey: String
+		get() {
+			val parent = findNearestAncestor(traverseKey) as? FocusKeyNode
+			return parent?.let { "${it.fullKey}.$key" } ?: key
+		}
+
+	private val manager
+		get() = currentValueOf(LocalFocusPersistManager)
+
+	override fun onAttach() {
+		updateRegistration()
+	}
+
+	fun update(key: String, focusRequester: FocusRequester) {
+		val oldKey = fullKey
+
+		this.key = key
+
+		val keyChanged = oldKey != fullKey
+		val requesterChanged = this.focusRequester !== focusRequester
+
+		if (requesterChanged) {
+			this.focusRequester = focusRequester
+		}
+
+		if (requesterChanged || keyChanged) {
+			updateRegistration()
+		}
+
+		if (keyChanged) {
+			notifyDescendants()
+		}
+	}
+
+	fun onParentChanged() {
+		updateRegistration()
+		notifyDescendants()
+	}
+
+	private fun notifyDescendants() {
+		traverseDescendants(traverseKey) { node ->
+			when (node) {
+				is FocusKeyNode -> {
+					node.onParentChanged()
+					TraverseDescendantsAction.SkipSubtreeAndContinueTraversal
+				}
+
+				else ->
+					TraverseDescendantsAction.ContinueTraversal
+			}
+		}
+	}
+
+	private fun updateRegistration() {
+		val newFullKey = fullKey
+		if (newFullKey == cachedKey) return
+
+		cachedKey?.let(manager::unregister)
+		cachedKey = newFullKey
+		manager.register(newFullKey, focusRequester)
+	}
+
+	override fun onDetach() {
+		cachedKey?.let { manager.unregister(it) }
+		cachedKey = null
+	}
+
+	override fun onFocusEvent(focusState: FocusState) {
+		if (focusState.isFocused) manager.onFocusChanged(fullKey, true)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/router.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/router.kt
@@ -21,6 +21,7 @@ import androidx.navigationevent.NavigationEvent
 import androidx.savedstate.compose.serialization.serializers.SnapshotStateListSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
+import org.jellyfin.androidtv.ui.navigation.focus.rememberFocusRestorationNavEntryDecorator
 
 typealias RouteParameters = Map<String, String>
 typealias RouteComposable = @Composable ((context: RouteContext) -> Unit)
@@ -103,6 +104,7 @@ fun RouterContent(
 				onBack = { router.back() },
 				entryDecorators = listOf(
 					rememberSaveableStateHolderNavEntryDecorator(),
+					rememberFocusRestorationNavEntryDecorator(),
 				),
 				transitionSpec = transitionSpec,
 				popTransitionSpec = popTransitionSpec,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsDeveloperScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsDeveloperScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import coil3.ImageLoader
@@ -16,6 +17,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.util.isTvDevice
@@ -44,7 +46,8 @@ fun SettingsDeveloperScreen() {
 				headingContent = { Text(stringResource(R.string.lbl_enable_debug)) },
 				trailingContent = { Checkbox(checked = debuggingEnabled) },
 				captionContent = { Text(stringResource(R.string.desc_debug)) },
-				onClick = { debuggingEnabled = !debuggingEnabled }
+				onClick = { debuggingEnabled = !debuggingEnabled },
+				modifier = Modifier.focusKey("debugging_enabled")
 			)
 		}
 
@@ -54,7 +57,8 @@ fun SettingsDeveloperScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.disable_ui_mode_warning)) },
 				trailingContent = { Checkbox(checked = disableUiModeWarning) },
-				onClick = { disableUiModeWarning = !disableUiModeWarning }
+				onClick = { disableUiModeWarning = !disableUiModeWarning },
+				modifier = Modifier.focusKey("disable_ui_mode_warning")
 			)
 		}
 
@@ -76,7 +80,8 @@ fun SettingsDeveloperScreen() {
 					imageLoader.memoryCache?.clear()
 					imageLoader.diskCache?.clear()
 					imageCacheSize = imageLoader.diskCache?.size ?: 0L
-				}
+				},
+				modifier = Modifier.focusKey("clear_image_cache")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsMainScreen.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.androidtv.ui.settings.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
@@ -9,6 +10,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 
@@ -30,6 +32,7 @@ fun SettingsMainScreen() {
 				leadingContent = { Icon(painterResource(R.drawable.ic_users), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_login)) },
 				onClick = { router.push(Routes.AUTHENTICATION) },
+				modifier = Modifier.focusKey(Routes.AUTHENTICATION),
 			)
 		}
 
@@ -37,7 +40,8 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_adjust), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_customization)) },
-				onClick = { router.push(Routes.CUSTOMIZATION) }
+				onClick = { router.push(Routes.CUSTOMIZATION) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION),
 			)
 		}
 
@@ -46,7 +50,8 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_photos), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_screensaver)) },
-				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER) }
+				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SCREENSAVER),
 			)
 		}
 
@@ -54,7 +59,8 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_next), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback)) },
-				onClick = { router.push(Routes.PLAYBACK) }
+				onClick = { router.push(Routes.PLAYBACK) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK),
 			)
 		}
 
@@ -62,7 +68,8 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_error), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_telemetry_category)) },
-				onClick = { router.push(Routes.TELEMETRY) }
+				onClick = { router.push(Routes.TELEMETRY) },
+				modifier = Modifier.focusKey(Routes.TELEMETRY),
 			)
 
 		}
@@ -71,7 +78,8 @@ fun SettingsMainScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_jellyfin), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_about_title)) },
-				onClick = { router.push(Routes.ABOUT) }
+				onClick = { router.push(Routes.ABOUT) },
+				modifier = Modifier.focusKey(Routes.ABOUT),
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsTelemetryScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/SettingsTelemetryScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.TelemetryPreferences
@@ -10,6 +11,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -35,7 +37,8 @@ fun SettingsTelemetryScreen() {
 					if (crashReportEnabled) Text(stringResource(R.string.pref_crash_reports_enabled))
 					else Text(stringResource(R.string.pref_crash_reports_disabled))
 				},
-				onClick = { crashReportEnabled = !crashReportEnabled }
+				onClick = { crashReportEnabled = !crashReportEnabled },
+				modifier = Modifier.focusKey("crash_report_enabled")
 			)
 		}
 
@@ -48,7 +51,8 @@ fun SettingsTelemetryScreen() {
 					if (crashReportIncludeLogs) Text(stringResource(R.string.pref_crash_report_logs_enabled))
 					else Text(stringResource(R.string.pref_crash_report_logs_disabled))
 				},
-				onClick = { crashReportIncludeLogs = !crashReportIncludeLogs }
+				onClick = { crashReportIncludeLogs = !crashReportIncludeLogs },
+				modifier = Modifier.focusKey("crash_report_logs")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/about/SettingsAboutScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/about/SettingsAboutScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.about
 import android.content.ClipData
 import android.os.Build
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.BuildConfig
@@ -12,6 +13,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.ui.settings.util.copyAction
@@ -41,6 +43,7 @@ fun SettingsAboutScreen(launchedFromLogin: Boolean = false) {
 				headingContent = { Text(heading) },
 				captionContent = { Text(caption) },
 				onClick = copyAction(ClipData.newPlainText(heading, caption)),
+				modifier = Modifier.focusKey("version")
 			)
 		}
 
@@ -52,6 +55,7 @@ fun SettingsAboutScreen(launchedFromLogin: Boolean = false) {
 				headingContent = { Text(heading) },
 				captionContent = { Text(caption) },
 				onClick = copyAction(ClipData.newPlainText(heading, caption)),
+				modifier = Modifier.focusKey("device_model")
 			)
 		}
 
@@ -60,6 +64,7 @@ fun SettingsAboutScreen(launchedFromLogin: Boolean = false) {
 				leadingContent = { Icon(painterResource(R.drawable.ic_guide), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.licenses_link)) },
 				onClick = { router.push(Routes.LICENSES) },
+				modifier = Modifier.focusKey(Routes.LICENSES)
 			)
 		}
 
@@ -67,7 +72,8 @@ fun SettingsAboutScreen(launchedFromLogin: Boolean = false) {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_flask), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_developer_link)) },
-				onClick = { router.push(Routes.DEVELOPER) }
+				onClick = { router.push(Routes.DEVELOPER) },
+				modifier = Modifier.focusKey(Routes.DEVELOPER)
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationAutoSignInScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationAutoSignInScreen.kt
@@ -24,6 +24,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -61,7 +62,8 @@ fun SettingsAuthenticationAutoSignInScreen() {
 				onClick = {
 					autoLoginUserBehavior = UserSelectBehavior.DISABLED
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("disable")
 			)
 		}
 
@@ -73,7 +75,8 @@ fun SettingsAuthenticationAutoSignInScreen() {
 				onClick = {
 					autoLoginUserBehavior = UserSelectBehavior.LAST_USER
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("last_user")
 			)
 		}
 
@@ -102,7 +105,8 @@ fun SettingsAuthenticationAutoSignInScreen() {
 						autoLoginUserId = userId
 
 						router.back()
-					}
+					},
+					modifier = Modifier.focusKey("user_$userId")
 				)
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
@@ -20,6 +21,7 @@ import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -71,7 +73,8 @@ fun SettingsAuthenticationScreen(launchedFromLogin: Boolean = false) {
 						UserSelectBehavior.SPECIFIC_USER -> Text(autoLoginUser?.name ?: stringResource(R.string.loading))
 					}
 				},
-				onClick = { router.push(Routes.AUTHENTICATION_AUTO_SIGN_IN) }
+				onClick = { router.push(Routes.AUTHENTICATION_AUTO_SIGN_IN) },
+				modifier = Modifier.focusKey(Routes.AUTHENTICATION_AUTO_SIGN_IN)
 			)
 		}
 
@@ -80,7 +83,8 @@ fun SettingsAuthenticationScreen(launchedFromLogin: Boolean = false) {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.sort_accounts_by)) },
 				captionContent = { Text(stringResource(sortBy.nameRes)) },
-				onClick = { router.push(Routes.AUTHENTICATION_SORT_BY) }
+				onClick = { router.push(Routes.AUTHENTICATION_SORT_BY) },
+				modifier = Modifier.focusKey(Routes.AUTHENTICATION_SORT_BY)
 			)
 		}
 
@@ -99,7 +103,8 @@ fun SettingsAuthenticationScreen(launchedFromLogin: Boolean = false) {
 								"serverId" to server.id.toString(),
 							),
 						)
-					}
+					},
+					modifier = Modifier.focusKey("server_${server.id}")
 				)
 			}
 		}
@@ -115,7 +120,8 @@ fun SettingsAuthenticationScreen(launchedFromLogin: Boolean = false) {
 					headingContent = { Text(stringResource(R.string.always_authenticate)) },
 					trailingContent = { Checkbox(checked = alwaysAuthenticate) },
 					captionContent = { Text(stringResource(R.string.always_authenticate_description)) },
-					onClick = { alwaysAuthenticate = !alwaysAuthenticate }
+					onClick = { alwaysAuthenticate = !alwaysAuthenticate },
+					modifier = Modifier.focusKey("always_authenticate")
 				)
 			}
 		}
@@ -124,7 +130,8 @@ fun SettingsAuthenticationScreen(launchedFromLogin: Boolean = false) {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_jellyfin), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_about_title)) },
-				onClick = { router.push(Routes.ABOUT, mapOf("fromLogin" to "true")) }
+				onClick = { router.push(Routes.ABOUT, mapOf("fromLogin" to "true")) },
+				modifier = Modifier.focusKey(Routes.ABOUT)
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerScreen.kt
@@ -27,6 +27,7 @@ import org.jellyfin.androidtv.ui.base.button.IconButtonDefaults
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -97,7 +98,8 @@ fun SettingsAuthenticationServerScreen(serverId: UUID) {
 								"userId" to user.id.toString(),
 							),
 						)
-					}
+					},
+					modifier = Modifier.focusKey("user_${user.id}")
 				)
 			}
 		}
@@ -114,7 +116,8 @@ fun SettingsAuthenticationServerScreen(serverId: UUID) {
 						serverRepository.deleteServer(server?.id ?: serverId)
 						router.back()
 					}
-				}
+				},
+				modifier = Modifier.focusKey("remove_server")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerUserScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationServerUserScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -20,6 +21,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
 import java.util.UUID
@@ -58,7 +60,8 @@ fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 						if (user != null) authenticationRepository.logout(user)
 						router.back()
 					}
-				}
+				},
+				modifier = Modifier.focusKey("sign_out")
 			)
 		}
 
@@ -72,7 +75,8 @@ fun SettingsAuthenticationServerUserScreen(serverId: UUID, userId: UUID) {
 						if (user != null) serverUserRepository.deleteStoredUser(user)
 						router.back()
 					}
-				}
+				},
+				modifier = Modifier.focusKey("remove")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationSortByScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/authentication/SettingsAuthenticationSortByScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.model.AuthenticationSortBy
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsAuthenticationSortByScreen() {
 				onClick = {
 					sortBy = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("sort_by_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationBackdropScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationBackdropScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsCustomizationBackdropScreen() {
 				onClick = {
 					backdropBehavior = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("backdrop_behavior_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationClockScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationClockScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsCustomizationClockScreen() {
 				onClick = {
 					clockBehavior = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("clock_behavior_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.customization
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -37,7 +39,8 @@ fun SettingsCustomizationScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_app_theme)) },
 				captionContent = { Text(stringResource(appTheme.nameRes)) },
-				onClick = { router.push(Routes.CUSTOMIZATION_THEME) }
+				onClick = { router.push(Routes.CUSTOMIZATION_THEME) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_THEME)
 			)
 		}
 
@@ -47,7 +50,8 @@ fun SettingsCustomizationScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_clock_display)) },
 				captionContent = { Text(stringResource(clockBehavior.nameRes)) },
-				onClick = { router.push(Routes.CUSTOMIZATION_CLOCK) }
+				onClick = { router.push(Routes.CUSTOMIZATION_CLOCK) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_CLOCK)
 			)
 		}
 
@@ -57,7 +61,8 @@ fun SettingsCustomizationScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_watched_indicator)) },
 				captionContent = { Text(stringResource(watchedIndicatorBehavior.nameRes)) },
-				onClick = { router.push(Routes.CUSTOMIZATION_WATCHED_INDICATOR) }
+				onClick = { router.push(Routes.CUSTOMIZATION_WATCHED_INDICATOR) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_WATCHED_INDICATOR)
 			)
 		}
 
@@ -67,7 +72,8 @@ fun SettingsCustomizationScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_show_backdrop)) },
 				captionContent = { Text(stringResource(backdropBehavior.nameRes)) },
-				onClick = { router.push(Routes.CUSTOMIZATION_BACKDROP) }
+				onClick = { router.push(Routes.CUSTOMIZATION_BACKDROP) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_BACKDROP)
 			)
 		}
 
@@ -78,7 +84,8 @@ fun SettingsCustomizationScreen() {
 				headingContent = { Text(stringResource(R.string.lbl_use_series_thumbnails)) },
 				trailingContent = { Checkbox(checked = seriesThumbnailsEnabled) },
 				captionContent = { Text(stringResource(R.string.lbl_use_series_thumbnails_description)) },
-				onClick = { seriesThumbnailsEnabled = !seriesThumbnailsEnabled }
+				onClick = { seriesThumbnailsEnabled = !seriesThumbnailsEnabled },
+				modifier = Modifier.focusKey("series_thumbnails_enabled")
 			)
 		}
 
@@ -88,7 +95,8 @@ fun SettingsCustomizationScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_grid), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_libraries)) },
-				onClick = { router.push(Routes.LIBRARIES) }
+				onClick = { router.push(Routes.LIBRARIES) },
+				modifier = Modifier.focusKey(Routes.LIBRARIES)
 			)
 		}
 
@@ -96,7 +104,8 @@ fun SettingsCustomizationScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_house), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.home_prefs)) },
-				onClick = { router.push(Routes.HOME) }
+				onClick = { router.push(Routes.HOME) },
+				modifier = Modifier.focusKey(Routes.HOME)
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationThemeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationThemeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsCustomizationThemeScreen() {
 				onClick = {
 					appTheme = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("app_theme_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationWatchedIndicatorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/SettingsCustomizationWatchedIndicatorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsCustomizationWatchedIndicatorScreen() {
 				onClick = {
 					watchedIndicatorBehavior = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("watched_indicator_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitleTextStrokeColorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitleTextStrokeColorScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.customization.subtitle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import androidx.compose.ui.graphics.toArgb
@@ -11,6 +12,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.composable.SubtitleColorPresetsControl
@@ -60,7 +62,8 @@ fun SettingsSubtitleTextStrokeColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_red)) },
 				channel = Color.Red,
 				value = colorValue,
-				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() }
+				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_red")
 			)
 		}
 
@@ -69,7 +72,8 @@ fun SettingsSubtitleTextStrokeColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_green)) },
 				channel = Color.Green,
 				value = colorValue,
-				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() }
+				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_green")
 			)
 		}
 
@@ -78,7 +82,8 @@ fun SettingsSubtitleTextStrokeColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_blue)) },
 				channel = Color.Blue,
 				value = colorValue,
-				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() }
+				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_blue")
 			)
 		}
 
@@ -87,7 +92,8 @@ fun SettingsSubtitleTextStrokeColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_alpha)) },
 				channel = Color.Transparent,
 				value = colorValue,
-				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() }
+				onValueChange = { subtitleTextStrokeColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_alpha")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitlesBackgroundColorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitlesBackgroundColorScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.customization.subtitle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import androidx.compose.ui.graphics.toArgb
@@ -11,6 +12,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.composable.SubtitleColorPresetsControl
@@ -60,7 +62,8 @@ fun SettingsSubtitlesBackgroundColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_red)) },
 				channel = Color.Red,
 				value = colorValue,
-				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_red")
 			)
 		}
 
@@ -69,7 +72,8 @@ fun SettingsSubtitlesBackgroundColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_green)) },
 				channel = Color.Green,
 				value = colorValue,
-				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_green")
 			)
 		}
 
@@ -78,7 +82,8 @@ fun SettingsSubtitlesBackgroundColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_blue)) },
 				channel = Color.Blue,
 				value = colorValue,
-				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_blue")
 			)
 		}
 
@@ -87,7 +92,8 @@ fun SettingsSubtitlesBackgroundColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_alpha)) },
 				channel = Color.Transparent,
 				value = colorValue,
-				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesBackgroundColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_alpha")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitlesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitlesScreen.kt
@@ -26,6 +26,7 @@ import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListControl
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -71,6 +72,7 @@ fun SettingsSubtitlesScreen() {
 			ListControl(
 				headingContent = { Text(stringResource(R.string.pref_subtitles_size)) },
 				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("subtitles_size")
 			) {
 				Row(
 					verticalAlignment = Alignment.CenterVertically,
@@ -125,6 +127,7 @@ fun SettingsSubtitlesScreen() {
 					Text(name)
 				},
 				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("subtitles_weight")
 			) {
 				RangeControl(
 					modifier = Modifier
@@ -145,6 +148,7 @@ fun SettingsSubtitlesScreen() {
 				headingContent = { Text(stringResource(R.string.lbl_subtitle_text_color)) },
 				trailingContent = { ColorSwatch(color = Color(subtitlesTextColor.toInt())) },
 				onClick = { router.push(Routes.CUSTOMIZATION_SUBTITLES_TEXT_COLOR) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SUBTITLES_TEXT_COLOR)
 			)
 		}
 
@@ -153,6 +157,7 @@ fun SettingsSubtitlesScreen() {
 				headingContent = { Text(stringResource(R.string.lbl_subtitle_background_color)) },
 				trailingContent = { ColorSwatch(color = Color(subtitlesBackgroundColor.toInt())) },
 				onClick = { router.push(Routes.CUSTOMIZATION_SUBTITLES_BACKGROUND_COLOR) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SUBTITLES_BACKGROUND_COLOR)
 			)
 		}
 
@@ -161,6 +166,7 @@ fun SettingsSubtitlesScreen() {
 				headingContent = { Text(stringResource(R.string.lbl_subtitle_text_stroke_color)) },
 				trailingContent = { ColorSwatch(color = Color(subtitleTextStrokeColor.toInt())) },
 				onClick = { router.push(Routes.CUSTOMIZATION_SUBTITLES_EDGE_COLOR) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SUBTITLES_EDGE_COLOR)
 			)
 		}
 
@@ -170,6 +176,7 @@ fun SettingsSubtitlesScreen() {
 			ListControl(
 				headingContent = { Text(stringResource(R.string.pref_subtitles_position)) },
 				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("subtitles_position")
 			) {
 				Row(
 					verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitlesTextColorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/SettingsSubtitlesTextColorScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.customization.subtitle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import androidx.compose.ui.graphics.toArgb
@@ -11,6 +12,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.composable.SubtitleColorPresetsControl
@@ -60,7 +62,8 @@ fun SettingsSubtitlesTextColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_red)) },
 				channel = Color.Red,
 				value = colorValue,
-				onValueChange = { subtitlesTextColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesTextColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_red")
 			)
 		}
 
@@ -69,7 +72,8 @@ fun SettingsSubtitlesTextColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_green)) },
 				channel = Color.Green,
 				value = colorValue,
-				onValueChange = { subtitlesTextColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesTextColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_green")
 			)
 		}
 
@@ -78,7 +82,8 @@ fun SettingsSubtitlesTextColorScreen() {
 				headingContent = { Text(stringResource(R.string.color_blue)) },
 				channel = Color.Blue,
 				value = colorValue,
-				onValueChange = { subtitlesTextColor = it.toArgb().toLong() }
+				onValueChange = { subtitlesTextColor = it.toArgb().toLong() },
+				modifier = Modifier.focusKey("custom_blue")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/composable/SubtitleColorPresetsControl.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/customization/subtitle/composable/SubtitleColorPresetsControl.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import org.jellyfin.androidtv.ui.base.form.ColorSwatch
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.design.Tokens
 
 @Composable
@@ -42,6 +44,7 @@ fun SubtitleColorPresetsControl(
 				modifier = Modifier
 					.size(26.dp)
 					.scale(scale)
+					.focusKey("preset_${color.toArgb()}")
 					.clickable(
 						interactionSource = interactionSource,
 						role = Role.Button,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeScreen.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui.settings.screen.home
 
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserSettingPreferences
@@ -9,6 +10,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -30,7 +32,8 @@ fun SettingsHomeScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.home_section_i, index + 1)) },
 				captionContent = { Text(stringResource(userSettingPreferences[section].nameRes)) },
-				onClick = { router.push(Routes.HOME_SECTION, mapOf("index" to index.toString())) }
+				onClick = { router.push(Routes.HOME_SECTION, mapOf("index" to index.toString())) },
+				modifier = Modifier.focusKey("home_section_$index")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeSectionScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeSectionScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.HomeSectionType
@@ -14,6 +15,7 @@ import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListMessage
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -49,7 +51,8 @@ fun SettingsHomeSectionScreen(index: Int) {
 				onClick = {
 					sectionType = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("section_type_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayGridScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayGridScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.GridDirection
@@ -15,6 +16,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -43,7 +45,8 @@ fun SettingsLibrariesDisplayGridScreen(itemId: UUID, displayPreferencesId: Strin
 				onClick = {
 					gridDirection = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("grid_direction_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayImageSizeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayImageSizeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.PosterSize
@@ -15,6 +16,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -43,7 +45,8 @@ fun SettingsLibrariesDisplayImageSizeScreen(itemId: UUID, displayPreferencesId: 
 				onClick = {
 					posterSize = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("poster_size_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayImageTypeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayImageTypeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.ImageType
@@ -15,6 +16,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -43,7 +45,8 @@ fun SettingsLibrariesDisplayImageTypeScreen(itemId: UUID, displayPreferencesId: 
 				onClick = {
 					imageType = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("image_type_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesDisplayScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
@@ -14,6 +15,7 @@ import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -49,7 +51,8 @@ fun SettingsLibrariesDisplayScreen(itemId: UUID, displayPreferencesId: String) {
 						Routes.LIBRARIES_DISPLAY_IMAGE_SIZE,
 						mapOf("itemId" to itemId.toString(), "displayPreferencesId" to displayPreferencesId)
 					)
-				}
+				},
+				modifier = Modifier.focusKey(Routes.LIBRARIES_DISPLAY_IMAGE_SIZE)
 			)
 		}
 
@@ -64,7 +67,8 @@ fun SettingsLibrariesDisplayScreen(itemId: UUID, displayPreferencesId: String) {
 						Routes.LIBRARIES_DISPLAY_IMAGE_TYPE,
 						mapOf("itemId" to itemId.toString(), "displayPreferencesId" to displayPreferencesId)
 					)
-				}
+				},
+				modifier = Modifier.focusKey(Routes.LIBRARIES_DISPLAY_IMAGE_TYPE)
 			)
 		}
 
@@ -79,7 +83,8 @@ fun SettingsLibrariesDisplayScreen(itemId: UUID, displayPreferencesId: String) {
 						Routes.LIBRARIES_DISPLAY_GRID,
 						mapOf("itemId" to itemId.toString(), "displayPreferencesId" to displayPreferencesId)
 					)
-				}
+				},
+				modifier = Modifier.focusKey(Routes.LIBRARIES_DISPLAY_GRID)
 			)
 		}
 
@@ -90,7 +95,8 @@ fun SettingsLibrariesDisplayScreen(itemId: UUID, displayPreferencesId: String) {
 				headingContent = { Text(stringResource(R.string.enable_smart_view)) },
 				trailingContent = { Checkbox(checked = enableSmartScreen) },
 				captionContent = { Text(stringResource(R.string.enable_smart_view_description)) },
-				onClick = { enableSmartScreen = !enableSmartScreen }
+				onClick = { enableSmartScreen = !enableSmartScreen },
+				modifier = Modifier.focusKey("enable_smart_view")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesScreen.kt
@@ -4,13 +4,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import kotlinx.coroutines.flow.map
 import org.jellyfin.androidtv.R
-import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
@@ -20,15 +17,13 @@ import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.sdk.model.api.CollectionType
-import org.koin.compose.koinInject
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun SettingsLibrariesScreen() {
 	val router = LocalRouter.current
-	val userViewsRepository = koinInject<UserViewsRepository>()
-	val userViews by remember {
-		userViewsRepository.views.map { it.toList() }
-	}.collectAsState(emptyList())
+	val viewModel = koinViewModel<SettingsLibrariesScreenViewModel>()
+	val userViews by viewModel.userViews.collectAsState()
 
 	SettingsColumn {
 		item {
@@ -39,7 +34,7 @@ fun SettingsLibrariesScreen() {
 		}
 
 		items(userViews) { userView ->
-			val allowGridView = userViewsRepository.allowGridView(userView.collectionType)
+			val allowGridView = viewModel.allowGridView(userView.collectionType)
 			val displayPreferencesId = userView.displayPreferencesId
 
 			if (userView.collectionType == CollectionType.LIVETV) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.flow.map
@@ -15,6 +16,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.sdk.model.api.CollectionType
@@ -44,7 +46,8 @@ fun SettingsLibrariesScreen() {
 				ListButton(
 					leadingContent = { Icon(painterResource(R.drawable.ic_guide), contentDescription = null) },
 					headingContent = { Text(userView.name.orEmpty()) },
-					onClick = { router.push(Routes.LIVETV_GUIDE_OPTIONS) }
+					onClick = { router.push(Routes.LIVETV_GUIDE_OPTIONS) },
+					modifier = Modifier.focusKey(Routes.LIVETV_GUIDE_OPTIONS)
 				)
 			} else {
 				val canOpen = allowGridView && displayPreferencesId != null
@@ -60,7 +63,8 @@ fun SettingsLibrariesScreen() {
 								mapOf("itemId" to userView.id.toString(), "displayPreferencesId" to userView.displayPreferencesId!!)
 							)
 						}
-					}
+					},
+					modifier = Modifier.focusKey("library_${userView.id}")
 				)
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesScreenViewModel.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/library/SettingsLibrariesScreenViewModel.kt
@@ -1,0 +1,23 @@
+package org.jellyfin.androidtv.ui.settings.screen.library
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.jellyfin.androidtv.data.repository.UserViewsRepository
+import org.jellyfin.sdk.model.api.CollectionType
+
+class SettingsLibrariesScreenViewModel(
+	private val userViewsRepository: UserViewsRepository,
+) : ViewModel() {
+	val userViews = userViewsRepository.views
+		.map { it.toList() }
+		.stateIn(
+			viewModelScope,
+			SharingStarted.WhileSubscribed(5_000),
+			emptyList()
+		)
+
+	fun allowGridView(collectionType: CollectionType?) = userViewsRepository.allowGridView(collectionType)
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicenseScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicenseScreen.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.mikepenz.aboutlibraries.Libs
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListMessage
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.ui.settings.util.copyAction
 
@@ -60,6 +62,7 @@ fun SettingsLicenseScreen(artifactId: String) {
 				headingContent = { Text(title) },
 				captionContent = { Text(value.orEmpty()) },
 				onClick = copyAction(ClipData.newPlainText(title, value)),
+				modifier = Modifier.focusKey("license_info_$title")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicensesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicensesScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.license
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.mikepenz.aboutlibraries.Libs
@@ -12,6 +13,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 
@@ -40,7 +42,8 @@ fun SettingsLicensesScreen() {
 			ListButton(
 				headingContent = { Text("${library.name} ${library.artifactVersion}") },
 				captionContent = { Text(library.licenses.joinToString(", ") { license -> license.name }) },
-				onClick = { router.push(Routes.LICENSE, mapOf("artifactId" to library.artifactId)) }
+				onClick = { router.push(Routes.LICENSE, mapOf("artifactId" to library.artifactId)) },
+				modifier = Modifier.focusKey("library_${library.artifactId}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/livetv/SettingsLiveTvGuideChannelOrderScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/livetv/SettingsLiveTvGuideChannelOrderScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.LiveTvPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -39,7 +41,8 @@ fun SettingsLiveTvGuideChannelOrderScreen() {
 				onClick = {
 					channelOrder = entry.stringValue
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("channel_order_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/livetv/SettingsLiveTvGuideFiltersScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/livetv/SettingsLiveTvGuideFiltersScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.SystemPreferences
@@ -11,6 +12,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -42,7 +44,8 @@ fun SettingsLiveTvGuideFiltersScreen() {
 			ListButton(
 				headingContent = { Text(label) },
 				trailingContent = { Checkbox(checked = enabled) },
-				onClick = { enabled = !enabled }
+				onClick = { enabled = !enabled },
+				modifier = Modifier.focusKey("filter_$label")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/livetv/SettingsLiveTvGuideOptionsScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/livetv/SettingsLiveTvGuideOptionsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.LiveTvPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -45,7 +47,8 @@ fun SettingsLiveTvGuideOptionsScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_sort_by)) },
 				captionContent = { Text(stringResource(LiveTvChannelOrder.fromString(channelOrder).nameRes)) },
-				onClick = { router.push(Routes.LIVETV_GUIDE_CHANNEL_ORDER) }
+				onClick = { router.push(Routes.LIVETV_GUIDE_CHANNEL_ORDER) },
+				modifier = Modifier.focusKey(Routes.LIVETV_GUIDE_CHANNEL_ORDER)
 			)
 		}
 
@@ -55,7 +58,8 @@ fun SettingsLiveTvGuideOptionsScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_start_favorites)) },
 				trailingContent = { Checkbox(checked = favsAtTop) },
-				onClick = { favsAtTop = !favsAtTop }
+				onClick = { favsAtTop = !favsAtTop },
+				modifier = Modifier.focusKey("favs_at_top")
 			)
 		}
 
@@ -65,7 +69,8 @@ fun SettingsLiveTvGuideOptionsScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_colored_backgrounds)) },
 				trailingContent = { Checkbox(checked = colorCodeGuide) },
-				onClick = { colorCodeGuide = !colorCodeGuide }
+				onClick = { colorCodeGuide = !colorCodeGuide },
+				modifier = Modifier.focusKey("color_code_guide")
 			)
 		}
 
@@ -77,7 +82,8 @@ fun SettingsLiveTvGuideOptionsScreen() {
 			ListButton(
 				headingContent = { Text(label) },
 				trailingContent = { Checkbox(checked = enabled) },
-				onClick = { enabled = !enabled }
+				onClick = { enabled = !enabled },
+				modifier = Modifier.focusKey("indicator_$label")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAVCLevelScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAVCLevelScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -41,7 +43,8 @@ fun SettingsPlaybackAVCLevelScreen() {
 				onClick = {
 					userAVCLevel = AVCLevel.AUTO
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("avc_level_auto")
 			)
 		}
 
@@ -54,7 +57,8 @@ fun SettingsPlaybackAVCLevelScreen() {
 				onClick = {
 					userAVCLevel = level
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("avc_level_${level.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -29,6 +29,7 @@ import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListControl
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsAsyncActionListButton
@@ -67,7 +68,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_resume_preroll)) },
 				captionContent = { Text(options[resumeSubtractDuration].orEmpty()) },
-				onClick = { router.push(Routes.PLAYBACK_RESUME_SUBTRACT_DURATION) }
+				onClick = { router.push(Routes.PLAYBACK_RESUME_SUBTRACT_DURATION) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_RESUME_SUBTRACT_DURATION)
 			)
 		}
 
@@ -78,6 +80,7 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListControl(
 				headingContent = { Text(stringResource(R.string.skip_forward_length)) },
 				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("skip_forward_length")
 			) {
 				Row(
 					verticalAlignment = Alignment.CenterVertically,
@@ -114,6 +117,7 @@ fun SettingsPlaybackAdvancedScreen() {
 				headingContent = { Text(stringResource(R.string.playback_buffer_length)) },
 				captionContent = { Text(stringResource(bufferLength.nameRes)) },
 				onClick = { router.push(Routes.PLAYBACK_BUFFER_LENGTH) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_BUFFER_LENGTH)
 			)
 		}
 
@@ -126,7 +130,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_max_bitrate_title)) },
 				captionContent = { Text(options[maxBitrate].orEmpty()) },
-				onClick = { router.push(Routes.PLAYBACK_MAX_BITRATE) }
+				onClick = { router.push(Routes.PLAYBACK_MAX_BITRATE) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_MAX_BITRATE)
 			)
 		}
 
@@ -136,7 +141,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_refresh_switching)) },
 				captionContent = { Text(stringResource(refreshRateSwitchingBehavior.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_REFRESH_RATE_SWITCHING_BEHAVIOR) }
+				onClick = { router.push(Routes.PLAYBACK_REFRESH_RATE_SWITCHING_BEHAVIOR) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_REFRESH_RATE_SWITCHING_BEHAVIOR)
 			)
 		}
 
@@ -147,6 +153,7 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListControl(
 				headingContent = { Text(stringResource(R.string.video_start_delay)) },
 				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("video_start_delay")
 			) {
 				Row(
 					verticalAlignment = Alignment.CenterVertically,
@@ -183,7 +190,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.default_video_zoom)) },
 				captionContent = { Text(stringResource(playerZoomMode.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_ZOOM_MODE) }
+				onClick = { router.push(Routes.PLAYBACK_ZOOM_MODE) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_ZOOM_MODE)
 			)
 		}
 
@@ -191,7 +199,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.preference_codecs)) },
 				captionContent = { Text(stringResource(R.string.preference_codecs_summary)) },
-				onClick = { router.push(Routes.PLAYBACK_CODEC) }
+				onClick = { router.push(Routes.PLAYBACK_CODEC) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_CODEC)
 			)
 		}
 
@@ -204,7 +213,8 @@ fun SettingsPlaybackAdvancedScreen() {
 				headingContent = { Text(stringResource(R.string.preference_enable_pgs)) },
 				captionContent = { Text(stringResource(R.string.preference_enable_pgs_description)) },
 				trailingContent = { Checkbox(checked = pgsDirectPlay) },
-				onClick = { pgsDirectPlay = !pgsDirectPlay }
+				onClick = { pgsDirectPlay = !pgsDirectPlay },
+				modifier = Modifier.focusKey("pgs_direct_play")
 			)
 		}
 
@@ -215,7 +225,8 @@ fun SettingsPlaybackAdvancedScreen() {
 				headingContent = { Text(stringResource(R.string.preference_enable_ass)) },
 				captionContent = { Text(stringResource(R.string.preference_enable_ass_description)) },
 				trailingContent = { Checkbox(checked = assDirectPlay) },
-				onClick = { assDirectPlay = !assDirectPlay }
+				onClick = { assDirectPlay = !assDirectPlay },
+				modifier = Modifier.focusKey("ass_direct_play")
 			)
 		}
 
@@ -226,7 +237,8 @@ fun SettingsPlaybackAdvancedScreen() {
 				headingContent = { Text(stringResource(R.string.pref_burn_subtitles_when_transcoding)) },
 				captionContent = { Text(stringResource(R.string.pref_burn_subtitles_when_transcoding_description)) },
 				trailingContent = { Checkbox(checked = subtitlesBurnDuringTranscode) },
-				onClick = { subtitlesBurnDuringTranscode = !subtitlesBurnDuringTranscode }
+				onClick = { subtitlesBurnDuringTranscode = !subtitlesBurnDuringTranscode },
+				modifier = Modifier.focusKey("subtitles_burn_during_transcode")
 			)
 		}
 
@@ -238,7 +250,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_direct_stream_live)) },
 				trailingContent = { Checkbox(checked = liveTvDirectPlayEnabled) },
-				onClick = { liveTvDirectPlayEnabled = !liveTvDirectPlayEnabled }
+				onClick = { liveTvDirectPlayEnabled = !liveTvDirectPlayEnabled },
+				modifier = Modifier.focusKey("live_tv_direct_play_enabled")
 			)
 		}
 
@@ -250,7 +263,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_audio_output)) },
 				captionContent = { Text(stringResource(audioBehaviour.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_AUDIO_BEHAVIOR) }
+				onClick = { router.push(Routes.PLAYBACK_AUDIO_BEHAVIOR) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_AUDIO_BEHAVIOR)
 			)
 		}
 
@@ -260,7 +274,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_audio_night_mode)) },
 				trailingContent = { Checkbox(checked = audioNightMode) },
-				onClick = { audioNightMode = !audioNightMode }
+				onClick = { audioNightMode = !audioNightMode },
+				modifier = Modifier.focusKey("audio_night_mode")
 			)
 		}
 
@@ -270,7 +285,8 @@ fun SettingsPlaybackAdvancedScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.lbl_bitstream_ac3)) },
 				trailingContent = { Checkbox(checked = ac3Enabled) },
-				onClick = { ac3Enabled = !ac3Enabled }
+				onClick = { ac3Enabled = !ac3Enabled },
+				modifier = Modifier.focusKey("ac3_enabled")
 			)
 		}
 
@@ -280,7 +296,8 @@ fun SettingsPlaybackAdvancedScreen() {
 				headingContent = { Text(stringResource(R.string.prefer_exoplayer_ffmpeg)) },
 				trailingContent = { Checkbox(checked = preferExoPlayerFfmpeg) },
 				captionContent = { Text(stringResource(R.string.prefer_exoplayer_ffmpeg_content)) },
-				onClick = { preferExoPlayerFfmpeg = !preferExoPlayerFfmpeg }
+				onClick = { preferExoPlayerFfmpeg = !preferExoPlayerFfmpeg },
+				modifier = Modifier.focusKey("prefer_exoplayer_ffmpeg")
 			)
 		}
 
@@ -309,6 +326,7 @@ fun SettingsPlaybackAdvancedScreen() {
 				onFailure = {
 					Toast.makeText(context, R.string.pref_report_device_profile_failure, Toast.LENGTH_LONG).show()
 				},
+				modifier = Modifier.focusKey("report_device_profile")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAudioBehaviorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAudioBehaviorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsPlaybackAudioBehaviorScreen() {
 				onClick = {
 					audioBehaviour = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("audio_behavior_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackBufferLengthScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackBufferLengthScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -39,6 +41,7 @@ fun SettingsPlaybackBufferLengthScreen() {
 					bufferLength = entry
 					router.back()
 				},
+				modifier = Modifier.focusKey("buffer_length_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackCodecScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackCodecScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.playback
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -11,6 +12,7 @@ import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -37,7 +39,8 @@ fun SettingsPlaybackCodecScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.user_avc_level)) },
 				captionContent = { Text(stringResource(userAVCLevel.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_AVC_LEVEL) }
+				onClick = { router.push(Routes.PLAYBACK_AVC_LEVEL) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_AVC_LEVEL)
 			)
 		}
 
@@ -47,7 +50,8 @@ fun SettingsPlaybackCodecScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.user_hevc_level)) },
 				captionContent = { Text(stringResource(userHEVCLevel.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_HEVC_LEVEL) }
+				onClick = { router.push(Routes.PLAYBACK_HEVC_LEVEL) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_HEVC_LEVEL)
 			)
 		}
 
@@ -59,7 +63,8 @@ fun SettingsPlaybackCodecScreen() {
 					headingContent = { Text(stringResource(R.string.pref_software_codecs_enabled)) },
 					captionContent = { Text(stringResource(R.string.pref_software_codecs_enabled_description)) },
 					trailingContent = { Checkbox(checked = softwareCodecsEnabled) },
-					onClick = { softwareCodecsEnabled = !softwareCodecsEnabled }
+					onClick = { softwareCodecsEnabled = !softwareCodecsEnabled },
+					modifier = Modifier.focusKey("software_codecs_enabled")
 				)
 			}
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackHEVCLevelScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackHEVCLevelScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -41,7 +43,8 @@ fun SettingsPlaybackHEVCLevelScreen() {
 				onClick = {
 					userHEVCLevel = HEVCLevel.AUTO
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("hevc_level_auto")
 			)
 		}
 
@@ -54,7 +57,8 @@ fun SettingsPlaybackHEVCLevelScreen() {
 				onClick = {
 					userHEVCLevel = level
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("hevc_level_${level.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackInactivityPromptScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackInactivityPromptScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsPlaybackInactivityPromptScreen() {
 				onClick = {
 					stillWatchingBehavior = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("inactivity_prompt_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackMaxBitrateScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackMaxBitrateScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
@@ -15,6 +16,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -42,7 +44,8 @@ fun SettingsPlaybackMaxBitrateScreen() {
 				onClick = {
 					maxBitrate = value
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("max_bitrate_$value")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPlayerScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPlayerScreen.kt
@@ -24,6 +24,7 @@ import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListMessage
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.jellyfin.androidtv.util.componentName
@@ -69,7 +70,8 @@ fun SettingsPlaybackPlayerScreen() {
 					playbackRewriteVideoEnabled = false
 					externalAppRepository.setExternalPlayerapp(null)
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("player_internal")
 			)
 		}
 
@@ -91,7 +93,8 @@ fun SettingsPlaybackPlayerScreen() {
 					playbackRewriteVideoEnabled = true
 					externalAppRepository.setExternalPlayerapp(null)
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("player_new")
 			)
 		}
 
@@ -125,7 +128,8 @@ fun SettingsPlaybackPlayerScreen() {
 				onClick = {
 					externalAppRepository.setExternalPlayerapp(app.activityInfo)
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("player_external_${app.activityInfo.componentName}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPrerollsScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackPrerollsScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.playback
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -10,6 +11,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -33,7 +35,8 @@ fun SettingsPlaybackPrerollsScreen() {
 				headingContent = { Text(stringResource(R.string.pref_prerolls_enabled)) },
 				trailingContent = { Checkbox(checked = cinemaModeEnabled) },
 				captionContent = { Text(stringResource(R.string.pref_prerolls_enabled_description)) },
-				onClick = { cinemaModeEnabled = !cinemaModeEnabled }
+				onClick = { cinemaModeEnabled = !cinemaModeEnabled },
+				modifier = Modifier.focusKey("cinema_mode_enabled")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackRefreshRateSwitchingBehaviorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackRefreshRateSwitchingBehaviorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsPlaybackRefreshRateSwitchingBehaviorScreen() {
 				onClick = {
 					refreshRateSwitchingBehavior = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("refresh_rate_switching_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackResumeSubtractDurationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackResumeSubtractDurationScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -12,6 +13,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsPlaybackResumeSubtractDurationScreen() {
 				onClick = {
 					resumeSubtractDuration = value
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("resume_subtract_duration_$value")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackScreen.kt
@@ -22,6 +22,7 @@ import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -59,7 +60,8 @@ fun SettingsPlaybackScreen() {
 							.clip(LocalShapes.current.small)
 					)
 				},
-				onClick = { router.push(Routes.PLAYBACK_PLAYER) }
+				onClick = { router.push(Routes.PLAYBACK_PLAYER) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_PLAYER)
 			)
 		}
 
@@ -67,7 +69,8 @@ fun SettingsPlaybackScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_next_up), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback_next_up)) },
-				onClick = { router.push(Routes.PLAYBACK_NEXT_UP) }
+				onClick = { router.push(Routes.PLAYBACK_NEXT_UP) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_NEXT_UP)
 			)
 		}
 
@@ -77,7 +80,8 @@ fun SettingsPlaybackScreen() {
 				leadingContent = { Icon(painterResource(R.drawable.ic_zzz), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback_inactivity_prompt)) },
 				captionContent = { Text(stringResource(stillWatchingBehavior.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_INACTIVITY_PROMPT) }
+				onClick = { router.push(Routes.PLAYBACK_INACTIVITY_PROMPT) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_INACTIVITY_PROMPT)
 			)
 		}
 
@@ -85,7 +89,8 @@ fun SettingsPlaybackScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_trailer), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback_prerolls)) },
-				onClick = { router.push(Routes.PLAYBACK_PREROLLS) }
+				onClick = { router.push(Routes.PLAYBACK_PREROLLS) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_PREROLLS)
 			)
 		}
 
@@ -93,7 +98,8 @@ fun SettingsPlaybackScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_subtitles), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_customization_subtitles)) },
-				onClick = { router.push(Routes.CUSTOMIZATION_SUBTITLES) }
+				onClick = { router.push(Routes.CUSTOMIZATION_SUBTITLES) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SUBTITLES)
 			)
 		}
 
@@ -101,7 +107,8 @@ fun SettingsPlaybackScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_clapperboard), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback_media_segments)) },
-				onClick = { router.push(Routes.PLAYBACK_MEDIA_SEGMENTS) }
+				onClick = { router.push(Routes.PLAYBACK_MEDIA_SEGMENTS) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_MEDIA_SEGMENTS)
 			)
 		}
 
@@ -109,7 +116,8 @@ fun SettingsPlaybackScreen() {
 			ListButton(
 				leadingContent = { Icon(painterResource(R.drawable.ic_more), contentDescription = null) },
 				headingContent = { Text(stringResource(R.string.pref_playback_advanced)) },
-				onClick = { router.push(Routes.PLAYBACK_ADVANCED) }
+				onClick = { router.push(Routes.PLAYBACK_ADVANCED) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_ADVANCED)
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackZoomModeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackZoomModeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsPlaybackZoomModeScreen() {
 				onClick = {
 					playerZoomMode = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("zoom_mode_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentScreen.kt
@@ -2,6 +2,7 @@ package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
 
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
@@ -9,6 +10,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentAction
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -38,7 +40,8 @@ fun SettingsPlaybackMediaSegmentScreen(
 				onClick = {
 					mediaSegmentRepository.setDefaultSegmentTypeAction(segmentType, entry)
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("media_segment_action_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentsScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentsScreen.kt
@@ -2,12 +2,14 @@ package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
 
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -39,7 +41,8 @@ fun SettingsPlaybackMediaSegmentsScreen() {
 							"segmentType" to segmentType.toString(),
 						),
 					)
-				}
+				},
+				modifier = Modifier.focusKey("media_segment_type_$segmentType")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpBehaviorScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpBehaviorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -13,6 +14,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsPlaybackNextUpBehaviorScreen() {
 				onClick = {
 					nextUpBehavior = entry
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("next_up_behavior_${entry.name}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/nextup/SettingsPlaybackNextUpScreen.kt
@@ -25,6 +25,7 @@ import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListControl
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -52,7 +53,8 @@ fun SettingsPlaybackNextUpScreen() {
 				headingContent = { Text(stringResource(R.string.pref_media_queueing)) },
 				trailingContent = { Checkbox(checked = mediaQueuingEnabled) },
 				captionContent = { Text(stringResource(R.string.pref_media_queueing_description)) },
-				onClick = { mediaQueuingEnabled = !mediaQueuingEnabled }
+				onClick = { mediaQueuingEnabled = !mediaQueuingEnabled },
+				modifier = Modifier.focusKey("media_queuing_enabled")
 			)
 		}
 
@@ -62,7 +64,8 @@ fun SettingsPlaybackNextUpScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_next_up_behavior_title)) },
 				captionContent = { Text(stringResource(nextUpBehavior.nameRes)) },
-				onClick = { router.push(Routes.PLAYBACK_NEXT_UP_BEHAVIOR) }
+				onClick = { router.push(Routes.PLAYBACK_NEXT_UP_BEHAVIOR) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_NEXT_UP_BEHAVIOR)
 			)
 		}
 
@@ -74,6 +77,7 @@ fun SettingsPlaybackNextUpScreen() {
 				headingContent = { Text(stringResource(R.string.pref_next_up_timeout_title)) },
 				captionContent = { Text(stringResource(R.string.pref_next_up_timeout_summary)) },
 				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("next_up_timeout")
 			) {
 				Row(
 					verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverAgeRatingScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverAgeRatingScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -12,6 +13,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsScreensaverAgeRatingScreen() {
 				onClick = {
 					screensaverAgeRatingMax = ageRating
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("age_rating_$ageRating")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverScreen.kt
@@ -3,6 +3,7 @@ package org.jellyfin.androidtv.ui.settings.screen.screensaver
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -11,6 +12,7 @@ import org.jellyfin.androidtv.ui.base.form.Checkbox
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
@@ -36,7 +38,8 @@ fun SettingsScreensaverScreen() {
 				headingContent = { Text(stringResource(R.string.pref_screensaver_inapp_enabled)) },
 				trailingContent = { Checkbox(checked = screensaverInAppEnabled) },
 				captionContent = { Text(stringResource(R.string.pref_screensaver_inapp_enabled_description)) },
-				onClick = { screensaverInAppEnabled = !screensaverInAppEnabled }
+				onClick = { screensaverInAppEnabled = !screensaverInAppEnabled },
+				modifier = Modifier.focusKey("screensaver_in_app_enabled")
 			)
 		}
 
@@ -49,7 +52,8 @@ fun SettingsScreensaverScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_screensaver_inapp_timeout)) },
 				captionContent = { Text(caption) },
-				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER_TIMEOUT) }
+				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER_TIMEOUT) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SCREENSAVER_TIMEOUT)
 			)
 		}
 
@@ -60,7 +64,8 @@ fun SettingsScreensaverScreen() {
 				headingContent = { Text(stringResource(R.string.pref_screensaver_ageratingrequired_title)) },
 				trailingContent = { Checkbox(checked = screensaverAgeRatingRequired) },
 				captionContent = { Text(stringResource(R.string.pref_screensaver_ageratingrequired_enabled)) },
-				onClick = { screensaverAgeRatingRequired = !screensaverAgeRatingRequired }
+				onClick = { screensaverAgeRatingRequired = !screensaverAgeRatingRequired },
+				modifier = Modifier.focusKey("screensaver_age_rating_required")
 			)
 		}
 
@@ -73,7 +78,8 @@ fun SettingsScreensaverScreen() {
 			ListButton(
 				headingContent = { Text(stringResource(R.string.pref_screensaver_ageratingmax)) },
 				captionContent = { Text(caption) },
-				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER_AGE_RATING) }
+				onClick = { router.push(Routes.CUSTOMIZATION_SCREENSAVER_AGE_RATING) },
+				modifier = Modifier.focusKey(Routes.CUSTOMIZATION_SCREENSAVER_AGE_RATING)
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverTimeoutScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/screensaver/SettingsScreensaverTimeoutScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.preference.UserPreferences
@@ -12,6 +13,7 @@ import org.jellyfin.androidtv.ui.base.form.RadioButton
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
@@ -38,7 +40,8 @@ fun SettingsScreensaverTimeoutScreen() {
 				onClick = {
 					screensaverInAppTimeout = duration.inWholeMilliseconds
 					router.back()
-				}
+				},
+				modifier = Modifier.focusKey("timeout_${duration.inWholeMilliseconds}")
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/util/ListColorChannelRangeControl.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/util/ListColorChannelRangeControl.kt
@@ -29,6 +29,7 @@ fun ListColorChannelRangeControl(
 	channel: Color,
 	value: Color,
 	onValueChange: (color: Color) -> Unit,
+	modifier: Modifier = Modifier,
 ) {
 	val interactionSource = remember { MutableInteractionSource() }
 
@@ -57,6 +58,7 @@ fun ListColorChannelRangeControl(
 	ListControl(
 		headingContent = headingContent,
 		interactionSource = interactionSource,
+		modifier = modifier,
 	) {
 		Row(
 			verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
**Changes**

Adds a new focus system that restores focus when navigating back or recreating the activity within the router composable. Unfortunately Google doesn't care about Android TV so they don't support proper focus restoration, so we had to do it ourselves.

The way this works is you can now add the `.focusKey("name")` modifier to any composable which will then automatically make that specific composable work with the new persistent focus restoration system.
Nested composables will use a combined key, so if I have a box with key "a" and a button somewhere in it with key "b", the full key will be "a.b". This will be useful for future usages of the router (e.g. home sections have a key and their cards can _just_ use the item key).

The first commit adds the system and converts the main screen of the settings. The second commit adds keys to everything else.

In the third commit I added a view model for the SettingsLibrariesScreen, so the available libraries are cached on restoration.

**Code assistance**

Gemini Flash 3 preview was used for commit 2 to add all the keys.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
