### PR TITLE
Polish media segment skip overlay

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1274,6 +1274,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
 
     public void clearSkipOverlay() {
         binding.skipOverlay.setTargetPositionMs(null);
+        binding.skipOverlay.setSegmentType(null);
     }
 
     private void prepareChapterAdapter() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragmentHelper.kt
@@ -17,6 +17,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import java.time.Instant
@@ -188,6 +189,7 @@ fun CustomPlaybackOverlayFragment.recordProgram(program: BaseItemDto, isSeries: 
 	}
 }
 
-fun CustomPlaybackOverlayFragment.askToSkip(position: Duration) {
+fun CustomPlaybackOverlayFragment.askToSkip(position: Duration, segmentType: MediaSegmentType) {
+	binding.skipOverlay.segmentType = segmentType
 	binding.skipOverlay.targetPosition = position
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackControllerHelper.kt
@@ -210,7 +210,7 @@ private fun PlaybackController.addSkipAction(mediaSegment: MediaSegmentDto) {
 private fun PlaybackController.addAskToSkipAction(mediaSegment: MediaSegmentDto) {
 	mVideoManager.mExoPlayer
 		.createMessage { _, _ ->
-			fragment?.askToSkip(mediaSegment.end)
+			fragment?.askToSkip(mediaSegment.end, mediaSegment.type)
 		}
 		// Segments at position 0 will never be hit by ExoPlayer so we need to add a minimum value
 		.setPosition(mediaSegment.start.inWholeMilliseconds.coerceAtLeast(1))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -45,6 +45,9 @@ import org.jellyfin.sdk.model.api.MediaSegmentType
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
+private const val SLIDE_IN_OFFSET_DIVISOR = 3
+private const val SLIDE_OUT_OFFSET_DIVISOR = 4
+
 @Composable
 fun SkipOverlayComposable(
 	visible: Boolean,
@@ -60,8 +63,8 @@ fun SkipOverlayComposable(
 	) {
 		AnimatedVisibility(
 			visible = visible,
-			enter = fadeIn() + slideInHorizontally { it / 3 },
-			exit = fadeOut() + slideOutHorizontally { it / 4 },
+			enter = fadeIn() + slideInHorizontally { it / SLIDE_IN_OFFSET_DIVISOR },
+			exit = fadeOut() + slideOutHorizontally { it / SLIDE_OUT_OFFSET_DIVISOR },
 		) {
 			Row(
 				modifier = Modifier

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -98,20 +98,6 @@ fun SkipOverlayComposable(
 					fontWeight = FontWeight.SemiBold,
 				)
 
-				Box(
-					contentAlignment = Alignment.Center,
-					modifier = Modifier
-						.size(30.dp)
-						.clip(CircleShape)
-						.background(contentColor.copy(alpha = 0.08f))
-				) {
-					Icon(
-						imageVector = ImageVector.vectorResource(R.drawable.ic_control_select),
-						contentDescription = stringResource(R.string.segment_skip_control_hint),
-						modifier = Modifier.size(21.dp),
-						tint = Color.Unspecified,
-					)
-				}
 			}
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -195,6 +195,7 @@ class SkipOverlayView @JvmOverloads constructor(
 		LaunchedEffect(skipUiEnabled, targetPosition) {
 			delay(MediaSegmentRepository.AskToSkipAutoHideDuration)
 			_targetPosition.value = null
+			_segmentType.value = null
 		}
 
 		SkipOverlayComposable(visible, segmentType)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -5,11 +5,16 @@ import android.util.AttributeSet
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -20,11 +25,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
@@ -33,40 +41,88 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
+import org.jellyfin.sdk.model.api.MediaSegmentType
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun SkipOverlayComposable(
 	visible: Boolean,
+	segmentType: MediaSegmentType?,
 ) {
+	val shape = RoundedCornerShape(18.dp)
+	val contentColor = Color.White
+	val accentColor = colorResource(R.color.jellyfin_blue)
+
 	Box(
 		contentAlignment = Alignment.BottomEnd,
-		modifier = Modifier
-			.padding(48.dp, 48.dp)
+		modifier = Modifier.padding(horizontal = 56.dp, vertical = 44.dp)
 	) {
-		AnimatedVisibility(visible, enter = fadeIn(), exit = fadeOut()) {
+		AnimatedVisibility(
+			visible = visible,
+			enter = fadeIn() + slideInHorizontally { it / 3 },
+			exit = fadeOut() + slideOutHorizontally { it / 4 },
+		) {
 			Row(
 				modifier = Modifier
-					.clip(RoundedCornerShape(6.dp))
-					.background(colorResource(R.color.popup_menu_background).copy(alpha = 0.6f))
-					.padding(10.dp),
-				horizontalArrangement = Arrangement.spacedBy(8.dp),
+					.shadow(14.dp, shape)
+					.clip(shape)
+					.background(colorResource(R.color.popup_menu_background).copy(alpha = 0.92f))
+					.border(1.dp, contentColor.copy(alpha = 0.16f), shape)
+					.padding(horizontal = 18.dp, vertical = 12.dp),
+				horizontalArrangement = Arrangement.spacedBy(12.dp),
 				verticalAlignment = Alignment.CenterVertically,
 			) {
-				Icon(
-					imageVector = ImageVector.vectorResource(R.drawable.ic_control_select),
-					contentDescription = null,
-				)
+				Box(
+					contentAlignment = Alignment.Center,
+					modifier = Modifier
+						.size(34.dp)
+						.clip(CircleShape)
+						.background(accentColor.copy(alpha = 0.22f))
+				) {
+					Icon(
+						imageVector = ImageVector.vectorResource(R.drawable.ic_next),
+						contentDescription = null,
+						modifier = Modifier.size(22.dp),
+						tint = contentColor,
+					)
+				}
 
 				Text(
-					text = stringResource(R.string.segment_action_skip),
-					color = colorResource(R.color.button_default_normal_text),
-					fontSize = 18.sp,
+					text = skipLabel(segmentType),
+					color = contentColor,
+					fontSize = 20.sp,
+					fontWeight = FontWeight.SemiBold,
 				)
+
+				Box(
+					contentAlignment = Alignment.Center,
+					modifier = Modifier
+						.size(30.dp)
+						.clip(CircleShape)
+						.background(contentColor.copy(alpha = 0.08f))
+				) {
+					Icon(
+						imageVector = ImageVector.vectorResource(R.drawable.ic_control_select),
+						contentDescription = stringResource(R.string.segment_skip_control_hint),
+						modifier = Modifier.size(21.dp),
+						tint = Color.Unspecified,
+					)
+				}
 			}
 		}
 	}
+}
+
+@Composable
+private fun skipLabel(segmentType: MediaSegmentType?) = when (segmentType) {
+	MediaSegmentType.INTRO -> stringResource(R.string.segment_skip_intro)
+	MediaSegmentType.OUTRO -> stringResource(R.string.segment_skip_outro)
+	MediaSegmentType.RECAP -> stringResource(R.string.segment_skip_recap)
+	MediaSegmentType.PREVIEW -> stringResource(R.string.segment_skip_preview)
+	MediaSegmentType.COMMERCIAL -> stringResource(R.string.segment_skip_commercial)
+	MediaSegmentType.UNKNOWN,
+	null -> stringResource(R.string.segment_action_skip)
 }
 
 class SkipOverlayView @JvmOverloads constructor(
@@ -76,6 +132,7 @@ class SkipOverlayView @JvmOverloads constructor(
 ) : AbstractComposeView(context, attrs, defStyle) {
 	private val _currentPosition = MutableStateFlow(Duration.ZERO)
 	private val _targetPosition = MutableStateFlow<Duration?>(null)
+	private val _segmentType = MutableStateFlow<MediaSegmentType?>(null)
 	private val _skipUiEnabled = MutableStateFlow(true)
 
 	var currentPosition: Duration
@@ -102,6 +159,12 @@ class SkipOverlayView @JvmOverloads constructor(
 			_targetPosition.value = value?.milliseconds
 		}
 
+	var segmentType: MediaSegmentType?
+		get() = _segmentType.value
+		set(value) {
+			_segmentType.value = value
+		}
+
 	var skipUiEnabled: Boolean
 		get() = _skipUiEnabled.value
 		set(value) {
@@ -122,6 +185,7 @@ class SkipOverlayView @JvmOverloads constructor(
 		val skipUiEnabled by _skipUiEnabled.collectAsState()
 		val currentPosition by _currentPosition.collectAsState()
 		val targetPosition by _targetPosition.collectAsState()
+		val segmentType by _segmentType.collectAsState()
 
 		val visible by remember(skipUiEnabled, currentPosition, targetPosition) {
 			derivedStateOf { visible }
@@ -133,6 +197,6 @@ class SkipOverlayView @JvmOverloads constructor(
 			_targetPosition.value = null
 		}
 
-		SkipOverlayComposable(visible)
+		SkipOverlayComposable(visible, segmentType)
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,7 +549,6 @@
     <string name="segment_skip_recap">Skip recap</string>
     <string name="segment_skip_preview">Skip preview</string>
     <string name="segment_skip_commercial">Skip commercial</string>
-    <string name="segment_skip_control_hint">Press the center button to skip</string>
     <string name="segment_type_commercial">Commercials</string>
     <string name="segment_type_intro">Intros</string>
     <string name="segment_type_outro">Outros</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -544,6 +544,12 @@
     <string name="segment_action_ask_to_skip">Ask to skip</string>
     <string name="segment_action_nothing">Do nothing</string>
     <string name="segment_action_skip">Skip</string>
+    <string name="segment_skip_intro">Skip intro</string>
+    <string name="segment_skip_outro">Skip outro</string>
+    <string name="segment_skip_recap">Skip recap</string>
+    <string name="segment_skip_preview">Skip preview</string>
+    <string name="segment_skip_commercial">Skip commercial</string>
+    <string name="segment_skip_control_hint">Press the center button to skip</string>
     <string name="segment_type_commercial">Commercials</string>
     <string name="segment_type_intro">Intros</string>
     <string name="segment_type_outro">Outros</string>


### PR DESCRIPTION
## Changes

- refresh the skip overlay with a larger, higher-contrast button and slide/fade transitions
- label the action for intros, outros, recaps, previews, and commercials
- propagate the active media segment type to the overlay and clear it when the prompt hides

## Preview

| Intro | Outro |
| --- | --- |
| <img src="https://raw.githubusercontent.com/brandonp2412/jellyfin-androidtv/pr-assets/skip-overlay-buttons/skip-intro.png" alt="Skip intro overlay" width="480"> | <img src="https://raw.githubusercontent.com/brandonp2412/jellyfin-androidtv/pr-assets/skip-overlay-buttons/skip-outro.png" alt="Skip outro overlay" width="480"> |
| Recap | Preview |
| <img src="https://raw.githubusercontent.com/brandonp2412/jellyfin-androidtv/pr-assets/skip-overlay-buttons/skip-recap.png" alt="Skip recap overlay" width="480"> | <img src="https://raw.githubusercontent.com/brandonp2412/jellyfin-androidtv/pr-assets/skip-overlay-buttons/skip-preview.png" alt="Skip preview overlay" width="480"> |
| Commercial | Generic |
| <img src="https://raw.githubusercontent.com/brandonp2412/jellyfin-androidtv/pr-assets/skip-overlay-buttons/skip-commercial.png" alt="Skip commercial overlay" width="480"> | <img src="https://raw.githubusercontent.com/brandonp2412/jellyfin-androidtv/pr-assets/skip-overlay-buttons/skip-generic.png" alt="Generic skip overlay" width="480"> |

## Testing

- `./gradlew detekt lintDebug testDebugUnitTest`