### PR TITLE
Fix back navigation exiting the app when opened into a deep screen

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -54,7 +54,9 @@ class MainActivity : FragmentActivity() {
 				else window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 			}.launchIn(lifecycleScope)
 
-		if (savedInstanceState == null && navigationRepository.canGoBack) navigationRepository.reset(clearHistory = true)
+		// Drop leftover navigation from a previous run, but keep a single destination the app was
+		// opened into directly, such as a launcher tile or a deep link.
+		if (savedInstanceState == null && navigationRepository.hasBackStack) navigationRepository.reset(clearHistory = true)
 
 		navigationRepository.currentAction
 			.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/navigation/NavigationRepository.kt
@@ -40,6 +40,13 @@ interface NavigationRepository {
 	val canGoBack: Boolean
 
 	/**
+	 * Whether destinations exist below the current one. Unlike [canGoBack] this is false when the app
+	 * was opened directly into a single screen, which is the state a freshly created activity should
+	 * keep rather than reset.
+	 */
+	val hasBackStack: Boolean
+
+	/**
 	 * Go back to the previous fragment. The back stack does not consider other destination types.
 	 *
 	 * @see [canGoBack]
@@ -62,10 +69,23 @@ interface NavigationRepository {
 class NavigationRepositoryImpl(
 	private val defaultDestination: Destination.Fragment,
 ) : NavigationRepository {
-	private val fragmentHistory = Stack<Destination.Fragment>()
+	/**
+	 * The destinations currently on screen, deepest last. The top of the stack is what the user is
+	 * looking at, mirroring the history kept by the view that renders the fragments. Keeping both in
+	 * step matters: [canGoBack] gates the back handler, and a handler that is disabled hands the key
+	 * press to the activity, which finishes it and closes the app.
+	 */
+	private val fragmentHistory = Stack<Destination.Fragment>().apply { push(defaultDestination) }
 
 	private val _currentAction = MutableSharedFlow<NavigationAction>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 	override val currentAction = _currentAction.asSharedFlow()
+
+	/**
+	 * Whether the visible destination is the one the app starts on. Compared by fragment type because
+	 * [Destination.Fragment] carries a [android.os.Bundle], which does not implement equality.
+	 */
+	private val isAtDefaultDestination: Boolean
+		get() = fragmentHistory.size == 1 && fragmentHistory.peek().fragment == defaultDestination.fragment
 
 	override fun navigate(destination: Destination, replace: Boolean) {
 		Timber.i("Navigating to $destination (via navigate function)")
@@ -79,22 +99,35 @@ class NavigationRepositoryImpl(
 		_currentAction.tryEmit(action)
 	}
 
-	override val canGoBack: Boolean get() = fragmentHistory.isNotEmpty()
+	override val canGoBack: Boolean get() = !isAtDefaultDestination
+
+	override val hasBackStack: Boolean get() = fragmentHistory.size > 1
 
 	override fun goBack(): Boolean {
-		if (fragmentHistory.empty()) return false
+		if (fragmentHistory.size > 1) {
+			Timber.i("Navigating back")
+			fragmentHistory.pop()
+			_currentAction.tryEmit(NavigationAction.GoBack)
+			return true
+		}
 
-		Timber.i("Navigating back")
-		fragmentHistory.pop()
-		_currentAction.tryEmit(NavigationAction.GoBack)
-		return true
+		// The app was opened straight into a screen below the root, for example through a launcher
+		// tile, a deep link or a search result. There is nothing to pop, but closing the app would be
+		// wrong while a detail screen is on display: go to the default destination instead.
+		if (!isAtDefaultDestination) {
+			Timber.i("Navigating back to the default destination")
+			reset(defaultDestination, clearHistory = true)
+			return true
+		}
+
+		return false
 	}
 
 	override fun reset(destination: Destination.Fragment?, clearHistory: Boolean) {
 		fragmentHistory.clear()
 		val actualDestination = destination ?: defaultDestination
+		fragmentHistory.push(actualDestination)
 		_currentAction.tryEmit(NavigationAction.NavigateFragment(actualDestination, true, false, clearHistory))
 		Timber.i("Navigating to $actualDestination (via reset, clearHistory=$clearHistory)")
 	}
 }
-

--- a/app/src/test/kotlin/ui/navigation/NavigationRepositoryTests.kt
+++ b/app/src/test/kotlin/ui/navigation/NavigationRepositoryTests.kt
@@ -1,0 +1,94 @@
+package ui.navigation
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.jellyfin.androidtv.ui.navigation.Destination
+import org.jellyfin.androidtv.ui.navigation.NavigationRepositoryImpl
+
+private class HomeFragmentStub : Fragment()
+private class DetailFragmentStub : Fragment()
+private class OtherFragmentStub : Fragment()
+
+private fun destination(fragment: kotlin.reflect.KClass<out Fragment>) = Destination.Fragment(
+	fragment = fragment,
+	arguments = mockk<Bundle>(relaxed = true),
+)
+
+class NavigationRepositoryTests : FunSpec({
+	val home = destination(HomeFragmentStub::class)
+
+	test("starts at the default destination and cannot go back") {
+		val repository = NavigationRepositoryImpl(home)
+
+		repository.canGoBack shouldBe false
+		repository.hasBackStack shouldBe false
+		repository.goBack() shouldBe false
+	}
+
+	test("navigating adds a level that back removes again") {
+		val repository = NavigationRepositoryImpl(home)
+		repository.navigate(destination(DetailFragmentStub::class))
+
+		repository.canGoBack shouldBe true
+		repository.hasBackStack shouldBe true
+
+		repository.goBack() shouldBe true
+		repository.canGoBack shouldBe false
+		repository.hasBackStack shouldBe false
+	}
+
+	// The app can be opened straight into a detail screen through a launcher tile, a deep link or a
+	// search result. Before the fix the history was empty in that state, canGoBack was false, the
+	// back handler stayed disabled and the key press closed the app while a detail screen was shown.
+	test("back returns to the default destination when the app opened into a deep screen") {
+		val repository = NavigationRepositoryImpl(home)
+		repository.reset(destination(DetailFragmentStub::class), clearHistory = true)
+
+		repository.canGoBack shouldBe true
+		repository.hasBackStack shouldBe false
+
+		repository.goBack() shouldBe true
+
+		repository.canGoBack shouldBe false
+		repository.goBack() shouldBe false
+	}
+
+	test("resetting to the default destination leaves nothing to go back to") {
+		val repository = NavigationRepositoryImpl(home)
+		repository.navigate(destination(DetailFragmentStub::class))
+		repository.reset(null, clearHistory = true)
+
+		repository.canGoBack shouldBe false
+		repository.hasBackStack shouldBe false
+	}
+
+	test("levels above a deep entry point unwind before returning to the default destination") {
+		val repository = NavigationRepositoryImpl(home)
+		repository.reset(destination(DetailFragmentStub::class), clearHistory = true)
+		repository.navigate(destination(OtherFragmentStub::class))
+
+		repository.hasBackStack shouldBe true
+
+		// back to the deep entry point
+		repository.goBack() shouldBe true
+		repository.hasBackStack shouldBe false
+		repository.canGoBack shouldBe true
+
+		// and from there to the default destination
+		repository.goBack() shouldBe true
+		repository.canGoBack shouldBe false
+	}
+
+	test("replace swaps the current level instead of adding one") {
+		val repository = NavigationRepositoryImpl(home)
+		repository.navigate(destination(DetailFragmentStub::class))
+		repository.navigate(destination(OtherFragmentStub::class), replace = true)
+
+		repository.hasBackStack shouldBe true
+		repository.goBack() shouldBe true
+		repository.canGoBack shouldBe false
+	}
+})


### PR DESCRIPTION
**Changes**

Pressing back closed the app instead of navigating to the home screen when the app was opened directly into a deeper screen, such as from a launcher tile, a deep link or a search result.

`NavigationRepositoryImpl.reset()` cleared `fragmentHistory` and navigated to the destination without pushing it onto the stack, while the view layer (`DestinationFragmentView`) does push it onto its own stack. The two stacks therefore diverged by exactly one level. With an empty history `canGoBack` was false, so the `BackHandler` in `AppNavigationHost` stayed disabled, the key press reached the activity and finished it.

`fragmentHistory` now also holds the visible destination, matching the view. `canGoBack` no longer asks whether the stack is empty but whether the current destination is the default one, and `goBack()` navigates to the default destination when there is no history left but the app is not on it. A separate `hasBackStack` was added because `MainActivity` used `canGoBack` to discard stale navigation state on a fresh activity, which under the new meaning would have sent every deep link straight back to home.

Six unit tests cover the deep entry point, unwinding levels above it, replace, and the unchanged behaviour at the root.

**Code assistance**

Substantial. The root cause was located by driving a physical device over ADB and comparing `dumpsys activity` output between navigation steps, which is what showed that the UI survives backgrounding while the navigation stack does not. An LLM was used for reading the navigation code, forming the hypothesis, writing the patch and the tests, and drafting this description. Every claim above is backed either by an observation recorded in https://github.com/jellyfin/jellyfin-androidtv/issues/5010#issuecomment-5421048326 or by the code itself, and the reasoning is laid out so it can be checked rather than taken on trust.

One limitation stated plainly: this passes test, lint and build in CI, but it has **not** been verified on a device yet. The box used for the original measurements went offline before the patch existed. If a maintainer would rather hold this until a device test is posted, that is fair, and I will add one.

**Issues**

Fixes #5010
