### PR TITLE
主题: 新增 Netflix 黑红 / Infuse 橙 两套配色

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,51 @@
-<h1 align="center">Jellyfin for Android TV</h1>
-<h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
+# Netflix & Infuse Themes for Jellyfin Android TV
 
----
+> Fork of [jellyfin/jellyfin-androidtv](https://github.com/jellyfin/jellyfin-androidtv) with **two new dark color themes**.
 
-<p align="center">
-<img alt="Logo banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
-<br/><br/>
-<a href="https://github.com/jellyfin/jellyfin-androidtv">
-<img alt="GPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-androidtv.svg"/>
-</a>
-<a href="https://github.com/jellyfin/jellyfin-androidtv/releases">
-<img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-androidtv.svg"/>
-</a>
-<a href="https://translate.jellyfin.org/projects/jellyfin-android/jellyfin-androidtv/">
-<img alt="Translation Status" src="https://translate.jellyfin.org/widgets/jellyfin-android/-/jellyfin-androidtv/svg-badge.svg"/>
-</a>
-<br/>
-<a href="https://opencollective.com/jellyfin">
-<img alt="Donate" src="https://img.shields.io/opencollective/all/jellyfin.svg?label=backers"/>
-</a>
-<a href="https://features.jellyfin.org">
-<img alt="Feature Requests" src="https://img.shields.io/badge/fider-vote%20on%20features-success.svg"/>
-</a>
-<a href="https://matrix.to/#/+jellyfin:matrix.org">
-<img alt="Chat on Matrix" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix"/>
-</a>
-<br/>
-<a href="https://play.google.com/store/apps/details?id=org.jellyfin.androidtv">
-<img width="153" alt="Jellyfin on Google Play" src="https://jellyfin.org/images/store-icons/google-play.png"/>
-</a>
-<a href="https://www.amazon.com/gp/aw/d/B07TX7Z725">
-<img width="153" alt="Jellyfin on Amazon Appstore" src="https://jellyfin.org/images/store-icons/amazon.png"/>
-</a>
-<a href="https://f-droid.org/en/packages/org.jellyfin.androidtv/">
-<img width="153" alt="Jellyfin on F-Droid" src="https://jellyfin.org/images/store-icons/fdroid.png"/>
-</a>
-<br/>
-<a href="https://repo.jellyfin.org/releases/client/androidtv/">Download archive</a>
-</p>
+## 🎨 Themes
 
-Jellyfin for Android TV is a Jellyfin client for Android TV, Nvidia Shield, and Amazon Fire TV devices. We welcome all contributions and pull
-requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start. 
+| Theme | 主题色 | 背景 | 名称 |
+|---|---|---|---|
+| **Netflix** | `#E50914` (网飞招牌红) | `#141414` (纯黑) | Netflix (black & red) |
+| **Infuse** | `#FF6B1A` (Apple TV 暖橙) | `#1A1A1E` (深黑) | Infuse (orange) |
 
-## Building
+切换主题：APP 设置 → 外观 → 主题。在 `Default / Emerald / Muted purple` 之外新增两个选项。
 
-The app uses Gradle and requires the Android SDK. We recommend using Android Studio, which includes all required dependencies, for
-development and building. For manual building without Android Studio make sure a compatible JDK and Android SDK are installed and in your
-PATH, then use the Gradle wrapper (`./gradlew`) to build the project with the `assembleDebug` Gradle task to generate an apk file:
+## 📦 What's Changed
 
-```shell
-./gradlew assembleDebug
+### Files Added (2)
+- `app/src/main/res/values/theme_netflix.xml` — Netflix 黑红主题
+- `app/src/main/res/values/theme_infuse.xml` — Infuse 橙主题
+
+### Files Modified (5)
+- `AppTheme.kt` — `enum class AppTheme` 增加 `NETFLIX`, `INFUSE`
+- `ActivityThemeExtensions.kt` — `AppTheme.style` 映射加两条
+- `strings.xml` × 3 语言（英文 / 简体 / 繁体）— 主题名
+
+## 🛠️ 编译 (Build)
+
+需要 JDK 17 + Android SDK 34+：
+
+```bash
+git clone https://github.com/bzl1982/jellyfin-androidtv.git
+cd jellyfin-androidtv
+./gradlew assembleTv  # 输出 app/build/outputs/apk/tv/release/*.apk
 ```
 
-The task will create an APK file in the `/app/build/outputs/apk/debug` directory. This APK file uses a different app-id from our stable
-builds and can be manually installed to your device.
+## 📥 安装到小米电视
 
-## Branching
+```bash
+adb connect 192.168.50.x   # 小米电视 IP
+adb install app/build/outputs/apk/tv/release/app-tv-release.apk
+```
 
-The `master` branch is the primary development branch and the target for all pull requests. It is **unstable** and may contain breaking
-changes or unresolved bugs. For production deployments and forks, always use the latest `release-x.y.z` branch. Do not base production work
-or long-lived forks on `master`.
+## 🔮 路线图
 
-Release branches are created at the start of a beta cycle and are kept up to date with each published release. Maintainers will cherry-pick
-selected changes into release branches as needed for backports. These branches are reused for subsequent patch releases.
+- [x] P1 — 主题色（V1，含此 PR）
+- [ ] P2 — 首页 hero + 横滑行（网飞首页感）
+- [ ] P2 — 详情页 + 搜索 + 播放器 OSD
+- [ ] P3 — 编译 APK 发布到 Releases
 
-## Translating
+## 📜 License
 
-Translations can be improved very easily from our [Weblate](https://translate.jellyfin.org/projects/jellyfin-android/jellyfin-androidtv)
-instance. Look through the following graphic to see if your native language could use some work! We cannot accept changes to translation
-files via pull requests.
-
-<p align="center">
-<a href="https://translate.jellyfin.org/engage/jellyfin-android/">
-<img alt="Detailed Translation Status" src="https://translate.jellyfin.org/widgets/jellyfin-android/-/jellyfin-androidtv/multi-auto.svg"/>
-</a>
-</p>
+GPL-2.0 (same as upstream jellyfin-androidtv)

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/AppTheme.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/AppTheme.kt
@@ -20,4 +20,14 @@ enum class AppTheme(
 	 * A theme with a more muted accent color, inspired by CTalvio's Monochromic CSS theme for Jellyfin Web
 	 */
 	MUTED_PURPLE(R.string.pref_theme_muted_purple),
+
+	/**
+	 * Netflix-style black & red theme (custom)
+	 */
+	NETFLIX(R.string.pref_theme_netflix),
+
+	/**
+	 * Infuse-style warm orange theme (custom)
+	 */
+	INFUSE(R.string.pref_theme_infuse),
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/ActivityThemeExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/ActivityThemeExtensions.kt
@@ -17,6 +17,8 @@ private val AppTheme.style
 		AppTheme.DARK -> R.style.Theme_Jellyfin
 		AppTheme.EMERALD -> R.style.Theme_Jellyfin_Emerald
 		AppTheme.MUTED_PURPLE -> R.style.Theme_Jellyfin_MutedPurple
+		AppTheme.NETFLIX -> R.style.Theme_Jellyfin_Netflix
+		AppTheme.INFUSE -> R.style.Theme_Jellyfin_Infuse
 	}
 
 /**

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -310,6 +310,8 @@
     <string name="lbl_switch_user">切换账户</string>
     <string name="no_network_permissions">Jellyfin需要网络权限才能运行</string>
     <string name="pref_theme_muted_purple">淡紫色</string>
+    <string name="pref_theme_netflix">网飞（黑红）</string>
+    <string name="pref_theme_infuse">Infuse（橙）</string>
     <string name="lbl_episode_number">第%1$d集</string>
     <string name="lbl_season_number">第%1$d季</string>
     <string name="add_user">添加帐号</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -388,6 +388,8 @@
     <string name="press_to_close">點擊以關閉</string>
     <string name="no_network_permissions">Jellyfin需要網路權限才能運作</string>
     <string name="pref_theme_muted_purple">淡紫色</string>
+    <string name="pref_theme_netflix">Netflix（黑紅）</string>
+    <string name="pref_theme_infuse">Infuse（橙）</string>
     <string name="lbl_switch_user">切換帳號</string>
     <string name="user_picker_last_user_summary">使用最後一個活躍帳號</string>
     <string name="user_picker_last_user_title">最近使用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -359,6 +359,8 @@
     <string name="user_picker_last_user_summary">Use the last active account</string>
     <string name="lbl_switch_user">Switch account</string>
     <string name="pref_theme_muted_purple">Muted purple</string>
+    <string name="pref_theme_netflix">Netflix (Black &amp; Red)</string>
+    <string name="pref_theme_infuse">Infuse (Orange)</string>
     <string name="no_network_permissions">Jellyfin requires network permissions to function</string>
     <string name="press_to_close">Press to close</string>
     <string name="saved_servers">Saved servers</string>

--- a/app/src/main/res/values/theme_infuse.xml
+++ b/app/src/main/res/values/theme_infuse.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Infuse 橙主题（Apple TV Infuse 风格暖橙） -->
+    <color name="theme_infuse_light">#FF6B1A</color>
+    <color name="theme_infuse_dark">#1A1A1E</color>
+    <color name="theme_infuse_black">#000000</color>
+    <color name="theme_infuse_grey">#2C2C30</color>
+
+    <style name="Theme.Jellyfin.Infuse" parent="Theme.Jellyfin">
+        <item name="android:colorPrimary">@color/theme_infuse_dark</item>
+        <item name="android:colorPrimaryDark">@color/theme_infuse_black</item>
+        <item name="android:colorAccent">@color/theme_infuse_light</item>
+        <item name="defaultBackground">@drawable/moviebg</item>
+        <item name="defaultSearchColor">@color/theme_infuse_light</item>
+        <item name="progressPrimary">@color/theme_infuse_light</item>
+        <item name="progressSecondary">@color/theme_infuse_dark</item>
+        <item name="popupMenuBackground">@color/theme_infuse_black</item>
+
+        <!-- Control icons -->
+        <item name="controlIconBackground">@color/theme_infuse_black</item>
+        <item name="controlIconForegroundActive">@color/theme_infuse_light</item>
+        <item name="controlIconForegroundInactive">@color/theme_infuse_grey</item>
+
+        <!-- QR drawables -->
+        <item name="qrForeground">@color/theme_infuse_dark</item>
+
+        <!-- Tile colors -->
+        <item name="tile_search_bg">@color/theme_infuse_light</item>
+        <item name="tile_suggestions_bg">@color/theme_infuse_light</item>
+        <item name="tile_actors_bg">@color/theme_infuse_light</item>
+        <item name="tile_artists_bg">@color/theme_infuse_light</item>
+        <item name="tile_audio_bg">@color/theme_infuse_light</item>
+        <item name="tile_chapter_bg">@color/theme_infuse_light</item>
+        <item name="tile_genres_bg">@color/theme_infuse_light</item>
+        <item name="tile_letters_bg">@color/theme_infuse_light</item>
+        <item name="tile_land_folder_bg">@color/theme_infuse_light</item>
+        <item name="tile_land_photo_bg">@color/theme_infuse_light</item>
+        <item name="tile_land_series_timer_bg">@color/theme_infuse_light</item>
+        <item name="tile_land_tv_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_time_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_tv_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_video_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_folder_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_grid_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_guide_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_person_bg">@color/theme_infuse_light</item>
+        <item name="tile_port_series_timer_bg">@color/theme_infuse_light</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/theme_netflix.xml
+++ b/app/src/main/res/values/theme_netflix.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- 网飞黑红主题 Netflix Red -->
+    <color name="theme_netflix_light">#E50914</color>
+    <color name="theme_netflix_dark">#141414</color>
+    <color name="theme_netflix_black">#000000</color>
+    <color name="theme_netflix_grey">#2F2F2F</color>
+
+    <style name="Theme.Jellyfin.Netflix" parent="Theme.Jellyfin">
+        <item name="android:colorPrimary">@color/theme_netflix_dark</item>
+        <item name="android:colorPrimaryDark">@color/theme_netflix_black</item>
+        <item name="android:colorAccent">@color/theme_netflix_light</item>
+        <item name="defaultBackground">@drawable/moviebg</item>
+        <item name="defaultSearchColor">@color/theme_netflix_light</item>
+        <item name="progressPrimary">@color/theme_netflix_light</item>
+        <item name="progressSecondary">@color/theme_netflix_dark</item>
+        <item name="popupMenuBackground">@color/theme_netflix_black</item>
+
+        <!-- Control icons -->
+        <item name="controlIconBackground">@color/theme_netflix_black</item>
+        <item name="controlIconForegroundActive">@color/theme_netflix_light</item>
+        <item name="controlIconForegroundInactive">@color/theme_netflix_grey</item>
+
+        <!-- QR drawables -->
+        <item name="qrForeground">@color/theme_netflix_dark</item>
+
+        <!-- Tile colors -->
+        <item name="tile_search_bg">@color/theme_netflix_light</item>
+        <item name="tile_suggestions_bg">@color/theme_netflix_light</item>
+        <item name="tile_actors_bg">@color/theme_netflix_light</item>
+        <item name="tile_artists_bg">@color/theme_netflix_light</item>
+        <item name="tile_audio_bg">@color/theme_netflix_light</item>
+        <item name="tile_chapter_bg">@color/theme_netflix_light</item>
+        <item name="tile_genres_bg">@color/theme_netflix_light</item>
+        <item name="tile_letters_bg">@color/theme_netflix_light</item>
+        <item name="tile_land_folder_bg">@color/theme_netflix_light</item>
+        <item name="tile_land_photo_bg">@color/theme_netflix_light</item>
+        <item name="tile_land_series_timer_bg">@color/theme_netflix_light</item>
+        <item name="tile_land_tv_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_time_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_tv_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_video_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_folder_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_grid_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_guide_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_person_bg">@color/theme_netflix_light</item>
+        <item name="tile_port_series_timer_bg">@color/theme_netflix_light</item>
+    </style>
+</resources>


### PR DESCRIPTION
## 🎨 新增 Netflix & Infuse 两套主题

在原生 Jellyfin Android TV 10.11.11 基础上新增两套深色主题色，与原生的 Default / Emerald / Muted purple 并列可在「设置 → 主题」中切换。

### 主题包
- **Netflix**：`#E50914` 网飞招牌红 + `#141414` 纯黑背景
- **Infuse**：`#FF6B1A` Apple TV Infuse 暖橙 + `#1A1A1E` 深黑背景

### 文件改动
- 新建：`app/src/main/res/values/theme_netflix.xml` (~70 行)
- 新建：`app/src/main/res/values/theme_infuse.xml` (~70 行)
- 修改：`AppTheme.kt`：enum 增加 `NETFLIX` 和 `INFUSE` 两条
- 修改：`ActivityThemeExtensions.kt`：style 映射增加两条
- 修改：`strings.xml` × 3 语言（英文 / 简体中文 / 繁体中文）

### 设计原则
- 完全照原有 emerald.xml 同构：包含 light / dark / black 三套 attr + controlIconBackground / defaultSearchColor / progressPrimary / 20 个 tile_* 主题色 → 切换主题时按钮、进度条、搜索高亮、卡片 tile、播放器控制图标全部跟着走
- 不破坏任何原有主题（包括 Default / Emerald / Muted purple）
- 主题色严格遵循 Netflix / Infuse 官方色卡

### 测试
- 主题切换走 `UserPreferences.appTheme` → `ActivityThemeExtensions.style` → 自动应用全 APP
- 已通过 xml 验证所有 attr 覆盖
