### PR TITLE
fix(playback): restore subtitles by language + title across episodes

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -643,23 +643,57 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        // get subtitle info - prefer saved language preference over server default
+        // get subtitle info - prefer saved language + title preference over server default.
+        // Matching priority: exact (language + title) -> language only -> server default.
         String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
+        String lastSubtitleTitle = videoQueueManager.getValue().getLastPlayedSubtitleTitle();
         if (lastSubtitleLanguage != null) {
             if (lastSubtitleLanguage.isEmpty()) {
                 // User explicitly disabled subtitles
                 mCurrentOptions.setSubtitleStreamIndex(null);
             } else if (response.getMediaSource().getMediaStreams() != null) {
-                // Find subtitle stream matching saved language
+                // Pass 1: try to find a subtitle stream matching both the saved language and title
                 Integer matchingIndex = null;
-                for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
-                    if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
-                        matchingIndex = stream.getIndex();
-                        break;
+                if (lastSubtitleTitle != null) {
+                    for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
+                        if (stream.getType() == MediaStreamType.SUBTITLE
+                            && lastSubtitleLanguage.equals(stream.getLanguage())
+                            && lastSubtitleTitle.equals(stream.getTitle() != null ? stream.getTitle() : stream.getDisplayTitle())) {
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
                     }
+                }
+                // Pass 2: fall back to any subtitle stream matching the saved language
+                if (matchingIndex == null) {
+                    for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
+                        if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                // Pass 3: no language match at all, fall back to the server default
+                if (matchingIndex == null) {
+                    matchingIndex = response.getMediaSource().getDefaultSubtitleStreamIndex();
                 }
                 mCurrentOptions.setSubtitleStreamIndex(matchingIndex);
             }
+        } else if (lastSubtitleTitle != null && response.getMediaSource().getMediaStreams() != null) {
+            // No language preference, but a title was saved (e.g. tracks without a language tag).
+            // Try to restore the track by its title alone.
+            Integer matchingIndex = null;
+            for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
+                if (stream.getType() == MediaStreamType.SUBTITLE
+                    && lastSubtitleTitle.equals(stream.getTitle() != null ? stream.getTitle() : stream.getDisplayTitle())) {
+                    matchingIndex = stream.getIndex();
+                    break;
+                }
+            }
+            if (matchingIndex == null) {
+                matchingIndex = response.getMediaSource().getDefaultSubtitleStreamIndex();
+            }
+            mCurrentOptions.setSubtitleStreamIndex(matchingIndex);
         } else {
             // No saved preference, use server default
             mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -59,14 +59,16 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 	// Already using this subtitle index
 	if (mCurrentOptions.subtitleStreamIndex == index && !force) return
 
-	// Save subtitle language preference for restoration after NextUp screen
+	// Save subtitle language + title preference for restoration after NextUp screen
 	val videoQueueManager by fragment.inject<VideoQueueManager>()
 	if (index == -1) {
 		// Use empty string to indicate "subtitles explicitly disabled" vs null meaning "no preference"
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode("")
+		videoQueueManager.setLastPlayedSubtitleTitle(null)
 	} else {
 		val stream = currentMediaSource.mediaStreams?.firstOrNull { it.type == MediaStreamType.SUBTITLE && it.index == index }
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(stream?.language)
+		videoQueueManager.setLastPlayedSubtitleTitle(stream?.title ?: stream?.displayTitle)
 	}
 
 	// Disable subtitles

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
@@ -7,6 +7,7 @@ class VideoQueueManager {
 	private var _currentMediaPosition = -1
 	private var _lastPlayedAudioLanguageIsoCode: String? = null
 	private var _lastPlayedSubtitleLanguageIsoCode: String? = null
+	private var _lastPlayedSubtitleTitle: String? = null
 
 	fun setCurrentVideoQueue(items: List<BaseItemDto>?) {
 		if (items.isNullOrEmpty()) return clearVideoQueue()
@@ -41,10 +42,19 @@ class VideoQueueManager {
 		_lastPlayedSubtitleLanguageIsoCode = isoCode
 	}
 
+	fun getLastPlayedSubtitleTitle(): String? {
+		return _lastPlayedSubtitleTitle
+	}
+
+	fun setLastPlayedSubtitleTitle(title: String?) {
+		_lastPlayedSubtitleTitle = title
+	}
+
 	fun clearVideoQueue() {
 		_currentVideoQueue = emptyList()
 		_currentMediaPosition = -1
 		_lastPlayedAudioLanguageIsoCode = null
 		_lastPlayedSubtitleLanguageIsoCode = null
+		_lastPlayedSubtitleTitle = null
 	}
 }


### PR DESCRIPTION
**Changes**
Sometimes the same sub could be on different ids in episodes. And the playback could use a different language sub. This commit fixed the issue by getting subtitle info. The entire process looks like this:
exact (language + title) -> language only -> server default

**Code assistance**
Most of the code is generated by deepseek v4 flash, I tested and made some changes.