### PR TITLE
Add PopOverMenu composable

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/Popover.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/Popover.kt
@@ -45,7 +45,7 @@ fun Popover(
 ) {
 	val density = LocalDensity.current
 	val popupPositionProvider = remember(alignment, density, offset) {
-		PopoverMenuPositionProvider(
+		PopoverPositionProvider(
 			alignment = alignment,
 			offset = IntOffset(
 				x = with(density) { offset.x.roundToPx() },

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/PopoverMenu.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/PopoverMenu.kt
@@ -1,0 +1,89 @@
+package org.jellyfin.androidtv.ui.base.popover
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.button.Button
+import org.jellyfin.androidtv.ui.base.button.ButtonDefaults
+
+@Composable
+fun PopoverMenu(
+	modifier: Modifier = Modifier,
+	paddingValues: PaddingValues = PaddingValues(4.dp),
+	content: @Composable ColumnScope.() -> Unit,
+) = Column(
+	modifier = Modifier
+		.padding(paddingValues)
+		.width(IntrinsicSize.Max)
+		.then(modifier)
+) {
+	content()
+}
+
+@Composable
+fun PopoverMenuItem(
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+	shape: Shape = RoundedCornerShape(3.dp),
+	content: @Composable RowScope.() -> Unit,
+) = Button(
+	onClick = onClick,
+	modifier = Modifier
+		.fillMaxWidth()
+		.then(modifier),
+	shape = shape,
+	colors = ButtonDefaults.colors(
+		containerColor = Color.Transparent,
+	),
+) {
+	content()
+}
+
+@Composable
+fun PopoverMenuCheckboxItem(
+	selected: Boolean,
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+	content: @Composable RowScope.() -> Unit,
+) = PopoverMenuItem(
+	onClick = onClick,
+	modifier = modifier,
+) {
+	val alpha by animateFloatAsState(
+		targetValue = if (selected) 1f else 0f,
+		animationSpec = tween(durationMillis = 150),
+	)
+
+	Icon(
+		imageVector = ImageVector.vectorResource(R.drawable.ic_check),
+		contentDescription = null,
+		modifier = Modifier
+			.size(16.dp)
+			.alpha(alpha),
+	)
+
+	Spacer(Modifier.width(16.dp))
+
+	content()
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/PopoverPositionProvider.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/base/popover/PopoverPositionProvider.kt
@@ -7,9 +7,9 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.PopupPositionProvider
 
-class PopoverMenuPositionProvider(
-	val alignment: Alignment = Alignment.Companion.BottomCenter,
-	val offset: IntOffset = IntOffset.Companion.Zero,
+class PopoverPositionProvider(
+	val alignment: Alignment = Alignment.BottomCenter,
+	val offset: IntOffset = IntOffset.Zero,
 ) : PopupPositionProvider {
 	private companion object {
 		private const val EPSILON = 1e-3f
@@ -34,7 +34,7 @@ class PopoverMenuPositionProvider(
 
 		// Measure bias
 		val biasPosition = alignment.align(
-			size = IntSize.Companion.Zero,
+			size = IntSize.Zero,
 			space = PROBE_SPACE,
 			layoutDirection = layoutDirection,
 		)


### PR DESCRIPTION
**Changes**

I have multiple branches that use popover menus but their designs are all different because we didn't have base composables yet. This PR cherrypicks the best implementation I had and refines it. In addition it renames the popover position provider and fixes some companion usages.

The `PopoverMenu` compsoable is a simple column wrapper that is expected to be used within a Popover. Then there are two possible child composables: PopoverMenuItem and PopoverMenuCheckboxItem. Example:

```kotlin
var subtitleTracks by remember {
	mutableStateOf(
		setOf(
			"English" to false,
			"Nederlands" to true,
			"方言" to false,
			"霊の言葉" to false,
			"Delvish" to false,
		)
	)
}

Popover(
	expanded = expanded,
	onDismissRequest = { expanded = false },
	alignment = Alignment.TopCenter,
	offset = DpOffset(0.dp, (-5).dp)
) {
	PopoverMenu {
		for ((name, active) in subtitleTracks) {
			PopoverMenuCheckboxItem(
				selected = active,
				onClick = {
					subtitleTracks = subtitleTracks
						.map { it.first to if (it.first == name) !it.second else it.second }
						.toSet()
				},
			) {
				Text(name)
			}
		}
	}
}
```

<img width="253" height="428" alt="afbeelding" src="https://github.com/user-attachments/assets/40f84d2f-5500-41cc-aba2-43d631b8a47a" />

will likely see some changes in future PRs, but at least we have the foundation now

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
