### PR TITLE
Use strong reference to licenses resource

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicenseScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicenseScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.util.withContext
+import com.mikepenz.aboutlibraries.util.withJson
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
@@ -24,6 +25,7 @@ fun SettingsLicenseScreen(artifactId: String) {
 
 	val library = remember(context, artifactId) {
 		val libs = Libs.Builder()
+			.withJson(context, R.raw.aboutlibraries)
 			.withContext(context)
 			.build()
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicensesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/settings/screen/license/SettingsLicensesScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.mikepenz.aboutlibraries.Libs
-import com.mikepenz.aboutlibraries.util.withContext
+import com.mikepenz.aboutlibraries.util.withJson
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.ui.base.Text
 import org.jellyfin.androidtv.ui.base.list.ListButton
@@ -24,7 +24,7 @@ fun SettingsLicensesScreen() {
 
 	val libraries = remember(context) {
 		val libs = Libs.Builder()
-			.withContext(context)
+			.withJson(context, R.raw.aboutlibraries)
 			.build()
 
 		libs.libraries.sortedBy { it.name.lowercase() }


### PR DESCRIPTION
**Changes**

Use a strong reference to the aboutlicenses resource. This fixes a crash on release builds where the licenses file (a raw json in the Android resources) would get optimized out by AGP.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Reported via comment in 0.20 release plan discussion