### PR TITLE
fix audio and subtitle playback from previous media

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
+++ b/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java
@@ -72,7 +72,7 @@ public class StreamInfo {
 
     public final org.jellyfin.sdk.model.api.SubtitleDeliveryMethod getSubtitleDeliveryMethod() {
         Integer subtitleStreamIndex = MediaSource.getDefaultSubtitleStreamIndex();
-        if (subtitleStreamIndex == null || subtitleStreamIndex == -1) return SubtitleDeliveryMethod.DROP;
+        if (subtitleStreamIndex == null || subtitleStreamIndex == -1 || MediaSource.getMediaStreams() == null) return SubtitleDeliveryMethod.DROP;
         return MediaSource.getMediaStreams().get(subtitleStreamIndex).getDeliveryMethod();
     }
 
@@ -96,7 +96,7 @@ public class StreamInfo {
 
     public final ArrayList<org.jellyfin.sdk.model.api.MediaStream> getSelectableStreams(MediaStreamType type) {
         ArrayList<org.jellyfin.sdk.model.api.MediaStream> list = new ArrayList<org.jellyfin.sdk.model.api.MediaStream>();
-
+        if (MediaSource.getMediaStreams() == null) return list;
         for (org.jellyfin.sdk.model.api.MediaStream stream : getMediaSource().getMediaStreams()) {
             if (type == stream.getType()) {
                 list.add(stream);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackController.java
@@ -50,6 +50,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Objects;
 
 import kotlin.Lazy;
 import timber.log.Timber;
@@ -204,7 +205,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             } else {
                 // Prefer the media source with the same id as the item
                 for (MediaSourceInfo mediaSource : mediaSources) {
-                    if (item.getId().equals(UUIDSerializerKt.toUUIDOrNull(mediaSource.getId()))) {
+                    if (mediaSource.getId() != null && item.getId().equals(UUIDSerializerKt.toUUIDOrNull(mediaSource.getId()))) {
                         return mediaSource;
                     }
                 }
@@ -496,7 +497,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
                 // undo setting mSeekPosition for liveTV
                 if (isLiveTv) mSeekPosition = -1;
 
-                VideoOptions internalOptions = buildExoPlayerOptions(forcedSubtitleIndex, forcedAudioLanguage, item);
+                VideoOptions internalOptions = buildExoPlayerOptions(forcedSubtitleIndex, item);
 
                 playInternal(getCurrentlyPlayingItem(), position, internalOptions);
                 mPlaybackState = PlaybackState.BUFFERING;
@@ -514,7 +515,6 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     @NonNull
     private VideoOptions buildExoPlayerOptions(
             @Nullable Integer forcedSubtitleIndex,
-            @Nullable String forcedAudioLanguage,
             BaseItemDto item) {
         VideoOptions internalOptions = new VideoOptions();
         internalOptions.setItemId(item.getId());
@@ -522,24 +522,14 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         internalOptions.setAlwaysBurnInSubtitleWhenTranscoding(userPreferences.getValue().get(UserPreferences.Companion.getSubtitlesBurnDuringTranscode()));
         if (playbackRetries > 0 || (isLiveTv && !directStreamLiveTv)) internalOptions.setEnableDirectPlay(false);
         if (playbackRetries > 1) internalOptions.setEnableDirectStream(false);
-        if (mCurrentOptions != null) {
-            internalOptions.setSubtitleStreamIndex(mCurrentOptions.getSubtitleStreamIndex());
-            internalOptions.setAudioStreamIndex(mCurrentOptions.getAudioStreamIndex());
-        }
+        MediaSourceInfo currentMediaSource = getCurrentMediaSource();
         if (forcedSubtitleIndex != null) {
             internalOptions.setSubtitleStreamIndex(forcedSubtitleIndex);
+        }else{
+            internalOptions.setSubtitleStreamIndex(getBestSubtitleIndex(currentMediaSource));
         }
-        MediaSourceInfo currentMediaSource = getCurrentMediaSource();
-        if (forcedAudioLanguage != null) {
-            // find the first audio stream with the requested language
-            for (MediaStream stream : currentMediaSource.getMediaStreams()) {
-                if (stream.getType() == MediaStreamType.AUDIO && forcedAudioLanguage.equals(stream.getLanguage())) {
-                    internalOptions.setAudioStreamIndex(stream.getIndex());
-                    break;
-                }
-            }
-        }
-        if (!isLiveTv && currentMediaSource != null) {
+        internalOptions.setAudioStreamIndex(getBestAudioIndex(currentMediaSource));
+        if (!isLiveTv) {
             internalOptions.setMediaSourceId(currentMediaSource.getId());
         }
         DeviceProfile internalProfile = DeviceProfileKt.createDeviceProfile(
@@ -625,6 +615,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
+        Timber.d("reset audio stream index to null");
         mCurrentOptions.setAudioStreamIndex(null); // reset audio stream index to allow auto selection on new item
 
         mStartPosition = position;
@@ -643,30 +634,12 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        // get subtitle info - prefer saved language preference over server default
-        String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
-        if (lastSubtitleLanguage != null) {
-            if (lastSubtitleLanguage.isEmpty()) {
-                // User explicitly disabled subtitles
-                mCurrentOptions.setSubtitleStreamIndex(null);
-            } else if (response.getMediaSource().getMediaStreams() != null) {
-                // Find subtitle stream matching saved language
-                Integer matchingIndex = null;
-                for (MediaStream stream : response.getMediaSource().getMediaStreams()) {
-                    if (stream.getType() == MediaStreamType.SUBTITLE && lastSubtitleLanguage.equals(stream.getLanguage())) {
-                        matchingIndex = stream.getIndex();
-                        break;
-                    }
-                }
-                mCurrentOptions.setSubtitleStreamIndex(matchingIndex);
-            }
-        } else {
-            // No saved preference, use server default
-            mCurrentOptions.setSubtitleStreamIndex(response.getMediaSource().getDefaultSubtitleStreamIndex());
-        }
         setDefaultAudioIndex(response);
+        int bSubIndex = getBestSubtitleIndex(response.getMediaSource());
+        var mSubIndex = mCurrentOptions.getSubtitleStreamIndex();
+        PlaybackControllerHelperKt.setSubtitleIndex(this, bSubIndex, (mSubIndex == null || !Objects.equals(mSubIndex, bSubIndex)));
         Timber.i("default audio index set to %s remote default %s", mDefaultAudioIndex, response.getMediaSource().getDefaultAudioStreamIndex());
-        Timber.i("default sub index set to %s remote default %s", mCurrentOptions.getSubtitleStreamIndex(), response.getMediaSource().getDefaultSubtitleStreamIndex());
+        Timber.i("default sub index set to %s remote default %s", mSubIndex, response.getMediaSource().getDefaultSubtitleStreamIndex());
 
         Long mbPos = position * 10000;
 
@@ -736,52 +709,308 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     private Integer bestGuessAudioTrack(MediaSourceInfo info) {
-        if (info == null)
-            return null;
-
-        boolean videoFound = false;
-        for (MediaStream track : info.getMediaStreams()) {
-            if (track.getType() == MediaStreamType.VIDEO) {
-                videoFound = true;
-            } else {
-                if (videoFound && track.getType() == MediaStreamType.AUDIO)
-                    return track.getIndex();
+        if (info != null && info.getMediaStreams() != null) {
+            for (MediaStream track : info.getMediaStreams()) {
+                    if (track.getType() == MediaStreamType.AUDIO)
+                        return track.getIndex();
             }
         }
         return null;
     }
 
-    private Integer lastChosenLanguageAudioTrack(MediaSourceInfo info) {
-        if (info == null)
-            return null;
+    private Integer getBestAudioIndex(MediaSourceInfo info) {
+        if (info != null && info.getMediaStreams() != null) {
+            String lastAudioLanguage = videoQueueManager.getValue().getLastPlayedAudioLanguageIsoCode();
+            String lastAudioCodec = videoQueueManager.getValue().getLastPlayedAudioCodec();
+            List<MediaStream> allAudioStreams = info.getMediaStreams().stream().filter(stream -> stream.getType() == MediaStreamType.AUDIO).toList();
+            if ((allAudioStreams != null) && (lastAudioLanguage != null) && (lastAudioCodec != null)) {
+                // find the best matching audio stream
+                Boolean lastAudioDefaultState = videoQueueManager.getValue().getLastPlayedAudioDefaultState();
+                Boolean lastAudioHearingImpairedState = videoQueueManager.getValue().getLastPlayedAudioHearingImpairedState();
+                Integer matchingIndex = null;
 
-        boolean videoFound = false;
-        for (MediaStream track : info.getMediaStreams()) {
-            if (track.getType() == MediaStreamType.VIDEO) {
-                videoFound = true;
-            } else {
-                if (videoFound
-                    && track.getType() == MediaStreamType.AUDIO
-                    && (track.getLanguage() != null && track.getLanguage().equals(videoQueueManager.getValue().getLastPlayedAudioLanguageIsoCode()))
-                )
-                    return track.getIndex();
+                // find the exact audio stream with the requested language, codec & indicators
+                for (MediaStream stream : allAudioStreams) {
+                    if (lastAudioLanguage.equals(stream.getLanguage())
+                            && lastAudioCodec.equals(stream.getCodec())
+                            && lastAudioDefaultState.equals(stream.isDefault())
+                            && lastAudioHearingImpairedState.equals(stream.isHearingImpaired())
+                    ) {
+                        Timber.d("Best audio found ! (lang+all)");
+                        matchingIndex = stream.getIndex();
+                        break;
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #1: find the first audio stream with the requested language, codec and SDH indicator
+                    for (MediaStream stream : allAudioStreams) {
+                        if (lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                                && lastAudioHearingImpairedState.equals(stream.isHearingImpaired())
+                        ) {
+                            Timber.d("Best audio found on fallback #1 (lang+codec+SDH)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #2: find the first audio stream with the requested language and codec but with only 'default' indicator
+                    for (MediaStream stream : allAudioStreams) {
+                        if (lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                                && lastAudioDefaultState.equals(stream.isDefault())
+                        ) {
+                            Timber.d("Best audio found on fallback #2 (lang+codec+default)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #3: find the first audio stream with the requested language and codec
+                    for (MediaStream stream : allAudioStreams) {
+                        if (lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                        ) {
+                            Timber.d("Best audio found on fallback #3 (lang+codec)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #4: find the first audio stream with the requested language and SDH indicator
+                    for (MediaStream stream : allAudioStreams) {
+                        if (lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioDefaultState.equals(stream.isDefault())
+                                && lastAudioHearingImpairedState.equals(stream.isHearingImpaired())
+                        ) {
+                            Timber.d("Best audio found on fallback #4 (lang+default+SDH)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #5: find the first audio stream with the requested language and 'default' indicator
+                    for (MediaStream stream : allAudioStreams) {
+                        if (lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioDefaultState.equals(stream.isDefault())
+                        ) {
+                            Timber.d("Best audio found on fallback #5 (lang+default)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #6: find the first audio stream with the requested language (fallback to language only)
+                    for (MediaStream stream : allAudioStreams) {
+                        if (lastAudioLanguage.equals(stream.getLanguage())) {
+                            Timber.d("Best audio found on fallback #6 (lang only)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #7: if audio languages are different but other indicators match
+                    for (MediaStream stream : allAudioStreams) {
+                        if (!lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                                && lastAudioDefaultState.equals(stream.isDefault())
+                                && lastAudioHearingImpairedState.equals(stream.isHearingImpaired())
+                        ) {
+                            Timber.d("Best audio found on fallback #7 (!lang+all)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #8: if audio languages are different
+                    for (MediaStream stream : allAudioStreams) {
+                        if (!lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                                && lastAudioDefaultState.equals(stream.isDefault())
+                        ) {
+                            Timber.d("Best audio found on fallback #8 (!lang+codec+default)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #9: if audio languages are different
+                    for (MediaStream stream : allAudioStreams) {
+                        if (!lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                                && lastAudioHearingImpairedState.equals(stream.isHearingImpaired())
+                        ) {
+                            Timber.d("Best audio found on fallback #9 (!lang+codec+SDH)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                if (matchingIndex == null) {
+                    // fallback #10: if audio languages are different
+                    for (MediaStream stream : allAudioStreams) {
+                        if (!lastAudioLanguage.equals(stream.getLanguage())
+                                && lastAudioCodec.equals(stream.getCodec())
+                        ) {
+                            Timber.d("Best audio found on fallback #10 (!lang+codec)");
+                            matchingIndex = stream.getIndex();
+                            break;
+                        }
+                    }
+                }
+                Timber.i("Best audio found on index: %d for media: '%s'", matchingIndex, info.getName());
+                return matchingIndex;
+            }
+            else {
+                Integer matchingIndex = getCurrentMediaSource().getDefaultAudioStreamIndex();
+                Timber.i("Best audio found on server with index: %d for media: '%s'", matchingIndex, info.getName());
+                return matchingIndex;
             }
         }
         return null;
+    }
+
+    public Integer getBestSubtitleIndex(MediaSourceInfo info) {
+        // get subtitle info - prefer saved language preference over server default
+        Integer matchingIndex = null;
+        String lastSubtitleLanguage = videoQueueManager.getValue().getLastPlayedSubtitleLanguageIsoCode();
+        if (lastSubtitleLanguage != null) {
+            if (lastSubtitleLanguage.isEmpty()) {
+                // User explicitly disabled subtitles
+                Timber.i("Best subtitle found on index: -1");
+                return -1;
+            } else if (info.getMediaStreams() != null) {
+                // find the best matching subtitle stream
+                String lastSubtitleCodec = videoQueueManager.getValue().getLastPlayedSubtitleCodec();
+                Boolean lastSubtitleDefaultState = videoQueueManager.getValue().getLastPlayedSubtitleDefaultState();
+                Boolean lastSubtitleForcedState = videoQueueManager.getValue().getLastPlayedSubtitleForcedState();
+                Boolean lastSubtitleHearingImpairedState = videoQueueManager.getValue().getLastPlayedSubtitleHearingImpairedState();
+                String lastSubtitleTitle = videoQueueManager.getValue().getLastPlayedSubtitleTitle();
+                List<MediaStream> allSubtitleStreams = info.getMediaStreams().stream().filter(s -> s.getType() == MediaStreamType.SUBTITLE).toList();
+                if ((allSubtitleStreams != null) && (lastSubtitleCodec != null)) {
+                    // find the exact subtitle stream with the requested language, title, codec & indicators
+                    if (lastSubtitleTitle != null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleDefaultState.equals(stream.isDefault())
+                                    && lastSubtitleForcedState.equals(stream.isForced())
+                                    && lastSubtitleCodec.equals(stream.getCodec())
+                                    && lastSubtitleHearingImpairedState.equals(stream.isHearingImpaired())
+                                    && lastSubtitleTitle.equals(stream.getTitle())
+                            ) {
+                                Timber.d("Best subtitle found ! (lang+all)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                    // fallback #1: find the first subtitle stream with the requested language, codec and indicators but without title
+                    if (matchingIndex == null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleDefaultState.equals(stream.isDefault())
+                                    && lastSubtitleForcedState.equals(stream.isForced())
+                                    && lastSubtitleCodec.equals(stream.getCodec())
+                                    && lastSubtitleHearingImpairedState.equals(stream.isHearingImpaired())
+                            ) {
+                                Timber.d("Best subtitle found on fallback #1 (lang+codec+default+forced+SDH)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                    // fallback #2: find the first subtitle stream with the requested language, codec and indicators but without title and SDH
+                    if (matchingIndex == null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleDefaultState.equals(stream.isDefault())
+                                    && lastSubtitleForcedState.equals(stream.isForced())
+                                    && lastSubtitleCodec.equals(stream.getCodec())
+                            ) {
+                                Timber.d("Best subtitle found on fallback #2 (lang+codec+default+forced)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                    // fallback #3: find the first subtitle stream with the requested language and standard indicators but without title, codec and SDH
+                    // without codec, the first default forced
+                    if (matchingIndex == null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleDefaultState.equals(stream.isDefault())
+                                    && lastSubtitleForcedState.equals(stream.isForced())
+                            ) {
+                                Timber.d("Best subtitle found on fallback #3 (lang+default+forced)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                    if (matchingIndex == null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleDefaultState.equals(stream.isDefault())
+                                    && lastSubtitleCodec.equals(stream.getCodec())
+                            ) {
+                                Timber.d("Best subtitle found on fallback #4 (lang+codec+default)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                    // without codec, the first forced
+                    if (matchingIndex == null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleForcedState.equals(stream.isForced())
+                            ) {
+                                Timber.d("Best subtitle found on fallback #5 (lang+forced)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                    if (matchingIndex == null) {
+                        for (MediaStream stream : allSubtitleStreams) {
+                            if (lastSubtitleLanguage.equals(stream.getLanguage())
+                                    && lastSubtitleCodec.equals(stream.getCodec())
+                            ) {
+                                Timber.d("Best subtitle found on fallback #6 (lang+codec)");
+                                matchingIndex = stream.getIndex();
+                                break;
+                            }
+                        }
+                    }
+                } else { Timber.d("Best subtitle not found: no subtitle stream"); }
+            } else { Timber.d("Best subtitle not found: no stream"); }
+        }else { Timber.d("Best subtitle: lastsubtitlelanguage is null"); }
+        // No saved preference, use server default
+        if (matchingIndex == null) {
+            Timber.d("Best subtitle found on server side");
+            matchingIndex = info.getDefaultSubtitleStreamIndex();
+        }
+        Timber.i("Best subtitle found on index: %d for media: '%s'", matchingIndex, info.getName());
+        return matchingIndex;
     }
 
     private void setDefaultAudioIndex(StreamInfo info) {
         if (mDefaultAudioIndex != -1)
             return;
 
-        Integer lastChosenLanguage = lastChosenLanguageAudioTrack(info.getMediaSource());
-        Integer remoteDefault = info.getMediaSource().getDefaultAudioStreamIndex();
+        Integer lastChosenLanguage = getBestAudioIndex(info.getMediaSource());
         Integer bestGuess = bestGuessAudioTrack(info.getMediaSource());
 
         if (lastChosenLanguage != null)
             mDefaultAudioIndex = lastChosenLanguage;
-        else if (remoteDefault != null)
-            mDefaultAudioIndex = remoteDefault;
         else if (bestGuess != null)
             mDefaultAudioIndex = bestGuess;
         Timber.d("default audio index set to %s", mDefaultAudioIndex);
@@ -798,14 +1027,13 @@ public class PlaybackController implements PlaybackControllerNotifiable {
             return;
         }
 
-        String lastAudioIsoCode = videoQueueManager.getValue().getLastPlayedAudioLanguageIsoCode();
-        String currentAudioIsoCode = currentMediaSource.getMediaStreams().get(index).getLanguage();
-
-        if (currentAudioIsoCode != null
-                && (lastAudioIsoCode == null || !lastAudioIsoCode.equals(currentAudioIsoCode))) {
-            videoQueueManager.getValue().setLastPlayedAudioLanguageIsoCode(
-                    currentAudioIsoCode
-            );
+        MediaStream currentMediaStream = currentMediaSource.getMediaStreams().get(index);
+        String currentAudioIsoCode = currentMediaStream.getLanguage();
+        if (currentAudioIsoCode != null) {
+            videoQueueManager.getValue().setLastPlayedAudioLanguageIsoCode(currentAudioIsoCode);
+            if (currentMediaStream.getCodec() != null) videoQueueManager.getValue().setLastPlayedAudioCodec(currentMediaStream.getCodec());
+            videoQueueManager.getValue().setLastPlayedAudioDefaultState(currentMediaStream.isDefault());
+            videoQueueManager.getValue().setLastPlayedAudioHearingImpairedState(currentMediaStream.isHearingImpaired());
         }
 
         int currAudioIndex = getAudioStreamIndex();
@@ -902,6 +1130,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
         mFragment = null;
         mVideoManager = null;
         resetPlayerErrors();
+        videoQueueManager.getValue().clearVideoQueue();
     }
 
     public void endPlayback() {
@@ -913,6 +1142,7 @@ public class PlaybackController implements PlaybackControllerNotifiable {
     }
 
     private void clearPlaybackSessionOptions() {
+        Timber.d("Clear Playback Session Options.");
         mDefaultAudioIndex = -1;
         mSeekPosition = -1;
         finishedInitialSeek = false;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -56,18 +56,28 @@ fun PlaybackController.disableDefaultSubtitles() {
 fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 	Timber.i("Switching subtitles from index ${mCurrentOptions.subtitleStreamIndex} to $index")
 
-	// Already using this subtitle index
-	if (mCurrentOptions.subtitleStreamIndex == index && !force) return
-
 	// Save subtitle language preference for restoration after NextUp screen
 	val videoQueueManager by fragment.inject<VideoQueueManager>()
 	if (index == -1) {
 		// Use empty string to indicate "subtitles explicitly disabled" vs null meaning "no preference"
+		videoQueueManager.setLastPlayedSubtitleCodec(null)
+		videoQueueManager.setLastPlayedSubtitleDefaultState(false)
+		videoQueueManager.setLastPlayedSubtitleForcedState(false)
+		videoQueueManager.setLastPlayedSubtitleHearingImpairedState(false)
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode("")
+		videoQueueManager.setLastPlayedSubtitleTitle(null)
 	} else {
 		val stream = currentMediaSource.mediaStreams?.firstOrNull { it.type == MediaStreamType.SUBTITLE && it.index == index }
+		videoQueueManager.setLastPlayedSubtitleCodec(stream?.codec)
+		videoQueueManager.setLastPlayedSubtitleDefaultState(stream?.isDefault ?: false)
+		videoQueueManager.setLastPlayedSubtitleForcedState(stream?.isForced ?: false)
+		videoQueueManager.setLastPlayedSubtitleHearingImpairedState(stream?.isHearingImpaired ?: false)
 		videoQueueManager.setLastPlayedSubtitleLanguageIsoCode(stream?.language)
+		videoQueueManager.setLastPlayedSubtitleTitle(stream?.title)
 	}
+
+	// Already using this subtitle index
+	if (mCurrentOptions.subtitleStreamIndex == index && !force) return
 
 	// Disable subtitles
 	if (index == -1) {
@@ -117,7 +127,7 @@ fun PlaybackController.setSubtitleIndex(index: Int, force: Boolean = false) {
 					mVideoManager.mExoPlayer.currentTracks.groups.firstOrNull { group ->
 						// Verify this is a group with a single format (the subtitles) that is added by us. Because ExoPlayer uses a
 						// MergingMediaSource, each external subtitle format id is prefixed with its source index (normally starting at 1,
-						// increasing for each external subttitle). So we only check the end of the id
+						// increasing for each external subtitle). So we only check the end of the id
 						group.length == 1 && group.getTrackFormat(0).id?.endsWith(":JF_EXTERNAL:$index") == true
 					}
 				} else {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoQueueManager.kt
@@ -5,8 +5,16 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 class VideoQueueManager {
 	private var _currentVideoQueue: List<BaseItemDto> = emptyList()
 	private var _currentMediaPosition = -1
+	private var _lastPlayedAudioDefaultState: Boolean = false
+	private var _lastPlayedAudioCodec: String? = null
+	private var _lastPlayedAudioHearingImpairedState: Boolean = false
 	private var _lastPlayedAudioLanguageIsoCode: String? = null
+	private var _lastPlayedSubtitleCodec: String? = null
+	private var _lastPlayedSubtitleDefaultState: Boolean = false
+	private var _lastPlayedSubtitleForcedState: Boolean = false
+	private var _lastPlayedSubtitleHearingImpairedState: Boolean = false
 	private var _lastPlayedSubtitleLanguageIsoCode: String? = null
+	private var _lastPlayedSubtitleTitle: String? = null
 
 	fun setCurrentVideoQueue(items: List<BaseItemDto>?) {
 		if (items.isNullOrEmpty()) return clearVideoQueue()
@@ -25,12 +33,67 @@ class VideoQueueManager {
 
 	fun getCurrentMediaPosition() = _currentMediaPosition
 
+	fun getLastPlayedAudioCodec(): String? {
+		return _lastPlayedAudioCodec
+	}
+
+	fun setLastPlayedAudioCodec(codec: String) {
+		_lastPlayedAudioCodec = codec
+	}
+	fun getLastPlayedAudioDefaultState (): Boolean {
+		return _lastPlayedAudioDefaultState
+	}
+
+	fun setLastPlayedAudioDefaultState(state: Boolean) {
+		_lastPlayedAudioDefaultState = state
+	}
+
+	fun getLastPlayedAudioHearingImpairedState(): Boolean {
+		return _lastPlayedAudioHearingImpairedState
+	}
+
+	fun setLastPlayedAudioHearingImpairedState(state: Boolean) {
+		_lastPlayedAudioHearingImpairedState = state
+	}
+
 	fun getLastPlayedAudioLanguageIsoCode(): String? {
 		return _lastPlayedAudioLanguageIsoCode
 	}
 
 	fun setLastPlayedAudioLanguageIsoCode(isoCode: String) {
 		_lastPlayedAudioLanguageIsoCode = isoCode
+	}
+
+	fun getLastPlayedSubtitleCodec(): String? {
+		return _lastPlayedSubtitleCodec
+	}
+
+	fun setLastPlayedSubtitleCodec(codecTag: String?) {
+		_lastPlayedSubtitleCodec = codecTag
+	}
+
+	fun getLastPlayedSubtitleDefaultState(): Boolean {
+		return _lastPlayedSubtitleDefaultState
+	}
+
+	fun setLastPlayedSubtitleDefaultState(state: Boolean) {
+		_lastPlayedSubtitleDefaultState = state
+	}
+
+	fun getLastPlayedSubtitleForcedState(): Boolean {
+		return _lastPlayedSubtitleForcedState
+	}
+
+	fun setLastPlayedSubtitleForcedState(state: Boolean) {
+		_lastPlayedSubtitleForcedState = state
+	}
+
+	fun getLastPlayedSubtitleHearingImpairedState(): Boolean {
+		return _lastPlayedSubtitleHearingImpairedState
+	}
+
+	fun setLastPlayedSubtitleHearingImpairedState(state: Boolean) {
+		_lastPlayedSubtitleHearingImpairedState = state
 	}
 
 	fun getLastPlayedSubtitleLanguageIsoCode(): String? {
@@ -41,10 +104,26 @@ class VideoQueueManager {
 		_lastPlayedSubtitleLanguageIsoCode = isoCode
 	}
 
+	fun getLastPlayedSubtitleTitle(): String? {
+		return _lastPlayedSubtitleTitle
+	}
+
+	fun setLastPlayedSubtitleTitle(title: String?) {
+		_lastPlayedSubtitleTitle = title
+	}
+
 	fun clearVideoQueue() {
 		_currentVideoQueue = emptyList()
 		_currentMediaPosition = -1
+		_lastPlayedAudioCodec = null
+		_lastPlayedAudioDefaultState = false
+		_lastPlayedAudioHearingImpairedState = false
 		_lastPlayedAudioLanguageIsoCode = null
+		_lastPlayedSubtitleCodec = null
+		_lastPlayedSubtitleDefaultState = false
+		_lastPlayedSubtitleForcedState = false
+		_lastPlayedSubtitleHearingImpairedState = false
 		_lastPlayedSubtitleLanguageIsoCode = null
+		_lastPlayedSubtitleTitle = null
 	}
 }


### PR DESCRIPTION
- Fix audio and subtitle management from previous media.
- Fix appcrash with NullPointException on updateburningsub call (in a few instances where the number of indexes differs)
- Clear videoqueue when endPlayback is triggered

This is a first working draft for the update of my old PR (https://github.com/jellyfin/jellyfin-androidtv/pull/5644 & https://github.com/jellyfin/jellyfin-androidtv/pull/5724).

When you start a new media item, the client requests index information from the server.
You can change the audio and subtitles while playback is in progress.
When playing the next or previous episode, the same information is reused to provide the new indices; otherwise, the system tests various fallback options to determine the best solution.
Upon fully stopping playback (returning to the menu), the information from the last session is cleared, allowing the remote server to provide its own indices when the next piece of content is played.

**Changes**
The main change involves the addition of two functions used to return the best index depending on the situation.
The other modifications relate to the integration of these functions and the mechanism.

**Code assistance**
Android Studio (No AI).

**Issues**
Fix issue: https://github.com/jellyfin/jellyfin-androidtv/issues/5407
Fix issue: https://github.com/jellyfin/jellyfin-androidtv/issues/5636
Feature: https://github.com/jellyfin/jellyfin-androidtv/issues/5656