### PR TITLE
Add relative skip mode for d-pad seeking

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -12,6 +12,7 @@ import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.HEVCLevel
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
+import org.jellyfin.androidtv.preference.constant.SkipMode
 import org.jellyfin.androidtv.preference.constant.StillWatchingBehavior
 import org.jellyfin.androidtv.preference.constant.WatchedIndicatorBehavior
 import org.jellyfin.androidtv.preference.constant.ZoomMode
@@ -239,6 +240,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * Preferred behavior for player aspect ratio (zoom mode).
 		 */
 		var playerZoomMode = enumPreference("player_zoom_mode", ZoomMode.FIT)
+
+		/**
+		 * Behavior of the left/right buttons while playing media with the controls hidden.
+		 */
+		var skipMode = enumPreference("skip_mode", SkipMode.ABSOLUTE)
 
 		/**
 		 * Enable libass.

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/SkipMode.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/SkipMode.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.androidtv.preference.constant
+
+import org.jellyfin.androidtv.R
+import org.jellyfin.preference.PreferenceEnum
+
+enum class SkipMode(
+	override val nameRes: Int,
+	val descriptionRes: Int,
+) : PreferenceEnum {
+	ABSOLUTE(R.string.skip_mode_absolute, R.string.skip_mode_absolute_description),
+	RELATIVE(R.string.skip_mode_relative, R.string.skip_mode_relative_description),
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -42,6 +42,8 @@ import org.jellyfin.androidtv.constant.CustomMessage;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
 import org.jellyfin.androidtv.data.service.BackgroundService;
 import org.jellyfin.androidtv.databinding.OverlayTvGuideBinding;
+import org.jellyfin.androidtv.preference.UserPreferences;
+import org.jellyfin.androidtv.preference.constant.SkipMode;
 import org.jellyfin.androidtv.databinding.VlcPlayerInterfaceBinding;
 import org.jellyfin.androidtv.ui.GuideChannelHeader;
 import org.jellyfin.androidtv.ui.GuidePagingButton;
@@ -135,6 +137,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private final Lazy<ImageHelper> imageHelper = inject(ImageHelper.class);
+    private final Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
 
     private final PlaybackOverlayFragmentHelper helper = new PlaybackOverlayFragmentHelper(this);
 
@@ -588,12 +591,21 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
                     if (!mIsVisible) {
                         if (!playbackControllerContainer.getValue().getPlaybackController().isLiveTv()) {
-                            if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
-                                setFadingEnabled(true);
-                                return true;
-                            }
-
-                            if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+                            if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+                                if (canRelativeSkip()) {
+                                    // Prevent the leanback fragment from showing the controls overlay for this key press,
+                                    // the flag is re-armed once the key is released
+                                    suppressOverlayUntilKeyUp = true;
+                                    leanbackOverlayFragment.setShouldShowOverlay(false);
+                                    // A manual skip supersedes a pending media segment skip prompt
+                                    if (binding.skipOverlay.getVisible()) clearSkipOverlay();
+                                    if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                                        playbackControllerContainer.getValue().getPlaybackController().fastForward();
+                                    } else {
+                                        playbackControllerContainer.getValue().getPlaybackController().rewind();
+                                    }
+                                    return true;
+                                }
                                 setFadingEnabled(true);
                                 return true;
                             }
@@ -616,12 +628,34 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             switch (keyCode) {
                 case KeyEvent.KEYCODE_DPAD_LEFT:
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
+                    if (suppressOverlayUntilKeyUp) {
+                        // Consume the event so the controls overlay isn't shown by the leanback fragment,
+                        // then re-arm the overlay flag once the key press is fully dispatched
+                        if (event.getAction() == KeyEvent.ACTION_UP) {
+                            suppressOverlayUntilKeyUp = false;
+                            mHandler.post(() -> leanbackOverlayFragment.setShouldShowOverlay(true));
+                        }
+                        return true;
+                    }
                     leanbackOverlayFragment.getPlayerGlue().setInjectedViewsVisibility();
             }
 
             return false;
         }
     };
+
+    private boolean suppressOverlayUntilKeyUp = false;
+
+    private boolean canRelativeSkip() {
+        if (mIsVisible || mGuideVisible || mPopupPanelVisible) return false;
+
+        PlaybackController playbackController = playbackControllerContainer.getValue().getPlaybackController();
+        return playbackController.canSeek()
+                // Match the readiness requirements of PlaybackController.skip() so unskippable
+                // presses fall through to the controls overlay instead of being silently consumed
+                && (playbackController.isPlaying() || playbackController.isPaused())
+                && userPreferences.getValue().get(UserPreferences.Companion.getSkipMode()) == SkipMode.RELATIVE;
+    }
 
     public LocalDateTime getCurrentLocalStartDate() {
         return mCurrentGuideStart;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -44,6 +44,7 @@ import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackPrerol
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackRefreshRateSwitchingBehaviorScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackResumeSubtractDurationScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackSkipModeScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackZoomModeScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentsScreen
@@ -98,6 +99,7 @@ object Routes {
 	const val PLAYBACK_MAX_BITRATE = "/playback/max-bitrate"
 	const val PLAYBACK_REFRESH_RATE_SWITCHING_BEHAVIOR = "/playback/refresh-rate-switching-behavior"
 	const val PLAYBACK_ZOOM_MODE = "/playback/zoom-mode"
+	const val PLAYBACK_SKIP_MODE = "/playback/skip-mode"
 	const val PLAYBACK_BUFFER_LENGTH = "/playback/buffer-length"
 	const val PLAYBACK_AUDIO_BEHAVIOR = "/playback/audio-behavior"
 	const val PLAYBACK_CODEC = "/playback/codec"
@@ -249,6 +251,9 @@ val routes = mapOf<String, RouteComposable>(
 	},
 	Routes.PLAYBACK_ZOOM_MODE to {
 		SettingsPlaybackZoomModeScreen()
+	},
+	Routes.PLAYBACK_SKIP_MODE to {
+		SettingsPlaybackSkipModeScreen()
 	},
 	Routes.PLAYBACK_BUFFER_LENGTH to {
 		SettingsPlaybackBufferLengthScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackAdvancedScreen.kt
@@ -50,6 +50,7 @@ fun SettingsPlaybackAdvancedScreen() {
 	val router = LocalRouter.current
 	val userPreferences = koinInject<UserPreferences>()
 	val userSettingPreferences = koinInject<UserSettingPreferences>()
+	val skipMode by rememberPreference(userPreferences, UserPreferences.skipMode)
 
 	SettingsColumn {
 		item {
@@ -70,6 +71,15 @@ fun SettingsPlaybackAdvancedScreen() {
 				captionContent = { Text(options[resumeSubtractDuration].orEmpty()) },
 				onClick = { router.push(Routes.PLAYBACK_RESUME_SUBTRACT_DURATION) },
 				modifier = Modifier.focusKey(Routes.PLAYBACK_RESUME_SUBTRACT_DURATION)
+			)
+		}
+
+		item {
+			ListButton(
+				headingContent = { Text(stringResource(R.string.skip_mode)) },
+				captionContent = { Text(stringResource(skipMode.nameRes)) },
+				onClick = { router.push(Routes.PLAYBACK_SKIP_MODE) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_SKIP_MODE)
 			)
 		}
 
@@ -105,6 +115,43 @@ fun SettingsPlaybackAdvancedScreen() {
 						contentAlignment = Alignment.CenterEnd
 					) {
 						Text("${skipForwardLength / 1000}s")
+					}
+				}
+			}
+		}
+
+		item {
+			var skipBackLength by rememberPreference(userSettingPreferences, UserSettingPreferences.skipBackLength)
+			val interactionSource = remember { MutableInteractionSource() }
+
+			ListControl(
+				headingContent = { Text(stringResource(R.string.skip_back_length)) },
+				interactionSource = interactionSource,
+				modifier = Modifier.focusKey("skip_back_length")
+			) {
+				Row(
+					verticalAlignment = Alignment.CenterVertically,
+				) {
+					RangeControl(
+						modifier = Modifier
+							.height(4.dp)
+							.weight(1f),
+						interactionSource = interactionSource,
+						// 5 - 30 seconds with 5 second increment
+						min = 5_000f,
+						max = 30_000f,
+						stepForward = 5_000f,
+						value = skipBackLength.toFloat(),
+						onValueChange = { skipBackLength = it.roundToInt() }
+					)
+
+					Spacer(Modifier.width(Tokens.Space.spaceSm))
+
+					Box(
+						modifier = Modifier.sizeIn(minWidth = 32.dp),
+						contentAlignment = Alignment.CenterEnd
+					) {
+						Text("${skipBackLength / 1000}s")
 					}
 				}
 			}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackSkipModeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackSkipModeScreen.kt
@@ -1,0 +1,49 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.SkipMode
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackSkipModeScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var skipMode by rememberPreference(userPreferences, UserPreferences.skipMode)
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback_advanced).uppercase()) },
+				headingContent = { Text(stringResource(R.string.skip_mode)) },
+			)
+		}
+
+		items(SkipMode.entries) { entry ->
+			ListButton(
+				headingContent = { Text(stringResource(entry.nameRes)) },
+				captionContent = { Text(stringResource(entry.descriptionRes)) },
+				trailingContent = { RadioButton(checked = skipMode == entry) },
+				onClick = {
+					skipMode = entry
+					router.back()
+				},
+				modifier = Modifier.focusKey("skip_mode_${entry.name}")
+			)
+		}
+	}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -551,6 +551,12 @@
     <string name="segment_type_recap">Recaps</string>
     <string name="segment_type_unknown">Unknown segments</string>
     <string name="skip_forward_length">Skip forward length</string>
+    <string name="skip_back_length">Skip back length</string>
+    <string name="skip_mode">Skip mode</string>
+    <string name="skip_mode_absolute">Absolute</string>
+    <string name="skip_mode_absolute_description">Left and right open the seek bar and step between fixed positions, select confirms the seek</string>
+    <string name="skip_mode_relative">Relative</string>
+    <string name="skip_mode_relative_description">Left and right immediately skip from the current position by the configured skip lengths</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
     <string name="pref_subtitles_background_opacity">Subtitle background opacity</string>
     <string name="pref_troubleshooting">Troubleshooting</string>


### PR DESCRIPTION
### Changes

**1: "Skip mode" setting**

- Within Settings > Playback > Advanced, a new "Skip mode" setting is available.
- Setting has two options: "Absolute" and "Relative", defaulting to the status quo "absolute" behaviour.
- When set to "absolute", the existing behaviour of stepping the seek bar cursor and confirming the seek is preserved (ie. users need to select an absolute timestamp on the seek bar and confirm it).
- When set to "relative", pressing the right or left buttons during playback (while the control overlay UI is hidden) skips immediately forward or backward (respectively) from the current timestamp and does not reveal the control overlay UI or require a confirmation press.
- The amount of time skipped is user-configurable via `skipBackLength` and `skipForwardLength`.
- Relative skipping uses the same pattern as the dedicated FF/RW buttons (including press accumulation).

**Note:** only the legacy player consumes this setting as the rewrite player's seekbar already seeks relatively when focused.

**2: Exposes skipBackLength slider**

- Previously the `skipBackLength` preference was not exposed in the UI, but now gets a slider just like the `skipForwardLength` preference.
- These sliders determine the skip amounts for the dedicated FF/RW buttons (as before), and now also for the left/right buttons when "Skip mode" is set to "Relative".

### Code Assistance

This PR has been implemented with Claude Code including: code generation, codebase exploration, and quality control and self-review. All changes have also been reviewed, understood, and tested by me on my Sony Bravia 8 (direct play and transcode).

### Issues

Fixes #1185
Related to #3033