### PR TITLE
Bump compile SDK to 37 (Android 17)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 aboutlibraries = "14.2.1"
 accompanist = "0.37.3"
 acra = "5.13.1"
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-desugar = "2.1.5"
 android-gradle = "9.2.1"
 android-minSdk = "23"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Bump the compile SDK to 37 (Android 17) while keeping the target SDK at 36 (Android 16). There is no Android TV based on Android 17 yet so we cannot test it yet.

Needed to unblock new androidx updates.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
