### PR TITLE
feat(playback): add skip button duration preference

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -262,6 +262,12 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		)
 
 		/**
+		 * The duration in seconds to wait before automatically hiding the "ask to skip" UI.
+		 * 0 = never auto-hide (stay until segment ends).
+		 */
+		var mediaSegmentAutoHideDuration = intPreference("media_segment_auto_hide_duration", 8)
+
+		/**
 		 * Preferred behavior for player aspect ratio (zoom mode).
 		 */
 		var playerZoomMode = enumPreference("player_zoom_mode", ZoomMode.FIT)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/overlay/SkipOverlayView.kt
@@ -30,11 +30,15 @@ import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.Icon
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun SkipOverlayComposable(
@@ -73,7 +77,8 @@ class SkipOverlayView @JvmOverloads constructor(
 	context: Context,
 	attrs: AttributeSet? = null,
 	defStyle: Int = 0
-) : AbstractComposeView(context, attrs, defStyle) {
+) : AbstractComposeView(context, attrs, defStyle), KoinComponent {
+	private val userPreferences by inject<UserPreferences>()
 	private val _currentPosition = MutableStateFlow(Duration.ZERO)
 	private val _targetPosition = MutableStateFlow<Duration?>(null)
 	private val _skipUiEnabled = MutableStateFlow(true)
@@ -129,8 +134,13 @@ class SkipOverlayView @JvmOverloads constructor(
 
 		// Auto hide
 		LaunchedEffect(skipUiEnabled, targetPosition) {
-			delay(MediaSegmentRepository.AskToSkipAutoHideDuration)
-			_targetPosition.value = null
+			if (targetPosition != null) {
+				val autoHideSeconds = userPreferences[UserPreferences.mediaSegmentAutoHideDuration]
+				if (autoHideSeconds > 0) {
+					delay(autoHideSeconds.seconds)
+					_targetPosition.value = null
+				}
+			}
 		}
 
 		SkipOverlayComposable(visible)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/routes.kt
@@ -49,6 +49,7 @@ import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackRefres
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackResumeSubtractDurationScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.SettingsPlaybackZoomModeScreen
+import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentAutoHideDurationScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment.SettingsPlaybackMediaSegmentsScreen
 import org.jellyfin.androidtv.ui.settings.screen.playback.nextup.SettingsPlaybackNextUpBehaviorScreen
@@ -98,6 +99,7 @@ object Routes {
 	const val PLAYBACK_PREROLLS = "/playback/prerolls"
 	const val PLAYBACK_MEDIA_SEGMENTS = "/playback/media-segments"
 	const val PLAYBACK_MEDIA_SEGMENT = "/playback/media-segments/{segmentType}"
+	const val PLAYBACK_MEDIA_SEGMENT_AUTO_HIDE_DURATION = "/playback/media-segments/duration"
 	const val PLAYBACK_ADVANCED = "/playback/advanced"
 	const val PLAYBACK_RESUME_SUBTRACT_DURATION = "/playback/resume-subtract-duration"
 	const val PLAYBACK_MAX_BITRATE = "/playback/max-bitrate"
@@ -244,6 +246,9 @@ val routes = mapOf<String, RouteComposable>(
 		SettingsPlaybackMediaSegmentScreen(
 			segmentType = context.parameters["segmentType"]?.let(MediaSegmentType::fromNameOrNull)!!,
 		)
+	},
+	Routes.PLAYBACK_MEDIA_SEGMENT_AUTO_HIDE_DURATION to {
+		SettingsPlaybackMediaSegmentAutoHideDurationScreen()
 	},
 	Routes.PLAYBACK_ADVANCED to {
 		SettingsPlaybackAdvancedScreen()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentAutoHideDurationScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentAutoHideDurationScreen.kt
@@ -1,0 +1,49 @@
+package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.form.RadioButton
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListSection
+import org.jellyfin.androidtv.ui.navigation.LocalRouter
+import org.jellyfin.androidtv.ui.navigation.focus.focusKey
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
+import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingsPlaybackMediaSegmentAutoHideDurationScreen() {
+	val router = LocalRouter.current
+	val userPreferences = koinInject<UserPreferences>()
+	var autoHideDuration by rememberPreference(userPreferences, UserPreferences.mediaSegmentAutoHideDuration)
+	val options = getMediaSegmentAutoHideDurationOptions()
+
+	SettingsColumn {
+		item {
+			ListSection(
+				overlineContent = { Text(stringResource(R.string.pref_playback_media_segments).uppercase()) },
+				headingContent = { Text(stringResource(R.string.pref_skip_button_duration)) },
+			)
+		}
+
+		items(options.toList()) { (duration, label) ->
+			ListButton(
+				headingContent = { Text(label) },
+				trailingContent = { RadioButton(checked = autoHideDuration == duration) },
+				onClick = {
+					autoHideDuration = duration
+					router.back()
+				},
+				modifier = Modifier
+					.focusKey("media_segment_auto_hide_duration_$duration", initialFocus = autoHideDuration == duration)
+			)
+		}
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentsScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/SettingsPlaybackMediaSegmentsScreen.kt
@@ -2,9 +2,11 @@ package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
 
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
 import org.jellyfin.androidtv.ui.base.list.ListSection
@@ -12,6 +14,7 @@ import org.jellyfin.androidtv.ui.navigation.LocalRouter
 import org.jellyfin.androidtv.ui.navigation.focus.focusKey
 import org.jellyfin.androidtv.ui.playback.segment.MediaSegmentRepository
 import org.jellyfin.androidtv.ui.settings.Routes
+import org.jellyfin.androidtv.ui.settings.compat.rememberPreference
 import org.jellyfin.androidtv.ui.settings.composable.SettingsColumn
 import org.koin.compose.koinInject
 
@@ -19,6 +22,7 @@ import org.koin.compose.koinInject
 fun SettingsPlaybackMediaSegmentsScreen() {
 	val router = LocalRouter.current
 	val mediaSegmentRepository = koinInject<MediaSegmentRepository>()
+	val userPreferences = koinInject<UserPreferences>()
 
 	SettingsColumn {
 		item {
@@ -43,6 +47,18 @@ fun SettingsPlaybackMediaSegmentsScreen() {
 					)
 				},
 				modifier = Modifier.focusKey("media_segment_type_$segmentType")
+			)
+		}
+
+		item {
+			val autoHideDuration by rememberPreference(userPreferences, UserPreferences.mediaSegmentAutoHideDuration)
+			val options = getMediaSegmentAutoHideDurationOptions()
+
+			ListButton(
+				headingContent = { Text(stringResource(R.string.pref_skip_button_duration)) },
+				captionContent = { Text(options[autoHideDuration].orEmpty()) },
+				onClick = { router.push(Routes.PLAYBACK_MEDIA_SEGMENT_AUTO_HIDE_DURATION) },
+				modifier = Modifier.focusKey(Routes.PLAYBACK_MEDIA_SEGMENT_AUTO_HIDE_DURATION)
 			)
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/strings.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/playback/mediasegment/strings.kt
@@ -1,6 +1,11 @@
 package org.jellyfin.androidtv.ui.settings.screen.playback.mediasegment
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.util.TimeUtils
 import org.jellyfin.sdk.model.api.MediaSegmentType
 
 val MediaSegmentType.nameRes
@@ -12,3 +17,22 @@ val MediaSegmentType.nameRes
 		MediaSegmentType.OUTRO -> R.string.segment_type_outro
 		MediaSegmentType.INTRO -> R.string.segment_type_intro
 	}
+
+@Composable
+@Stable
+fun getMediaSegmentAutoHideDurationOptions(): Map<Int, String> {
+	val context = LocalContext.current
+	return listOf(
+		3,
+		5,
+		8,
+		10,
+		15,
+		20,
+		30,
+		0,
+	).associateWith { seconds ->
+		if (seconds == 0) stringResource(R.string.pref_skip_button_until_segment_ends)
+		else TimeUtils.formatSeconds(context, seconds)
+	}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,6 +565,8 @@
     <string name="segment_type_preview">Previews</string>
     <string name="segment_type_recap">Recaps</string>
     <string name="segment_type_unknown">Unknown segments</string>
+    <string name="pref_skip_button_duration">Skip button duration</string>
+    <string name="pref_skip_button_until_segment_ends">Until segment ends</string>
     <string name="skip_forward_length">Skip forward length</string>
     <string name="preference_enable_trickplay">Enable trickplay in video player</string>
     <string name="pref_subtitles_background_opacity">Subtitle background opacity</string>


### PR DESCRIPTION
**Changes**
Adds a user preference under Playback > Media segments to configure the auto-hide duration of the skip button. Users can select from 3, 5, 8, 10, 15, 20, or 30 seconds, or disable auto-hiding (until segment ends).

**Code assistance**
Code drafted and adapted to upstream Compose settings architecture with assistance from an LLM coding assistant; verified with Detekt and unit tests.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d56c3ab6-ad3e-447e-8abf-3f0d0c5f6869" />

<img width="1920" height="1080" alt="skip_duration_options_screenshot" src="https://github.com/user-attachments/assets/bd673bbe-f42d-40f5-993b-6f30d870a3b0" />
