### PR TITLE
Add triage workflow to add pull requests to review project

### DIFF
--- a/.github/workflows/repo-triage.yaml
+++ b/.github/workflows/repo-triage.yaml
@@ -1,0 +1,19 @@
+name: Repo / Triage
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - ready_for_review
+
+jobs:
+  review-add:
+    name: Add to reviews project
+    runs-on: ubuntu-24.04
+    if: ${{ contains(github.repository_owner, 'jellyfin') && !github.event.pull_request.draft }}
+    steps:
+      - name: Add pull request to organization project
+        env:
+          GH_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
+          PROJECT_ID: ${{ secrets.PROJECT_ANDROID_TRIAGE }}
+        run: gh project item-add "$PROJECT_ID" --owner "${{ github.repository_owner }}" --url "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

We use a (private) GitHub project to track reviews for the Android, Android TV and Kotlin SDK repositories. However GitHub in their wise-wisdom limits their built-in automation to only allow adding pull requests automatically for a maximum of 1 repository. With this workflow we'll just do it ourselves, for multiple repositories.

Pull requests get added automagically once opened as non-draft or converted from draft.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
