### PR TITLE
fix appcrash when call updateBurningSubs

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -72,7 +72,7 @@ public class StreamInfo {
 
     public final org.jellyfin.sdk.model.api.SubtitleDeliveryMethod getSubtitleDeliveryMethod() {
         Integer subtitleStreamIndex = MediaSource.getDefaultSubtitleStreamIndex();
-        if (subtitleStreamIndex == null || subtitleStreamIndex == -1) return SubtitleDeliveryMethod.DROP;
+        if (subtitleStreamIndex == null || subtitleStreamIndex == -1 || MediaSource.getMediaStreams() == null) return SubtitleDeliveryMethod.DROP;
         return MediaSource.getMediaStreams().get(subtitleStreamIndex).getDeliveryMethod();
     }
 
@@ -96,7 +96,7 @@ public class StreamInfo {
 
     public final ArrayList<org.jellyfin.sdk.model.api.MediaStream> getSelectableStreams(MediaStreamType type) {
         ArrayList<org.jellyfin.sdk.model.api.MediaStream> list = new ArrayList<org.jellyfin.sdk.model.api.MediaStream>();
-
+        if (MediaSource.getMediaStreams() == null) return list;
         for (org.jellyfin.sdk.model.api.MediaStream stream : getMediaSource().getMediaStreams()) {
             if (type == stream.getType()) {
                 list.add(stream);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -523,8 +523,8 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         if (playbackRetries > 0 || (isLiveTv && !directStreamLiveTv)) internalOptions.setEnableDirectPlay(false);
         if (playbackRetries > 1) internalOptions.setEnableDirectStream(false);
         if (mCurrentOptions != null) {
-            internalOptions.setSubtitleStreamIndex(mCurrentOptions.getSubtitleStreamIndex());
-            internalOptions.setAudioStreamIndex(mCurrentOptions.getAudioStreamIndex());
+            internalOptions.setSubtitleStreamIndex(getCurrentMediaSource().getDefaultSubtitleStreamIndex());
+            internalOptions.setAudioStreamIndex(getCurrentMediaSource().getDefaultAudioStreamIndex());
         }
         if (forcedSubtitleIndex != null) {
             internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);


### PR DESCRIPTION
Fix appcrash IndexOutOfBoundsException when number of streams differs from the current video and the previous one and targeted index doesn't exist.

**Changes**
Get the default streams index in place of the previous stream index.

**Code assistance**
None

**Issues**
Fix issue: https://github.com/jellyfin/jellyfin-androidtv/issues/5407
