### PR TITLE
Add user-controlled HDR support reporting

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -10,6 +10,7 @@ import org.jellyfin.androidtv.preference.constant.BackdropBehavior
 import org.jellyfin.androidtv.preference.constant.BufferLength
 import org.jellyfin.androidtv.preference.constant.ClockBehavior
 import org.jellyfin.androidtv.preference.constant.HEVCLevel
+import org.jellyfin.androidtv.preference.constant.HDRSupport
 import org.jellyfin.androidtv.preference.constant.NextUpBehavior
 import org.jellyfin.androidtv.preference.constant.RefreshRateSwitchingBehavior
 import org.jellyfin.androidtv.preference.constant.StillWatchingBehavior
@@ -115,6 +116,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		 * User defined HEVC level override. AUTO uses device-reported capabilities.
 		 */
 		var userHEVCLevel = enumPreference("user_hevc_level", HEVCLevel.AUTO)
+
+		/**
+		 * How HDR support is reported to the server.
+		 */
+		var hdrSupport = enumPreference("hdr_support", HDRSupport.AUTOMATIC)
 
 		/**
 		 * Playback buffer size preset.

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/HDRSupport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/HDRSupport.kt
@@ -1,0 +1,14 @@
+package org.jellyfin.androidtv.preference.constant
+
+import androidx.annotation.StringRes
+import org.jellyfin.androidtv.R
+import org.jellyfin.preference.PreferenceEnum
+
+enum class HDRSupport(
+	override val nameRes: Int,
+	@get:StringRes val descriptionRes: Int,
+) : PreferenceEnum {
+	AUTOMATIC(R.string.hdr_support_automatic, R.string.hdr_support_automatic_description),
+	ENABLED(R.string.hdr_support_enabled, R.string.hdr_support_enabled_description),
+	DISABLED(R.string.state_disabled, R.string.hdr_support_disabled_description),
+}

--- a/app/src/main/java/org/jellyfin/androidtv/preference/constant/HDRSupport.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/constant/HDRSupport.kt
@@ -8,7 +8,7 @@ enum class HDRSupport(
 	override val nameRes: Int,
 	@get:StringRes val descriptionRes: Int,
 ) : PreferenceEnum {
-	AUTOMATIC(R.string.hdr_support_automatic, R.string.hdr_support_automatic_description),
+	AUTOMATIC(R.string.auto, R.string.hdr_support_automatic_description),
 	ENABLED(R.string.hdr_support_enabled, R.string.hdr_support_enabled_description),
 	DISABLED(R.string.state_disabled, R.string.hdr_support_disabled_description),
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -37,6 +37,7 @@ import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackAudioB
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackBufferLengthScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackCodecScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackHEVCLevelScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackHDRSupportScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackInactivityPromptScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackMaxBitrateScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackPlayerScreen
@@ -103,6 +104,7 @@ object Routes {
 	const val PLAYBACK_CODEC = "/playback/codec"
 	const val PLAYBACK_AVC_LEVEL = "/playback/codec/avc-level"
 	const val PLAYBACK_HEVC_LEVEL = "/playback/codec/hevc-level"
+	const val PLAYBACK_HDR_SUPPORT = "/playback/codec/hdr-support"
 	const val TELEMETRY = "/telemetry"
 	const val DEVELOPER = "/developer"
 	const val ABOUT = "/about"
@@ -264,6 +266,9 @@ val routes = mapOf<String, RouteComposable>(
 	},
 	Routes.PLAYBACK_HEVC_LEVEL to {
 		SettingsPlaybackHEVCLevelScreen()
+	},
+	Routes.PLAYBACK_HDR_SUPPORT to {
+		SettingsPlaybackHDRSupportScreen()
 	},
 	Routes.TELEMETRY to {
 		SettingsTelemetryScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackCodecScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackCodecScreen.kt
@@ -55,6 +55,17 @@ fun SettingsPlaybackCodecScreen() {
 			)
 		}
 
+		item {
+			var hdrSupport by rememberPreference(userPreferences, UserPreferences.hdrSupport)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.hdr_support)) },
+				captionContent = { Text(stringResource(hdrSupport.nameRes)) },
+				onClick = { router.push(Routes.PLAYBACK_HDR_SUPPORT) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_HDR_SUPPORT)
+			)
+		}
+
 		if (AndroidVersion.isAtLeastQ) {
 			item {
 				var softwareCodecsEnabled by rememberPreference(userPreferences, UserPreferences.softwareCodecsEnabled)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackHDRSupportScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/SettingsPlaybackHDRSupportScreen.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.preference.constant.HDRSupport
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackHDRSupportScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var hdrSupport by rememberPreference(userPreferences, UserPreferences.hdrSupport)
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.preference_codecs).uppercase()) },
+				headingContent = { Text(stringResource(R.string.hdr_support)) },
+				captionContent = { Text(stringResource(R.string.hdr_support_description)) },
+			)
+		}
+
+		items(HDRSupport.entries) { entry ->
+			ListButton(
+				headingContent = { Text(stringResource(entry.nameRes)) },
+				captionContent = { Text(stringResource(entry.descriptionRes)) },
+				trailingContent = { RadioButton(checked = hdrSupport == entry) },
+				onClick = {
+					hdrSupport = entry
+					router.back()
+				},
+				modifier = Modifier.focusKey("hdr_support_${entry.name}")
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.MimeTypes
 import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.constant.AudioBehavior
+import org.jellyfin.androidtv.preference.constant.HDRSupport
 import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.CodecType
 import org.jellyfin.sdk.model.api.DlnaProfileType
@@ -64,6 +65,17 @@ private val hlsFmp4AudioCodecs = arrayOf(
 	Codec.Audio.TRUEHD
 )
 
+private val supportedVideoCodecs = arrayOf(
+	Codec.Video.AV1,
+	Codec.Video.H264,
+	Codec.Video.HEVC,
+	Codec.Video.MPEG,
+	Codec.Video.MPEG2VIDEO,
+	Codec.Video.VC1,
+	Codec.Video.VP8,
+	Codec.Video.VP9,
+)
+
 private fun UserPreferences.getMaxBitrate(): Int {
 	var maxBitrate = this[UserPreferences.maxBitrate].toFloatOrNull()
 
@@ -87,6 +99,7 @@ fun createDeviceProfile(
 	pgsDirectPlay = userPreferences[UserPreferences.pgsDirectPlay],
 	userAVCLevel = userPreferences[UserPreferences.userAVCLevel].level,
 	userHEVCLevel = userPreferences[UserPreferences.userHEVCLevel].level,
+	hdrSupport = userPreferences[UserPreferences.hdrSupport],
 )
 
 fun createDeviceProfile(
@@ -98,6 +111,7 @@ fun createDeviceProfile(
 	pgsDirectPlay: Boolean,
 	userAVCLevel: Int?,
 	userHEVCLevel: Int?,
+	hdrSupport: HDRSupport,
 ) = buildDeviceProfile {
 	val allowedAudioCodecs = when {
 		downMixAudio -> downmixSupportedAudioCodecs
@@ -208,16 +222,7 @@ fun createDeviceProfile(
 			Codec.Container.XVID,
 		)
 
-		videoCodec(
-			Codec.Video.AV1,
-			Codec.Video.H264,
-			Codec.Video.HEVC,
-			Codec.Video.MPEG,
-			Codec.Video.MPEG2VIDEO,
-			Codec.Video.VC1,
-			Codec.Video.VP8,
-			Codec.Video.VP9,
-		)
+		videoCodec(*supportedVideoCodecs)
 
 		audioCodec(*allowedAudioCodecs)
 	}
@@ -428,7 +433,7 @@ fun createDeviceProfile(
 
 	/// HDR exclude list
 
-	val unsupportedRangeTypesAv1 = buildSet {
+	val automaticallyUnsupportedRangeTypesAv1 = buildSet {
 		add(VideoRangeType.DOVI_INVALID)
 
 		if (!supportsAV1DolbyVision) {
@@ -444,7 +449,7 @@ fun createDeviceProfile(
 		}
 	}
 
-	val unsupportedRangeTypesHevc = buildSet {
+	val automaticallyUnsupportedRangeTypesHevc = buildSet {
 		add(VideoRangeType.DOVI_INVALID)
 
 		if (!supportsHevcDolbyVisionEL) {
@@ -484,32 +489,34 @@ fun createDeviceProfile(
 	// profile be active when the media in question uses one of the unsupported range types. The server will then use the value of the
 	// notEquals in the StreamBuilder to create a correct transcode pipeline
 
-	// Codecs
-	// AV1
-	if (unsupportedRangeTypesAv1.isNotEmpty()) codecProfile {
-		type = CodecType.VIDEO
-		codec = Codec.Video.AV1
-
-		conditions {
-			ProfileConditionValue.VIDEO_RANGE_TYPE notEquals unsupportedRangeTypesAv1.joinToString("|") { it.serialName }
-		}
-
-		applyConditions {
-			ProfileConditionValue.VIDEO_RANGE_TYPE inCollection unsupportedRangeTypesAv1.map { it.serialName }
+	val unsupportedRangeTypesByCodec = when (hdrSupport) {
+		HDRSupport.AUTOMATIC -> mapOf(
+			Codec.Video.AV1 to automaticallyUnsupportedRangeTypesAv1,
+			Codec.Video.HEVC to automaticallyUnsupportedRangeTypesHevc,
+		)
+		HDRSupport.ENABLED -> mapOf(
+			Codec.Video.AV1 to setOf(VideoRangeType.DOVI_INVALID),
+			Codec.Video.HEVC to setOf(VideoRangeType.DOVI_INVALID),
+		)
+		HDRSupport.DISABLED -> supportedVideoCodecs.associateWith {
+			VideoRangeType.entries.filterNot { rangeType -> rangeType == VideoRangeType.SDR }.toSet()
 		}
 	}
 
-	// HEVC
-	if (unsupportedRangeTypesHevc.isNotEmpty()) codecProfile {
-		type = CodecType.VIDEO
-		codec = Codec.Video.HEVC
+	for ((codecName, unsupportedRangeTypes) in unsupportedRangeTypesByCodec) {
+		if (unsupportedRangeTypes.isEmpty()) continue
 
-		conditions {
-			ProfileConditionValue.VIDEO_RANGE_TYPE notEquals unsupportedRangeTypesHevc.joinToString("|") { it.serialName }
-		}
+		codecProfile {
+			type = CodecType.VIDEO
+			codec = codecName
 
-		applyConditions {
-			ProfileConditionValue.VIDEO_RANGE_TYPE inCollection unsupportedRangeTypesHevc.map { it.serialName }
+			conditions {
+				ProfileConditionValue.VIDEO_RANGE_TYPE notEquals unsupportedRangeTypes.joinToString("|") { it.serialName }
+			}
+
+			applyConditions {
+				ProfileConditionValue.VIDEO_RANGE_TYPE inCollection unsupportedRangeTypes.map { it.serialName }
+			}
 		}
 	}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -607,7 +607,6 @@
     <string name="preference_codecs_summary">Override device-reported codec capabilities</string>
     <string name="hdr_support">HDR Support</string>
     <string name="hdr_support_description">Choose how HDR support is reported to the server for direct play and transcoding decisions.</string>
-    <string name="hdr_support_automatic">Automatic</string>
     <string name="hdr_support_automatic_description">Use this device’s detected HDR capabilities.</string>
     <string name="hdr_support_enabled">Enabled</string>
     <string name="hdr_support_enabled_description">Report valid HDR formats as supported, even when this device does not report them.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,6 +605,13 @@
     <string name="codec_level_warning">Changing from auto may cause playback issues if your device doesn\'t actually support the selected level.</string>
     <string name="preference_codecs">Media codecs</string>
     <string name="preference_codecs_summary">Override device-reported codec capabilities</string>
+    <string name="hdr_support">HDR Support</string>
+    <string name="hdr_support_description">Choose how HDR support is reported to the server for direct play and transcoding decisions.</string>
+    <string name="hdr_support_automatic">Automatic</string>
+    <string name="hdr_support_automatic_description">Use this device’s detected HDR capabilities.</string>
+    <string name="hdr_support_enabled">Enabled</string>
+    <string name="hdr_support_enabled_description">Report valid HDR formats as supported, even when this device does not report them.</string>
+    <string name="hdr_support_disabled_description">Report HDR formats as unsupported so the server converts HDR video to SDR.</string>
     <string name="codec_level_manual">Manual override</string>
     <string name="codec_level_6_2">Level 6.2</string>
     <string name="codec_level_6_1">Level 6.1</string>

--- a/app/src/test/kotlin/preference/HDRSupportPreferenceTests.kt
+++ b/app/src/test/kotlin/preference/HDRSupportPreferenceTests.kt
@@ -1,0 +1,42 @@
+package org.jellyfin.androidtv.preference
+
+import android.content.SharedPreferences
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.jellyfin.androidtv.preference.constant.HDRSupport
+import org.jellyfin.preference.store.SharedPreferenceStore
+
+class HDRSupportPreferenceTests : FunSpec({
+	test("HDR support defaults to automatic when no value is stored") {
+		val store = testPreferenceStore()
+
+		store[UserPreferences.hdrSupport] shouldBe HDRSupport.AUTOMATIC
+		UserPreferences.hdrSupport.key shouldBe "hdr_support"
+	}
+
+	test("HDR support values round-trip through the preference store") {
+		val store = testPreferenceStore()
+
+		for (mode in HDRSupport.entries) {
+			store[UserPreferences.hdrSupport] = mode
+			store[UserPreferences.hdrSupport] shouldBe mode
+		}
+	}
+})
+
+private fun testPreferenceStore(): SharedPreferenceStore {
+	var storedValue: String? = null
+	val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+	val sharedPreferences = mockk<SharedPreferences> {
+		every { getString("hdr_support", "") } answers { storedValue.orEmpty() }
+		every { edit() } returns editor
+	}
+	every { editor.putString("hdr_support", any()) } answers {
+		storedValue = secondArg()
+		editor
+	}
+
+	return object : SharedPreferenceStore(sharedPreferences) {}
+}

--- a/app/src/test/kotlin/util/profile/DeviceProfileHDRSupportTests.kt
+++ b/app/src/test/kotlin/util/profile/DeviceProfileHDRSupportTests.kt
@@ -1,0 +1,142 @@
+package org.jellyfin.androidtv.util.profile
+
+import android.util.Size
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.jellyfin.androidtv.preference.constant.HDRSupport
+import org.jellyfin.sdk.model.api.CodecProfile
+import org.jellyfin.sdk.model.api.DeviceProfile
+import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.jellyfin.sdk.model.api.ProfileConditionValue
+import org.jellyfin.sdk.model.api.VideoRangeType
+
+class DeviceProfileHDRSupportTests : FunSpec({
+	beforeEach {
+		mockkObject(KnownDefects)
+		every { KnownDefects.hevcDoviHdr10PlusBug } returns false
+		every { KnownDefects.unreportedDoviProfile7Support } returns false
+	}
+
+	afterEach {
+		unmockkObject(KnownDefects)
+	}
+
+	test("automatic preserves platform-derived AV1 and HEVC HDR exclusions") {
+		val profile = createProfile(HDRSupport.AUTOMATIC)
+
+		profile.hdrExclusionsByCodec() shouldContainExactly mapOf(
+			"av1" to setOf(
+				VideoRangeType.DOVI_INVALID,
+				VideoRangeType.DOVI,
+				VideoRangeType.DOVI_WITH_HDR10,
+				VideoRangeType.DOVI_WITH_HDR10_PLUS,
+				VideoRangeType.HDR10_PLUS,
+				VideoRangeType.HDR10,
+			),
+			"hevc" to setOf(
+				VideoRangeType.DOVI_INVALID,
+				VideoRangeType.DOVI_WITH_EL,
+				VideoRangeType.DOVI_WITH_ELHDR10_PLUS,
+				VideoRangeType.DOVI,
+				VideoRangeType.DOVI_WITH_HDR10,
+				VideoRangeType.DOVI_WITH_HDR10_PLUS,
+				VideoRangeType.HDR10_PLUS,
+				VideoRangeType.HDR10,
+			),
+		)
+	}
+
+	test("enabled permits valid HDR ranges but still rejects malformed Dolby Vision") {
+		val profile = createProfile(HDRSupport.ENABLED)
+
+		profile.hdrExclusionsByCodec() shouldContainExactly mapOf(
+			"av1" to setOf(VideoRangeType.DOVI_INVALID),
+			"hevc" to setOf(VideoRangeType.DOVI_INVALID),
+		)
+	}
+
+	test("disabled rejects every non-SDR range for every advertised video codec") {
+		val profile = createProfile(HDRSupport.DISABLED)
+		val advertisedVideoCodecs = profile.directPlayProfiles
+			.single { it.type == DlnaProfileType.VIDEO }
+			.videoCodec.orEmpty()
+			.split(',')
+			.toSet()
+		val expectedRanges = VideoRangeType.entries.filterNot { it == VideoRangeType.SDR }.toSet()
+		val exclusions = profile.hdrExclusionsByCodec()
+
+		exclusions.keys shouldBe advertisedVideoCodecs
+		profile.hdrApplyConditionsByCodec() shouldBe exclusions
+		for (codec in advertisedVideoCodecs) {
+			exclusions.getValue(codec) shouldBe expectedRanges
+			exclusions.getValue(codec) shouldNotContain VideoRangeType.SDR
+		}
+	}
+
+	test("HDR overrides leave non-HDR codec restrictions unchanged") {
+		val automatic = createProfile(HDRSupport.AUTOMATIC)
+		val enabled = createProfile(HDRSupport.ENABLED)
+		val disabled = createProfile(HDRSupport.DISABLED)
+
+		automatic.nonHDRCodecProfiles() shouldBe enabled.nonHDRCodecProfiles()
+		automatic.nonHDRCodecProfiles() shouldBe disabled.nonHDRCodecProfiles()
+		automatic.codecProfiles.flatMap(CodecProfile::conditions).map { it.property } shouldContain ProfileConditionValue.WIDTH
+	}
+})
+
+private fun createProfile(hdrSupport: HDRSupport): DeviceProfile {
+	val resolution = mockk<Size> {
+		every { width } returns 1920
+		every { height } returns 1080
+	}
+	val mediaTest = mockk<MediaCodecCapabilitiesTest>(relaxed = true) {
+		every { getMaxResolution(any()) } returns resolution
+	}
+
+	return createDeviceProfile(
+		mediaTest = mediaTest,
+		maxBitrate = 100_000_000,
+		isAC3Enabled = true,
+		downMixAudio = false,
+		assDirectPlay = false,
+		pgsDirectPlay = true,
+		userAVCLevel = 51,
+		userHEVCLevel = 51,
+		hdrSupport = hdrSupport,
+	)
+}
+
+private fun DeviceProfile.hdrExclusionsByCodec(): Map<String, Set<VideoRangeType>> = codecProfiles
+	.filter { profile -> profile.conditions.any { it.property == ProfileConditionValue.VIDEO_RANGE_TYPE } }
+	.associate { profile ->
+		profile.codec.orEmpty() to profile.conditions
+			.single { it.property == ProfileConditionValue.VIDEO_RANGE_TYPE }
+			.value
+			.orEmpty()
+			.split('|')
+			.map(VideoRangeType::fromName)
+			.toSet()
+	}
+
+private fun DeviceProfile.nonHDRCodecProfiles(): List<CodecProfile> = codecProfiles.filterNot { profile ->
+	profile.conditions.any { it.property == ProfileConditionValue.VIDEO_RANGE_TYPE }
+}
+
+private fun DeviceProfile.hdrApplyConditionsByCodec(): Map<String, Set<VideoRangeType>> = codecProfiles
+	.filter { profile -> profile.applyConditions.any { it.property == ProfileConditionValue.VIDEO_RANGE_TYPE } }
+	.associate { profile ->
+		profile.codec.orEmpty() to profile.applyConditions
+			.single { it.property == ProfileConditionValue.VIDEO_RANGE_TYPE }
+			.value
+			.orEmpty()
+			.split('|')
+			.map(VideoRangeType::fromName)
+			.toSet()
+	}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Gives the user a menu option under Settings > Playback > Advanced > Media Codecs that lets them configure HDR to be automatically detected, always on, or always off. The reason is that NVIDIA Shield (and possibly other devices) may report HDR capability based on codecs rather than on the display device. This allows for easy override of this reporting. However, it will not lie about the codec capability. If the device lacks codec support, enabling it will not magically provide HDR support.

**Code assistance**
OpenAI Codex wrote the entire change using a custom skill designed for this purpose. It was based on my instructions and created a plan that I reviewed. The resulting debug and later release was verified on an NVIDIA Shield 2019. The final code was manually reviewed to avoid unnecessary dependencies or changes.

**Issues**
