### PR TITLE
Stop playback when the display link drops

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -66,6 +66,7 @@ import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter;
 import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter;
 import org.jellyfin.androidtv.util.CoroutineUtils;
 import org.jellyfin.androidtv.util.DateTimeExtensionsKt;
+import org.jellyfin.androidtv.util.HdcpMonitor;
 import org.jellyfin.androidtv.util.ImageHelper;
 import org.jellyfin.androidtv.util.InfoLayoutHelper;
 import org.jellyfin.androidtv.util.TextUtilsKt;
@@ -137,6 +138,8 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
 
     private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
+
+    private HdcpMonitor hdcpMonitor;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -223,11 +226,18 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         if (playbackController != null) {
             playbackController.init(new VideoManager(requireActivity(), view, helper), this);
         }
+
+        hdcpMonitor = CustomPlaybackOverlayFragmentHelperKt.startHdcpMonitor(this);
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+
+        if (hdcpMonitor != null) {
+            hdcpMonitor.stop();
+            hdcpMonitor = null;
+        }
 
         binding = null;
         // To fix race condition in hide timer

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
@@ -13,6 +13,7 @@ import org.jellyfin.androidtv.data.repository.ItemMutationRepository
 import org.jellyfin.androidtv.ui.GuideChannelHeader
 import org.jellyfin.androidtv.ui.asTimerInfoDto
 import org.jellyfin.androidtv.ui.livetv.TvManager
+import org.jellyfin.androidtv.util.HdcpMonitor
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
@@ -190,4 +191,24 @@ fun CustomPlaybackOverlayFragment.recordProgram(program: BaseItemDto, isSeries: 
 
 fun CustomPlaybackOverlayFragment.askToSkip(position: Duration) {
 	binding.skipOverlay.targetPosition = position
+}
+
+/**
+ * Stop playback when the display link drops, which happens when the television is switched off.
+ *
+ * Televisions that keep hotplug detect asserted while powered off produce no display state change,
+ * no hotplug event and no CEC standby message, so playback otherwise continues indefinitely into a
+ * dark room. The HDCP link does drop, so watch that instead.
+ */
+fun CustomPlaybackOverlayFragment.startHdcpMonitor(): HdcpMonitor {
+	val playbackControllerContainer by inject<PlaybackControllerContainer>()
+
+	val monitor = HdcpMonitor {
+		Timber.i("Display link lost, ending playback")
+		playbackControllerContainer.playbackController?.endPlayback(true)
+	}
+
+	monitor.start(lifecycleScope)
+
+	return monitor
 }

--- a/app/src/main/java/org/jellyfin/androidtv/util/HdcpMonitor.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/HdcpMonitor.kt
@@ -1,0 +1,128 @@
+package org.jellyfin.androidtv.util
+
+import android.media.MediaDrm
+import android.os.Build
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Watches the HDCP level of the connected display and reports when the link drops.
+ *
+ * Some televisions keep HDMI hotplug detect asserted while powered off, so the device never sees
+ * a display state change, a hotplug event or a CEC standby message and playback continues into a
+ * dark room. The HDCP link does drop in that situation, which is why DRM protected apps stop on
+ * their own. This gives unprotected playback the same signal.
+ *
+ * The poll interval is deliberately short. It bounds how long audio keeps playing after the
+ * television is switched off.
+ */
+class HdcpMonitor(
+	private val pollInterval: Duration = 5.seconds,
+	private val onHdcpLost: () -> Unit,
+) {
+	companion object {
+		private val WIDEVINE_UUID = UUID(-0x121074568629b532L, -0x5c37d8232ae2de13L)
+
+		/**
+		 * True once a real protected level has been observed. Prevents stopping playback on
+		 * displays that never negotiate HDCP at all, where the level reads as none from the start.
+		 *
+		 * Process wide rather than per instance: a monitor created while the display link is
+		 * already down would otherwise start with this unset and never stop playback, which is
+		 * precisely the situation it needs to act on.
+		 */
+		private val sawProtectedLevel = AtomicBoolean(false)
+
+		/**
+		 * Consecutive readings of no protection required before playback is stopped. Changing
+		 * video mode renegotiates HDCP, so a single reading can be a false positive.
+		 */
+		private const val REQUIRED_CONSECUTIVE_LOST = 2
+	}
+
+	private var job: Job? = null
+	private val fired = AtomicBoolean(false)
+	private var consecutiveLost = 0
+
+	fun start(scope: CoroutineScope) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+			Timber.i("HDCP monitor unavailable below API 28, not starting")
+			return
+		}
+
+		if (job != null) return
+
+		job = scope.launch(Dispatchers.IO) { watch() }
+	}
+
+	@RequiresApi(Build.VERSION_CODES.P)
+	private suspend fun watch() {
+		val drm = try {
+			MediaDrm(WIDEVINE_UUID)
+		} catch (error: Exception) {
+			Timber.w(error, "Unable to open MediaDrm, HDCP monitoring disabled")
+			return
+		}
+
+		try {
+			while (currentCoroutineContext().isActive) {
+				poll(drm)
+				// Stop as soon as playback has been ended rather than waiting for the view to be
+				// destroyed, so the session is always released even if teardown does not run.
+				if (fired.get()) break
+				delay(pollInterval)
+			}
+		} finally {
+			Timber.i("HDCP monitor stopped, releasing session")
+			drm.close()
+		}
+	}
+
+	@RequiresApi(Build.VERSION_CODES.P)
+	private suspend fun poll(drm: MediaDrm) {
+		val level = try {
+			drm.connectedHdcpLevel
+		} catch (error: Exception) {
+			Timber.w(error, "Unable to read connected HDCP level")
+			return
+		}
+
+		val lost = level == MediaDrm.HDCP_NONE
+		Timber.i(
+			"HDCP level=%d lost=%b consecutiveLost=%d sawProtectedLevel=%b",
+			level, lost, consecutiveLost, sawProtectedLevel.get()
+		)
+
+		if (!lost) {
+			consecutiveLost = 0
+			if (level != MediaDrm.HDCP_LEVEL_UNKNOWN) sawProtectedLevel.set(true)
+			return
+		}
+
+		consecutiveLost++
+
+		if (!sawProtectedLevel.get()) return
+		if (consecutiveLost < REQUIRED_CONSECUTIVE_LOST) return
+		if (!fired.compareAndSet(false, true)) return
+
+		Timber.i("HDCP link lost, stopping playback")
+		withContext(Dispatchers.Main) { onHdcpLost() }
+	}
+
+	fun stop() {
+		job?.cancel()
+		job = null
+	}
+}


### PR DESCRIPTION
## Problem

Playback continues indefinitely after the television is switched off. In my case four episodes autoplayed unattended over an hour with the TV off the whole time.

This has been reported before as #4007, which was closed as not planned. I think the reason no fix was found is that the obvious signals genuinely do not exist on this hardware, and it is worth documenting why.

## Why the obvious approaches do not work

Chromecast with Google TV 4K (`sabrina`, Amlogic), Android 14, attached to an LG panel. With the television **switched off**:

```
/sys/class/amhdmitx/amhdmitx0/hpd_state = 1
```

Hotplug detect stays asserted, so from Android's point of view nothing changes:

- `mScreenState=ON`, `mState=ON`, `committedState ON`, `mIsEnabled=true`
- EDID still readable, `deviceProductInfo{name=LG TV, ...}` still populated
- no hotplug event
- `mWakefulness=Awake` throughout
- `STREAM_MUSIC Devices: hdmi(400)` unchanged

So a `DisplayManager.DisplayListener` never fires, and there is no `ACTION_SCREEN_OFF` or `PowerManager` transition to observe.

CEC is not available either. Over three days of logs on this device:

```
dumpsys hdmi_control | grep -c '\[S\]'   ->  238
dumpsys hdmi_control | grep -c '\[R\]'   ->    0
```

238 messages sent, zero ever received, and the TV was never discovered as a CEC device. Every `<Give Device Power Status>` to logical address 0 is `(NACK, NACK)`.

## What does change

HDCP. With the television off the transmitter cannot authenticate and retries continuously:

```
E/hdcp_tx22: [TX] Capability check failed: -662.  Retrying...
E/hdcp_tx22: [ESM] SYSTEM_RESET / RESET COMPLETE / COMM RD-NAK
E/hdcp_tx22: [TX] enable low value content
```

With the television on, zero such errors. This is why DRM protected apps stop on their own and unprotected local playback does not — they are not detecting the television, they are simply losing their secure path.

`MediaDrm.getConnectedHdcpLevel()` exposes this to applications, and it tracks the sink correctly here: `6` (`HDCP_V2_3`) with the TV on, `1` (`HDCP_NONE`) with it off.

## The change

`HdcpMonitor` polls the connected HDCP level during playback and ends playback when it reports no protection.

- Polls every 5 seconds and requires two consecutive readings before acting, because changing video mode renegotiates HDCP and a single reading can be a false positive between episodes of differing frame rate.
- The flag recording that a protected level was ever seen is process wide. Per instance it reset on every fragment recreation, which meant a monitor created while the link was already down started unarmed and never acted — precisely the autoplay path this is meant to catch.
- Displays that never negotiate HDCP at all are unaffected, since the monitor only acts on a transition away from a real protected level.
- The poll loop exits as soon as playback has been ended, releasing the `MediaDrm` session without depending on view teardown, which does not run on every path out of playback.
- No-op below API 28.

## Testing

On the hardware above:

- Mid-episode, TV switched off: stopped 2.4s after the HDCP failure appeared in the kernel log.
- Across an autoplay rollover: polls continue uninterrupted through `itemComplete()` -> next up -> new fragment, then the stop fires correctly during episode 2, ~10s after power off.
- Play -> stop -> play -> stop: second stop fires correctly.
- Session release confirmed 149ms after the stop, with no further polling.
- In each case verified actually stopped, not merely logged: `dumpsys media.audio_flinger` active streams 0 and the player torn down.

I only have this one device to test on, so I would welcome checks on other hardware — particularly anything where the panel drops HPD on power off, where I would expect the existing display path to already work and this to be redundant but harmless.
