### PR TITLE
Fix Live TV guide crash when channel loading fails

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopup.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/LiveProgramDetailPopup.java
@@ -257,9 +257,11 @@ public class LiveProgramDetailPopup {
 
     public android.widget.ImageButton createFavoriteButton() {
         BaseItemDto channel = TvManager.getChannel(TvManager.getAllChannelsIndex(mProgram.getChannelId()));
-        boolean isFav = channel.getUserData() != null && channel.getUserData().isFavorite();
+        boolean isFav = channel != null && channel.getUserData() != null && channel.getUserData().isFavorite();
 
         android.widget.ImageButton fave = addImgButton(mDButtonRow, isFav ? R.drawable.ic_heart_red : R.drawable.ic_heart);
+        fave.setEnabled(channel != null);
+        if (channel == null) return fave;
         fave.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/LiveTvGuideFragment.java
@@ -532,6 +532,7 @@ public class LiveTvGuideFragment extends Fragment implements LiveTvGuide, View.O
             for (int i = start; i <= end; i++) {
                 if (isCancelled()) return null;
                 final BaseItemDto channel = TvManager.getChannel(i);
+                if (channel == null) continue;
                 List<BaseItemDto> programs = TvManager.getProgramsForChannel(channel.getId(), mFilters);
                 final LinearLayout row = getProgramRow(programs, channel.getId());
                 if (row == null) continue; // no row to show

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -31,6 +31,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class TvManager {
     }
 
     public static List<BaseItemDto> getAllChannels() {
-        return allChannels;
+        return allChannels == null ? Collections.emptyList() : allChannels;
     }
 
     public static void forceReload() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/livetv/TvManager.java
@@ -6,6 +6,7 @@ import android.text.format.DateUtils;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.leanback.widget.HeaderItem;
 import androidx.leanback.widget.ListRow;
@@ -81,8 +82,10 @@ public class TvManager {
         return -1;
     }
 
+    @Nullable
     public static BaseItemDto getChannel(int ndx) {
-        return allChannels.get(ndx);
+        List<BaseItemDto> channels = getAllChannels();
+        return ndx >= 0 && ndx < channels.size() ? channels.get(ndx) : null;
     }
 
     public static void updateLastPlayedDate(UUID channelId) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -866,6 +866,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
             for (int i = start; i <= end; i++) {
                 if (isCancelled()) return null;
                 final BaseItemDto channel = TvManager.getChannel(i);
+                if (channel == null) continue;
                 List<BaseItemDto> programs = TvManager.getProgramsForChannel(channel.getId());
                 final LinearLayout row = getProgramRow(programs, channel.getId());
                 if (first) {

--- a/app/src/test/kotlin/ui/livetv/TvManagerTests.kt
+++ b/app/src/test/kotlin/ui/livetv/TvManagerTests.kt
@@ -1,0 +1,41 @@
+package org.jellyfin.androidtv.ui.livetv
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import java.util.UUID
+
+class TvManagerTests : FunSpec({
+	val channelsField = TvManager::class.java.getDeclaredField("allChannels").apply { isAccessible = true }
+	var previousChannels: Any? = null
+
+	beforeTest {
+		previousChannels = channelsField.get(null)
+		channelsField.set(null, null)
+	}
+
+	afterTest {
+		channelsField.set(null, previousChannels)
+	}
+
+	test("missing channel cache returns an empty list and no channel") {
+		TvManager.getAllChannels() shouldBe emptyList()
+		TvManager.getChannel(0) shouldBe null
+		TvManager.getChannel(-1) shouldBe null
+	}
+
+	test("empty channel cache returns no channel") {
+		channelsField.set(null, emptyList<BaseItemDto>())
+		TvManager.getChannel(0) shouldBe null
+	}
+
+	test("cached channel lookup preserves valid channels and rejects invalid indices") {
+		val channel = BaseItemDto(id = UUID.randomUUID(), type = BaseItemKind.TV_CHANNEL)
+		channelsField.set(null, listOf(channel))
+		TvManager.getChannel(0) shouldBe channel
+		TvManager.getChannel(-1) shouldBe null
+		TvManager.getChannel(1) shouldBe null
+		TvManager.getChannel(Int.MAX_VALUE) shouldBe null
+	}
+})


### PR DESCRIPTION
**Changes**

When a Live TV channel-list request fails before any channels have been cached, `loadAllChannels()` still invokes its completion callback, but `getAllChannels()` returns null. Both the standalone guide and playback guide then call `isEmpty()` on that value and can crash with a `NullPointerException`. Return an empty list from the shared getter when no cache exists so the guides use their existing empty-state handling; a previously loaded channel list remains available after a failed refresh.

Validation: reviewed all three getter call sites and passed `git diff --check`. Attempted `./gradlew test` with Java 21, but Gradle stopped before running tests because the Android SDK is unavailable. Device regression testing has not been performed.

**Code assistance**

OpenAI Codex traced the failure path, authored the patch, and prepared this description.

**Issues**

No linked issue. Addresses a channel-list timeout followed by a null dereference in `LiveTvGuideFragment.load()`.