### PR TITLE
Merge cast & crew cards for people with multiple crew roles

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -78,6 +78,7 @@ import org.jellyfin.androidtv.util.Utils;
 import org.jellyfin.androidtv.util.apiclient.BaseItemUtils;
 import org.jellyfin.androidtv.util.apiclient.Response;
 import org.jellyfin.androidtv.util.sdk.BaseItemExtensionsKt;
+import org.jellyfin.androidtv.util.sdk.BaseItemPersonExtensionsKt;
 import org.jellyfin.androidtv.util.sdk.TrailerUtils;
 import org.jellyfin.androidtv.util.sdk.compat.JavaCompat;
 import org.jellyfin.sdk.model.api.BaseItemDto;
@@ -531,7 +532,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 //Cast/Crew
                 if (mBaseItem.getPeople() != null && !mBaseItem.getPeople().isEmpty()) {
-                    ItemRowAdapter castAdapter = new ItemRowAdapter(mBaseItem.getPeople(), requireContext(), new CardPresenter(true, 130), adapter);
+                    ItemRowAdapter castAdapter = new ItemRowAdapter(BaseItemPersonExtensionsKt.mergeCrewRoles(mBaseItem.getPeople()), requireContext(), new CardPresenter(true, 130), adapter);
                     addItemRow(adapter, castAdapter, 1, getString(R.string.lbl_cast_crew));
                 }
 
@@ -562,7 +563,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 //Cast/Crew
                 if (mBaseItem.getPeople() != null && !mBaseItem.getPeople().isEmpty()) {
-                    ItemRowAdapter castAdapter = new ItemRowAdapter(mBaseItem.getPeople(), requireContext(), new CardPresenter(true, 130), adapter);
+                    ItemRowAdapter castAdapter = new ItemRowAdapter(BaseItemPersonExtensionsKt.mergeCrewRoles(mBaseItem.getPeople()), requireContext(), new CardPresenter(true, 130), adapter);
                     addItemRow(adapter, castAdapter, 0, getString(R.string.lbl_cast_crew));
                 }
 
@@ -603,7 +604,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 addItemRow(adapter, upcomingAdapter, 2, getString(R.string.lbl_upcoming));
 
                 if (mBaseItem.getPeople() != null && !mBaseItem.getPeople().isEmpty()) {
-                    ItemRowAdapter seriesCastAdapter = new ItemRowAdapter(mBaseItem.getPeople(), requireContext(), new CardPresenter(true, 130), adapter);
+                    ItemRowAdapter seriesCastAdapter = new ItemRowAdapter(BaseItemPersonExtensionsKt.mergeCrewRoles(mBaseItem.getPeople()), requireContext(), new CardPresenter(true, 130), adapter);
                     addItemRow(adapter, seriesCastAdapter, 3, getString(R.string.lbl_cast_crew));
                 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemPersonExtensions.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/sdk/BaseItemPersonExtensions.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.androidtv.util.sdk
+
+import org.jellyfin.sdk.model.UUID
+import org.jellyfin.sdk.model.api.BaseItemPerson
+import org.jellyfin.sdk.model.api.PersonKind
+
+private const val ROLE_SEPARATOR = " / "
+
+/**
+ * The person kinds the server reports once per job, making someone credited for multiple jobs show up as
+ * multiple people.
+ */
+private val mergeableCrewKinds = setOf(
+	PersonKind.DIRECTOR,
+	PersonKind.WRITER,
+	PersonKind.PRODUCER,
+)
+
+/**
+ * Combine the credits of a person holding multiple crew jobs into a single entry listing all their roles,
+ * like "Director / Producer". Credits of a kind outside [mergeableCrewKinds] are never combined, so an actor
+ * playing multiple characters keeps one entry per character. The combined entry keeps the position of the
+ * first credit.
+ */
+fun Collection<BaseItemPerson>.mergeCrewRoles(): List<BaseItemPerson> {
+	val people = mutableListOf<BaseItemPerson>()
+	val mergedIndices = mutableMapOf<UUID, Int>()
+
+	for (person in this) {
+		val mergeable = person.type in mergeableCrewKinds
+		val index = if (mergeable) mergedIndices[person.id] else null
+
+		if (index == null) {
+			if (mergeable) mergedIndices[person.id] = people.size
+			people += person
+		} else {
+			people[index] = people[index].withAdditionalRole(person.role)
+		}
+	}
+
+	return people
+}
+
+private fun BaseItemPerson.withAdditionalRole(additionalRole: String?) = copy(
+	role = listOfNotNull(role, additionalRole)
+		.filter(String::isNotBlank)
+		.distinct()
+		.joinToString(ROLE_SEPARATOR)
+		.ifEmpty { null }
+)

--- a/app/src/test/kotlin/util/sdk/BaseItemPersonExtensionsTests.kt
+++ b/app/src/test/kotlin/util/sdk/BaseItemPersonExtensionsTests.kt
@@ -1,0 +1,90 @@
+package org.jellyfin.androidtv.util.sdk
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jellyfin.sdk.model.api.BaseItemPerson
+import org.jellyfin.sdk.model.api.PersonKind
+import java.util.UUID
+
+private fun person(
+	id: UUID,
+	type: PersonKind,
+	role: String?,
+) = BaseItemPerson(
+	id = id,
+	name = "Person $id",
+	type = type,
+	role = role,
+)
+
+class BaseItemPersonExtensionsTests : FunSpec({
+	val personId = UUID.randomUUID()
+	val otherPersonId = UUID.randomUUID()
+
+	test("mergeCrewRoles() combines the crew jobs of a single person") {
+		val people = listOf(
+			person(personId, PersonKind.DIRECTOR, "Director"),
+			person(personId, PersonKind.PRODUCER, "Producer"),
+		).mergeCrewRoles()
+
+		people.size shouldBe 1
+		people[0].role shouldBe "Director / Producer"
+		people[0].type shouldBe PersonKind.DIRECTOR
+	}
+
+	test("mergeCrewRoles() keeps different people separate") {
+		val people = listOf(
+			person(personId, PersonKind.DIRECTOR, "Director"),
+			person(otherPersonId, PersonKind.PRODUCER, "Producer"),
+		).mergeCrewRoles()
+
+		people.size shouldBe 2
+		people[0].role shouldBe "Director"
+		people[1].role shouldBe "Producer"
+	}
+
+	test("mergeCrewRoles() keeps a credit per character for actors") {
+		val people = listOf(
+			person(personId, PersonKind.ACTOR, "Ana"),
+			person(personId, PersonKind.ACTOR, "Ana's twin"),
+		).mergeCrewRoles()
+
+		people.size shouldBe 2
+	}
+
+	test("mergeCrewRoles() keeps the position of the first credit") {
+		val people = listOf(
+			person(otherPersonId, PersonKind.ACTOR, "Ana"),
+			person(personId, PersonKind.DIRECTOR, "Director"),
+			person(otherPersonId, PersonKind.WRITER, "Screenplay"),
+			person(personId, PersonKind.PRODUCER, "Producer"),
+		).mergeCrewRoles()
+
+		people.size shouldBe 3
+		people[1].role shouldBe "Director / Producer"
+		people[2].role shouldBe "Screenplay"
+	}
+
+	test("mergeCrewRoles() lists a repeated job once") {
+		val people = listOf(
+			person(personId, PersonKind.WRITER, "Writer"),
+			person(personId, PersonKind.WRITER, "Writer"),
+		).mergeCrewRoles()
+
+		people.size shouldBe 1
+		people[0].role shouldBe "Writer"
+	}
+
+	test("mergeCrewRoles() ignores missing job names") {
+		val people = listOf(
+			person(personId, PersonKind.DIRECTOR, null),
+			person(personId, PersonKind.PRODUCER, "Producer"),
+			person(otherPersonId, PersonKind.WRITER, null),
+			person(otherPersonId, PersonKind.PRODUCER, null),
+		).mergeCrewRoles()
+
+		people.size shouldBe 2
+		people[0].role shouldBe "Producer"
+		people[1].role shouldBe null
+	}
+})


### PR DESCRIPTION
**Changes**

The server sends one `People` entry per credit, so a person credited for several crew jobs on the same item gets one card each — a director who also produced appears twice in the cast & crew row, same photo, different subtitle. This merges the director, writer and producer credits belonging to the same person into a single card listing every role, e.g. "Director / Producer". Actors are deliberately left alone, so someone playing two characters still gets a card per character.

It mirrors what jellyfin-web has done since https://github.com/jellyfin/jellyfin-web/pull/8209 (shipped in 12.0), keeping the same merged kinds — director, writer, producer, which is also what the server keeps in `TmdbUtils.WantedCrewKinds` — and the same `" / "` separator.

Merging lives in a new `Collection<BaseItemPerson>.mergeCrewRoles()` extension, applied to the three cast & crew rows in `FullDetailsFragment` (movie, trailer, series). Episode guest stars are untouched, as guest stars are never merged. Unit tests cover the merge, the actor exemption, ordering, repeated jobs and missing job names.

One thing worth a maintainer's opinion: with three or more roles the subtitle truncates at the card width, e.g. Edgar Wright on *Scott Pilgrim vs. the World* renders as "Director / Screenpl…". Two roles fit comfortably. I kept the `" / "` join to stay consistent with the web client, but I'm happy to change the separator or fall back to the person kinds if you'd prefer.

**Code assistance**

Written with Claude Code using the Opus 5 model. It audited which clients were missing the behavior, wrote the extension, the call-site changes and the unit tests, ran the build, unit tests and detekt, and verified the result on an Android TV emulator (Android 16, x86_64) against a Jellyfin 12.0 server. I reviewed the change myself.

I only reproduced the duplicate cards on Android TV, but the same gap exists in Swiftfin, jellyfin-roku and jellyfin-vue, so I'm opening the equivalent PR against each of those as well rather than leaving the fix partial across clients.

**Issues**

N/A — no existing issue. Follows up on https://github.com/jellyfin/jellyfin-web/pull/8209.
