### PR TITLE
Improve D-pad navigation performance

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/BackgroundService.kt
@@ -108,9 +108,13 @@ class BackgroundService(
 		// Cancel current loading job
 		loadBackgroundsJob?.cancel()
 		loadBackgroundsJob = scope.launch(Dispatchers.IO) {
+			val displayMetrics = context.resources.displayMetrics
 			_backgrounds = backdropUrls.mapNotNull { url ->
 				imageLoader.execute(
-					request = ImageRequest.Builder(context).data(url).build()
+					request = ImageRequest.Builder(context)
+						.data(url)
+						.size(displayMetrics.widthPixels, displayMetrics.heightPixels)
+						.build()
 				).image?.toBitmap()?.asImageBitmap()
 			}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseFolderFragment.kt
@@ -12,6 +12,8 @@ import androidx.leanback.widget.RowPresenter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.jellyfin.androidtv.constant.Extras
@@ -25,6 +27,8 @@ import org.jellyfin.androidtv.ui.presentation.PositionableListRowPresenter
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.koin.android.ext.android.inject
 
+private const val FOCUS_SETTLE_DELAY_MS = 250L
+
 abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 	protected var folder: BaseItemDto? = null
 	protected var includeType: String? = null
@@ -33,6 +37,7 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 
 	private val backgroundService by inject<BackgroundService>()
 	private val itemLauncher by inject<ItemLauncher>()
+	private var backgroundUpdateJob: Job? = null
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -56,13 +61,21 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 			}
 		}
 		onItemViewSelectedListener = OnItemViewSelectedListener { _: Presenter.ViewHolder?, item: Any?, _: RowPresenter.ViewHolder?, row: Row ->
+			backgroundUpdateJob?.cancel()
+
 			if (item !is BaseRowItem) {
-				backgroundService.clearBackgrounds()
+				backgroundUpdateJob = lifecycleScope.launch {
+					delay(FOCUS_SETTLE_DELAY_MS)
+					backgroundService.clearBackgrounds()
+				}
 			} else {
 				val adapter = (row as? ListRow)?.adapter
 				if (adapter is ItemRowAdapter) adapter.loadMoreItemsIfNeeded(adapter.indexOf(item))
 
-				backgroundService.setBackground(item.baseItem)
+				backgroundUpdateJob = lifecycleScope.launch {
+					delay(FOCUS_SETTLE_DELAY_MS)
+					backgroundService.setBackground(item.baseItem)
+				}
 			}
 		}
 
@@ -72,6 +85,11 @@ abstract class BrowseFolderFragment : BrowseSupportFragment(), RowLoader {
 				setupQueries(this@BrowseFolderFragment)
 			}
 		}
+	}
+
+	override fun onDestroy() {
+		backgroundUpdateJob?.cancel()
+		super.onDestroy()
 	}
 
 	protected abstract suspend fun setupQueries(rowLoader: RowLoader)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java
@@ -623,7 +623,6 @@ public class BrowseGridFragment extends Fragment implements View.OnKeyListener {
             chunkSize = Math.min(mCardsScreenEst + mCardsScreenStride, 150); // cap at 150
             Timber.d("buildAdapter adjusting chunkSize to <%s> screenEst <%s>", chunkSize, mCardsScreenEst);
         }
-        chunkSize=100;
 
         switch (mRowDef.getQueryType()) {
             case NextUp:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -84,6 +84,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     protected static final int SERIES = 11;
     protected static final int ALBUM_ARTISTS = 12;
     protected static final int SHUFFLE_SONGS = 13;
+    private static final int VIEW_SELECT_UPDATE_DELAY = 250;
     protected BaseItemDto mFolder;
     protected BaseItemKind itemType;
     protected boolean showViews = true;
@@ -98,6 +99,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     protected BaseRowItem mCurrentItem;
     protected ListRow mCurrentRow;
 
+    private final Handler mSelectionHandler = new Handler();
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
     private Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
@@ -151,6 +153,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
 
     @Override
     public void onDestroyView() {
+        mSelectionHandler.removeCallbacks(mDelayedSelectionUpdate);
         super.onDestroyView();
         mClickedListener.removeListeners();
         mSelectedListener.removeListeners();
@@ -456,28 +459,19 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
         }
     }
 
-    private final class ItemViewSelectedListener implements OnItemViewSelectedListener {
+    private final Runnable mDelayedSelectionUpdate = new Runnable() {
         @Override
-        public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
-                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
-            if (!(item instanceof BaseRowItem)) {
-                mTitle.setText(mFolder != null ? mFolder.getName() : "");
-                mInfoRow.removeAllViews();
+        public void run() {
+            if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) return;
+
+            BaseRowItem rowItem = mCurrentItem;
+            mInfoRow.removeAllViews();
+
+            if (rowItem == null) {
                 mSummary.setText("");
-                mCurrentItem = null;
-                mCurrentRow = null;
-                // Fill in default background
                 backgroundService.getValue().clearBackgrounds();
                 return;
             }
-
-            BaseRowItem rowItem = (BaseRowItem) item;
-
-            mCurrentItem = rowItem;
-            mCurrentRow = (ListRow) row;
-            mInfoRow.removeAllViews();
-
-            mTitle.setText(rowItem.getName(requireContext()));
 
             String summary = rowItem.getSummary(requireContext());
             if (summary != null)
@@ -485,11 +479,33 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
             else mSummary.setText(null);
 
             InfoLayoutHelper.addInfoRow(requireContext(), rowItem.getBaseItem(), mInfoRow, true);
+            backgroundService.getValue().setBackground(rowItem.getBaseItem());
+        }
+    };
+
+    private final class ItemViewSelectedListener implements OnItemViewSelectedListener {
+        @Override
+        public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
+                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
+            mSelectionHandler.removeCallbacks(mDelayedSelectionUpdate);
+
+            if (!(item instanceof BaseRowItem)) {
+                mTitle.setText(mFolder != null ? mFolder.getName() : "");
+                mCurrentItem = null;
+                mCurrentRow = null;
+                mSelectionHandler.postDelayed(mDelayedSelectionUpdate, VIEW_SELECT_UPDATE_DELAY);
+                return;
+            }
+
+            BaseRowItem rowItem = (BaseRowItem) item;
+            mCurrentItem = rowItem;
+            mCurrentRow = (ListRow) row;
+            mTitle.setText(rowItem.getName(requireContext()));
 
             ItemRowAdapter adapter = (ItemRowAdapter) ((ListRow) row).getAdapter();
             adapter.loadMoreItemsIfNeeded(adapter.indexOf(rowItem));
 
-            backgroundService.getValue().setBackground(rowItem.getBaseItem());
+            mSelectionHandler.postDelayed(mDelayedSelectionUpdate, VIEW_SELECT_UPDATE_DELAY);
         }
     }
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/composable/item/ItemCardBaseItemOverlay.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/composable/item/ItemCardBaseItemOverlay.kt
@@ -34,10 +34,13 @@ import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.koin.compose.koinInject
 
+private const val PERCENTAGE_SCALE = 100f
+
 @Composable
 @Stable
 fun ItemCardBaseItemOverlay(
 	item: BaseItemDto,
+	focused: Boolean = false,
 	footer: (@Composable () -> Unit)? = null,
 ) = Box(
 	modifier = Modifier
@@ -60,6 +63,7 @@ fun ItemCardBaseItemOverlay(
 	) {
 		ProgressIndicator(
 			item = item,
+			focused = focused,
 		)
 
 		if (footer != null) footer()
@@ -145,16 +149,19 @@ private fun WatchIndicator(
 @Composable
 private fun ProgressIndicator(
 	item: BaseItemDto,
+	focused: Boolean,
 	modifier: Modifier = Modifier,
 ) {
-	val playbackManager = koinInject<org.jellyfin.playback.core.PlaybackManager>()
-	val playState by playbackManager.state.playState.collectAsState()
-	val currentQueueEntry by rememberQueueEntry(playbackManager)
+	val staticPlayedPercentage = item.userData?.playedPercentage
+		?.toFloat()
+		?.div(PERCENTAGE_SCALE)
+		?.coerceIn(0f, 1f)
+		?.takeIf { it > 0f && it < 1f }
 
-	val playedPercentage = if (playState == PlayState.PLAYING && currentQueueEntry?.baseItem?.id == item.id) {
-		rememberPlayerProgress(playbackManager).value
+	val playedPercentage = if (focused) {
+		FocusedPlaybackProgress(item) ?: staticPlayedPercentage
 	} else {
-		item.userData?.playedPercentage?.toFloat()?.div(100f)?.coerceIn(0f, 1f)?.takeIf { it > 0f && it < 1f }
+		staticPlayedPercentage
 	}
 
 	if (playedPercentage != null) {
@@ -167,5 +174,18 @@ private fun ProgressIndicator(
 					.height(4.dp)
 			)
 		}
+	}
+}
+
+@Composable
+private fun FocusedPlaybackProgress(item: BaseItemDto): Float? {
+	val playbackManager = koinInject<org.jellyfin.playback.core.PlaybackManager>()
+	val playState by playbackManager.state.playState.collectAsState()
+	val currentQueueEntry by rememberQueueEntry(playbackManager)
+
+	return if (playState == PlayState.PLAYING && currentQueueEntry?.baseItem?.id == item.id) {
+		rememberPlayerProgress(playbackManager).value
+	} else {
+		null
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -59,6 +60,9 @@ import org.koin.android.ext.android.inject
 import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
 
+private const val FOCUS_SETTLE_DELAY_MS = 250L
+private const val HOME_ROW_CACHE_SIZE = 12
+
 class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyListener {
 	private val api by inject<ApiClient>()
 	private val backgroundService by inject<BackgroundService>()
@@ -79,11 +83,21 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	// Data
 	private var currentItem: BaseRowItem? = null
 	private var currentRow: ListRow? = null
+	private var backgroundUpdateJob: Job? = null
 	private var justLoaded = true
 
 	// Special rows
 	private val notificationsRow by lazy { NotificationsHomeFragmentRow(lifecycleScope, notificationsRepository) }
 	private val nowPlaying by lazy { HomeFragmentNowPlayingRow(lifecycleScope, playbackManager, mediaManager) }
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+		super.onViewCreated(view, savedInstanceState)
+
+		verticalGridView.apply {
+			setItemViewCacheSize(HOME_ROW_CACHE_SIZE)
+			setExtraLayoutSpace(resources.displayMetrics.heightPixels * 2)
+		}
+	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -235,6 +249,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	}
 
 	override fun onDestroy() {
+		backgroundUpdateJob?.cancel()
 		super.onDestroy()
 
 		mediaManager.removeAudioEventListener(this)
@@ -270,10 +285,15 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 			rowViewHolder: RowPresenter.ViewHolder?,
 			row: Row?,
 		) {
+			backgroundUpdateJob?.cancel()
+
 			if (item !is BaseRowItem) {
 				currentItem = null
-				//fill in default background
-				backgroundService.clearBackgrounds()
+				currentRow = null
+				backgroundUpdateJob = lifecycleScope.launch {
+					delay(FOCUS_SETTLE_DELAY_MS)
+					if (currentItem == null) backgroundService.clearBackgrounds()
+				}
 			} else {
 				currentItem = item
 				currentRow = row as ListRow
@@ -281,7 +301,10 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 				val itemRowAdapter = row.adapter as? ItemRowAdapter
 				itemRowAdapter?.loadMoreItemsIfNeeded(itemRowAdapter.indexOf(item))
 
-				backgroundService.setBackground(item.baseItem)
+				backgroundUpdateJob = lifecycleScope.launch {
+					delay(FOCUS_SETTLE_DELAY_MS)
+					if (currentItem === item) backgroundService.setBackground(item.baseItem)
+				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CardPresenter.kt
@@ -4,6 +4,7 @@ import android.view.KeyEvent
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.compose.foundation.Image
+import coil3.compose.rememberAsyncImagePainter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Box
@@ -13,11 +14,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -32,12 +40,15 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.constant.ImageType
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.Text
-import org.jellyfin.androidtv.ui.composable.AsyncImage
 import org.jellyfin.androidtv.ui.composable.item.ItemCard
 import org.jellyfin.androidtv.ui.composable.item.ItemCardBaseItemOverlay
 import org.jellyfin.androidtv.ui.composable.item.ItemPreview
@@ -45,6 +56,7 @@ import org.jellyfin.androidtv.ui.itemhandling.BaseItemDtoBaseRowItem
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowType
 import org.jellyfin.androidtv.ui.itemhandling.GridButtonBaseRowItem
+import org.jellyfin.androidtv.util.BlurHashDecoder
 import org.jellyfin.androidtv.util.ImageHelper
 import org.jellyfin.androidtv.util.apiclient.JellyfinImage
 import org.jellyfin.androidtv.util.apiclient.getUrl
@@ -53,6 +65,10 @@ import org.jellyfin.design.Tokens
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.koin.compose.koinInject
+import kotlin.math.roundToInt
+
+private const val IMAGE_CROSSFADE_DURATION_MS = 100
+private const val BLUR_HASH_RESOLUTION = 32
 
 class CardPresenter(
 	val showInfo: Boolean,
@@ -96,12 +112,11 @@ class CardPresenter(
 
 	private inner class CardViewHolder(composeView: ComposeView) : ViewHolder(composeView) {
 		private val _item = MutableStateFlow<BaseRowItem?>(null)
-		private val _focused = MutableStateFlow(false)
+		private val focused = mutableStateOf(false)
 
 		init {
 			composeView.setContent {
 				val item by _item.collectAsState()
-				val focused by _focused.collectAsState()
 
 				CardViewHolderContent(
 					item = item,
@@ -113,18 +128,18 @@ class CardPresenter(
 				)
 			}
 
-			_focused.value = view.isFocused
-			composeView.onFocusChangeListener = { _, focused -> _focused.value = focused }
+			focused.value = view.isFocused
+			composeView.onFocusChangeListener = { _, isFocused -> focused.value = isFocused }
 		}
 
 		fun bind(item: BaseRowItem) {
 			_item.value = item
-			_focused.value = view.isFocused
+			focused.value = view.isFocused
 		}
 
 		fun unbind() {
 			_item.value = null
-			_focused.value = false
+			focused.value = false
 		}
 	}
 }
@@ -136,6 +151,35 @@ private data class BaseRowItemDisplayConfig(
 	val overrideShowInfo: Boolean? = null,
 	val scaleType: ImageView.ScaleType? = null,
 )
+
+private fun ImageView.ScaleType.toContentScale() = when (this) {
+	ImageView.ScaleType.CENTER_CROP -> ContentScale.Crop
+	ImageView.ScaleType.FIT_XY -> ContentScale.FillBounds
+	ImageView.ScaleType.CENTER -> ContentScale.None
+	ImageView.ScaleType.CENTER_INSIDE,
+	ImageView.ScaleType.FIT_CENTER,
+	ImageView.ScaleType.FIT_START,
+	ImageView.ScaleType.FIT_END,
+	ImageView.ScaleType.MATRIX -> ContentScale.Fit
+}
+
+@Composable
+private fun rememberBlurHashPainter(
+	blurHash: String?,
+	aspectRatio: Float,
+): Painter? {
+	val bitmap by produceState<android.graphics.Bitmap?>(null, blurHash, aspectRatio) {
+		value = if (blurHash == null || aspectRatio <= 0f) null else withContext(Dispatchers.Default) {
+			BlurHashDecoder.decode(
+				blurHash = blurHash,
+				width = if (aspectRatio > 1f) (BLUR_HASH_RESOLUTION * aspectRatio).roundToInt() else BLUR_HASH_RESOLUTION,
+				height = if (aspectRatio >= 1f) BLUR_HASH_RESOLUTION else (BLUR_HASH_RESOLUTION / aspectRatio).roundToInt(),
+			)
+		}
+	}
+
+	return remember(bitmap) { bitmap?.let { BitmapPainter(it.asImageBitmap()) } }
+}
 
 private fun BaseRowItem.getDisplayConfig(imageType: ImageType, uniformAspect: Boolean): BaseRowItemDisplayConfig = when (baseRowType) {
 	BaseRowType.BaseItem -> {
@@ -280,7 +324,7 @@ private fun BaseRowItem.getDisplayConfig(imageType: ImageType, uniformAspect: Bo
 @Stable
 private fun CardViewHolderContent(
 	item: BaseRowItem?,
-	focused: Boolean,
+	focused: State<Boolean>,
 	showInfo: Boolean,
 	imageType: ImageType,
 	staticHeight: Int,
@@ -311,17 +355,30 @@ private fun CardViewHolderContent(
 			image = {
 				if (image != null) {
 					val api = koinInject<ApiClient>()
-					AsyncImage(
-						url = image.getUrl(
+					val imageUrl = remember(image, api, size, localDensity) {
+						image.getUrl(
 							api,
 							maxWidth = with(localDensity) { size.width.roundToPx() },
 							maxHeight = with(localDensity) { size.height.roundToPx() },
+						)
+					}
+					val contentScale = (displayConfig.scaleType ?: ImageView.ScaleType.CENTER_CROP).toContentScale()
+					val placeholder = rememberBlurHashPainter(image.blurHash, aspectRatio)
+					val request = remember(imageUrl, context) {
+						ImageRequest.Builder(context)
+							.data(imageUrl)
+							.crossfade(IMAGE_CROSSFADE_DURATION_MS)
+							.build()
+					}
+					Image(
+						painter = rememberAsyncImagePainter(
+							model = request,
+							placeholder = placeholder,
+							contentScale = contentScale,
 						),
-						blurHash = image.blurHash,
-						aspectRatio = aspectRatio,
-						scaleType = displayConfig.scaleType ?: ImageView.ScaleType.CENTER_CROP,
-						modifier = Modifier
-							.fillMaxSize()
+						contentDescription = null,
+						contentScale = contentScale,
+						modifier = Modifier.fillMaxSize(),
 					)
 				} else if (item is GridButtonBaseRowItem && item.gridButton.imageRes != null) {
 					Image(
@@ -343,14 +400,12 @@ private fun CardViewHolderContent(
 			overlay = {
 				val showInfo = !usePreview && item.showCardInfoOverlay
 				item.baseItem?.let { baseItem ->
-					ItemCardBaseItemOverlay(
+					FocusAwareItemOverlay(
 						item = baseItem,
+						focused = focused,
 						footer = {
 							if (showInfo && title != null) {
-								val focusModifier = if (focused) Modifier.basicMarquee(
-									iterations = Int.MAX_VALUE,
-									initialDelayMillis = 0,
-								) else Modifier
+								val focusModifier = focusedMarqueeModifier(focused)
 
 								Box(
 									modifier = Modifier
@@ -379,11 +434,6 @@ private fun CardViewHolderContent(
 	}
 
 	if (usePreview) {
-		val focusModifier = if (focused) Modifier.basicMarquee(
-			iterations = Int.MAX_VALUE,
-			initialDelayMillis = 0,
-		) else Modifier
-
 		ItemPreview(
 			card = { card() },
 			title = title?.let { text ->
@@ -393,7 +443,7 @@ private fun CardViewHolderContent(
 						maxLines = 1,
 						overflow = TextOverflow.Ellipsis,
 						textAlign = TextAlign.Center,
-						modifier = Modifier.then(focusModifier),
+						modifier = Modifier.then(focusedMarqueeModifier(focused)),
 					)
 				}
 			},
@@ -404,7 +454,7 @@ private fun CardViewHolderContent(
 						maxLines = 1,
 						overflow = TextOverflow.Ellipsis,
 						textAlign = TextAlign.Center,
-						modifier = Modifier.then(focusModifier),
+						modifier = Modifier.then(focusedMarqueeModifier(focused)),
 					)
 				}
 			},
@@ -412,4 +462,23 @@ private fun CardViewHolderContent(
 	} else {
 		card()
 	}
+}
+
+@Composable
+private fun focusedMarqueeModifier(focused: State<Boolean>): Modifier = if (focused.value) Modifier.basicMarquee(
+	iterations = Int.MAX_VALUE,
+	initialDelayMillis = 0,
+) else Modifier
+
+@Composable
+private fun FocusAwareItemOverlay(
+	item: org.jellyfin.sdk.model.api.BaseItemDto,
+	focused: State<Boolean>,
+	footer: (@Composable () -> Unit)? = null,
+) {
+	ItemCardBaseItemOverlay(
+		item = item,
+		focused = focused.value,
+		footer = footer,
+	)
 }


### PR DESCRIPTION
**Changes**

Improve D-pad navigation responsiveness across the home and browse screens by reducing work performed on focus changes and row transitions.

- Retain and pre-layout home rows so moving vertically does not synchronously create/measure a full row of Compose cards during the D-pad frame.
- Keep card focus state local to the focus-dependent overlay/marquee content instead of recomposing the full card/image subtree.
- Only subscribe to live playback progress for the focused card; unfocused cards use their static server-provided progress.
- Render card artwork directly with Compose/Coil while preserving BlurHash placeholders and crossfade behavior, avoiding the previous Compose/AndroidView image bridge.
- Debounce expensive backdrop/metadata updates until focus has settled while leaving pagination immediate.
- Restore the adaptive BrowseGrid chunk size instead of overriding it with a fixed value.
- Size backdrop image requests to the display rather than decoding unconstrained images.

**Performance testing**

Tested on a physical Google TV Streamer at 1080p/60 Hz using repeated D-pad navigation and Android `gfxinfo`/atrace measurements.

For real home-screen up/down navigation, the original implementation measured 7.38% janky frames with p95 77 ms and p99 129 ms. After the row retention/pre-layout changes, a warm trace measured 2.87% janky frames with p95 38 ms and p99 48 ms. The largest `RV OnLayout` slice dropped from 90.6 ms to 7.6 ms.

A separate media-card workload exercising actual `BaseItemDto` cards, unique network images, BlurHash placeholders, overlays and playback progress produced the following five-pair mixed-navigation averages:

| Metric | Baseline | Improved |
| --- | ---: | ---: |
| Janky frames | 10.44% | 3.58% |
| p90 | 46.4 ms | 29.6 ms |
| p95 | 58.6 ms | 35.2 ms |
| p99 | 98.6 ms | 57.0 ms |
| Deadline misses | 138.8 | 48.0 |

Focus-state isolation was also traced independently. Compared with the row-cache-only version, `Recomposer:recompose` time fell from 678 ms to 473 ms over the same navigation workload, with the worst recomposition falling from 22.1 ms to 11.5 ms. Total animation work fell from 1434 ms to 1001 ms and traversal work from 2719 ms to 2119 ms.

The final behavior was also manually tested on the same Google TV Streamer with normal Jellyfin navigation.

**Validation**

- `./gradlew test lint :app:assembleRelease` passes locally.
- `git diff --check` passes.
- Local `./gradlew detekt` currently aborts with `26.0.2.1`; an untouched checkout of current upstream `master` fails identically in the same environment, so this is not introduced by these changes.

**Related work**

I checked existing open and historical PRs before opening this. #5543 and #5544 improve home startup/API loading, #4927 and #5719 address focus correctness/restoration, #5146 is a separate Compose BrowseGrid rewrite, and #5343 introduced the Compose card presenter. I could not find an existing PR using the row caching/offscreen layout or focus-recomposition approach in this change.

**Code assistance**

ChatGPT was used to inspect the code paths, create and refine the implementation, build benchmark harnesses, drive repeated tests on the physical device, and analyze Android frame traces. Changes were iteratively retained or reverted based on measured results; several initially proposed optimizations were discarded after benchmarks showed regressions.

**Issues**

None.
