### PR TITLE
Add next up date cutoff setting

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -196,6 +196,12 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var seriesThumbnailsEnabled = booleanPreference("pref_enable_series_thumbnails", true)
 
 		/**
+		 * Maximum days since last watch to show an item in next up.
+		 * Set to 0 to disable (no cutoff).
+		 */
+		var maxDaysInNextUp = intPreference("pref_max_days_in_next_up", 0)
+
+		/**
 		 * Subtitles foreground color
 		 */
 		var subtitlesBackgroundColor = longPreference("subtitles_background_color", 0x00FFFFFF)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeFragmentHelper.kt
@@ -5,6 +5,7 @@ import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.constant.ChangeTriggerType
 import org.jellyfin.androidtv.data.repository.ItemRepository
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.browsing.BrowseRowDef
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -13,10 +14,12 @@ import org.jellyfin.sdk.model.api.request.GetNextUpRequest
 import org.jellyfin.sdk.model.api.request.GetRecommendedProgramsRequest
 import org.jellyfin.sdk.model.api.request.GetRecordingsRequest
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
+import java.time.LocalDateTime
 
 class HomeFragmentHelper(
 	private val context: Context,
 	private val userRepository: UserRepository,
+	private val userPreferences: UserPreferences,
 ) {
 	fun loadRecentlyAdded(userViews: Collection<BaseItemDto>): HomeFragmentRow {
 		return HomeFragmentLatestRow(userRepository, userViews)
@@ -54,11 +57,19 @@ class HomeFragmentHelper(
 	}
 
 	fun loadNextUp(): HomeFragmentRow {
+		val maxDays = userPreferences[UserPreferences.maxDaysInNextUp]
+		val nextUpDateCutoff = if (maxDays > 0) {
+			LocalDateTime.now().minusDays(maxDays.toLong())
+		} else {
+			null
+		}
+
 		val query = GetNextUpRequest(
 			imageTypeLimit = 1,
 			limit = ITEM_LIMIT_NEXT_UP,
 			enableResumable = false,
-			fields = ItemRepository.browseFields
+			fields = ItemRepository.browseFields,
+			nextUpDateCutoff = nextUpDateCutoff,
 		)
 
 		return HomeFragmentBrowseRowDefRow(BrowseRowDef(context.getString(R.string.lbl_next_up), query, arrayOf(ChangeTriggerType.TvPlayback)))

--- a/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/home/HomeRowsFragment.kt
@@ -34,6 +34,7 @@ import org.jellyfin.androidtv.data.repository.CustomMessageRepository
 import org.jellyfin.androidtv.data.repository.NotificationsRepository
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.data.service.BackgroundService
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.jellyfin.androidtv.ui.GridButton
 import org.jellyfin.androidtv.ui.browsing.CompositeClickedListener
@@ -66,6 +67,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	private val mediaManager by inject<MediaManager>()
 	private val notificationsRepository by inject<NotificationsRepository>()
 	private val userRepository by inject<UserRepository>()
+	private val userPreferences by inject<UserPreferences>()
 	private val userSettingPreferences by inject<UserSettingPreferences>()
 	private val userViewsRepository by inject<UserViewsRepository>()
 	private val dataRefreshService by inject<DataRefreshService>()
@@ -74,7 +76,7 @@ class HomeRowsFragment : RowsSupportFragment(), AudioEventListener, View.OnKeyLi
 	private val itemLauncher by inject<ItemLauncher>()
 	private val keyProcessor by inject<KeyProcessor>()
 
-	private val helper by lazy { HomeFragmentHelper(requireContext(), userRepository) }
+	private val helper by lazy { HomeFragmentHelper(requireContext(), userRepository, userPreferences) }
 
 	// Data
 	private var currentItem: BaseRowItem? = null

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -20,6 +20,7 @@ import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.Settings
 import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.SettingsSubtitlesBackgroundColorScreen
 import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.SettingsSubtitlesScreen
 import org.jellyfin.androidtv.ui.settings.screen.customization.subtitle.SettingsSubtitlesTextColorScreen
+import org.jellyfin.androidtv.ui.settings.screen.home.SettingsHomeNextUpCutoffScreen
 import org.jellyfin.androidtv.ui.settings.screen.home.SettingsHomeScreen
 import org.jellyfin.androidtv.ui.settings.screen.home.SettingsHomeSectionScreen
 import org.jellyfin.androidtv.ui.settings.screen.library.SettingsLibrariesDisplayGridScreen
@@ -86,6 +87,7 @@ object Routes {
 	const val LIBRARIES_DISPLAY_GRID = "/libraries/display/{itemId}/{displayPreferencesId}/grid"
 	const val HOME = "/home"
 	const val HOME_SECTION = "/home/section/{index}"
+	const val HOME_NEXT_UP_CUTOFF = "/home/next-up-cutoff"
 	const val LIVETV_GUIDE_FILTERS = "/livetv/guide/filters"
 	const val LIVETV_GUIDE_OPTIONS = "/livetv/guide/options"
 	const val LIVETV_GUIDE_CHANNEL_ORDER = "/livetv/guide/channel-order"
@@ -206,6 +208,9 @@ val routes = mapOf<String, RouteComposable>(
 	},
 	Routes.HOME_SECTION to { context ->
 		SettingsHomeSectionScreen(context.parameters["index"]?.toInt()!!)
+	},
+	Routes.HOME_NEXT_UP_CUTOFF to {
+		SettingsHomeNextUpCutoffScreen()
 	},
 	Routes.LIVETV_GUIDE_FILTERS to {
 		SettingsLiveTvGuideFiltersScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeNextUpCutoffScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeNextUpCutoffScreen.kt
@@ -1,0 +1,62 @@
+package org.jellyfin.androidtv.ui.settings.screen.home
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.jellyfin.androidtv.util.getQuantityString
+import org.koin.compose.koinInject
+
+@Composable
+fun getNextUpCutoffOptions(): List<Pair<Int, String>> {
+	val context = LocalContext.current
+	return buildList {
+		add(0 to stringResource(R.string.pref_max_days_in_next_up_disabled))
+		listOf(7, 14, 30, 60, 90, 180, 365).forEach { days ->
+			add(days to context.getQuantityString(R.plurals.days, days))
+		}
+	}
+}
+
+@Composable
+fun SettingsHomeNextUpCutoffScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var maxDaysInNextUp by rememberPreference(userPreferences, UserPreferences.maxDaysInNextUp)
+	val options = getNextUpCutoffOptions()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.home_prefs).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_max_days_in_next_up)) },
+			)
+		}
+
+		items(options) { (days, label) ->
+			ListButton(
+				headingContent = { Text(label) },
+				trailingContent = { RadioButton(checked = maxDaysInNextUp == days) },
+				onClick = {
+					maxDaysInNextUp = days
+					router.back()
+				},
+				modifier = Modifier
+					.focusKey("cutoff_$days", initialFocus = maxDaysInNextUp == days)
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/home/SettingsHomeScreen.kt
@@ -2,9 +2,11 @@ package org.jellyfin.androidtv.ui.settings.screen.home
 
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.preference.UserSettingPreferences
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
@@ -12,12 +14,14 @@ import org.jellyfin.androidtv.ui.base.list.ListSection
 import org.jellyfin.androidtv.ui.navigation.LocalRouter
 import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
 
 @Composable
 fun SettingsHomeScreen() {
 	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
 	val userSettingPreferences = koinInject<UserSettingPreferences>()
 
 	SettingsColumn {
@@ -34,6 +38,26 @@ fun SettingsHomeScreen() {
 				captionContent = { Text(stringResource(userSettingPreferences[section].nameRes)) },
 				onClick = { router.push(Routes.HOME_SECTION, mapOf("index" to index.toString())) },
 				modifier = Modifier.focusKey("home_section_$index")
+			)
+		}
+
+		item {
+			ListSection(
+				headingContent = { Text(stringResource(R.string.lbl_next_up)) },
+			)
+		}
+
+		item {
+			val maxDaysInNextUp by rememberPreference(userPreferences, UserPreferences.maxDaysInNextUp)
+			val options = getNextUpCutoffOptions()
+			val selectedCaption = options.firstOrNull { it.first == maxDaysInNextUp }?.second
+				?: stringResource(R.string.pref_max_days_in_next_up_disabled)
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_max_days_in_next_up)) },
+				captionContent = { Text(selectedCaption) },
+				onClick = { router.push(Routes.HOME_NEXT_UP_CUTOFF) },
+				modifier = Modifier.focusKey(Routes.HOME_NEXT_UP_CUTOFF)
 			)
 		}
 	}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,6 +431,8 @@
     <string name="home_section_livetv">Live TV</string>
     <string name="home_section_none">None</string>
     <string name="home_section_i">Home section %1$d</string>
+    <string name="pref_max_days_in_next_up">Next up date cutoff</string>
+    <string name="pref_max_days_in_next_up_disabled">Disabled</string>
     <string name="searchable_hint">Search Jellyfin</string>
     <string name="searchable_settings_description">Media</string>
     <string name="pref_subtitles_background_title">Enable background</string>
@@ -645,6 +647,10 @@
     <plurals name="hours">
         <item quantity="one">%1$s hour</item>
         <item quantity="other">%1$s hours</item>
+    </plurals>
+    <plurals name="days">
+        <item quantity="one">%1$s day</item>
+        <item quantity="other">%1$s days</item>
     </plurals>
     <plurals name="tracks">
         <item quantity="one">%1$s track</item>


### PR DESCRIPTION
**Changes**
Adds a user preference under Home settings to filter the home Next Up row using the server's built-in `nextUpDateCutoff` parameter. Users can select from 7, 14, 30, 60, 90, 180, or 365 days, or disable the cutoff.
**Code assistance**
Code drafted and adapted to upstream Compose settings architecture with assistance from an LLM coding assistant; verified with Detekt and unit tests.
**Issues**
Fixes #2406 #4772

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8cc4bf06-160e-470b-b275-e3f0d806bbc0" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/48898981-ae16-4dae-b24b-83ee1bb071af" />
