### PR TITLE
Add SyncPlay group playback to Android TV

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/AuthenticationRepository.kt
@@ -47,7 +47,7 @@ import java.time.Instant
  */
 interface AuthenticationRepository {
 	fun authenticate(server: Server, method: AuthenticateMethod): Flow<LoginState>
-	fun logout(user: User): Boolean
+	suspend fun logout(user: User): Boolean
 	fun getUserImageUrl(server: Server, user: User): String?
 }
 
@@ -194,7 +194,12 @@ class AuthenticationRepositoryImpl(
 		return authenticated
 	}
 
-	override fun logout(user: User): Boolean {
+	override suspend fun logout(user: User): Boolean {
+		val session = sessionRepository.currentSession.value
+		if (session?.userId == user.id && session.serverId == user.serverId) {
+			sessionRepository.destroyCurrentSession(expectedSession = session)
+		}
+
 		val authStoreUser = authenticationStore
 			.getUser(user.serverId, user.id)
 			?.copy(accessToken = null)

--- a/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/auth/repository/SessionRepository.kt
@@ -44,10 +44,11 @@ interface SessionRepository {
 
 	suspend fun restoreSession(destroyOnly: Boolean)
 	suspend fun switchCurrentSession(serverId: UUID, userId: UUID): Boolean
-	fun destroyCurrentSession()
+	suspend fun destroyCurrentSession(expectedSession: Session? = null)
 }
 
-class SessionRepositoryImpl(
+// Session dependencies and the teardown hook are supplied together by dependency injection.
+class SessionRepositoryImpl @Suppress("LongParameterList") constructor(
 	private val authenticationPreferences: AuthenticationPreferences,
 	private val authenticationStore: AuthenticationStore,
 	private val userApiClient: ApiClient,
@@ -56,6 +57,7 @@ class SessionRepositoryImpl(
 	private val userRepository: UserRepository,
 	private val serverRepository: ServerRepository,
 	private val telemetryPreferences: TelemetryPreferences,
+	private val onSessionEnding: suspend () -> Unit,
 ) : SessionRepository {
 	private val currentSessionMutex = Mutex()
 	private val _currentSession = MutableStateFlow<Session?>(null)
@@ -73,8 +75,8 @@ class SessionRepositoryImpl(
 			val autoLoginBehavior = authenticationPreferences[AuthenticationPreferences.autoLoginUserBehavior]
 
 			when {
-				alwaysAuthenticate -> destroyCurrentSession()
-				autoLoginBehavior == DISABLED -> destroyCurrentSession()
+				alwaysAuthenticate -> clearCurrentSession()
+				autoLoginBehavior == DISABLED -> clearCurrentSession()
 				autoLoginBehavior == LAST_USER && !destroyOnly -> setCurrentSession(createLastUserSession())
 				autoLoginBehavior == SPECIFIC_USER && !destroyOnly -> {
 					val serverId = authenticationPreferences[AuthenticationPreferences.autoLoginServerId].toUUIDOrNull()
@@ -87,31 +89,40 @@ class SessionRepositoryImpl(
 		}
 	}
 
-	override suspend fun switchCurrentSession(serverId: UUID, userId: UUID): Boolean {
+	override suspend fun switchCurrentSession(serverId: UUID, userId: UUID): Boolean = currentSessionMutex.withLock {
 		// No change in user - don't switch
-		if (currentSession.value?.userId == userId) {
+		if (currentSession.value?.userId == userId && currentSession.value?.serverId == serverId) {
 			Timber.d("Current session user is the same as the requested user")
-			return false
+			return@withLock false
 		}
 
 		_state.value = SessionRepositoryState.SWITCHING_SESSION
 		Timber.i("Switching current session to user $userId")
 
-		val session = createUserSession(serverId, userId)
-		if (session == null) {
-			Timber.w("Could not switch to non-existing session for user $userId")
-			_state.value = SessionRepositoryState.READY
-			return false
-		}
+		try {
+			val session = createUserSession(serverId, userId)
+			if (session == null) {
+				Timber.w("Could not switch to non-existing session for user $userId")
+				return@withLock false
+			}
 
-		val switched = setCurrentSession(session)
-		_state.value = SessionRepositoryState.READY
-		return switched
+			setCurrentSession(session)
+		} finally {
+			_state.value = SessionRepositoryState.READY
+		}
 	}
 
-	override fun destroyCurrentSession() {
+	override suspend fun destroyCurrentSession(expectedSession: Session?) = withContext(NonCancellable) {
+		currentSessionMutex.withLock {
+			if (expectedSession == null || _currentSession.value == expectedSession) clearCurrentSession()
+		}
+	}
+
+	private suspend fun clearCurrentSession() {
 		Timber.i("Destroying current session")
 
+		if (_currentSession.value != null) withContext(NonCancellable) { onSessionEnding() }
+		userApiClient.applySession(null)
 		userRepository.setCurrentUser(null)
 		serverRepository.setCurrentServer(null)
 		_currentSession.value = null
@@ -123,7 +134,7 @@ class SessionRepositoryImpl(
 
 		if (session != null) {
 			// No change in session - don't switch
-			if (currentSession.value?.userId == session.userId) return true
+			if (currentSession.value?.userId == session.userId && currentSession.value?.serverId == session.serverId) return true
 
 			// Update last active user
 			authenticationPreferences[AuthenticationPreferences.lastServerId] = session.serverId.toString()
@@ -133,6 +144,9 @@ class SessionRepositoryImpl(
 			server = serverRepository.getServer(session.serverId, true)
 			if (server == null || !server.versionSupported) return false
 		}
+
+		// Leave any playback group while the API still belongs to the outgoing session.
+		if (_currentSession.value != null) withContext(NonCancellable) { onSessionEnding() }
 
 		// Update session after binding the apiclient settings
 		val deviceInfo = session?.let { defaultDeviceInfo.forUser(it.userId) } ?: defaultDeviceInfo
@@ -148,7 +162,7 @@ class SessionRepositoryImpl(
 				serverRepository.setCurrentServer(server)
 			} catch (err: ApiClientException) {
 				Timber.e(err, "Unable to authenticate: bad response when getting user info")
-				destroyCurrentSession()
+				clearCurrentSession()
 				return false
 			}
 

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -62,6 +62,7 @@ import org.jellyfin.androidtv.util.apiclient.ReportingHelper
 import org.jellyfin.androidtv.util.coil.CoilTimberLogger
 import org.jellyfin.androidtv.util.coil.createCoilConnectivityChecker
 import org.jellyfin.androidtv.util.sdk.SdkPlaybackHelper
+import org.jellyfin.playback.jellyfin.network.ReliableApiClientFactory
 import org.jellyfin.sdk.android.androidDevice
 import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.api.okhttp.OkHttpFactory
@@ -97,7 +98,7 @@ val appModule = module {
 			minimumServerVersion = ServerRepository.minimumServerVersion
 
 			// Use our own shared factory instance
-			apiClientFactory = get<OkHttpFactory>()
+			apiClientFactory = ReliableApiClientFactory(get())
 			socketConnectionFactory = get<OkHttpFactory>()
 		}
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AuthModule.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.androidtv.di
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.auth.repository.AuthenticationRepository
 import org.jellyfin.androidtv.auth.repository.AuthenticationRepositoryImpl
 import org.jellyfin.androidtv.auth.repository.ServerRepository
@@ -10,6 +12,8 @@ import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.SessionRepositoryImpl
 import org.jellyfin.androidtv.auth.store.AuthenticationPreferences
 import org.jellyfin.androidtv.auth.store.AuthenticationStore
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
 import org.koin.dsl.module
 
 val authModule = module {
@@ -22,7 +26,11 @@ val authModule = module {
 	single<ServerRepository> { ServerRepositoryImpl(get(), get()) }
 	single<ServerUserRepository> { ServerUserRepositoryImpl(get(), get()) }
 	single<SessionRepository> {
-		SessionRepositoryImpl(get(), get(), get(), get(), get(defaultDeviceInfo), get(), get(), get())
+		SessionRepositoryImpl(get(), get(), get(), get(), get(defaultDeviceInfo), get(), get(), get()) {
+			withContext(Dispatchers.Main.immediate) {
+				get<PlaybackManager>().getService<SyncPlayService>()?.endSession()
+			}
+		}
 	}
 
 	factory {

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -40,7 +40,7 @@ val playbackModule = module {
 	single { VideoQueueManager() }
 	single<MediaManager> { RewriteMediaManager(get(), get()) }
 
-	single { PlaybackLauncher(get(), get(), get(), get()) }
+	single { PlaybackLauncher(get(), get(), get(), get(), get()) }
 
 	single<HttpDataSource.Factory> {
 		val okHttpFactory = get<OkHttpFactory>()

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/MainActivity.kt
@@ -13,10 +13,17 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
 import org.jellyfin.androidtv.integration.LeanbackChannelWorker
@@ -25,11 +32,19 @@ import org.jellyfin.androidtv.ui.background.AppBackground
 import org.jellyfin.androidtv.ui.base.JellyfinTheme
 import org.jellyfin.androidtv.ui.base.ProvideLocalInteractionTracker
 import org.jellyfin.androidtv.ui.composable.compat.AppNavigationHost
+import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.androidtv.ui.playback.AudioNowPlayingFragment
+import org.jellyfin.androidtv.ui.player.video.VideoPlayerFragment
 import org.jellyfin.androidtv.ui.screensaver.InAppScreensaver
 import org.jellyfin.androidtv.ui.settings.compat.MainActivitySettings
 import org.jellyfin.androidtv.ui.startup.StartupActivity
 import org.jellyfin.androidtv.util.applyTheme
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
+import org.jellyfin.sdk.model.api.MediaType
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
@@ -40,6 +55,7 @@ class MainActivity : FragmentActivity() {
 	private val userRepository by inject<UserRepository>()
 	private val interactionTrackerViewModel by viewModel<InteractionTrackerViewModel>()
 	private val workManager by inject<WorkManager>()
+	private val playbackManager by inject<PlaybackManager>()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		applyTheme()
@@ -55,6 +71,14 @@ class MainActivity : FragmentActivity() {
 			}.launchIn(lifecycleScope)
 
 		if (savedInstanceState == null && navigationRepository.canGoBack) navigationRepository.reset(clearHistory = true)
+
+		sessionRepository.currentSession
+			.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+			.filter { it == null }
+			.onEach { validateAuthentication() }
+			.launchIn(lifecycleScope)
+
+		observeSyncPlayNavigation()
 
 		navigationRepository.currentAction
 			.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
@@ -78,6 +102,27 @@ class MainActivity : FragmentActivity() {
 		}
 	}
 
+	private fun observeSyncPlayNavigation() {
+		val service = playbackManager.getService<SyncPlayService>() ?: return
+		combine(service.group, playbackManager.queue.entry) { group, entry ->
+			if (group != null && service.isGroupEntry(entry)) group.groupId to entry?.baseItem?.mediaType
+			else null
+		}
+			.distinctUntilChanged()
+			.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+			.onEach { playback ->
+				val destination = when (playback?.second) {
+					MediaType.VIDEO -> Destinations.videoPlayerNew(null)
+					MediaType.AUDIO -> Destinations.nowPlaying
+					else -> return@onEach
+				}
+				val currentFragment = supportFragmentManager.findFragmentById(R.id.container)
+				if (currentFragment?.let { destination.fragment.isInstance(it) } == true) return@onEach
+				val switchingPlayer = currentFragment is VideoPlayerFragment || currentFragment is AudioNowPlayingFragment
+				navigationRepository.navigate(destination, replace = switchingPlayer)
+			}.launchIn(lifecycleScope)
+	}
+
 	override fun onResume() {
 		super.onResume()
 
@@ -89,6 +134,7 @@ class MainActivity : FragmentActivity() {
 	}
 
 	private fun validateAuthentication(): Boolean {
+		if (isFinishing) return false
 		if (sessionRepository.currentSession.value == null || userRepository.currentUser.value == null) {
 			Timber.w("Activity ${this::class.qualifiedName} started without a session, bouncing to StartupActivity")
 			startActivity(Intent(this, StartupActivity::class.java))
@@ -110,9 +156,18 @@ class MainActivity : FragmentActivity() {
 
 		workManager.enqueue(OneTimeWorkRequestBuilder<LeanbackChannelWorker>().build())
 
-		lifecycleScope.launch(Dispatchers.IO) {
-			Timber.i("MainActivity stopped")
-			sessionRepository.restoreSession(destroyOnly = true)
+		lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+			withContext(NonCancellable) {
+				Timber.i("MainActivity stopped")
+				val syncPlay = playbackManager.getService<SyncPlayService>()
+				if (syncPlay?.active == true) {
+					if (isChangingConfigurations) return@withContext
+					syncPlay.endSession()
+				}
+				if (!lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+					withContext(Dispatchers.IO) { sessionRepository.restoreSession(destroyOnly = true) }
+				}
+			}
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackLauncher.kt
@@ -1,10 +1,17 @@
 package org.jellyfin.androidtv.ui.playback
 
 import android.content.Context
+import android.content.ContextWrapper
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.preference.UserPreferences
 import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaType
@@ -19,6 +26,7 @@ class PlaybackLauncher(
 	private val videoQueueManager: VideoQueueManager,
 	private val navigationRepository: NavigationRepository,
 	private val userPreferences: UserPreferences,
+	private val playbackManager: PlaybackManager,
 ) {
 	private val BaseItemDto.supportsExternalPlayer
 		get() = when (type) {
@@ -44,6 +52,20 @@ class PlaybackLauncher(
 		itemsPosition: Int = 0,
 		shuffle: Boolean = false,
 	) {
+		val syncPlay = playbackManager.getService<SyncPlayService>()
+		if (syncPlay?.group?.value != null) {
+			val groupItems = if (shuffle) items.shuffled() else items
+			if (groupItems.isEmpty()) return
+			val scope = generateSequence(context) { (it as? ContextWrapper)?.baseContext }
+				.filterIsInstance<LifecycleOwner>()
+				.firstOrNull()
+				?.lifecycleScope ?: ProcessLifecycleOwner.get().lifecycleScope
+			scope.launch {
+				syncPlay.playItems(groupItems.map { it.id }, itemsPosition, position?.milliseconds ?: Duration.ZERO)
+			}
+			return
+		}
+
 		val isAudio = items.any { it.mediaType == MediaType.AUDIO }
 
 		if (isAudio) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/rewrite/RewriteMediaManager.kt
@@ -23,8 +23,11 @@ import org.jellyfin.playback.core.queue.queue
 import org.jellyfin.playback.core.queue.supplier.QueueSupplier
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.createBaseItemQueueEntry
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.GroupRepeatMode
+import org.jellyfin.sdk.model.api.GroupShuffleMode
 import org.jellyfin.sdk.model.api.MediaType
 
 @Suppress("TooManyFunctions")
@@ -32,6 +35,8 @@ class RewriteMediaManager(
 	private val api: ApiClient,
 	private val playbackManager: PlaybackManager,
 ) : MediaManager {
+	private val syncPlay get() = playbackManager.getService<SyncPlayService>()?.takeIf { it.group.value != null }
+
 	override fun hasAudioQueueItems(): Boolean = playbackManager.queue.estimatedSize > 0 && currentAudioItem != null
 
 	override val currentAudioQueueSize: Int
@@ -54,20 +59,21 @@ class RewriteMediaManager(
 			?.takeIf { it.mediaType == MediaType.AUDIO }
 
 	override fun toggleRepeat(): Boolean {
-		val newMode = when (playbackManager.state.repeatMode.value) {
-			RepeatMode.NONE -> RepeatMode.REPEAT_ENTRY_INFINITE
-			else -> RepeatMode.NONE
-		}
+		val newMode = if (isRepeatMode) RepeatMode.NONE else RepeatMode.REPEAT_ENTRY_INFINITE
 		playbackManager.state.setRepeatMode(newMode)
 
 		return isRepeatMode
 	}
 
-	override val isRepeatMode get() = playbackManager.state.repeatMode.value != RepeatMode.NONE
+	override val isRepeatMode get() = syncPlay?.let {
+		it.queueState.value?.repeatMode?.let { mode -> mode != GroupRepeatMode.REPEAT_NONE } ?: false
+	} ?: (playbackManager.state.repeatMode.value != RepeatMode.NONE)
 
 	override val isAudioPlayerInitialized: Boolean = true
 	override val isShuffleMode: Boolean
-		get() = playbackManager.state.playbackOrder.value != PlaybackOrder.DEFAULT
+		get() = syncPlay?.let {
+			it.queueState.value?.shuffleMode == GroupShuffleMode.SHUFFLE
+		} ?: (playbackManager.state.playbackOrder.value != PlaybackOrder.DEFAULT)
 
 	private val audioListeners = mutableListOf<AudioEventListener>()
 	private var audioListenersJob: Job? = null
@@ -114,6 +120,9 @@ class RewriteMediaManager(
 
 		playbackManager.queue.entry.onEach { notifyListeners { onQueueReplaced() } }.launchIn(this)
 		playbackManager.state.playbackOrder.onEach { notifyListeners { onQueueReplaced() } }.launchIn(this)
+		playbackManager.getService<SyncPlayService>()?.queueState?.onEach {
+			notifyListeners { onQueueStatusChanged(hasAudioQueueItems()) }
+		}?.launchIn(this)
 	}
 
 	private fun notifyListeners(body: AudioEventListener.() -> Unit) {
@@ -141,6 +150,10 @@ class RewriteMediaManager(
 
 	override fun addToAudioQueue(items: List<BaseItemDto>) {
 		if (items.isEmpty()) return
+		syncPlay?.let {
+			it.queueItems(items.map { item -> item.id })
+			return
+		}
 
 		playbackManager.queue.addSupplier(BaseItemQueueSupplier(api, items, true))
 		playbackManager.state.setPlaybackOrder(if (isShuffleMode) PlaybackOrder.SHUFFLE else PlaybackOrder.DEFAULT)
@@ -173,10 +186,7 @@ class RewriteMediaManager(
 	}
 
 	override fun shuffleAudioQueue() {
-		val newMode = when (playbackManager.state.playbackOrder.value) {
-			PlaybackOrder.DEFAULT -> PlaybackOrder.SHUFFLE
-			else -> PlaybackOrder.DEFAULT
-		}
+		val newMode = if (isShuffleMode) PlaybackOrder.DEFAULT else PlaybackOrder.SHUFFLE
 
 		playbackManager.state.setPlaybackOrder(newMode)
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerOverlayLayout.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/base/PlayerOverlayLayout.kt
@@ -22,7 +22,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -42,6 +44,15 @@ import timber.log.Timber
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+private val overlayNavigationKeys = setOf(
+	Key.DirectionUp,
+	Key.DirectionDown,
+	Key.DirectionLeft,
+	Key.DirectionRight,
+	Key.DirectionCenter,
+	Key.Enter,
+)
+
 @Composable
 fun PlayerOverlayLayout(
 	modifier: Modifier = Modifier,
@@ -51,7 +62,6 @@ fun PlayerOverlayLayout(
 ) = Box(
 	modifier = modifier
 		.fillMaxSize()
-		.focusable()
 		.onPreviewKeyEvent {
 			// Reset hide timer on key presses
 			if (visibilityState.visible) visibilityState.show()
@@ -62,13 +72,15 @@ fun PlayerOverlayLayout(
 			if (it.key == Key.Back && visibilityState.visible) {
 				visibilityState.hide()
 				true
-			} else if (!it.nativeKeyEvent.isSystem && !visibilityState.visible) {
+			} else if (!visibilityState.visible && (it.key in overlayNavigationKeys || !it.nativeKeyEvent.isSystem)) {
 				visibilityState.show()
 				true
 			} else {
 				false
 			}
 		}
+		.focusRequester(rememberPlayerOverlayFocusRequester(visibilityState.visible))
+		.focusable()
 ) {
 	if (header != null) {
 		AnimatedVisibility(
@@ -148,6 +160,16 @@ fun PlayerOverlayLayout(
 			}
 		}
 	}
+}
+
+@Composable
+private fun rememberPlayerOverlayFocusRequester(visible: Boolean): FocusRequester {
+	val focusRequester = remember { FocusRequester() }
+	LaunchedEffect(visible) {
+		// Hidden controls have no focused child, so the overlay must receive remote keys itself.
+		if (!visible) focusRequester.requestFocus()
+	}
+	return focusRequester
 }
 
 data class PlayerOverlayVisibilityState(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerControls.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerControls.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -25,7 +26,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.onVisibilityChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.DpOffset
@@ -39,6 +39,7 @@ import org.jellyfin.androidtv.ui.base.button.IconButton
 import org.jellyfin.androidtv.ui.base.popover.Popover
 import org.jellyfin.androidtv.ui.composable.rememberPlayerPositionInfo
 import org.jellyfin.androidtv.ui.player.base.PlayerSeekbar
+import org.jellyfin.androidtv.ui.syncplay.SyncPlayButton
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.queue.queue
@@ -51,6 +52,7 @@ import kotlin.time.DurationUnit
 fun VideoPlayerControls(
 	playbackManager: PlaybackManager = koinInject(),
 	onPlaybackInfoClick: () -> Unit = {},
+	onSyncPlayClick: () -> Unit = {},
 ) {
 	val playState by playbackManager.state.playState.collectAsState()
 
@@ -70,6 +72,7 @@ fun VideoPlayerControls(
 			Spacer(Modifier.weight(1f))
 
 			PlaybackInfoButton(onClick = onPlaybackInfoClick)
+			SyncPlayButton(onClick = onSyncPlayClick, playbackManager = playbackManager)
 
 			MoreOptionsButton {
 				PreviousEntryButton(playbackManager)
@@ -102,6 +105,9 @@ private fun PlayPauseButton(
 	playState: PlayState,
 ) {
 	val focusRequester = remember { FocusRequester() }
+	LaunchedEffect(focusRequester) {
+		focusRequester.requestFocus()
+	}
 	IconButton(
 		onClick = {
 			when (playState) {
@@ -114,9 +120,6 @@ private fun PlayPauseButton(
 		},
 		modifier = Modifier
 			.focusRequester(focusRequester)
-			.onVisibilityChanged {
-				focusRequester.requestFocus()
-			}
 	) {
 		AnimatedContent(playState) { playState ->
 			when (playState) {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerFragment.kt
@@ -6,13 +6,19 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.androidtv.ui.base.BaseScreen
 import org.jellyfin.androidtv.ui.playback.VideoQueueManager
 import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.model.api.MediaType
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
@@ -25,9 +31,13 @@ class VideoPlayerFragment : Fragment() {
 	private val videoQueueManager by inject<VideoQueueManager>()
 	private val playbackManager by inject<PlaybackManager>()
 	private val api by inject<ApiClient>()
+	private val syncPlay get() = playbackManager.getService<SyncPlayService>()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
+
+		// The group owns its queue and start position, including preparation while paused.
+		if (syncPlay?.group?.value != null) return
 
 		// Create a queue from the items added to the legacy video queue
 		val queueSupplier = RewriteMediaManager.BaseItemQueueSupplier(api, videoQueueManager.getCurrentVideoQueue(), false)
@@ -43,7 +53,7 @@ class VideoPlayerFragment : Fragment() {
 		}
 
 		// Pause player until the initial resume
-		playbackManager.state.pause()
+		if (syncPlay?.group?.value == null) playbackManager.state.pause()
 	}
 
 	override fun onCreateView(
@@ -59,17 +69,30 @@ class VideoPlayerFragment : Fragment() {
 	override fun onPause() {
 		super.onPause()
 
-		playbackManager.state.pause()
+		if (syncPlay?.group?.value == null) playbackManager.state.pause()
 	}
 
 	override fun onResume() {
 		super.onResume()
 
-		playbackManager.state.unpause()
+		if (syncPlay?.group?.value == null) playbackManager.state.unpause()
 	}
 
 	override fun onStop() {
 		super.onStop()
+
+		val service = syncPlay
+		if (service?.active == true) {
+			// Switching to a group audio item moves to Now Playing without ending the group.
+			val entry = playbackManager.queue.entry.value
+			if (service.isGroupEntry(entry) && entry?.baseItem?.mediaType == MediaType.AUDIO) return
+			if (activity?.isChangingConfigurations == true) return
+			lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+				// Reset locally before the leave request; lifecycle changes must not pause or stop the group.
+				withContext(NonCancellable) { service.endSession() }
+			}
+			return
+		}
 
 		playbackManager.state.stop()
 	}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/player/video/VideoPlayerOverlay.kt
@@ -17,6 +17,7 @@ import org.jellyfin.androidtv.ui.player.base.PlayerOverlayLayout
 import org.jellyfin.androidtv.ui.player.base.rememberPlayerOverlayVisibility
 import org.jellyfin.androidtv.ui.player.base.toast.MediaToastRegistry
 import org.jellyfin.androidtv.ui.player.base.toast.MediaToasts
+import org.jellyfin.androidtv.ui.syncplay.SyncPlayDialog
 import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.baseItemFlow
@@ -30,6 +31,7 @@ fun VideoPlayerOverlay(
 ) {
 	val visibilityState = rememberPlayerOverlayVisibility()
 	var showPlaybackInfo by remember { mutableStateOf(false) }
+	var showSyncPlay by remember { mutableStateOf(false) }
 
 	val entry by rememberQueueEntry(playbackManager)
 	val item = entry?.run { baseItemFlow.collectAsState(baseItem) }?.value
@@ -48,6 +50,7 @@ fun VideoPlayerOverlay(
 				VideoPlayerControls(
 					playbackManager = playbackManager,
 					onPlaybackInfoClick = { showPlaybackInfo = !showPlaybackInfo },
+					onSyncPlayClick = { showSyncPlay = true },
 				)
 			},
 		)
@@ -63,5 +66,11 @@ fun VideoPlayerOverlay(
 		}
 
 		MediaToasts(mediaToastRegistry)
+
+		SyncPlayDialog(
+			visible = showSyncPlay,
+			onDismissRequest = { showSyncPlay = false },
+			playbackManager = playbackManager,
+		)
 	}
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/shared/toolbar/MainToolbar.kt
@@ -1,13 +1,15 @@
 package org.jellyfin.androidtv.ui.shared.toolbar
 
-import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
@@ -21,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImagePainter
 import coil3.compose.rememberAsyncImagePainter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.auth.repository.SessionRepository
 import org.jellyfin.androidtv.auth.repository.UserRepository
@@ -34,11 +37,12 @@ import org.jellyfin.androidtv.ui.base.button.Button
 import org.jellyfin.androidtv.ui.base.button.ButtonDefaults
 import org.jellyfin.androidtv.ui.base.button.IconButton
 import org.jellyfin.androidtv.ui.base.button.IconButtonDefaults
-import org.jellyfin.androidtv.ui.navigation.ActivityDestinations
 import org.jellyfin.androidtv.ui.navigation.Destinations
 import org.jellyfin.androidtv.ui.navigation.NavigationRepository
 import org.jellyfin.androidtv.ui.playback.MediaManager
 import org.jellyfin.androidtv.ui.settings.compat.SettingsViewModel
+import org.jellyfin.androidtv.ui.syncplay.SyncPlayButton
+import org.jellyfin.androidtv.ui.syncplay.SyncPlayDialog
 import org.jellyfin.androidtv.util.apiclient.getUrl
 import org.jellyfin.androidtv.util.apiclient.primaryImage
 import org.jellyfin.sdk.api.client.ApiClient
@@ -80,7 +84,8 @@ private fun MainToolbar(
 	val mediaManager = koinInject<MediaManager>()
 	val sessionRepository = koinInject<SessionRepository>()
 	val settingsViewModel = koinActivityViewModel<SettingsViewModel>()
-	val activity = LocalActivity.current
+	val scope = rememberCoroutineScope()
+	var showSyncPlay by remember { mutableStateOf(false) }
 	val activeButtonColors = ButtonDefaults.colors(
 		containerColor = JellyfinTheme.colorScheme.buttonActive,
 		contentColor = JellyfinTheme.colorScheme.onButtonActive,
@@ -99,12 +104,10 @@ private fun MainToolbar(
 				IconButton(
 					onClick = {
 						if (activeButton != MainToolbarActiveButton.User) {
-							mediaManager.clearAudioQueue()
-							sessionRepository.destroyCurrentSession()
-
-							// Open login activity
-							activity?.startActivity(ActivityDestinations.startup(activity))
-							activity?.finishAfterTransition()
+							scope.launch {
+								sessionRepository.destroyCurrentSession()
+								mediaManager.clearAudioQueue()
+							}
 						}
 					},
 					colors = if (activeButton == MainToolbarActiveButton.User) activeButtonColors else ButtonDefaults.colors(),
@@ -156,6 +159,8 @@ private fun MainToolbar(
 		},
 		end = {
 			ToolbarButtons {
+				SyncPlayButton(onClick = { showSyncPlay = true })
+
 				IconButton(
 					onClick = { settingsViewModel.show() },
 				) {
@@ -168,5 +173,10 @@ private fun MainToolbar(
 				ToolbarClock()
 			}
 		}
+	)
+
+	SyncPlayDialog(
+		visible = showSyncPlay,
+		onDismissRequest = { showSyncPlay = false },
 	)
 }

--- a/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/startup/fragment/ServerFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
@@ -223,7 +224,10 @@ class ServerFragment : Fragment() {
 				// Logout button
 				if (user is PrivateUser && user.accessToken != null) {
 					item(context.getString(R.string.lbl_sign_out)) {
-						authenticationRepository.logout(user)
+						holder.cardView.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+							authenticationRepository.logout(user)
+							startupViewModel.loadUsers(server)
+						}
 					}
 				}
 
@@ -246,4 +250,3 @@ class ServerFragment : Fragment() {
 		) : RecyclerView.ViewHolder(cardView)
 	}
 }
-

--- a/app/src/main/java/org/jellyfin/androidtv/ui/syncplay/SyncPlayButton.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/syncplay/SyncPlayButton.kt
@@ -1,0 +1,46 @@
+package org.jellyfin.androidtv.ui.syncplay
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.Icon
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.button.ButtonDefaults
+import org.jellyfin.androidtv.ui.base.button.IconButton
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
+import org.koin.compose.koinInject
+
+@Composable
+fun SyncPlayButton(
+	onClick: () -> Unit,
+	playbackManager: PlaybackManager = koinInject(),
+) {
+	val service = playbackManager.getService<SyncPlayService>() ?: return
+	val group by service.group.collectAsState()
+
+	IconButton(
+		onClick = onClick,
+		colors = if (group != null) {
+			ButtonDefaults.colors(
+				containerColor = JellyfinTheme.colorScheme.buttonActive,
+				contentColor = JellyfinTheme.colorScheme.onButtonActive,
+			)
+		} else {
+			ButtonDefaults.colors()
+		},
+	) {
+		Icon(
+			imageVector = ImageVector.vectorResource(R.drawable.ic_users),
+			contentDescription = if (group != null) {
+				stringResource(R.string.syncplay_active, group?.groupName.orEmpty())
+			} else {
+				stringResource(R.string.syncplay)
+			},
+		)
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/syncplay/SyncPlayDialog.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/syncplay/SyncPlayDialog.kt
@@ -1,0 +1,316 @@
+package org.jellyfin.androidtv.ui.syncplay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.base.JellyfinTheme
+import org.jellyfin.androidtv.ui.base.LocalTextStyle
+import org.jellyfin.androidtv.ui.base.ProvideTextStyle
+import org.jellyfin.androidtv.ui.base.Text
+import org.jellyfin.androidtv.ui.base.button.Button
+import org.jellyfin.androidtv.ui.base.dialog.DialogBase
+import org.jellyfin.androidtv.ui.base.form.Checkbox
+import org.jellyfin.androidtv.ui.base.list.ListButton
+import org.jellyfin.androidtv.ui.base.list.ListControl
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
+import org.jellyfin.sdk.model.api.GroupInfoDto
+import org.koin.compose.koinInject
+
+@Composable
+fun SyncPlayDialog(
+	visible: Boolean,
+	onDismissRequest: () -> Unit,
+	playbackManager: PlaybackManager = koinInject(),
+) {
+	val service = playbackManager.getService<SyncPlayService>() ?: return
+	LaunchedEffect(service, visible) {
+		if (visible) {
+			service.clearError()
+			service.refreshGroups()
+		}
+	}
+
+	DialogBase(
+		visible = visible,
+		onDismissRequest = onDismissRequest,
+	) {
+		ProvideTextStyle(LocalTextStyle.current.copy(color = JellyfinTheme.colorScheme.onBackground)) {
+			SyncPlayDialogContent(service, onDismissRequest)
+		}
+	}
+}
+
+@Composable
+private fun SyncPlayDialogContent(
+	service: SyncPlayService,
+	onDismissRequest: () -> Unit,
+) {
+	val group by service.group.collectAsState()
+	val busy by service.busy.collectAsState()
+	val scope = rememberCoroutineScope()
+	var creatingGroup by remember { mutableStateOf(false) }
+	val focusRequester = remember { FocusRequester() }
+	val scrollState = rememberScrollState()
+
+	Column(
+		verticalArrangement = Arrangement.spacedBy(16.dp),
+		modifier = Modifier
+			.width(560.dp)
+			.heightIn(max = 480.dp)
+			.background(JellyfinTheme.colorScheme.surface, JellyfinTheme.shapes.large)
+			.padding(24.dp)
+			.verticalScroll(scrollState)
+			.focusRequester(focusRequester)
+			.focusGroup(),
+	) {
+		Text(stringResource(R.string.syncplay), fontSize = 24.sp, fontWeight = FontWeight.Bold)
+		Text(stringResource(R.string.syncplay_description))
+
+		SyncPlayStatus(service, busy)
+
+		val currentGroup = group
+		when {
+			currentGroup != null -> CurrentGroup(
+				group = currentGroup,
+				busy = busy,
+				onLeave = { scope.launch { service.leaveGroup() } },
+			)
+
+			creatingGroup -> CreateGroupForm(
+				busy = busy,
+				onCreate = { name -> scope.launch { service.createGroup(name) } },
+				onCancel = {
+					creatingGroup = false
+					service.clearError()
+				},
+			)
+
+			else -> AvailableGroups(
+				service = service,
+				busy = busy,
+				onCreate = {
+					service.clearError()
+					creatingGroup = true
+				},
+			)
+		}
+
+		DriftCorrectionOption(service)
+
+		Button(onClick = onDismissRequest) {
+			Text(stringResource(R.string.syncplay_close))
+		}
+	}
+
+	LaunchedEffect(group?.groupId, creatingGroup, busy) {
+		// Joining, leaving, and changing forms can remove the focused control.
+		if (!busy) {
+			scrollState.scrollTo(0)
+			focusRequester.requestFocus()
+		}
+		if (group != null) creatingGroup = false
+	}
+}
+
+@Composable
+private fun SyncPlayStatus(service: SyncPlayService, busy: Boolean) {
+	val error by service.error.collectAsState()
+	if (error != null) {
+		Text(stringResource(R.string.syncplay_error, error.orEmpty()))
+		Button(onClick = service::clearError) {
+			Text(stringResource(R.string.syncplay_dismiss_error))
+		}
+	}
+	if (busy) Text(stringResource(R.string.loading))
+}
+
+@Composable
+private fun CurrentGroup(
+	group: GroupInfoDto,
+	busy: Boolean,
+	onLeave: () -> Unit,
+) {
+	Text(stringResource(R.string.syncplay_current_group, group.groupName), fontWeight = FontWeight.Bold)
+	GroupParticipants(group)
+	Text(stringResource(R.string.syncplay_group_hint))
+	Button(onClick = onLeave, enabled = !busy) {
+		Text(stringResource(R.string.syncplay_leave_group))
+	}
+}
+
+@Composable
+private fun AvailableGroups(
+	service: SyncPlayService,
+	busy: Boolean,
+	onCreate: () -> Unit,
+) {
+	val groups by service.groups.collectAsState()
+	val scope = rememberCoroutineScope()
+	Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+		Button(
+			onClick = { scope.launch { service.refreshGroups() } },
+			enabled = !busy,
+		) {
+			Text(stringResource(R.string.syncplay_refresh))
+		}
+		Button(onClick = onCreate, enabled = !busy) {
+			Text(stringResource(R.string.syncplay_create_group))
+		}
+	}
+	Text(stringResource(R.string.syncplay_available_groups), fontWeight = FontWeight.Bold)
+	if (groups.isEmpty() && !busy) Text(stringResource(R.string.syncplay_no_groups))
+	for (group in groups) {
+		ListButton(
+			onClick = { scope.launch { service.joinGroup(group.groupId) } },
+			enabled = !busy,
+			headingContent = { Text(stringResource(R.string.syncplay_join_group, group.groupName)) },
+			captionContent = { GroupParticipants(group) },
+		)
+	}
+}
+
+@Composable
+private fun DriftCorrectionOption(service: SyncPlayService) {
+	val enabled by service.syncCorrectionEnabled.collectAsState()
+	val interactionSource = remember { MutableInteractionSource() }
+	ListControl(
+		modifier = Modifier.toggleable(
+			value = enabled,
+			interactionSource = interactionSource,
+			indication = null,
+			role = Role.Checkbox,
+			onValueChange = service::setSyncCorrectionEnabled,
+		),
+		interactionSource = interactionSource,
+		headingContent = { Text(stringResource(R.string.syncplay_correct_drift)) },
+		captionContent = { Text(stringResource(R.string.syncplay_correct_drift_description)) },
+		trailingContent = { Checkbox(checked = enabled) },
+	)
+}
+
+@Composable
+private fun GroupParticipants(group: GroupInfoDto) {
+	val participants = group.participants
+	if (participants.isNotEmpty()) {
+		Text(stringResource(R.string.syncplay_participants, participants.joinToString()))
+	}
+}
+
+@Composable
+private fun CreateGroupForm(
+	busy: Boolean,
+	onCreate: (String) -> Unit,
+	onCancel: () -> Unit,
+) {
+	var name by remember { mutableStateOf("") }
+	val keyboardController = LocalSoftwareKeyboardController.current
+	val canCreate = !busy && name.isNotBlank()
+	val create = {
+		if (canCreate) {
+			keyboardController?.hide()
+			onCreate(name.trim())
+		}
+	}
+
+	GroupNameField(name, { name = it }, !busy, create)
+	Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+		Button(onClick = create, enabled = canCreate) {
+			Text(stringResource(R.string.syncplay_create_group))
+		}
+		Button(onClick = onCancel, enabled = !busy) {
+			Text(stringResource(R.string.lbl_cancel))
+		}
+	}
+}
+
+@Composable
+private fun GroupNameField(name: String, onNameChange: (String) -> Unit, enabled: Boolean, onDone: () -> Unit) {
+	val keyboardController = LocalSoftwareKeyboardController.current
+	val focusManager = LocalFocusManager.current
+	val interactionSource = remember { MutableInteractionSource() }
+	val focused by interactionSource.collectIsFocusedAsState()
+	val label = stringResource(R.string.syncplay_group_name)
+	Text(label, fontWeight = FontWeight.Bold)
+	BasicTextField(
+		value = name,
+		onValueChange = onNameChange,
+		singleLine = true,
+		enabled = enabled,
+		interactionSource = interactionSource,
+		textStyle = LocalTextStyle.current,
+		cursorBrush = SolidColor(JellyfinTheme.colorScheme.onInput),
+		keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+		keyboardActions = KeyboardActions(onDone = { onDone() }),
+		modifier = Modifier
+			.fillMaxWidth()
+			.onPreviewKeyEvent {
+				if (it.type == KeyEventType.KeyDown && it.key == Key.DirectionDown) {
+					keyboardController?.hide()
+					focusManager.moveFocus(FocusDirection.Next)
+				} else {
+					false
+				}
+			}
+			.semantics { contentDescription = label },
+		decorationBox = { innerTextField ->
+			Box(
+				modifier = Modifier
+					.border(
+						width = 2.dp,
+						color = if (focused) JellyfinTheme.colorScheme.inputFocused else JellyfinTheme.colorScheme.input,
+						shape = JellyfinTheme.shapes.small,
+					)
+					.padding(12.dp),
+			) {
+				innerTextField()
+			}
+		},
+	)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -687,4 +687,23 @@
     <string name="truehd">TrueHD</string>
     <string name="eac3_atmos">DD+ Atmos</string>
     <string name="truehd_atmos">TrueHD Atmos</string>
+    <!-- SyncPlay -->
+    <string name="syncplay">SyncPlay</string>
+    <string name="syncplay_active">SyncPlay: %1$s</string>
+    <string name="syncplay_description">Watch together with other Jellyfin clients. Group videos use the integrated player.</string>
+    <string name="syncplay_available_groups">Available groups</string>
+    <string name="syncplay_no_groups">No groups available. Create a group to start watching together.</string>
+    <string name="syncplay_refresh">Refresh</string>
+    <string name="syncplay_create_group">Create group</string>
+    <string name="syncplay_group_name">Group name</string>
+    <string name="syncplay_join_group">Join %1$s</string>
+    <string name="syncplay_current_group">Current group: %1$s</string>
+    <string name="syncplay_participants">Participants: %1$s</string>
+    <string name="syncplay_group_hint">Play a video to watch with your group. Playback controls affect everyone in the group.</string>
+    <string name="syncplay_leave_group">Leave group</string>
+    <string name="syncplay_close">Close</string>
+    <string name="syncplay_error">SyncPlay: %1$s</string>
+    <string name="syncplay_dismiss_error">Dismiss error</string>
+    <string name="syncplay_correct_drift">Correct playback drift</string>
+    <string name="syncplay_correct_drift_description">Adjust playback speed or seek when out of sync.</string>
 </resources>

--- a/app/src/test/kotlin/auth/repository/AuthenticationLogoutTests.kt
+++ b/app/src/test/kotlin/auth/repository/AuthenticationLogoutTests.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.auth.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.jellyfin.androidtv.auth.model.AuthenticationStoreUser
+import org.jellyfin.androidtv.auth.model.PrivateUser
+import org.jellyfin.androidtv.auth.store.AuthenticationStore
+import java.util.UUID
+
+class AuthenticationLogoutTests : FunSpec({
+	test("signing out the active user finishes playback before forgetting credentials") {
+		val user = storedUser()
+		val session = Session(user.id, user.serverId, requireNotNull(user.accessToken))
+		val sessions = mockk<SessionRepository>()
+		val store = mockk<AuthenticationStore>()
+		val actions = mutableListOf<String>()
+		every { sessions.currentSession } returns MutableStateFlow(session)
+		coEvery { sessions.destroyCurrentSession(session) } answers {
+			actions.add("end session")
+			Unit
+		}
+		every { store.getUser(user.serverId, user.id) } returns AuthenticationStoreUser(user.name, accessToken = user.accessToken)
+		every { store.putUser(user.serverId, user.id, any()) } answers {
+			thirdArg<AuthenticationStoreUser>().accessToken shouldBe null
+			actions.add("forget credentials")
+			true
+		}
+
+		logoutRepository(sessions, store).logout(user) shouldBe true
+
+		actions shouldBe listOf("end session", "forget credentials")
+		coVerify(exactly = 1) { sessions.destroyCurrentSession(expectedSession = session) }
+	}
+
+	test("signing out a stored user on another server preserves the active session") {
+		val user = storedUser()
+		val sessions = mockk<SessionRepository>()
+		val store = mockk<AuthenticationStore>()
+		every { sessions.currentSession } returns MutableStateFlow(Session(user.id, UUID.randomUUID(), "other-token"))
+		every { store.getUser(user.serverId, user.id) } returns AuthenticationStoreUser(user.name, accessToken = user.accessToken)
+		every { store.putUser(user.serverId, user.id, any()) } returns true
+
+		logoutRepository(sessions, store).logout(user) shouldBe true
+
+		coVerify(exactly = 0) { sessions.destroyCurrentSession(any()) }
+		verify { store.putUser(user.serverId, user.id, match { it.accessToken == null }) }
+	}
+})
+
+private fun storedUser() = PrivateUser(UUID.randomUUID(), UUID.randomUUID(), "Viewer", "test-token", null, 0)
+
+private fun logoutRepository(sessions: SessionRepository, store: AuthenticationStore) = AuthenticationRepositoryImpl(
+	jellyfin = mockk(),
+	sessionRepository = sessions,
+	authenticationStore = store,
+	userApiClient = mockk(),
+	authenticationPreferences = mockk(),
+	defaultDeviceInfo = mockk(),
+)

--- a/app/src/test/kotlin/ui/playback/rewrite/SyncPlayAudioControlsTests.kt
+++ b/app/src/test/kotlin/ui/playback/rewrite/SyncPlayAudioControlsTests.kt
@@ -1,0 +1,82 @@
+package org.jellyfin.androidtv.ui.playback.rewrite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.PlayerState
+import org.jellyfin.playback.core.model.PlaybackOrder
+import org.jellyfin.playback.core.model.RepeatMode
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.GroupInfoDto
+import org.jellyfin.sdk.model.api.GroupRepeatMode
+import org.jellyfin.sdk.model.api.GroupShuffleMode
+import org.jellyfin.sdk.model.api.PlayQueueUpdate
+import java.util.UUID
+
+class SyncPlayAudioControlsTests : FunSpec({
+	test("queueing audio in a group waits for the server queue instead of appending locally") {
+		val manager = mockk<PlaybackManager>()
+		val syncPlay = mockk<SyncPlayService>()
+		val item = BaseItemDto(id = UUID.randomUUID(), type = BaseItemKind.AUDIO)
+		every { manager.getService(SyncPlayService::class) } returns syncPlay
+		every { syncPlay.group } returns MutableStateFlow(mockk<GroupInfoDto>())
+		every { syncPlay.queueItems(listOf(item.id)) } returns Unit
+
+		RewriteMediaManager(mockk(), manager).addToAudioQueue(listOf(item))
+
+		verify(exactly = 1) { syncPlay.queueItems(listOf(item.id)) }
+		// The strict manager mock rejects all local queue and player accesses.
+	}
+
+	test("repeat toggle can disable the server mode while local repeat stays disabled") {
+		val controls = groupedControls(GroupRepeatMode.REPEAT_ONE, GroupShuffleMode.SORTED)
+		controls.media.isRepeatMode shouldBe true
+
+		controls.media.toggleRepeat()
+
+		verify { controls.state.setRepeatMode(RepeatMode.NONE) }
+	}
+
+	test("shuffle toggle can disable the server mode while local order stays default") {
+		val controls = groupedControls(GroupRepeatMode.REPEAT_NONE, GroupShuffleMode.SHUFFLE)
+		controls.media.isShuffleMode shouldBe true
+
+		controls.media.shuffleAudioQueue()
+
+		verify { controls.state.setPlaybackOrder(PlaybackOrder.DEFAULT) }
+	}
+
+	test("disabled server modes can be enabled through the existing audio controls") {
+		val controls = groupedControls(GroupRepeatMode.REPEAT_NONE, GroupShuffleMode.SORTED)
+
+		controls.media.toggleRepeat()
+		controls.media.shuffleAudioQueue()
+
+		verify { controls.state.setRepeatMode(RepeatMode.REPEAT_ENTRY_INFINITE) }
+		verify { controls.state.setPlaybackOrder(PlaybackOrder.SHUFFLE) }
+	}
+})
+
+private data class GroupedControls(val media: RewriteMediaManager, val state: PlayerState)
+
+private fun groupedControls(repeatMode: GroupRepeatMode, shuffleMode: GroupShuffleMode): GroupedControls {
+	val manager = mockk<PlaybackManager>()
+	val state = mockk<PlayerState>(relaxed = true)
+	val syncPlay = mockk<SyncPlayService>()
+	val queue = mockk<PlayQueueUpdate>()
+	every { manager.getService(SyncPlayService::class) } returns syncPlay
+	every { manager.state } returns state
+	every { state.repeatMode } returns MutableStateFlow(RepeatMode.NONE)
+	every { state.playbackOrder } returns MutableStateFlow(PlaybackOrder.DEFAULT)
+	every { syncPlay.group } returns MutableStateFlow(mockk<GroupInfoDto>())
+	every { syncPlay.queueState } returns MutableStateFlow(queue)
+	every { queue.repeatMode } returns repeatMode
+	every { queue.shuffleMode } returns shuffleMode
+	return GroupedControls(RewriteMediaManager(mockk(), manager), state)
+}

--- a/docs/syncplay.md
+++ b/docs/syncplay.md
@@ -1,0 +1,98 @@
+# SyncPlay on Android TV
+
+This implementation addresses [jellyfin/jellyfin-androidtv#538](https://github.com/jellyfin/jellyfin-androidtv/issues/538).
+It uses Jellyfin's existing SyncPlay groups and server protocol, so the TV can watch with Jellyfin Web and other compatible clients.
+
+## Using it
+
+1. Open **SyncPlay** from the home toolbar or the integrated video player's controls.
+2. Create a named group, or select an existing group to join.
+3. Select a title. Group playback opens the integrated TV player automatically.
+4. Play, pause, seek, and next/previous item controls are sent to the group.
+5. Use **Leave group** to return to independent playback. Leaving the player or putting the app in the background also leaves the group,
+   without sending a group-wide pause or stop.
+
+The account needs permission to use SyncPlay and access to the group's media. External video players are not used for group playback.
+The dialog shows participants, loading failures, and a **Correct playback drift** option. Ongoing speed/seek correction is off by default,
+matching Jellyfin Web; scheduled group commands and clock synchronization always run.
+
+## Implementation
+
+- `SyncPlayService` consumes ordered WebSocket group updates and commands using Jellyfin Kotlin SDK models and API calls.
+- SDK 1.8.12 stores raw socket frames in a conflating `StateFlow`, which can drop `GroupJoined` when `Stop` immediately follows.
+  `ReliableApiClient` retains SDK HTTP behavior and replaces the session's socket with a bounded ordered transport using the SDK's
+  decoder and authentication format. Overflow or a lost connection explicitly disconnects the group. All app subscribers share this
+  one connection: a separate SyncPlay socket is insufficient because the server sends session events only to the most recently active
+  connection, allowing the regular socket's keepalive to take over delivery.
+- Group queue entries are prepared at the server's requested position without autoplay. The TV reports `Ready` with the **playlist entry ID**,
+  then waits for the server's scheduled command. Library item IDs are used to fetch media, not to acknowledge playback.
+- User commands are intercepted before changing the local backend. Server commands go directly to the backend and never echo as new group requests.
+- Audio queue additions go to the shared playlist. Repeat and shuffle controls display the server's modes while local automatic queue
+  advancement remains disabled, so either mode can be turned on and off without overriding the group.
+- Server timestamps are translated using a clock estimate anchored to monotonic time. The estimate uses the best of eight latency samples.
+- A continuous three-second buffering interval is reported to the group. Becoming ready clears that wait.
+- Queue changes invalidate pending loads. Leaving, disconnecting, or switching accounts cancels scheduled playback and restores normal speed.
+- The new player is used for grouped video. This branch targets upstream `master`, where the playback rewrite lives; it is a development build.
+- Navigation follows the group's selected queue entry and media type. It does not open an old local audio item while joining or create another
+  player screen for each queue update. A group transition from video to audio preserves membership.
+- Closing a video screen or backgrounding the app resets local group playback before the best-effort leave request. This teardown survives
+  fragment destruction and cannot send a group-wide pause/stop or later stop playback started after returning to the app.
+- Session changes are serialized. A suspendable teardown hook runs before outgoing credentials are replaced or cleared, including current-user
+  signout. Playback services are resolved on the main thread even when session maintenance runs in the background.
+
+The SDK version pinned by this checkout exposes `timeSyncApi.getUtcTime()` and `userLibraryApi.getItem()`. Consult that version's source JAR
+when changing the integration: the SDK's development branch has moved these calls to other API classes, so its current generated source
+does not necessarily match the published dependency.
+
+Protocol behavior and drift defaults are based on Jellyfin Web commit `b24b70d18dccf71a58633cd9795a2663983f93c0`, especially
+[`PlaybackCore.js`](https://github.com/jellyfin/jellyfin-web/blob/b24b70d18dccf71a58633cd9795a2663983f93c0/src/plugins/syncPlay/core/PlaybackCore.js)
+and [`TimeSync.js`](https://github.com/jellyfin/jellyfin-web/blob/b24b70d18dccf71a58633cd9795a2663983f93c0/src/plugins/syncPlay/core/timeSync/TimeSync.js).
+
+## Building and verification
+
+Use JDK 21, the Android SDK, and the repository's Gradle wrapper. The current checkout uses SDK platform `android-37.0` and also needs
+build tools `36.0.0`. These versioned SDK package names differ from older Android SDK layouts.
+
+```sh
+./gradlew test
+./gradlew detekt lint
+./gradlew assembleDebug
+```
+
+The debug APK uses `org.jellyfin.androidtv.debug` and can be installed alongside the Google Play version. Building this branch does not
+update the app published on Google Play.
+
+### Verification performed
+
+- The full Gradle `test` run passed 140 tests with no failures, errors, or skips.
+- Detekt and Android lint reports were inspected because this repository configures both to allow findings without failing the build.
+  Existing findings remain on untouched lines; none were reported in the new SyncPlay or network code or on changed lines.
+- Runtime checks use an Android TV API 36 emulator, an isolated Jellyfin 12 server, the official Jellyfin Web app in Chromium, and a
+  generated 90-second H.264/AAC test video. The Web client actually decodes media; it is not a protocol-only test double.
+- Joining from TV opened the group's video paused at the same position as Web. Web play/pause advanced both to 30.418 seconds;
+  Web seek moved the decoded TV frame to 45.000 seconds. TV-origin media controls resumed actual playback, with TV position samples
+  advancing from 45.000 to 48.010 seconds before pausing at 50.371 seconds. TV fast-forward subsequently moved Web to 80.371 seconds.
+- Back from the TV player returned home and removed only the TV participant; Web remained in its original group.
+- Creating a named group from the TV and leaving it through the dialog both succeeded. Web retained its loaded player and working
+  controls after the TV left the earlier shared group.
+- A final D-pad-only play/pause sequence advanced both clients from 19.997 seconds to a shared paused position of 24.619 seconds.
+  Reopening the controls after the hide timer succeeded. The player requests focus when controls appear and returns focus to the
+  hidden overlay when they disappear; a disappearing button must not request focus again. The key handler precedes the focus target,
+  and D-pad keys are explicitly accepted even when Android classifies the event as a system key.
+- The player SyncPlay dialog retained D-pad focus after the underlying controls' hide timer, with both participants displayed.
+
+Focused tests cover clock correction, drift thresholds, scheduled commands without feedback, readiness and buffering, join failures,
+stale commands after leaving, stale queue loads after replacement or stop, account teardown, and shared audio queue controls.
+Network tests replay serialized message bursts, exercise queue overflow and keepalive expiry, verify shared subscriptions and reconnects,
+and reject buffered events from an earlier login even when the same credentials are reused.
+
+When testing constructor-created player listeners with MockK, stub the actual service instance. `spyk(service)` copies the instance,
+while a listener created in its constructor still captures the original; callbacks then inspect different membership state and can
+produce misleading readiness failures. The service tests use the original instance and stub only inherited player dependencies.
+
+Before a production release, test on the intended TV hardware with a second client: create/join, initial and mid-playback join, pause,
+seek in both directions, next/previous, a buffering participant, leave, background/return, account changes, and lost/recovered connectivity.
+Include the codecs and audio output used on that device; an emulator cannot establish hardware decoding or audio passthrough behavior.
+
+The TV dialog should remain open while the underlying player controls hide. Check D-pad focus, the group-name keyboard and Done action,
+Back/Close, refresh, participant updates, joining/leaving, and the correction checkbox.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ detekt = "1.23.8"
 java-jdk = "21"
 jellyfin-androidx-media = "1.9.0+1"
 jellyfin-sdk = "1.8.12"
+okhttp = "5.3.2"
 koin = "4.2.2"
 koin-compose = "4.2.2"
 kotest = "6.2.4"
@@ -53,6 +54,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 [libraries]
 # Jellyfin
 jellyfin-sdk = { module = "org.jellyfin.sdk:jellyfin-core", version.ref = "jellyfin-sdk" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 
 # Kotlin
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/playback/core/build.gradle.kts
+++ b/playback/core/build.gradle.kts
@@ -41,4 +41,5 @@ dependencies {
 	testImplementation(libs.kotest.runner.junit5)
 	testImplementation(libs.kotest.assertions)
 	testImplementation(libs.mockk)
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.kotlinx.coroutines.get()}")
 }

--- a/playback/core/src/main/kotlin/PlaybackManager.kt
+++ b/playback/core/src/main/kotlin/PlaybackManager.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import org.jellyfin.playback.core.backend.BackendService
 import org.jellyfin.playback.core.backend.PlayerBackend
+import org.jellyfin.playback.core.backend.PlayerBackendEventListener
 import org.jellyfin.playback.core.plugin.PlayerService
 import timber.log.Timber
 import kotlin.reflect.KClass
@@ -23,12 +24,21 @@ class PlaybackManager internal constructor(
 	val state: PlayerState = MutablePlayerState(
 		options = options,
 		backendService = backendService,
-		queue = getService()
+		queue = getService(),
+		commandHandler = ::handleCommand,
 	)
 
 	init {
 		services.forEach { it.initialize(this, state, Job(job)) }
 	}
+
+	fun handleCommand(command: PlayerCommand): Boolean = services
+		.filterIsInstance<PlayerCommandHandler>()
+		.any { it.handleCommand(command) }
+
+	fun addBackendListener(listener: PlayerBackendEventListener) = backendService.addListener(listener)
+
+	fun removeBackendListener(listener: PlayerBackendEventListener) = backendService.removeListener(listener)
 
 	fun addService(service: PlayerService) {
 		Timber.i("Adding service $service")

--- a/playback/core/src/main/kotlin/PlayerCommand.kt
+++ b/playback/core/src/main/kotlin/PlayerCommand.kt
@@ -1,0 +1,25 @@
+package org.jellyfin.playback.core
+
+import org.jellyfin.playback.core.model.PlaybackOrder
+import org.jellyfin.playback.core.model.RepeatMode
+import kotlin.time.Duration
+
+/** User intent, before it changes the local backend (for example, a synchronized group player). */
+sealed interface PlayerCommand {
+	data object Play : PlayerCommand
+	data object Pause : PlayerCommand
+	data object Stop : PlayerCommand
+	data class Seek(val position: Duration) : PlayerCommand
+	data object Next : PlayerCommand
+	data object Previous : PlayerCommand
+	data class Select(val index: Int) : PlayerCommand
+	data class Speed(val speed: Float) : PlayerCommand
+	data class Order(val order: PlaybackOrder) : PlayerCommand
+	data class Repeat(val mode: RepeatMode) : PlayerCommand
+	data class Remove(val index: Int) : PlayerCommand
+}
+
+interface PlayerCommandHandler {
+	/** Return true when the command was handled and should not run locally. */
+	fun handleCommand(command: PlayerCommand): Boolean
+}

--- a/playback/core/src/main/kotlin/PlayerState.kt
+++ b/playback/core/src/main/kotlin/PlayerState.kt
@@ -59,6 +59,7 @@ class MutablePlayerState(
 	private val options: PlaybackManagerOptions,
 	private val backendService: BackendService,
 	private val queue: QueueService?,
+	private val commandHandler: (PlayerCommand) -> Boolean = { false },
 ) : PlayerState {
 	override val volume: PlayerVolumeState
 
@@ -106,30 +107,35 @@ class MutablePlayerState(
 	}
 
 	override fun play() {
+		if (commandHandler(PlayerCommand.Play)) return
 		backendService.backend?.play()
 	}
 
 	override fun pause() {
+		if (commandHandler(PlayerCommand.Pause)) return
 		// TODO: enqueue action when backend is not set
 		backendService.backend?.pause()
 	}
 
 	override fun unpause() {
+		if (commandHandler(PlayerCommand.Play)) return
 		backendService.backend?.play()
 	}
 
 	override fun stop() {
+		if (commandHandler(PlayerCommand.Stop)) return
 		backendService.backend?.stop()
 		queue?.clear()
 	}
 
 	override fun seek(to: Duration) {
+		if (commandHandler(PlayerCommand.Seek(to))) return
 		backendService.backend?.seekTo(to)
 	}
 
 	private fun seekRelative(amount: Duration) {
 		val current = backendService.backend?.getPositionInfo()?.active ?: Duration.ZERO
-		backendService.backend?.seekTo(current + amount)
+		seek(current + amount)
 	}
 
 	override fun fastForward(amount: Duration?) {
@@ -146,15 +152,18 @@ class MutablePlayerState(
 	}
 
 	override fun setSpeed(speed: Float) {
+		if (commandHandler(PlayerCommand.Speed(speed))) return
 		_speed.value = speed
 		backendService.backend?.setSpeed(speed)
 	}
 
 	override fun setPlaybackOrder(order: PlaybackOrder) {
+		if (commandHandler(PlayerCommand.Order(order))) return
 		_playbackOrder.value = order
 	}
 
 	override fun setRepeatMode(mode: RepeatMode) {
+		if (commandHandler(PlayerCommand.Repeat(mode))) return
 		_repeatMode.value = mode
 	}
 }

--- a/playback/core/src/main/kotlin/backend/BackendService.kt
+++ b/playback/core/src/main/kotlin/backend/BackendService.kt
@@ -3,6 +3,7 @@ package org.jellyfin.playback.core.backend
 import androidx.core.view.doOnDetach
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.queue.QueueEntry
 import org.jellyfin.playback.core.ui.PlayerSubtitleView
 import org.jellyfin.playback.core.ui.PlayerSurfaceView
 
@@ -79,6 +80,17 @@ class BackendService {
 	}
 
 	inner class BackendEventListener : PlayerBackendEventListener() {
+		override fun onBuffering(entry: QueueEntry, buffering: Boolean) {
+			callListeners { onBuffering(entry, buffering) }
+		}
+
+		override fun onMediaStreamReady(entry: QueueEntry) {
+			callListeners { onMediaStreamReady(entry) }
+		}
+
+		override fun onMediaStreamError(entry: QueueEntry) {
+			callListeners { onMediaStreamError(entry) }
+		}
 		private fun <T> callListeners(
 			body: PlayerBackendEventListener.() -> T
 		): List<T> = listeners.map { listener -> listener.body() }

--- a/playback/core/src/main/kotlin/backend/PlayerBackendEventListener.kt
+++ b/playback/core/src/main/kotlin/backend/PlayerBackendEventListener.kt
@@ -2,9 +2,13 @@ package org.jellyfin.playback.core.backend
 
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.queue.QueueEntry
 
 abstract class PlayerBackendEventListener {
 	open fun onPlayStateChange(state: PlayState) = Unit
 	open fun onVideoSizeChange(width: Int, height: Int) = Unit
 	open fun onMediaStreamEnd(mediaStream: PlayableMediaStream) = Unit
+	open fun onBuffering(entry: QueueEntry, buffering: Boolean) = Unit
+	open fun onMediaStreamReady(entry: QueueEntry) = Unit
+	open fun onMediaStreamError(entry: QueueEntry) = Unit
 }

--- a/playback/core/src/main/kotlin/mediastream/MediaStreamService.kt
+++ b/playback/core/src/main/kotlin/mediastream/MediaStreamService.kt
@@ -1,10 +1,9 @@
 package org.jellyfin.playback.core.mediastream
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import org.jellyfin.playback.core.plugin.PlayerService
 import org.jellyfin.playback.core.queue.QueueEntry
@@ -24,17 +23,19 @@ internal class MediaStreamService(
 	}
 
 	override suspend fun onInitialize() {
-		manager.queue.entry.onEach { entry ->
-			Timber.d("Queue entry changed to $entry")
+		coroutineScope.launch(Dispatchers.Main) {
+			manager.queue.entry.collectLatest { entry ->
+				Timber.d("Queue entry changed to $entry")
 
-			if (entry == null) {
-				val backend = requireNotNull(manager.backend)
-				backend.stop()
-			} else {
-				playEntry(entry)
-				entry.ensurePreloadTimedEvent()
+				if (entry == null) {
+					val backend = requireNotNull(manager.backend)
+					backend.stop()
+				} else {
+					playEntry(entry)
+					entry.ensurePreloadTimedEvent()
+				}
 			}
-		}.launchIn(coroutineScope + Dispatchers.Main)
+		}
 	}
 
 	private suspend fun QueueEntry.ensureMediaStream(): Boolean {
@@ -44,6 +45,7 @@ internal class MediaStreamService(
 					resolver.getStream(this@ensureMediaStream)
 				}
 			}.onFailure {
+				if (it is CancellationException) throw it
 				Timber.e(it, "Media stream resolver failed for $this")
 			}.getOrNull()
 		}
@@ -72,12 +74,18 @@ internal class MediaStreamService(
 		val hasMediaStream = entry.ensureMediaStream()
 
 		if (hasMediaStream) {
-			backend.playItem(entry)
+			// A network lookup may finish after the authoritative queue has changed.
+			if (manager.queue.entry.value === entry) backend.playItem(entry)
 		} else {
+			if (manager.queue.entry.value !== entry) return
 			Timber.e("Unable to resolve stream for entry $entry")
+			manager.backendService.BackendEventListener().onMediaStreamError(entry)
+			if (manager.queue.entry.value !== entry) return
 
 			// TODO: Somehow notify the user that we skipped an unplayable entry
-			if (manager.queue.peekNext() != null) {
+			val nextEntry = manager.queue.peekNext()
+			if (manager.queue.entry.value !== entry) return
+			if (nextEntry != null) {
 				manager.queue.next(usePlaybackOrder = true, useRepeatMode = false)
 			} else {
 				backend.stop()
@@ -86,13 +94,14 @@ internal class MediaStreamService(
 	}
 
 	private fun preloadNextEntry() = coroutineScope.launch(Dispatchers.Main) {
+		val currentEntry = manager.queue.entry.value
 		// Peek into the next item to preload
 		val nextItem = manager.queue.peekNext() ?: return@launch
 
 		// Preload media stream information
 		val hasMediaStream = nextItem.ensureMediaStream()
 
-		if (hasMediaStream) {
+		if (hasMediaStream && manager.queue.entry.value === currentEntry && manager.queue.indexOf(nextItem) != null) {
 			// Preload media in backend
 			val backend = requireNotNull(manager.backend)
 			backend.prepareItem(nextItem)

--- a/playback/core/src/main/kotlin/queue/InitialPlayback.kt
+++ b/playback/core/src/main/kotlin/queue/InitialPlayback.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.playback.core.queue
+
+import org.jellyfin.playback.core.element.ElementKey
+import org.jellyfin.playback.core.element.requiredElement
+import kotlin.time.Duration
+
+/** Initial state applied before a stream starts, including preparation without autoplay. */
+data class InitialPlayback(val position: Duration = Duration.ZERO, val playWhenReady: Boolean = true)
+
+private val initialPlaybackKey = ElementKey<InitialPlayback>("InitialPlayback")
+var QueueEntry.initialPlayback by requiredElement(initialPlaybackKey) { InitialPlayback() }

--- a/playback/core/src/main/kotlin/queue/Queue.kt
+++ b/playback/core/src/main/kotlin/queue/Queue.kt
@@ -44,6 +44,9 @@ interface Queue {
 	 */
 	fun clear()
 
+	/** Replace the queue atomically with an authoritative playlist, without selecting item zero first. */
+	suspend fun synchronize(supplier: QueueSupplier, index: Int): QueueEntry?
+
 	/**
 	 * Set the current entry to the previously played entry. Does nothing if there is no previous entry.
 	 */

--- a/playback/core/src/main/kotlin/queue/QueueService.kt
+++ b/playback/core/src/main/kotlin/queue/QueueService.kt
@@ -1,12 +1,16 @@
 package org.jellyfin.playback.core.queue
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.PlayerCommand
 import org.jellyfin.playback.core.backend.PlayerBackendEventListener
 import org.jellyfin.playback.core.mediastream.PlayableMediaStream
 import org.jellyfin.playback.core.model.PlaybackOrder
@@ -19,12 +23,16 @@ import org.jellyfin.playback.core.queue.order.ShuffleOrderIndexProvider
 import org.jellyfin.playback.core.queue.supplier.QueueSupplier
 import kotlin.math.max
 
+// Keep the Queue operations and their shared loading generation in one service.
+@Suppress("TooManyFunctions")
 class QueueService internal constructor() : PlayerService(), Queue {
 	private val suppliers = mutableListOf<QueueSupplier>()
 	private var currentSupplierIndex = 0
 	private var currentSupplierEntryIndex = 0
 	private val fetchedEntries: MutableList<QueueEntry> = mutableListOf()
 	private var removedEntries = 0
+	private var generation = 0L
+	private var supplierMutex = Mutex()
 
 	private var defaultOrderIndexProvider = DefaultOrderIndexProvider()
 	private var orderIndexProvider: OrderIndexProvider = defaultOrderIndexProvider
@@ -54,7 +62,8 @@ class QueueService internal constructor() : PlayerService(), Queue {
 		// Automatically advance when current stream ends
 		manager.backendService.addListener(object : PlayerBackendEventListener() {
 			override fun onMediaStreamEnd(mediaStream: PlayableMediaStream) {
-				coroutineScope.launch {
+				coroutineScope.launch(Dispatchers.Main.immediate) {
+					if (mediaStream.queueEntry !== _entry.value) return@launch
 					val nextEntry = next(usePlaybackOrder = true, useRepeatMode = true)
 					if (nextEntry == null && _entryIndex.value != Queue.INDEX_NONE) setIndex(Queue.INDEX_NONE, true)
 				}
@@ -77,6 +86,15 @@ class QueueService internal constructor() : PlayerService(), Queue {
 	}
 
 	private suspend fun getOrSupplyEntry(index: Int): QueueEntry? {
+		val expectedGeneration = generation
+		return supplierMutex.withLock {
+			if (generation != expectedGeneration) return@withLock null
+			getOrSupplyEntryLocked(index)
+		}
+	}
+
+	private suspend fun getOrSupplyEntryLocked(index: Int): QueueEntry? {
+		val expectedGeneration = generation
 		// Fetch additional entries from suppliers until we reach the desired index
 		var entriesChanged = false
 		while (index >= fetchedEntries.size) {
@@ -85,6 +103,7 @@ class QueueService internal constructor() : PlayerService(), Queue {
 
 			val supplier = suppliers[currentSupplierIndex]
 			val nextEntry = supplier.getItem(currentSupplierEntryIndex)
+			if (generation != expectedGeneration) return null
 
 			if (nextEntry != null) {
 				// Add entry to cache and increase entry index
@@ -110,6 +129,7 @@ class QueueService internal constructor() : PlayerService(), Queue {
 
 	override suspend fun removeEntry(entry: QueueEntry) {
 		val index = indexOf(entry) ?: return
+		if (manager.handleCommand(PlayerCommand.Remove(index))) return
 
 		// Add to removed list
 		removedEntries++
@@ -132,6 +152,8 @@ class QueueService internal constructor() : PlayerService(), Queue {
 	}
 
 	override fun clear() {
+		generation++
+		supplierMutex = Mutex()
 		suppliers.clear()
 		currentSupplierIndex = 0
 		currentSupplierEntryIndex = 0
@@ -162,11 +184,13 @@ class QueueService internal constructor() : PlayerService(), Queue {
 
 	// Jumping
 
-	override suspend fun previous(): QueueEntry? = currentQueueIndicesPlayed.removeLastOrNull()?.let {
-		setIndex(it)
+	override suspend fun previous(): QueueEntry? {
+		if (manager.handleCommand(PlayerCommand.Previous)) return entry.value
+		return currentQueueIndicesPlayed.removeLastOrNull()?.let { setIndex(it) }
 	}
 
 	override suspend fun next(usePlaybackOrder: Boolean, useRepeatMode: Boolean): QueueEntry? {
+		if (manager.handleCommand(PlayerCommand.Next)) return entry.value
 		val index = getNextIndices(1, usePlaybackOrder, useRepeatMode).firstOrNull() ?: return null
 
 		val provider = if (usePlaybackOrder) orderIndexProvider else defaultOrderIndexProvider
@@ -183,6 +207,29 @@ class QueueService internal constructor() : PlayerService(), Queue {
 	}
 
 	override suspend fun setIndex(index: Int, saveHistory: Boolean): QueueEntry? {
+		if (manager.handleCommand(PlayerCommand.Select(index))) return entry.value
+		return updateIndex(index, saveHistory)
+	}
+
+	override suspend fun synchronize(supplier: QueueSupplier, index: Int): QueueEntry? {
+		generation++
+		// A stale supplier may still be awaiting the network; it must not block this generation.
+		supplierMutex = Mutex()
+		suppliers.clear()
+		suppliers.add(supplier)
+		currentSupplierIndex = 0
+		currentSupplierEntryIndex = 0
+		fetchedEntries.clear()
+		_entries.value = emptyList()
+		removedEntries = 0
+		currentQueueIndicesPlayed.clear()
+		defaultOrderIndexProvider = DefaultOrderIndexProvider()
+		orderIndexProvider = defaultOrderIndexProvider
+		return updateIndex(index, false)
+	}
+
+	private suspend fun updateIndex(index: Int, saveHistory: Boolean): QueueEntry? {
+		val expectedGeneration = generation
 		if (index < 0 && index != Queue.INDEX_NONE) return null
 
 		// Save previous index
@@ -192,6 +239,7 @@ class QueueService internal constructor() : PlayerService(), Queue {
 
 		// Set new index
 		val currentEntry = getOrSupplyEntry(index)
+		if (generation != expectedGeneration) return null
 		_entryIndex.value = if (currentEntry == null) Queue.INDEX_NONE else index
 		_entry.value = currentEntry
 

--- a/playback/core/src/test/kotlin/mediastream/MediaStreamReplacementTests.kt
+++ b/playback/core/src/test/kotlin/mediastream/MediaStreamReplacementTests.kt
@@ -1,0 +1,99 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package org.jellyfin.playback.core.mediastream
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.backend.PlayerBackend
+import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.QueueService
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class MediaStreamReplacementTests : FunSpec({
+	test("replacing a loading item cancels its resolver and starts the authoritative item immediately") {
+		runTest(timeout = 10.seconds) {
+			val dispatcher = StandardTestDispatcher(testScheduler)
+			Dispatchers.setMain(dispatcher)
+			val scope = CoroutineScope(SupervisorJob() + dispatcher)
+			val oldEntry = QueueEntry()
+			val newEntry = QueueEntry()
+			val selected = MutableStateFlow<QueueEntry?>(null)
+			val oldStarted = CompletableDeferred<Unit>()
+			val oldCancelled = CompletableDeferred<Unit>()
+			val newPlaying = CompletableDeferred<Unit>()
+			val fallbackAttempts = mutableListOf<QueueEntry>()
+			val resolver = object : MediaStreamResolver {
+				override suspend fun getStream(queueEntry: QueueEntry): PlayableMediaStream {
+					if (queueEntry === oldEntry) {
+						oldStarted.complete(Unit)
+						try {
+							awaitCancellation()
+						} finally {
+							oldCancelled.complete(Unit)
+						}
+					}
+					return PlayableMediaStream(
+						"new", MediaConversionMethod.None, MediaStreamContainer("mp4"), emptyList(), queueEntry, "https://example.test/video"
+					)
+				}
+			}
+			val fallback = object : MediaStreamResolver {
+				override suspend fun getStream(queueEntry: QueueEntry): PlayableMediaStream? {
+					fallbackAttempts.add(queueEntry)
+					return null
+				}
+			}
+			val backend = mockk<PlayerBackend>(relaxed = true)
+			val manager = mockk<PlaybackManager>()
+			val queue = mockk<QueueService>()
+			val service = MediaStreamService(listOf(resolver, fallback), Duration.ZERO)
+			mockkObject(service)
+			every { service.manager } returns manager
+			every { service.coroutineScope } returns scope
+			every { manager.backend } returns backend
+			every { manager.getService(QueueService::class) } returns queue
+			every { queue.entry } returns selected
+			every { backend.playItem(newEntry) } answers {
+				newPlaying.complete(Unit)
+				Unit
+			}
+
+			try {
+				service.onInitialize()
+				runCurrent()
+				selected.value = oldEntry
+				oldStarted.await()
+				selected.value = newEntry
+				newPlaying.await()
+				oldCancelled.await()
+				fallbackAttempts shouldBe emptyList()
+				verify(exactly = 0) { backend.playItem(oldEntry) }
+				verify(exactly = 1) { backend.playItem(newEntry) }
+			} finally {
+				scope.cancel()
+				runCurrent()
+				unmockkObject(service)
+				Dispatchers.resetMain()
+			}
+		}
+	}
+})

--- a/playback/core/src/test/kotlin/queue/QueueSynchronizationTests.kt
+++ b/playback/core/src/test/kotlin/queue/QueueSynchronizationTests.kt
@@ -1,0 +1,96 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package org.jellyfin.playback.core.queue
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.PlaybackManagerOptions
+import org.jellyfin.playback.core.queue.supplier.QueueSupplier
+import kotlin.time.Duration.Companion.seconds
+
+class QueueSynchronizationTests : FunSpec({
+	test("an old supplier completing after a group playlist replacement cannot repopulate the queue") {
+		runTest {
+			val queue = createQueue()
+			val oldEntry = QueueEntry()
+			val newEntry = QueueEntry()
+			val pending = CompletableDeferred<QueueEntry>()
+			val oldSelection = async {
+				queue.synchronize(object : QueueSupplier {
+					override val size = 1
+					override suspend fun getItem(index: Int): QueueEntry? = if (index == 0) pending.await() else null
+				}, 0)
+			}
+			runCurrent()
+			val newSelection = async { queue.synchronize(supplier(newEntry), 0) }
+			runCurrent()
+			newSelection.isCompleted shouldBe true
+			newSelection.await() shouldBe newEntry
+			queue.entry.value shouldBe newEntry
+			pending.complete(oldEntry)
+			oldSelection.await() shouldBe null
+			newSelection.await() shouldBe newEntry
+			queue.entry.value shouldBe newEntry
+			queue.entries.value.shouldContainExactly(newEntry)
+		}
+	}
+
+	test("clearing while a supplier is loading does not resurrect a stopped group video") {
+		runTest {
+			val queue = createQueue()
+			val pending = CompletableDeferred<QueueEntry>()
+			val selection = async {
+				queue.synchronize(object : QueueSupplier {
+					override val size = 1
+					override suspend fun getItem(index: Int): QueueEntry? = if (index == 0) pending.await() else null
+				}, 0)
+			}
+			runCurrent()
+			queue.clear()
+			pending.complete(QueueEntry())
+			selection.await() shouldBe null
+			queue.entry.value shouldBe null
+			queue.entryIndex.value shouldBe Queue.INDEX_NONE
+			queue.entries.value shouldBe emptyList()
+		}
+	}
+
+	test("metadata-only synchronization keeps the selected entry and updates its index") {
+		runTest {
+			val queue = createQueue()
+			val current = QueueEntry()
+			queue.synchronize(supplier(current), 0)
+			val previous = QueueEntry()
+			queue.synchronize(supplier(previous, current), 1)
+			queue.entry.value shouldBe current
+			queue.entryIndex.value shouldBe 1
+			queue.entries.value.shouldContainExactly(previous, current)
+			queue.synchronize(supplier(), Queue.INDEX_NONE)
+			queue.entries.value shouldBe emptyList()
+			queue.entry.value shouldBe null
+		}
+	}
+})
+
+private fun kotlinx.coroutines.test.TestScope.createQueue(): QueueService {
+	val queue = QueueService()
+	PlaybackManager(
+		backend = mockk(relaxed = true),
+		services = mutableListOf(queue),
+		options = PlaybackManagerOptions(mockk(relaxed = true), { 10.seconds }, { 10.seconds }),
+		parentJob = backgroundScope.coroutineContext[kotlinx.coroutines.Job],
+	)
+	return queue
+}
+
+private fun supplier(vararg entries: QueueEntry) = object : QueueSupplier {
+	override val size = entries.size
+	override suspend fun getItem(index: Int) = entries.getOrNull(index)
+}

--- a/playback/jellyfin/build.gradle.kts
+++ b/playback/jellyfin/build.gradle.kts
@@ -27,6 +27,7 @@ android {
 dependencies {
 	// Kotlin
 	implementation(libs.kotlinx.coroutines)
+	implementation(libs.okhttp)
 
 	// Android(x)
 	implementation(libs.androidx.lifecycle.runtime)
@@ -53,4 +54,5 @@ dependencies {
 	testImplementation(libs.kotest.runner.junit5)
 	testImplementation(libs.kotest.assertions)
 	testImplementation(libs.mockk)
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.kotlinx.coroutines.get()}")
 }

--- a/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
+++ b/playback/jellyfin/src/main/kotlin/JellyfinPlugin.kt
@@ -7,6 +7,7 @@ import org.jellyfin.playback.jellyfin.mediasegment.MediaSegmentService
 import org.jellyfin.playback.jellyfin.mediastream.JellyfinMediaStreamResolver
 import org.jellyfin.playback.jellyfin.playsession.PlaySessionService
 import org.jellyfin.playback.jellyfin.playsession.PlaySessionSocketService
+import org.jellyfin.playback.jellyfin.syncplay.SyncPlayService
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.MediaSegmentType
@@ -22,6 +23,7 @@ fun jellyfinPlugin(
 	val playSessionService = PlaySessionService(api)
 	provide(playSessionService)
 	provide(PlaySessionSocketService(api, playSessionService, lifecycle))
+	provide(SyncPlayService(api))
 
 	provide(LyricsPlayerService(api))
 

--- a/playback/jellyfin/src/main/kotlin/network/ReliableApiClient.kt
+++ b/playback/jellyfin/src/main/kotlin/network/ReliableApiClient.kt
@@ -1,0 +1,53 @@
+package org.jellyfin.playback.jellyfin.network
+
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.ApiClientFactory
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.client.HttpMethod
+import org.jellyfin.sdk.api.client.RawResponse
+import org.jellyfin.sdk.api.okhttp.OkHttpFactory
+import org.jellyfin.sdk.api.sockets.SocketApi
+import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+
+/** Keep SDK HTTP behavior while using a single lossless socket for this session's subscribers. */
+class ReliableApiClient internal constructor(
+	private val delegate: ApiClient,
+	createSocketApi: (ApiClient) -> ReliableSocketApi,
+) : ApiClient() {
+	override val baseUrl get() = delegate.baseUrl
+	override val accessToken get() = delegate.accessToken
+	override val clientInfo get() = delegate.clientInfo
+	override val deviceInfo get() = delegate.deviceInfo
+	override val httpClientOptions get() = delegate.httpClientOptions
+
+	private val socket = lazy { createSocketApi(this) }
+	override val webSocket: SocketApi get() = socket.value
+
+	override fun update(baseUrl: String?, accessToken: String?, clientInfo: ClientInfo, deviceInfo: DeviceInfo) {
+		delegate.update(baseUrl, accessToken, clientInfo, deviceInfo)
+		if (socket.isInitialized()) socket.value.notifyApiClientUpdate()
+	}
+
+	override suspend fun request(
+		method: HttpMethod,
+		pathTemplate: String,
+		pathParameters: Map<String, Any?>,
+		queryParameters: Map<String, Any?>,
+		requestBody: Any?,
+	): RawResponse = delegate.request(method, pathTemplate, pathParameters, queryParameters, requestBody)
+}
+
+class ReliableApiClientFactory(private val factory: OkHttpFactory) : ApiClientFactory {
+	override fun create(
+		baseUrl: String?,
+		accessToken: String?,
+		clientInfo: ClientInfo,
+		deviceInfo: DeviceInfo,
+		httpClientOptions: HttpClientOptions,
+		socketConnectionFactory: SocketConnectionFactory,
+	): ApiClient = ReliableApiClient(
+		factory.create(baseUrl, accessToken, clientInfo, deviceInfo, httpClientOptions, socketConnectionFactory),
+	) { api -> ReliableSocketApi(api, factory.createClient(httpClientOptions)) }
+}

--- a/playback/jellyfin/src/main/kotlin/network/ReliableSocketApi.kt
+++ b/playback/jellyfin/src/main/kotlin/network/ReliableSocketApi.kt
@@ -1,0 +1,173 @@
+package org.jellyfin.playback.jellyfin.network
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import okhttp3.WebSocket
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.sockets.SocketApi
+import org.jellyfin.sdk.api.sockets.SocketApiState
+import org.jellyfin.sdk.model.api.ActivityLogEntryMessage
+import org.jellyfin.sdk.model.api.ActivityLogEntryStartMessage
+import org.jellyfin.sdk.model.api.ActivityLogEntryStopMessage
+import org.jellyfin.sdk.model.api.InboundWebSocketMessage
+import org.jellyfin.sdk.model.api.OutboundWebSocketMessage
+import org.jellyfin.sdk.model.api.ScheduledTasksInfoMessage
+import org.jellyfin.sdk.model.api.ScheduledTasksInfoStartMessage
+import org.jellyfin.sdk.model.api.ScheduledTasksInfoStopMessage
+import org.jellyfin.sdk.model.api.SessionsMessage
+import org.jellyfin.sdk.model.api.SessionsStartMessage
+import org.jellyfin.sdk.model.api.SessionsStopMessage
+import org.jellyfin.sdk.model.socket.PeriodicListenerPeriod
+import timber.log.Timber
+import kotlin.reflect.KClass
+
+/**
+ * SocketApi-compatible lifecycle around one ordered transport for the entire authenticated session.
+ * Its message flow never passes through StateFlow; only connection status and credentials do.
+ * Subscription types and their default period match SDK 1.8.12's DefaultSocketApi.
+ */
+class ReliableSocketApi(
+	private val api: ApiClient,
+	factory: WebSocket.Factory,
+	private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+) : SocketApi {
+	private val connection = ReliableSocketConnection(api, factory)
+	override val state = connection.state
+	private data class Credentials(val generation: Long, val identity: List<Any?>?)
+	private val credentials = MutableStateFlow(Credentials(0, credentials()))
+	private val subscriptions = mutableMapOf<Subscription, Int>()
+	private val policy = api.httpClientOptions.socketReconnectPolicy
+
+	private data class ReceivedMessage(val identity: Credentials, val message: OutboundWebSocketMessage)
+
+	private val messages = channelFlow {
+		try {
+			credentials.collectLatest { identity ->
+				connection.close()
+				if (identity.identity == null) return@collectLatest
+				policy.notifyUpdated()
+				coroutineScope {
+					// Register before connecting, and cancel the receiver with its credentials.
+					launch(start = CoroutineStart.UNDISPATCHED) {
+						connection.messages.collect { send(ReceivedMessage(identity, it)) }
+					}
+					while (isActive) {
+						maintainConnection(this)
+						policy.notifyDisconnected()
+						val retryDelay = policy.getReconnectDelay() ?: awaitCancellation()
+						delay(retryDelay)
+					}
+				}
+			}
+		} finally {
+			connection.close()
+		}
+	}.shareIn(scope, SharingStarted.WhileSubscribed(stopTimeoutMillis = STOP_TIMEOUT_MILLIS))
+
+	fun notifyApiClientUpdate() {
+		val identity = credentials()
+		credentials.update { previous ->
+			if (previous.identity == identity) previous else Credentials(previous.generation + 1, identity)
+		}
+	}
+
+	@Suppress("TooGenericExceptionCaught") // A failed network attempt uses the SDK's reconnect policy.
+	private suspend fun maintainConnection(parentScope: CoroutineScope) {
+		try {
+			withTimeout(CONNECT_TIMEOUT_MILLIS) { connection.connect(parentScope) }
+			policy.notifyConnected()
+			synchronized(subscriptions) {
+				for (type in subscriptions.keys) connection.send(type.start())
+			}
+			state.first { it is SocketApiState.Disconnected }
+		} catch (exception: TimeoutCancellationException) {
+			Timber.w(exception, "WebSocket connection timed out")
+		} catch (exception: CancellationException) {
+			throw exception
+		} catch (exception: Exception) {
+			Timber.w(exception, "WebSocket connection failed")
+		} finally {
+			connection.close()
+		}
+	}
+
+	override fun subscribeAll(): Flow<OutboundWebSocketMessage> = subscribe(Subscription.entries.toSet())
+
+	override fun <T : OutboundWebSocketMessage> subscribe(messageType: KClass<T>): Flow<T> =
+		subscribe(Subscription.entries.filter { it.messageType == messageType }.toSet()).filterIsInstance(messageType)
+
+	private fun subscribe(types: Set<Subscription>): Flow<OutboundWebSocketMessage> = flow {
+		updateSubscriptions(types, add = true)
+		try {
+			messages.collect {
+				// Buffered messages must not cross a server/account change.
+				if (it.identity == credentials.value) emit(it.message)
+			}
+		} finally {
+			updateSubscriptions(types, add = false)
+		}
+	}
+
+	private fun updateSubscriptions(types: Set<Subscription>, add: Boolean) = synchronized(subscriptions) {
+		for (type in types) {
+			val before = subscriptions[type] ?: 0
+			val after = before + if (add) 1 else -1
+			if (after > 0) subscriptions[type] = after else subscriptions.remove(type)
+			if (state.value is SocketApiState.Connected) {
+				if (before == 0 && after > 0) connection.send(type.start())
+				if (before > 0 && after == 0) connection.send(type.stop())
+			}
+		}
+	}
+
+	private fun credentials(): List<Any?>? {
+		if (api.baseUrl == null || api.accessToken == null) return null
+		return listOf(api.baseUrl, api.accessToken, api.clientInfo, api.deviceInfo)
+	}
+
+	private enum class Subscription(val messageType: KClass<out OutboundWebSocketMessage>) {
+		SESSIONS(SessionsMessage::class),
+		ACTIVITY_LOG(ActivityLogEntryMessage::class),
+		SCHEDULED_TASKS(ScheduledTasksInfoMessage::class);
+
+		fun start(): InboundWebSocketMessage {
+			val period = PeriodicListenerPeriod().toString()
+			return when (this) {
+				SESSIONS -> SessionsStartMessage(period)
+				ACTIVITY_LOG -> ActivityLogEntryStartMessage(period)
+				SCHEDULED_TASKS -> ScheduledTasksInfoStartMessage(period)
+			}
+		}
+
+		fun stop(): InboundWebSocketMessage = when (this) {
+			SESSIONS -> SessionsStopMessage()
+			ACTIVITY_LOG -> ActivityLogEntryStopMessage()
+			SCHEDULED_TASKS -> ScheduledTasksInfoStopMessage()
+		}
+	}
+
+	private companion object {
+		const val CONNECT_TIMEOUT_MILLIS = 10_000L
+		const val STOP_TIMEOUT_MILLIS = 5_000L
+	}
+}

--- a/playback/jellyfin/src/main/kotlin/network/ReliableSocketConnection.kt
+++ b/playback/jellyfin/src/main/kotlin/network/ReliableSocketConnection.kt
@@ -1,0 +1,182 @@
+package org.jellyfin.playback.jellyfin.network
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.util.ApiSerializer
+import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
+import org.jellyfin.sdk.api.okhttp.OkHttpFactory
+import org.jellyfin.sdk.api.sockets.SocketApiState
+import org.jellyfin.sdk.model.api.ForceKeepAliveMessage
+import org.jellyfin.sdk.model.api.InboundKeepAliveMessage
+import org.jellyfin.sdk.model.api.InboundWebSocketMessage
+import org.jellyfin.sdk.model.api.OutboundKeepAliveMessage
+import org.jellyfin.sdk.model.api.OutboundWebSocketMessage
+import timber.log.Timber
+import java.io.IOException
+
+/**
+ * The SDK 1.8.12 socket stores incoming frames in StateFlow, which drops messages arriving in
+ * the same burst (notably GroupJoined followed by Stop). SyncPlay requires every frame in order.
+ * The session socket retains the SDK's authentication and typed message decoder,
+ * with a bounded channel installed before opening the connection. Overflow disconnects explicitly
+ * instead of continuing with a partial group state. All app events share this one connection:
+ * the server sends each session message to its most recently active socket only.
+ */
+class ReliableSocketConnection(
+	private val api: ApiClient,
+	private val factory: WebSocket.Factory = OkHttpFactory().createClient(api.httpClientOptions),
+) {
+	private val _messages = MutableSharedFlow<OutboundWebSocketMessage>()
+	val messages = _messages.asSharedFlow()
+	private val _state = MutableStateFlow<SocketApiState>(SocketApiState.Disconnected())
+	val state = _state.asStateFlow()
+	@Volatile private var connection: Connection? = null
+
+	fun send(message: InboundWebSocketMessage): Boolean =
+		connection?.socket?.send(ApiSerializer.encodeSocketMessage(message)) == true
+
+	/** Return after the server's first frame, before making the REST Create/Join request. */
+	@Suppress("TooGenericExceptionCaught") // Decoding is the boundary of an ordered network stream.
+	suspend fun connect(parentScope: CoroutineScope) {
+		close()
+		val session = Connection(CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentScope.coroutineContext[Job])))
+		connection = session
+		_state.value = SocketApiState.Connecting
+		session.scope.launch(start = CoroutineStart.UNDISPATCHED) {
+			try {
+				for (raw in session.frames) {
+					val message = ApiSerializer.decodeSocketMessage(raw)
+					if (connection !== session) break
+					_state.value = SocketApiState.Connected
+					session.connected.complete(Unit)
+					resetWatchdog(session)
+					when (message) {
+						is ForceKeepAliveMessage -> startKeepAlive(session, message.data)
+						is OutboundKeepAliveMessage -> Unit
+						else -> _messages.emit(message)
+					}
+				}
+			} catch (exception: CancellationException) {
+				throw exception
+			} catch (exception: Exception) {
+				// A malformed frame invalidates this ordered stream; never continue after a gap.
+				fail(session, exception)
+			}
+		}
+		val request = Request.Builder()
+			.url(api.createUrl("/socket"))
+			.header("Authorization", AuthorizationHeaderBuilder.buildHeader(
+				clientName = api.clientInfo.name,
+				clientVersion = api.clientInfo.version,
+				deviceId = api.deviceInfo.id,
+				deviceName = api.deviceInfo.name,
+				accessToken = requireNotNull(api.accessToken),
+			))
+			.build()
+		session.socket = factory.newWebSocket(request, listener(session))
+		if (connection !== session) session.socket?.cancel()
+		session.connected.await()
+	}
+
+	@Synchronized
+	fun close() {
+		val old = connection
+		connection = null
+		old?.connected?.cancel()
+		old?.frames?.cancel()
+		old?.scope?.cancel()
+		old?.socket?.cancel()
+		_state.value = SocketApiState.Disconnected()
+	}
+
+	private fun listener(session: Connection) = object : WebSocketListener() {
+		override fun onMessage(webSocket: WebSocket, text: String) {
+			if (connection === session && session.frames.trySend(text).isFailure) {
+				fail(session, IOException("SyncPlay socket message buffer exhausted"))
+			}
+		}
+
+		override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+			webSocket.close(code, reason)
+			fail(session, IOException("SyncPlay socket closing ($code)"))
+		}
+
+		override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+			fail(session, IOException("SyncPlay socket closed ($code)"))
+		}
+
+		override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+			fail(session, t)
+		}
+	}
+
+	private fun startKeepAlive(session: Connection, timeoutSeconds: Int) {
+		session.replyTimeoutMillis = timeoutSeconds.coerceAtLeast(1) * MILLIS_PER_DOUBLE_SECOND
+		resetWatchdog(session)
+		session.keepAlive?.cancel()
+		session.keepAlive = session.scope.launch {
+			val message = ApiSerializer.encodeSocketMessage(InboundKeepAliveMessage())
+			while (isActive) {
+				if (session.socket?.send(message) == false) {
+					fail(session, IOException("SyncPlay keepalive could not be sent"))
+					break
+				}
+				delay(timeoutSeconds.coerceAtLeast(1) * MILLIS_PER_HALF_SECOND)
+			}
+		}
+	}
+
+	private fun resetWatchdog(session: Connection) {
+		session.watchdog?.cancel()
+		val timeout = session.replyTimeoutMillis ?: return
+		session.watchdog = session.scope.launch {
+			delay(timeout)
+			fail(session, IOException("SyncPlay keepalive reply timed out"))
+		}
+	}
+
+	@Synchronized
+	private fun fail(session: Connection, error: Throwable) {
+		if (connection !== session) return
+		connection = null
+		Timber.w(error, "SyncPlay socket disconnected")
+		session.connected.completeExceptionally(error)
+		session.frames.cancel()
+		session.scope.cancel()
+		session.socket?.cancel()
+		_state.value = SocketApiState.Disconnected(error)
+	}
+
+	private class Connection(val scope: CoroutineScope) {
+		val frames = Channel<String>(FRAME_CAPACITY)
+		val connected = CompletableDeferred<Unit>()
+		@Volatile var socket: WebSocket? = null
+		var keepAlive: Job? = null
+		var watchdog: Job? = null
+		var replyTimeoutMillis: Long? = null
+	}
+
+	private companion object {
+		const val FRAME_CAPACITY = 256
+		const val MILLIS_PER_HALF_SECOND = 500L
+		const val MILLIS_PER_DOUBLE_SECOND = 2_000L
+	}
+}

--- a/playback/jellyfin/src/main/kotlin/syncplay/SyncPlayClock.kt
+++ b/playback/jellyfin/src/main/kotlin/syncplay/SyncPlayClock.kt
@@ -1,0 +1,100 @@
+package org.jellyfin.playback.jellyfin.syncplay
+
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToLong
+
+/**
+ * Estimates server UTC using Jellyfin Web's lowest-delay sample from the last eight measurements.
+ * Elapsed time comes from a monotonic clock so changes to the device clock cannot move playback.
+ *
+ * See Jellyfin Web's `src/plugins/syncPlay/core/timeSync/TimeSync.js`.
+ */
+class SyncPlayClock(
+	private val wallTimeMillis: () -> Long = System::currentTimeMillis,
+	private val monotonicTimeNanos: () -> Long = System::nanoTime,
+) {
+	private var anchorNanos = monotonicTimeNanos()
+	private var anchorEpochMillis = wallTimeMillis()
+	private var generation = 0L
+	private val measurements = ArrayDeque<Measurement>()
+	private var selectedMeasurement: Measurement? = null
+
+	val isSynchronized: Boolean
+		get() = synchronized(this) { selectedMeasurement != null }
+
+	/** Server UTC minus the monotonic projection of the device's initial UTC, in milliseconds. */
+	val offsetMillis: Double
+		get() = synchronized(this) { selectedMeasurement?.offsetMillis ?: 0.0 }
+
+	/** Jellyfin's Ping request expects one-way latency, rounded from half the network round trip. */
+	val pingMillis: Long
+		get() = synchronized(this) { ((selectedMeasurement?.delayMillis ?: 0.0) / 2).roundToLong() }
+
+	@Synchronized
+	fun beginMeasurement(): MeasurementRequest {
+		val sentAtNanos = monotonicTimeNanos()
+		return MeasurementRequest(generation, sentAtNanos, localTimeMillis(sentAtNanos))
+	}
+
+	/** Returns false for stale requests or timestamps that cannot represent a valid measurement. */
+	@Synchronized
+	fun completeMeasurement(
+		request: MeasurementRequest,
+		serverReceivedMillis: Long,
+		serverSentMillis: Long,
+	): Boolean {
+		if (request.generation != generation || serverSentMillis < serverReceivedMillis) return false
+		val receivedAtNanos = monotonicTimeNanos()
+		val elapsedNanos = receivedAtNanos - request.sentAtNanos
+		if (elapsedNanos < 0) return false
+
+		val elapsedMillis = elapsedNanos / NANOS_PER_MILLISECOND
+		val serverProcessingMillis = serverSentMillis.toDouble() - serverReceivedMillis.toDouble()
+		val delayMillis = elapsedMillis - serverProcessingMillis
+		if (delayMillis < 0) return false
+
+		val responseReceivedMillis = request.localSentMillis + elapsedMillis
+		val offsetMillis = ((serverReceivedMillis - request.localSentMillis) + (serverSentMillis - responseReceivedMillis)) / 2
+		measurements.addLast(Measurement(offsetMillis, delayMillis))
+		if (measurements.size > TRACKED_MEASUREMENTS) measurements.removeFirst()
+		selectedMeasurement = measurements.minBy { it.delayMillis }
+		return true
+	}
+
+	/** Current estimated server UTC, suitable for Ready/Buffering request timestamps. */
+	@Synchronized
+	fun nowMillis(): Long = (localTimeMillis(monotonicTimeNanos()) + offsetMillis).roundToLong()
+
+	/** Delay for a command's server UTC timestamp; late commands should run immediately. */
+	@Synchronized
+	fun delayUntil(serverTimeMillis: Long): Long = (serverTimeMillis - nowMillis()).coerceAtLeast(0)
+
+	/** Monotonic elapsed milliseconds for correction cooldowns and player event deadlines. */
+	@Synchronized
+	fun monotonicMillis(): Long = TimeUnit.NANOSECONDS.toMillis(monotonicTimeNanos() - anchorNanos)
+
+	/** Discards measurements and invalidates requests still in flight when changing servers. */
+	@Synchronized
+	fun reset() {
+		generation++
+		measurements.clear()
+		selectedMeasurement = null
+		anchorNanos = monotonicTimeNanos()
+		anchorEpochMillis = wallTimeMillis()
+	}
+
+	private fun localTimeMillis(nanos: Long): Double = anchorEpochMillis + (nanos - anchorNanos) / NANOS_PER_MILLISECOND
+
+	class MeasurementRequest internal constructor(
+		internal val generation: Long,
+		internal val sentAtNanos: Long,
+		internal val localSentMillis: Double,
+	)
+
+	private data class Measurement(val offsetMillis: Double, val delayMillis: Double)
+
+	private companion object {
+		const val TRACKED_MEASUREMENTS = 8
+		const val NANOS_PER_MILLISECOND = 1_000_000.0
+	}
+}

--- a/playback/jellyfin/src/main/kotlin/syncplay/SyncPlayDriftPolicy.kt
+++ b/playback/jellyfin/src/main/kotlin/syncplay/SyncPlayDriftPolicy.kt
@@ -1,0 +1,55 @@
+package org.jellyfin.playback.jellyfin.syncplay
+
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+/**
+ * Jellyfin Web's default SpeedToSync/SkipToSync policy. Ongoing correction is opt-in, as in Web.
+ * The caller schedules cooldowns, restores speed after [SyncPlayCorrection.ChangeSpeed], and
+ * cancels correction whenever a new group command arrives or the client leaves the group.
+ *
+ * See Jellyfin Web's `src/plugins/syncPlay/core/PlaybackCore.js`.
+ */
+class SyncPlayDriftPolicy {
+	val correctionIntervalMillis: Long = CORRECTION_INTERVAL_MILLIS
+	val unpauseGracePeriodMillis: Long = UNPAUSE_GRACE_PERIOD_MILLIS
+
+	/** Positive drift means the client is behind the group. */
+	fun correction(
+		driftMillis: Double,
+		supportsPlaybackRate: Boolean,
+		enabled: Boolean = false,
+	): SyncPlayCorrection {
+		if (!enabled || !driftMillis.isFinite()) return SyncPlayCorrection.None
+		val absoluteDriftMillis = abs(driftMillis)
+		if (supportsPlaybackRate && absoluteDriftMillis >= MIN_SPEED_DRIFT_MILLIS && absoluteDriftMillis < MAX_SPEED_DRIFT_MILLIS) {
+			var durationMillis = SPEED_DURATION_MILLIS
+			// Web lengthens recovery when ahead to avoid a non-positive playback rate.
+			if (driftMillis <= -durationMillis * MIN_SPEED) {
+				durationMillis = absoluteDriftMillis / (1 - MIN_SPEED)
+			}
+			return SyncPlayCorrection.ChangeSpeed(
+				rate = (1 + driftMillis / durationMillis).toFloat(),
+				durationMillis = durationMillis.roundToLong(),
+			)
+		}
+		if (absoluteDriftMillis >= MIN_SEEK_DRIFT_MILLIS) return SyncPlayCorrection.Seek
+		return SyncPlayCorrection.None
+	}
+
+	private companion object {
+		const val CORRECTION_INTERVAL_MILLIS = 1500L
+		const val UNPAUSE_GRACE_PERIOD_MILLIS = 1500L
+		const val MIN_SPEED_DRIFT_MILLIS = 60.0
+		const val MAX_SPEED_DRIFT_MILLIS = 3000.0
+		const val SPEED_DURATION_MILLIS = 1000.0
+		const val MIN_SEEK_DRIFT_MILLIS = 400.0
+		const val MIN_SPEED = 0.2
+	}
+}
+
+sealed interface SyncPlayCorrection {
+	data object None : SyncPlayCorrection
+	data class ChangeSpeed(val rate: Float, val durationMillis: Long) : SyncPlayCorrection
+	data object Seek : SyncPlayCorrection
+}

--- a/playback/jellyfin/src/main/kotlin/syncplay/SyncPlayService.kt
+++ b/playback/jellyfin/src/main/kotlin/syncplay/SyncPlayService.kt
@@ -1,0 +1,711 @@
+package org.jellyfin.playback.jellyfin.syncplay
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.jellyfin.playback.core.PlayerCommand
+import org.jellyfin.playback.core.PlayerCommandHandler
+import org.jellyfin.playback.core.backend.PlayerBackendEventListener
+import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.PlaybackOrder
+import org.jellyfin.playback.core.model.RepeatMode
+import org.jellyfin.playback.core.plugin.PlayerService
+import org.jellyfin.playback.core.queue.InitialPlayback
+import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.initialPlayback
+import org.jellyfin.playback.core.queue.queue
+import org.jellyfin.playback.core.queue.supplier.QueueSupplier
+import org.jellyfin.playback.jellyfin.queue.createBaseItemQueueEntry
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.syncPlayApi
+import org.jellyfin.sdk.api.client.extensions.timeSyncApi
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.api.sockets.SocketApiState
+import org.jellyfin.sdk.model.api.BufferRequestDto
+import org.jellyfin.sdk.model.api.GroupInfoDto
+import org.jellyfin.sdk.model.api.GroupQueueMode
+import org.jellyfin.sdk.model.api.GroupRepeatMode
+import org.jellyfin.sdk.model.api.GroupShuffleMode
+import org.jellyfin.sdk.model.api.GroupUpdate
+import org.jellyfin.sdk.model.api.JoinGroupRequestDto
+import org.jellyfin.sdk.model.api.NewGroupRequestDto
+import org.jellyfin.sdk.model.api.NextItemRequestDto
+import org.jellyfin.sdk.model.api.PingRequestDto
+import org.jellyfin.sdk.model.api.PlayQueueUpdate
+import org.jellyfin.sdk.model.api.PlayQueueUpdateReason
+import org.jellyfin.sdk.model.api.PlayRequestDto
+import org.jellyfin.sdk.model.api.PreviousItemRequestDto
+import org.jellyfin.sdk.model.api.QueueRequestDto
+import org.jellyfin.sdk.model.api.ReadyRequestDto
+import org.jellyfin.sdk.model.api.RemoveFromPlaylistRequestDto
+import org.jellyfin.sdk.model.api.SeekRequestDto
+import org.jellyfin.sdk.model.api.SendCommand
+import org.jellyfin.sdk.model.api.SendCommandType
+import org.jellyfin.sdk.model.api.SetPlaylistItemRequestDto
+import org.jellyfin.sdk.model.api.SetRepeatModeRequestDto
+import org.jellyfin.sdk.model.api.SetShuffleModeRequestDto
+import org.jellyfin.sdk.model.api.SyncPlayCommandMessage
+import org.jellyfin.sdk.model.api.SyncPlayGroupDoesNotExistUpdate
+import org.jellyfin.sdk.model.api.SyncPlayGroupJoinedUpdate
+import org.jellyfin.sdk.model.api.SyncPlayGroupLeftUpdate
+import org.jellyfin.sdk.model.api.SyncPlayGroupUpdateMessage
+import org.jellyfin.sdk.model.api.SyncPlayLibraryAccessDeniedUpdate
+import org.jellyfin.sdk.model.api.SyncPlayNotInGroupUpdate
+import org.jellyfin.sdk.model.api.SyncPlayPlayQueueUpdate
+import org.jellyfin.sdk.model.api.SyncPlayStateUpdate
+import org.jellyfin.sdk.model.api.SyncPlayUserJoinedUpdate
+import org.jellyfin.sdk.model.api.SyncPlayUserLeftUpdate
+import org.jellyfin.sdk.model.extensions.ticks
+import timber.log.Timber
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.math.abs
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The same server-authoritative SyncPlay protocol used by Jellyfin Web. User commands are sent
+ * to the group; scheduled server commands go directly to the backend, avoiding command echoes.
+ * All player and group state is confined to the main dispatcher.
+ */
+@Suppress("TooManyFunctions", "LargeClass")
+class SyncPlayService(
+	private val api: ApiClient,
+	private val clock: SyncPlayClock = SyncPlayClock(),
+) : PlayerService(), PlayerCommandHandler {
+	private val _group = MutableStateFlow<GroupInfoDto?>(null)
+	val group = _group.asStateFlow()
+	private val _groups = MutableStateFlow<List<GroupInfoDto>>(emptyList())
+	val groups = _groups.asStateFlow()
+	private val _busy = MutableStateFlow(false)
+	val busy = _busy.asStateFlow()
+	private val _error = MutableStateFlow<String?>(null)
+	val error = _error.asStateFlow()
+	private val _syncCorrectionEnabled = MutableStateFlow(false)
+	val syncCorrectionEnabled = _syncCorrectionEnabled.asStateFlow()
+	private val _queueState = MutableStateFlow<PlayQueueUpdate?>(null)
+	val queueState = _queueState.asStateFlow()
+
+	private val initialized = CompletableDeferred<Unit>()
+	private val operationMutex = Mutex()
+	private val requestMutex = Mutex()
+	private val driftPolicy = SyncPlayDriftPolicy()
+	private var generation = 0L
+	private var playbackGeneration = 0L
+	private var requestsJob: Job? = null
+	private var joining = false
+	private var joiningRequestSent = false
+	private var joinResult: CompletableDeferred<GroupInfoDto>? = null
+	private var sessionIdentity: Pair<String?, String?>? = null
+	private var playQueue: PlayQueueUpdate?
+		get() = _queueState.value
+		set(value) { _queueState.value = value }
+	private var currentEntry: QueueEntry? = null
+	private var entries = mutableMapOf<UUID, QueueEntry>()
+	private var awaitingReady = false
+	private var buffering = false
+	private var reportedBuffering = false
+	private var commandJob: Job? = null
+	private var bufferJob: Job? = null
+	private var correctionJob: Job? = null
+	private var timeSyncJob: Job? = null
+	private var lastCommand: SendCommand? = null
+	private var joinedAt: LocalDateTime? = null
+	private var playingAnchor: SendCommand? = null
+	private var unpausedAt = 0L
+
+	private val playlistItemId: UUID?
+		get() = playQueue?.let { it.playlist.getOrNull(it.playingItemIndex)?.playlistItemId }
+
+	val active: Boolean get() = group.value != null || joining
+
+	@Suppress("TooGenericExceptionCaught") // A failed protocol handler must not kill the socket collector.
+	override suspend fun onInitialize() = withContext(Dispatchers.Main.immediate) {
+		manager.addBackendListener(backendListener)
+		coroutineScope.launch(Dispatchers.Main.immediate, start = CoroutineStart.UNDISPATCHED) {
+			try {
+				awaitCancellation()
+			} finally {
+				withContext(NonCancellable + Dispatchers.Main.immediate) {
+					manager.removeBackendListener(backendListener)
+					if (active) reset(stopPlayback = true)
+				}
+			}
+		}
+		// One subscription preserves ordering between queue updates and playback commands.
+		coroutineScope.launch(Dispatchers.Main.immediate, start = CoroutineStart.UNDISPATCHED) {
+			api.webSocket.subscribeAll().collect { message ->
+				try {
+					if (sessionIdentity != null && sessionIdentity != identity()) reset(stopPlayback = true)
+					when (message) {
+						is SyncPlayGroupUpdateMessage -> receiveGroupUpdate(message.data)
+						is SyncPlayCommandMessage -> message.data?.let(::receiveCommand)
+						else -> Unit
+					}
+				} catch (exception: CancellationException) {
+					throw exception
+				} catch (exception: Exception) {
+					Timber.w(exception, "SyncPlay update failed")
+					failAndLeave("Unable to play this SyncPlay group.")
+				}
+			}
+		}
+		coroutineScope.launch(Dispatchers.Main.immediate) {
+			api.webSocket.state.collect { socketState ->
+				if (socketState is SocketApiState.Disconnected && active) {
+					failAndLeave("SyncPlay disconnected. Join the group again to resume.")
+				}
+			}
+		}
+		initialized.complete(Unit)
+		Unit
+	}
+
+	fun clearError() { _error.value = null }
+
+	fun isGroupEntry(entry: QueueEntry?): Boolean = group.value != null && entry != null && entry === currentEntry
+
+	fun setSyncCorrectionEnabled(enabled: Boolean) {
+		_syncCorrectionEnabled.value = enabled
+		if (!enabled) resetCorrection()
+	}
+
+	suspend fun refreshGroups() = operation("Unable to load SyncPlay groups.") {
+		val expectedGeneration = generation
+		val expectedIdentity = identity()
+		val available = api.syncPlayApi.syncPlayGetGroups().content
+		if (generation != expectedGeneration || identity() != expectedIdentity) return@operation
+		_groups.value = available
+		group.value?.groupId?.let { id -> _groups.value.firstOrNull { it.groupId == id }?.let { _group.value = it } }
+	}
+
+	suspend fun createGroup(name: String) = operation("Unable to create a SyncPlay group. Check your SyncPlay permissions.") {
+		require(name.isNotBlank())
+		beginJoin()
+		val expectedGeneration = generation
+		joiningRequestSent = true
+		val created = api.syncPlayApi.syncPlayCreateGroup(NewGroupRequestDto(name.trim())).content
+		if (expectedGeneration == generation && sessionIdentity == identity()) acceptGroup(created)
+	}
+
+	suspend fun joinGroup(id: UUID) = operation("Unable to join this SyncPlay group. It may have closed or access may be denied.") {
+		beginJoin()
+		val result = requireNotNull(joinResult)
+		joiningRequestSent = true
+		api.syncPlayApi.syncPlayJoinGroup(JoinGroupRequestDto(id))
+		withTimeout(JOIN_TIMEOUT_MILLIS) { require(result.await().groupId == id) }
+	}
+
+	suspend fun leaveGroup() = operation("Unable to leave the SyncPlay group.") {
+		val wasJoined = group.value != null || joining
+		reset(stopPlayback = false)
+		if (wasJoined) api.syncPlayApi.syncPlayLeaveGroup()
+	}
+
+	/** Called before changing server/user credentials; do not send requests with the next session. */
+	suspend fun endSession() = withContext(Dispatchers.Main.immediate) {
+		val wasJoined = group.value != null || joining
+		reset(stopPlayback = true)
+		_groups.value = emptyList()
+		_error.value = null
+		if (wasJoined) {
+			try {
+				withTimeout(LEAVE_TIMEOUT_MILLIS) { api.syncPlayApi.syncPlayLeaveGroup() }
+			} catch (_: TimeoutCancellationException) {
+				// Logout must still finish when the old server is unreachable.
+			} catch (exception: CancellationException) {
+				throw exception
+			} catch (_: Exception) {
+				// The server also removes this session when its socket closes.
+			}
+		}
+	}
+
+	/** Start a title/playlist selected while grouped, instead of replacing only the TV's queue. */
+	suspend fun playItems(ids: List<UUID>, index: Int, position: Duration) = operation("Unable to start group playback.") {
+		require(group.value != null && ids.isNotEmpty() && index in ids.indices)
+		api.syncPlayApi.syncPlaySetNewQueue(PlayRequestDto(ids, index, position.inWholeTicks))
+	}
+
+	/** Add media to the shared playlist without changing the TV's local queue ahead of the server. */
+	fun queueItems(ids: List<UUID>) {
+		if (group.value == null || ids.isEmpty()) return
+		launchRequest { api.syncPlayApi.syncPlayQueue(QueueRequestDto(ids, GroupQueueMode.QUEUE)) }
+	}
+
+	private suspend fun beginJoin() {
+		if (group.value != null) api.syncPlayApi.syncPlayLeaveGroup()
+		reset(stopPlayback = false)
+		joining = true
+		joinResult = CompletableDeferred()
+		sessionIdentity = identity()
+		withTimeout(JOIN_TIMEOUT_MILLIS) { api.webSocket.state.first { it is SocketApiState.Connected } }
+		measureTime()
+	}
+
+	private fun acceptGroup(info: GroupInfoDto) {
+		if (!joining && group.value?.groupId != info.groupId) return
+		val changed = group.value?.groupId != info.groupId
+		if (changed) {
+			// Local automatic repeat/order must stay disabled while the group owns the queue.
+			state.setRepeatMode(RepeatMode.NONE)
+			state.setPlaybackOrder(PlaybackOrder.DEFAULT)
+		}
+		_group.value = info
+		joining = false
+		joiningRequestSent = false
+		joinResult?.complete(info)
+		joinResult = null
+		if (!changed) return
+		joinedAt = info.lastUpdatedAt
+		requestsJob = SupervisorJob(coroutineScope.coroutineContext[Job])
+		manager.backend.setSpeed(1f)
+		timeSyncJob?.cancel()
+		timeSyncJob = coroutineScope.launch(Dispatchers.Main.immediate) {
+			var samples = 1
+			while (group.value != null) {
+				delay(if (samples < INITIAL_TIME_SAMPLES) INITIAL_TIME_INTERVAL else TIME_INTERVAL)
+				try {
+					measureTime()
+					api.syncPlayApi.syncPlayPing(PingRequestDto(clock.pingMillis))
+					samples++
+				} catch (exception: CancellationException) {
+					throw exception
+				} catch (_: Exception) {
+					// Retain the last good clock estimate; socket loss tears down the group separately.
+				}
+			}
+		}
+		startCorrectionLoop()
+	}
+
+	private suspend fun measureTime() {
+		val measurement = clock.beginMeasurement()
+		val response = api.timeSyncApi.getUtcTime().content
+		clock.completeMeasurement(measurement, response.requestReceptionTime.epochMillis, response.responseTransmissionTime.epochMillis)
+	}
+
+	@Suppress("CyclomaticComplexMethod") // Keep the complete server group-update dispatch in one place.
+	private suspend fun receiveGroupUpdate(update: GroupUpdate) {
+		when (update) {
+			is SyncPlayNotInGroupUpdate -> {
+				if (joining || group.value != null) {
+					reset(stopPlayback = true)
+					_error.value = "You are no longer in this SyncPlay group."
+				}
+				return
+			}
+			is SyncPlayGroupDoesNotExistUpdate -> {
+				if (joining || group.value != null) failAndLeave("This SyncPlay group no longer exists.")
+				return
+			}
+			is SyncPlayLibraryAccessDeniedUpdate -> {
+				if (joining || group.value != null) failAndLeave("You do not have access to the group's current media.")
+				return
+			}
+			else -> Unit
+		}
+		if (update is SyncPlayGroupJoinedUpdate) {
+			acceptGroup(update.data)
+			return
+		}
+		if (update.groupId != group.value?.groupId) return
+		when (update) {
+			is SyncPlayPlayQueueUpdate -> receiveQueue(update.data)
+			is SyncPlayGroupLeftUpdate -> reset(stopPlayback = false)
+			is SyncPlayStateUpdate -> _group.value = group.value?.copy(state = update.data.state)
+			is SyncPlayUserJoinedUpdate, is SyncPlayUserLeftUpdate -> {
+				refreshJoinedGroup(update.groupId)
+			}
+			is SyncPlayGroupJoinedUpdate, is SyncPlayNotInGroupUpdate,
+			is SyncPlayGroupDoesNotExistUpdate, is SyncPlayLibraryAccessDeniedUpdate -> Unit
+		}
+	}
+
+	/** Participant metadata must not hold up the ordered queue and playback command stream. */
+	@Suppress("TooGenericExceptionCaught") // Participant metadata is an independent, best-effort network request.
+	private fun refreshJoinedGroup(groupId: UUID) {
+		val expectedGeneration = generation
+		val expectedIdentity = identity()
+		coroutineScope.launch(Dispatchers.Main.immediate) {
+			try {
+				val info = api.syncPlayApi.syncPlayGetGroups().content.firstOrNull { it.groupId == groupId } ?: return@launch
+				if (generation != expectedGeneration || identity() != expectedIdentity) return@launch
+				val current = group.value ?: return@launch
+				if (current.groupId == groupId && info.lastUpdatedAt >= current.lastUpdatedAt) _group.value = info
+			} catch (exception: CancellationException) {
+				throw exception
+			} catch (exception: Exception) {
+				Timber.w(exception, "Unable to refresh SyncPlay participants")
+			}
+		}
+	}
+
+	private suspend fun receiveQueue(update: PlayQueueUpdate) {
+		val previous = playQueue
+		if (previous != null && update.lastUpdate < previous.lastUpdate) return
+		val next = update.playlist.getOrNull(update.playingItemIndex)
+		val sameItem = next?.playlistItemId == playlistItemId && currentEntry != null
+		playQueue = update
+		if (next == null) {
+			clearPlayback()
+			return
+		}
+		// A queue edit around the current item must not restart it, but indices still need updating.
+		val metadataOnly = update.reason in setOf(
+			PlayQueueUpdateReason.MOVE_ITEM, PlayQueueUpdateReason.QUEUE, PlayQueueUpdateReason.QUEUE_NEXT,
+			PlayQueueUpdateReason.REPEAT_MODE, PlayQueueUpdateReason.SHUFFLE_MODE, PlayQueueUpdateReason.REMOVE_ITEMS,
+		)
+		if (sameItem && metadataOnly) {
+			entries.keys.retainAll(update.playlist.map { it.playlistItemId }.toSet())
+			synchronizeQueue(update)
+			return
+		}
+		playbackGeneration++
+		lastCommand = null
+		cancelScheduledCommand()
+		currentEntry = null
+		bufferJob?.cancel()
+		val expectedGeneration = generation
+		val item = api.userLibraryApi.getItem(next.itemId).content
+		if (generation != expectedGeneration) return
+		val entry = createBaseItemQueueEntry(api, item).also {
+			it.initialPlayback = InitialPlayback(update.startPositionTicks.ticks, playWhenReady = false)
+		}
+		entries = mutableMapOf()
+		entries[next.playlistItemId] = entry
+		currentEntry = entry
+		awaitingReady = true
+		buffering = true
+		reportedBuffering = false
+		manager.backend.pause()
+		synchronizeQueue(update)
+	}
+
+	private suspend fun synchronizeQueue(update: PlayQueueUpdate) {
+		val queueEntries = entries
+		manager.queue.synchronize(object : QueueSupplier {
+			override val size = update.playlist.size
+			override suspend fun getItem(index: Int): QueueEntry? {
+				val queueItem = update.playlist.getOrNull(index) ?: return null
+				return queueEntries[queueItem.playlistItemId] ?: createBaseItemQueueEntry(
+					api, api.userLibraryApi.getItem(queueItem.itemId).content
+				).also { queueEntries[queueItem.playlistItemId] = it }
+			}
+		}, update.playingItemIndex)
+	}
+
+	@Suppress("CyclomaticComplexMethod", "ReturnCount") // Guard stale/duplicate commands before the four protocol actions.
+	private fun receiveCommand(command: SendCommand) {
+		if (command.groupId != group.value?.groupId) return
+		if (command.command != SendCommandType.STOP && command.playlistItemId != playlistItemId) return
+		if (command.emittedAt < (joinedAt ?: command.emittedAt)) return
+		if (lastCommand?.let { command.emittedAt < it.emittedAt } == true) return
+		val duplicate = lastCommand?.let {
+			it.command == command.command && it.`when` == command.`when` &&
+				it.positionTicks == command.positionTicks && it.playlistItemId == command.playlistItemId
+		} == true
+		lastCommand = command
+		if (duplicate) {
+			if (clock.delayUntil(command.`when`.epochMillis) > 0) return
+			val isPlaying = state.playState.value == PlayState.PLAYING
+			val atPosition = state.positionInfo.active.inWholeTicks == (command.positionTicks ?: 0)
+			when (command.command) {
+				SendCommandType.UNPAUSE -> if (isPlaying) return
+				SendCommandType.PAUSE -> if (!isPlaying && atPosition) return
+				SendCommandType.SEEK -> if (!isPlaying && atPosition && !buffering) {
+					reportReady()
+					return
+				}
+				SendCommandType.STOP -> if (currentEntry == null) return
+			}
+		}
+		cancelScheduledCommand()
+		val expectedGeneration = generation
+		commandJob = coroutineScope.launch(Dispatchers.Main.immediate) {
+			delay(clock.delayUntil(command.`when`.epochMillis))
+			if (generation != expectedGeneration) return@launch
+			val position = (command.positionTicks ?: 0).ticks
+			when (command.command) {
+				SendCommandType.UNPAUSE -> {
+					val target = position + (clock.nowMillis() - command.`when`.epochMillis).coerceAtLeast(0).milliseconds
+					if (abs((state.positionInfo.active - target).inWholeMilliseconds) >= SEEK_TOLERANCE_MILLIS) manager.backend.seekTo(target)
+					playingAnchor = command
+					unpausedAt = clock.monotonicMillis()
+					manager.backend.play()
+				}
+				SendCommandType.PAUSE -> {
+					manager.backend.pause()
+					manager.backend.seekTo(position)
+				}
+				SendCommandType.SEEK -> {
+					playbackGeneration++
+					awaitingReady = true
+					manager.backend.pause()
+					manager.backend.seekTo(position)
+					// ExoPlayer may keep STATE_READY when seeking inside its buffer.
+					if (!buffering) reportReady()
+				}
+				SendCommandType.STOP -> clearPlayback()
+			}
+		}
+	}
+
+	@Suppress("CyclomaticComplexMethod") // Exhaustive mapping from local controls to server requests.
+	override fun handleCommand(command: PlayerCommand): Boolean {
+		if (group.value == null) return false
+		val id = playlistItemId
+		val selectedId = when (command) {
+			is PlayerCommand.Select -> playQueue?.playlist?.getOrNull(command.index)?.playlistItemId
+			is PlayerCommand.Remove -> playQueue?.playlist?.getOrNull(command.index)?.playlistItemId
+			else -> null
+		}
+		launchRequest {
+			when (command) {
+				PlayerCommand.Play -> api.syncPlayApi.syncPlayUnpause()
+				PlayerCommand.Pause -> api.syncPlayApi.syncPlayPause()
+				PlayerCommand.Stop -> api.syncPlayApi.syncPlayStop()
+				is PlayerCommand.Seek -> api.syncPlayApi.syncPlaySeek(SeekRequestDto(command.position.coerceAtLeast(Duration.ZERO).inWholeTicks))
+				PlayerCommand.Next -> if (id != null) api.syncPlayApi.syncPlayNextItem(NextItemRequestDto(id))
+				PlayerCommand.Previous -> if (id != null) api.syncPlayApi.syncPlayPreviousItem(PreviousItemRequestDto(id))
+				is PlayerCommand.Select -> selectedId?.let {
+					api.syncPlayApi.syncPlaySetPlaylistItem(SetPlaylistItemRequestDto(it))
+				}
+				is PlayerCommand.Speed -> Unit // The group timeline runs at 1x; speed is reserved for temporary correction.
+				is PlayerCommand.Order -> api.syncPlayApi.syncPlaySetShuffleMode(SetShuffleModeRequestDto(
+					if (command.order == PlaybackOrder.DEFAULT) GroupShuffleMode.SORTED else GroupShuffleMode.SHUFFLE
+				))
+				is PlayerCommand.Repeat -> api.syncPlayApi.syncPlaySetRepeatMode(SetRepeatModeRequestDto(
+					if (command.mode == RepeatMode.NONE) GroupRepeatMode.REPEAT_NONE else GroupRepeatMode.REPEAT_ONE
+				))
+				is PlayerCommand.Remove -> selectedId?.let {
+					api.syncPlayApi.syncPlayRemoveFromPlaylist(RemoveFromPlaylistRequestDto(listOf(it), false, false))
+				}
+			}
+		}
+		return true
+	}
+
+	private val backendListener = object : PlayerBackendEventListener() {
+		override fun onBuffering(entry: QueueEntry, buffering: Boolean) {
+			if (entry !== currentEntry || group.value == null) return
+			this@SyncPlayService.buffering = buffering
+			bufferJob?.cancel()
+			if (!buffering || awaitingReady) return
+			bufferJob = coroutineScope.launch(Dispatchers.Main.immediate) {
+				delay(BUFFERING_DELAY_MILLIS)
+				val id = playlistItemId ?: return@launch
+				reportedBuffering = true
+				val request = BufferRequestDto(now(), state.positionInfo.active.inWholeTicks, playingAnchor != null, id)
+				launchRequest { api.syncPlayApi.syncPlayBuffering(request) }
+			}
+		}
+
+		override fun onMediaStreamReady(entry: QueueEntry) {
+			if (entry !== currentEntry || group.value == null) return
+			buffering = false
+			bufferJob?.cancel()
+			if (awaitingReady || reportedBuffering) reportReady()
+		}
+
+		override fun onMediaStreamError(entry: QueueEntry) {
+			if (entry !== currentEntry || group.value == null) return
+			coroutineScope.launch(Dispatchers.Main.immediate) { failAndLeave("Unable to play the group's current media.") }
+		}
+	}
+
+	private fun reportReady() {
+		val id = playlistItemId ?: return
+		awaitingReady = false
+		reportedBuffering = false
+		val request = ReadyRequestDto(now(), state.positionInfo.active.inWholeTicks, state.playState.value == PlayState.PLAYING, id)
+		launchRequest { api.syncPlayApi.syncPlayReady(request) }
+	}
+
+	// Eligibility guards precede one drift-policy decision.
+	@Suppress("CyclomaticComplexMethod", "ComplexCondition", "LoopWithTooManyJumpStatements")
+	private fun startCorrectionLoop() {
+		coroutineScope.launch(Dispatchers.Main.immediate) {
+			val expectedGeneration = generation
+			while (generation == expectedGeneration && group.value != null) {
+				delay(driftPolicy.correctionIntervalMillis)
+				if (generation != expectedGeneration || group.value == null) break
+				val anchor = playingAnchor ?: continue
+				if (buffering || awaitingReady || correctionJob?.isActive == true || state.playState.value != PlayState.PLAYING) continue
+				if (clock.monotonicMillis() - unpausedAt < driftPolicy.unpauseGracePeriodMillis) continue
+				val targetMillis = (anchor.positionTicks ?: 0).ticks.inWholeMilliseconds + clock.nowMillis() - anchor.`when`.epochMillis
+				val drift = (targetMillis - state.positionInfo.active.inWholeMilliseconds).toDouble()
+				when (val correction = driftPolicy.correction(drift, supportsPlaybackRate = true, enabled = syncCorrectionEnabled.value)) {
+					SyncPlayCorrection.None -> Unit
+					SyncPlayCorrection.Seek -> manager.backend.seekTo(targetMillis.coerceAtLeast(0).milliseconds)
+					is SyncPlayCorrection.ChangeSpeed -> {
+						manager.backend.setSpeed(correction.rate)
+						correctionJob = coroutineScope.launch(Dispatchers.Main.immediate) {
+							delay(correction.durationMillis)
+							manager.backend.setSpeed(1f)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@Suppress("TooGenericExceptionCaught") // All request failures detach locally; cancellation still propagates.
+	private fun launchRequest(block: suspend () -> Unit) {
+		val expectedGeneration = generation
+		val expectedPlaybackGeneration = playbackGeneration
+		val parent = requestsJob ?: return
+		coroutineScope.launch(Dispatchers.Main.immediate + parent) {
+			requestMutex.withLock {
+				if (generation != expectedGeneration || playbackGeneration != expectedPlaybackGeneration) return@withLock
+				if (group.value == null || identity() != sessionIdentity) return@withLock
+				try {
+					block()
+				} catch (exception: CancellationException) {
+					throw exception
+				} catch (exception: Exception) {
+					Timber.w(exception, "SyncPlay request failed")
+					if (generation == expectedGeneration && playbackGeneration == expectedPlaybackGeneration && identity() == sessionIdentity) {
+						failAndLeave("SyncPlay could not reach the server. Join the group again to resume.")
+					}
+				}
+			}
+		}
+	}
+
+	@Suppress("TooGenericExceptionCaught") // Convert network failures to visible operation errors, preserving cancellation.
+	private suspend fun operation(message: String, block: suspend () -> Unit) = withContext(Dispatchers.Main.immediate) {
+		initialized.await()
+		operationMutex.withLock {
+			_busy.value = true
+			_error.value = null
+			try {
+				block()
+			} catch (exception: TimeoutCancellationException) {
+				Timber.w(exception, "SyncPlay operation timed out")
+				abandonJoin()
+				_error.value = message
+			} catch (exception: CancellationException) {
+				withContext(NonCancellable) { abandonJoin() }
+				throw exception
+			} catch (exception: Exception) {
+				Timber.w(exception, "SyncPlay operation failed")
+				abandonJoin()
+				_error.value = message
+			} finally {
+				_busy.value = false
+			}
+		}
+	}
+
+	private suspend fun abandonJoin() {
+		if (!joining) return
+		val leave = joiningRequestSent && sessionIdentity == identity()
+		reset(stopPlayback = false)
+		if (leave) {
+			try {
+				withTimeout(LEAVE_TIMEOUT_MILLIS) { api.syncPlayApi.syncPlayLeaveGroup() }
+			} catch (_: TimeoutCancellationException) {
+				// Local state is already detached.
+			} catch (exception: CancellationException) {
+				throw exception
+			} catch (_: Exception) {
+				// Best-effort cleanup for a join whose acknowledgement never arrived.
+			}
+		}
+	}
+
+	private suspend fun failAndLeave(message: String) {
+		val wasJoined = group.value != null || joiningRequestSent
+		reset(stopPlayback = true)
+		_error.value = message
+		if (wasJoined) {
+			// A failed playback request may be inside the request job that reset just cancelled.
+			withContext(NonCancellable) {
+				try { withTimeout(LEAVE_TIMEOUT_MILLIS) { api.syncPlayApi.syncPlayLeaveGroup() } } catch (_: Exception) { }
+			}
+		}
+	}
+
+	private fun resetCorrection() {
+		correctionJob?.cancel()
+		correctionJob = null
+		manager.backend.setSpeed(1f)
+	}
+
+	private fun cancelScheduledCommand() {
+		commandJob?.cancel()
+		commandJob = null
+		playingAnchor = null
+		resetCorrection()
+	}
+
+	private fun clearPlayback() {
+		playbackGeneration++
+		cancelScheduledCommand()
+		bufferJob?.cancel()
+		currentEntry = null
+		awaitingReady = false
+		buffering = false
+		reportedBuffering = false
+		manager.backend.stop()
+		manager.queue.clear()
+	}
+
+	private fun reset(stopPlayback: Boolean) {
+		generation++
+		playbackGeneration++
+		requestsJob?.cancel()
+		requestsJob = null
+		joining = false
+		joiningRequestSent = false
+		joinResult?.completeExceptionally(IllegalStateException("SyncPlay join ended"))
+		joinResult = null
+		_group.value = null
+		playQueue = null
+		lastCommand = null
+		joinedAt = null
+		timeSyncJob?.cancel()
+		bufferJob?.cancel()
+		cancelScheduledCommand()
+		if (stopPlayback) clearPlayback()
+		currentEntry = null
+		entries = mutableMapOf()
+		sessionIdentity = null
+		clock.reset()
+		manager.backend.setSpeed(state.speed.value)
+	}
+
+	private fun identity() = api.baseUrl to api.accessToken
+	private fun now(): LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(clock.nowMillis()), ZoneOffset.UTC)
+	private val LocalDateTime.epochMillis get() = toInstant(ZoneOffset.UTC).toEpochMilli()
+	private val Duration.inWholeTicks get() = inWholeNanoseconds / NANOS_PER_TICK
+
+	private companion object {
+		const val NANOS_PER_TICK = 100L
+		const val JOIN_TIMEOUT_MILLIS = 10_000L
+		const val LEAVE_TIMEOUT_MILLIS = 3_000L
+		const val BUFFERING_DELAY_MILLIS = 3_000L
+		const val SEEK_TOLERANCE_MILLIS = 400L
+		const val INITIAL_TIME_SAMPLES = 4
+		const val INITIAL_TIME_INTERVAL = 1_000L
+		const val TIME_INTERVAL = 60_000L
+	}
+}

--- a/playback/jellyfin/src/test/kotlin/network/ReliableApiClientTests.kt
+++ b/playback/jellyfin/src/test/kotlin/network/ReliableApiClientTests.kt
@@ -1,0 +1,58 @@
+package org.jellyfin.playback.jellyfin.network
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpMethod
+import org.jellyfin.sdk.api.client.RawResponse
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+
+class ReliableApiClientTests : FunSpec({
+	test("all subscribers share the replacement socket and credentials change before reconnect") {
+		val delegate = mockk<ApiClient>()
+		val socket = mockk<ReliableSocketApi>()
+		val actions = mutableListOf<String>()
+		val clientInfo = ClientInfo("TV", "test")
+		val deviceInfo = DeviceInfo("test-device", "TV")
+		var token: String? = "old-token"
+		every { delegate.accessToken } answers { token }
+		every { delegate.update("https://example.invalid", "new-token", clientInfo, deviceInfo) } answers {
+			token = secondArg()
+			actions.add("credentials")
+		}
+		val client = ReliableApiClient(delegate) { socket }
+		every { socket.notifyApiClientUpdate() } answers {
+			client.accessToken shouldBe "new-token"
+			actions.add("reconnect")
+		}
+
+		client.webSocket shouldBe socket
+		client.webSocket shouldBe socket
+		client.update("https://example.invalid", "new-token", clientInfo, deviceInfo)
+
+		actions shouldBe listOf("credentials", "reconnect")
+		verify(exactly = 0) { delegate.webSocket }
+	}
+
+	test("HTTP requests and unused API updates do not initialize either socket") {
+		val delegate = mockk<ApiClient>()
+		val response = RawResponse(byteArrayOf(), 204, emptyMap())
+		val clientInfo = ClientInfo("TV", "test")
+		val deviceInfo = DeviceInfo("test-device", "TV")
+		val client = ReliableApiClient(delegate) { error("HTTP-only clients must not open a socket") }
+		every { delegate.update(null, null, clientInfo, deviceInfo) } returns Unit
+		coEvery { delegate.request(HttpMethod.POST, "/SyncPlay/Pause", emptyMap(), emptyMap(), null) } returns response
+
+		client.update(null, null, clientInfo, deviceInfo)
+		client.request(HttpMethod.POST, "/SyncPlay/Pause") shouldBe response
+
+		coVerify(exactly = 1) { delegate.request(HttpMethod.POST, "/SyncPlay/Pause", emptyMap(), emptyMap(), null) }
+		verify(exactly = 0) { delegate.webSocket }
+	}
+})

--- a/playback/jellyfin/src/test/kotlin/network/ReliableSocketApiTests.kt
+++ b/playback/jellyfin/src/test/kotlin/network/ReliableSocketApiTests.kt
@@ -1,0 +1,174 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package org.jellyfin.playback.jellyfin.network
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.sockets.SocketApiState
+import org.jellyfin.sdk.api.sockets.SocketReconnectPolicy
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.api.OutboundWebSocketMessage
+import org.jellyfin.sdk.model.api.SyncPlayCommandMessage
+import kotlin.time.Duration.Companion.seconds
+
+class ReliableSocketApiTests : FunSpec({
+	test("buffered commands cannot cross logout and login even when the credentials are identical") {
+		runTest {
+			val fixture = ApiSocketFixture(this)
+			val gate = CompletableDeferred<Unit>()
+			val received = mutableListOf<Long?>()
+			backgroundScope.launch {
+				fixture.socket.subscribe(SyncPlayCommandMessage::class).collect {
+					received += it.data?.positionTicks
+					if (received.size == 1) gate.await()
+				}
+			}
+			runCurrent()
+			fixture.deliver(API_KEEP_ALIVE)
+			fixture.deliver(apiCommand(1))
+			runCurrent()
+			repeat(10) { fixture.deliver(apiCommand(it + 2)) }
+			runCurrent()
+			val token = fixture.token
+			fixture.token = null
+			fixture.socket.notifyApiClientUpdate()
+			fixture.token = token
+			fixture.socket.notifyApiClientUpdate()
+			runCurrent()
+			fixture.listeners.size shouldBe 2
+			fixture.deliver(API_KEEP_ALIVE)
+			fixture.deliver(apiCommand(99))
+			runCurrent()
+			gate.complete(Unit)
+			runCurrent()
+			received shouldBe listOf(1L, 99L)
+		}
+	}
+
+	test("general and SyncPlay subscribers share one socket and retain every command in a burst") {
+		runTest {
+			val fixture = ApiSocketFixture(this)
+			val all = mutableListOf<OutboundWebSocketMessage>()
+			val sync = mutableListOf<SyncPlayCommandMessage>()
+			val general = backgroundScope.launch { fixture.socket.subscribeAll().collect { all += it } }
+			val group = backgroundScope.launch { fixture.socket.subscribe(SyncPlayCommandMessage::class).collect { sync += it } }
+			runCurrent()
+			fixture.listeners.size shouldBe 1
+			fixture.deliver(API_KEEP_ALIVE)
+			repeat(40) { fixture.deliver(apiCommand(it)) }
+			runCurrent()
+			all.size shouldBe 40
+			sync.map { it.data?.positionTicks } shouldBe (0L until 40L).toList()
+			verify(exactly = 1) { fixture.webSocket.send(match<String> { it.contains("SessionsStart") && it.contains("0,1000") }) }
+			group.cancel()
+			runCurrent()
+			verify(exactly = 0) { fixture.webSocket.cancel() }
+			general.cancel()
+			runCurrent()
+			advanceTimeBy(5000)
+			runCurrent()
+			verify { fixture.webSocket.send(match<String> { it.contains("SessionsStop") }) }
+			verify { fixture.webSocket.cancel() }
+		}
+	}
+
+	test("credentials start the shared socket and changing or clearing them closes the old connection") {
+		runTest {
+			val fixture = ApiSocketFixture(this, authenticated = false)
+			backgroundScope.launch { fixture.socket.subscribeAll().collect {} }
+			runCurrent()
+			fixture.listeners.size shouldBe 0
+			fixture.token = "first-user"
+			fixture.socket.notifyApiClientUpdate()
+			runCurrent()
+			fixture.deliver(API_KEEP_ALIVE)
+			runCurrent()
+			fixture.listeners.size shouldBe 1
+			val old = fixture.listeners.last()
+			fixture.token = "next-user"
+			fixture.socket.notifyApiClientUpdate()
+			runCurrent()
+			fixture.listeners.size shouldBe 2
+			fixture.deliver(API_KEEP_ALIVE)
+			runCurrent()
+			old.onFailure(fixture.webSocket, IllegalStateException("old session"), null)
+			fixture.socket.state.value shouldBe SocketApiState.Connected
+			fixture.token = null
+			fixture.socket.notifyApiClientUpdate()
+			runCurrent()
+			advanceTimeBy(10000)
+			runCurrent()
+			fixture.listeners.size shouldBe 2
+			fixture.socket.state.value shouldBe SocketApiState.Disconnected()
+		}
+	}
+
+	test("connection failure reconnects once and keeps existing typed subscriptions") {
+		runTest {
+			val fixture = ApiSocketFixture(this)
+			val received = mutableListOf<SyncPlayCommandMessage>()
+			backgroundScope.launch { fixture.socket.subscribe(SyncPlayCommandMessage::class).collect { received += it } }
+			runCurrent()
+			fixture.deliver(API_KEEP_ALIVE)
+			runCurrent()
+			fixture.listeners.last().onFailure(fixture.webSocket, IllegalStateException("network lost"), null)
+			runCurrent()
+			advanceTimeBy(1000)
+			runCurrent()
+			fixture.listeners.size shouldBe 2
+			fixture.deliver(API_KEEP_ALIVE)
+			fixture.deliver(apiCommand(7))
+			runCurrent()
+			received.single().data?.positionTicks shouldBe 7L
+		}
+	}
+})
+
+private class ApiSocketFixture(scope: TestScope, authenticated: Boolean = true) {
+	private val api = mockk<ApiClient>()
+	private val factory = mockk<WebSocket.Factory>()
+	val webSocket = mockk<WebSocket>(relaxed = true)
+	val listeners = mutableListOf<WebSocketListener>()
+	var token: String? = if (authenticated) "test-token" else null
+	val socket: ReliableSocketApi
+
+	init {
+		every { api.baseUrl } returns "https://jellyfin.example.test"
+		every { api.createUrl("/socket", any(), any(), any()) } returns "https://jellyfin.example.test/socket"
+		every { api.clientInfo } returns ClientInfo("TV", "test")
+		every { api.deviceInfo } returns DeviceInfo("tv-device", "Test TV")
+		every { api.accessToken } answers { token }
+		every { api.httpClientOptions } returns HttpClientOptions(socketReconnectPolicy = SocketReconnectPolicy.DelayReconnect(1.seconds))
+		every { factory.newWebSocket(any(), any()) } answers {
+			listeners += secondArg<WebSocketListener>()
+			webSocket
+		}
+		every { webSocket.send(any<String>()) } returns true
+		socket = ReliableSocketApi(api, factory, scope.backgroundScope)
+	}
+
+	fun deliver(raw: String) = listeners.last().onMessage(webSocket, raw)
+}
+
+private const val API_KEEP_ALIVE = """{"MessageType":"ForceKeepAlive","Data":60,"MessageId":"00000000000000000000000000000002"}"""
+private fun apiCommand(position: Int) = """{
+  "MessageType":"SyncPlayCommand","MessageId":"00000000000000000000000000000002",
+  "Data":{
+    "GroupId":"00000000000000000000000000000001","PlaylistItemId":"00000000000000000000000000000000",
+    "When":"2026-09-09T19:42:22.435Z","PositionTicks":$position,"Command":"Stop","EmittedAt":"2026-09-09T19:42:22.435Z"
+  }
+}"""

--- a/playback/jellyfin/src/test/kotlin/network/ReliableSocketConnectionTests.kt
+++ b/playback/jellyfin/src/test/kotlin/network/ReliableSocketConnectionTests.kt
@@ -1,0 +1,155 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package org.jellyfin.playback.jellyfin.network
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.sockets.SocketApiState
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.api.OutboundWebSocketMessage
+import org.jellyfin.sdk.model.api.SendCommandType
+import org.jellyfin.sdk.model.api.SyncPlayCommandMessage
+import org.jellyfin.sdk.model.api.SyncPlayGroupJoinedUpdate
+import org.jellyfin.sdk.model.api.SyncPlayGroupUpdateMessage
+
+class ReliableSocketConnectionTests : FunSpec({
+	test("serialized GroupJoined and Stop in one startup burst both reach the typed consumer") {
+		runTest {
+			val fixture = SocketFixture(this)
+			val received = mutableListOf<OutboundWebSocketMessage>()
+			backgroundScope.launch { fixture.socket.messages.collect { received += it } }
+			val connecting = async { fixture.socket.connect(backgroundScope) }
+			runCurrent()
+			// Deliberately do not yield between callbacks, reproducing the real server's burst.
+			fixture.deliver(GROUP_JOINED)
+			fixture.deliver(command("Stop", 0))
+			repeat(40) { fixture.deliver(command("Seek", it.toLong())) }
+			runCurrent()
+			connecting.await()
+			received.size shouldBe 42
+			received[0].shouldBeInstanceOf<SyncPlayGroupUpdateMessage>().data.shouldBeInstanceOf<SyncPlayGroupJoinedUpdate>()
+			received[1].shouldBeInstanceOf<SyncPlayCommandMessage>().data?.command shouldBe SendCommandType.STOP
+			received.drop(2).map { (it as SyncPlayCommandMessage).data?.positionTicks } shouldBe (0L until 40L).toList()
+			fixture.socket.close()
+		}
+	}
+
+	test("a stalled consumer exhausts a bounded buffer and disconnects instead of dropping commands") {
+		runTest {
+			val fixture = SocketFixture(this)
+			val blocked = CompletableDeferred<Unit>()
+			backgroundScope.launch { fixture.socket.messages.collect { blocked.await() } }
+			fixture.connect()
+			fixture.deliver(GROUP_JOINED)
+			runCurrent()
+			repeat(300) { fixture.deliver(command("Seek", it.toLong())) }
+			runCurrent()
+			fixture.socket.state.value.shouldBeInstanceOf<SocketApiState.Disconnected>().error?.message shouldBe
+				"SyncPlay socket message buffer exhausted"
+			verify { fixture.webSocket.cancel() }
+		}
+	}
+
+	test("late frames and failures from the previous connection cannot affect a new session") {
+		runTest {
+			val fixture = SocketFixture(this)
+			val received = mutableListOf<OutboundWebSocketMessage>()
+			backgroundScope.launch { fixture.socket.messages.collect { received += it } }
+			fixture.connect()
+			val oldListener = fixture.listener.captured
+			fixture.socket.close()
+			fixture.connect()
+			oldListener.onMessage(fixture.webSocket, GROUP_JOINED)
+			oldListener.onFailure(fixture.webSocket, IllegalStateException("old session"), null)
+			runCurrent()
+			received.size shouldBe 0
+			fixture.socket.state.value shouldBe SocketApiState.Connected
+			fixture.socket.close()
+		}
+	}
+
+	test("keepalive replies renew the timeout and a silent connection is detached") {
+		runTest {
+			val fixture = SocketFixture(this)
+			fixture.connect()
+			verify { fixture.webSocket.send(match<String> { it.contains("KeepAlive") }) }
+			advanceTimeBy(3000)
+			fixture.deliver(KEEP_ALIVE)
+			runCurrent()
+			advanceTimeBy(3000)
+			runCurrent()
+			fixture.socket.state.value shouldBe SocketApiState.Connected
+			advanceTimeBy(1000)
+			runCurrent()
+			fixture.socket.state.value.shouldBeInstanceOf<SocketApiState.Disconnected>().error?.message shouldBe
+				"SyncPlay keepalive reply timed out"
+		}
+	}
+})
+
+private class SocketFixture(private val scope: TestScope) {
+	private val api = mockk<ApiClient>()
+	private val factory = mockk<WebSocket.Factory>()
+	val webSocket = mockk<WebSocket>(relaxed = true)
+	val listener = slot<WebSocketListener>()
+	val socket = ReliableSocketConnection(api, factory)
+
+	init {
+		every { api.createUrl("/socket", any(), any(), any()) } returns "https://jellyfin.example.test/socket"
+		every { api.clientInfo } returns ClientInfo("TV", "test")
+		every { api.deviceInfo } returns DeviceInfo("tv-device", "Test TV")
+		every { api.accessToken } returns "test-token"
+		every { factory.newWebSocket(any<Request>(), capture(listener)) } returns webSocket
+		every { webSocket.send(any<String>()) } returns true
+	}
+
+	suspend fun connect() {
+		val connecting = scope.async { socket.connect(scope.backgroundScope) }
+		scope.runCurrent()
+		deliver(FORCE_KEEP_ALIVE)
+		scope.runCurrent()
+		connecting.await()
+	}
+
+	fun deliver(raw: String) = listener.captured.onMessage(webSocket, raw)
+}
+
+private const val GROUP_JOINED = """{
+  "MessageType":"SyncPlayGroupUpdate",
+  "Data":{
+    "GroupId":"00000000000000000000000000000001","Type":"GroupJoined",
+    "Data":{
+      "GroupId":"00000000000000000000000000000001","GroupName":"Movie night",
+      "State":"Idle","Participants":["Viewer"],"LastUpdatedAt":"2026-09-09T19:42:22.435Z"
+    }
+  },
+  "MessageId":"00000000000000000000000000000002"
+}"""
+private const val FORCE_KEEP_ALIVE = """{"MessageType":"ForceKeepAlive","Data":2,"MessageId":"00000000000000000000000000000002"}"""
+private const val KEEP_ALIVE = """{"MessageType":"KeepAlive","MessageId":"00000000000000000000000000000002"}"""
+
+private fun command(type: String, ticks: Long) = """{
+  "MessageType":"SyncPlayCommand",
+  "Data":{
+    "GroupId":"00000000000000000000000000000001","PlaylistItemId":"00000000000000000000000000000000",
+    "When":"2026-09-09T19:42:22.435Z","PositionTicks":$ticks,"Command":"$type","EmittedAt":"2026-09-09T19:42:22.435Z"
+  },
+  "MessageId":"00000000000000000000000000000002"
+}"""

--- a/playback/jellyfin/src/test/kotlin/syncplay/SyncPlayClockTests.kt
+++ b/playback/jellyfin/src/test/kotlin/syncplay/SyncPlayClockTests.kt
@@ -1,0 +1,104 @@
+package org.jellyfin.playback.jellyfin.syncplay
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SyncPlayClockTests : FunSpec({
+	test("server processing time is excluded from ping and offset uses all four timestamps") {
+		val time = ClockTime()
+		val clock = time.clock()
+		val request = clock.beginMeasurement()
+		time.advance(140)
+
+		clock.completeMeasurement(request, time.epoch + 1050, time.epoch + 1090) shouldBe true
+		clock.isSynchronized shouldBe true
+		clock.offsetMillis shouldBe 1000.0
+		clock.pingMillis shouldBe 50
+		clock.nowMillis() shouldBe time.epoch + 1140
+	}
+
+	test("the lowest latency sample is retained until it leaves the eight sample window") {
+		val time = ClockTime()
+		val clock = time.clock()
+		fun measure(offset: Long, delay: Long) {
+			val sent = time.epoch + time.elapsedMillis
+			val request = clock.beginMeasurement()
+			time.advance(delay)
+			clock.completeMeasurement(request, sent + delay / 2 + offset, sent + delay / 2 + offset) shouldBe true
+		}
+
+		measure(1000, 20)
+		repeat(7) { measure(2000, 100) }
+		clock.offsetMillis shouldBe 1000.0
+		clock.pingMillis shouldBe 10
+		measure(2000, 100)
+		clock.offsetMillis shouldBe 2000.0
+		clock.pingMillis shouldBe 50
+	}
+
+	test("device clock jumps cannot move server time or a scheduled command") {
+		val time = ClockTime()
+		val clock = time.clock()
+		val request = clock.beginMeasurement()
+		time.advance(100)
+		clock.completeMeasurement(request, time.epoch + 1050, time.epoch + 1050) shouldBe true
+		val scheduledTime = clock.nowMillis() + 1000
+
+		time.wallMillis += 3_600_000
+		time.advance(250)
+		clock.nowMillis() shouldBe time.epoch + 1350
+		clock.delayUntil(scheduledTime) shouldBe 750
+		time.wallMillis -= 7_200_000
+		time.advance(1000)
+		clock.delayUntil(scheduledTime) shouldBe 0
+		clock.monotonicMillis() shouldBe 1350
+	}
+
+	test("wall time changes during measurement do not corrupt the estimate") {
+		val time = ClockTime()
+		val clock = time.clock()
+		val request = clock.beginMeasurement()
+		time.wallMillis += 3_600_000
+		time.advance(100)
+		clock.completeMeasurement(request, time.epoch + 1050, time.epoch + 1050) shouldBe true
+		clock.offsetMillis shouldBe 1000.0
+		clock.pingMillis shouldBe 50
+	}
+
+	test("invalid timestamps and requests from before reset cannot replace a measurement") {
+		val time = ClockTime()
+		val clock = time.clock()
+		val request = clock.beginMeasurement()
+		time.advance(100)
+		clock.completeMeasurement(request, time.epoch + 200, time.epoch + 100) shouldBe false
+		clock.completeMeasurement(request, time.epoch, time.epoch + 200) shouldBe false
+		clock.isSynchronized shouldBe false
+		clock.completeMeasurement(request, time.epoch + 1050, time.epoch + 1050) shouldBe true
+		clock.reset()
+		clock.isSynchronized shouldBe false
+		clock.pingMillis shouldBe 0
+		clock.completeMeasurement(request, time.epoch + 1050, time.epoch + 1050) shouldBe false
+	}
+
+	test("ping rounds one way delay instead of reporting the round trip") {
+		val time = ClockTime()
+		val clock = time.clock()
+		val request = clock.beginMeasurement()
+		time.advance(101)
+		clock.completeMeasurement(request, time.epoch + 1050, time.epoch + 1050) shouldBe true
+		clock.pingMillis shouldBe 51
+	}
+})
+
+private class ClockTime {
+	val epoch = 1_700_000_000_000L
+	var wallMillis = epoch
+	var elapsedMillis = 0L
+
+	fun clock() = SyncPlayClock({ wallMillis }, { elapsedMillis * 1_000_000 })
+
+	fun advance(millis: Long) {
+		elapsedMillis += millis
+		wallMillis += millis
+	}
+}

--- a/playback/jellyfin/src/test/kotlin/syncplay/SyncPlayDriftPolicyTests.kt
+++ b/playback/jellyfin/src/test/kotlin/syncplay/SyncPlayDriftPolicyTests.kt
@@ -1,0 +1,50 @@
+package org.jellyfin.playback.jellyfin.syncplay
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class SyncPlayDriftPolicyTests : FunSpec({
+	val policy = SyncPlayDriftPolicy()
+
+	test("ongoing correction is disabled by default as in Jellyfin Web") {
+		policy.correction(5000.0, supportsPlaybackRate = true) shouldBe SyncPlayCorrection.None
+		policy.correctionIntervalMillis shouldBe 1500
+		policy.unpauseGracePeriodMillis shouldBe 1500
+	}
+
+	test("small drift is tolerated and speed correction starts at sixty milliseconds") {
+		policy.correction(59.0, true, enabled = true) shouldBe SyncPlayCorrection.None
+		policy.correction(-59.0, true, enabled = true) shouldBe SyncPlayCorrection.None
+		policy.correction(60.0, true, enabled = true) shouldBe SyncPlayCorrection.ChangeSpeed(1.06f, 1000)
+		policy.correction(-60.0, true, enabled = true) shouldBe SyncPlayCorrection.ChangeSpeed(0.94f, 1000)
+	}
+
+	test("a client behind the group speeds up for one second before the skip threshold") {
+		policy.correction(1500.0, true, enabled = true) shouldBe SyncPlayCorrection.ChangeSpeed(2.5f, 1000)
+		policy.correction(2999.0, true, enabled = true).shouldBeInstanceOf<SyncPlayCorrection.ChangeSpeed>()
+		policy.correction(3000.0, true, enabled = true) shouldBe SyncPlayCorrection.Seek
+		policy.correction(-3000.0, true, enabled = true) shouldBe SyncPlayCorrection.Seek
+	}
+
+	test("a client ahead of the group uses Web's longer duration and positive minimum speed") {
+		val correction = policy.correction(-1600.0, true, enabled = true).shouldBeInstanceOf<SyncPlayCorrection.ChangeSpeed>()
+		correction.rate shouldBe (0.2f plusOrMinus 0.00001f)
+		correction.durationMillis shouldBe 2000
+		policy.correction(-200.0, true, enabled = true) shouldBe SyncPlayCorrection.ChangeSpeed(0.2f, 250)
+	}
+
+	test("players without variable speed seek only after four hundred milliseconds") {
+		policy.correction(399.0, false, enabled = true) shouldBe SyncPlayCorrection.None
+		policy.correction(-399.0, false, enabled = true) shouldBe SyncPlayCorrection.None
+		policy.correction(400.0, false, enabled = true) shouldBe SyncPlayCorrection.Seek
+		policy.correction(-400.0, false, enabled = true) shouldBe SyncPlayCorrection.Seek
+	}
+
+	test("invalid position measurements cannot cause player corrections") {
+		policy.correction(Double.NaN, true, enabled = true) shouldBe SyncPlayCorrection.None
+		policy.correction(Double.POSITIVE_INFINITY, true, enabled = true) shouldBe SyncPlayCorrection.None
+		policy.correction(Double.NEGATIVE_INFINITY, true, enabled = true) shouldBe SyncPlayCorrection.None
+	}
+})

--- a/playback/jellyfin/src/test/kotlin/syncplay/SyncPlayServiceTests.kt
+++ b/playback/jellyfin/src/test/kotlin/syncplay/SyncPlayServiceTests.kt
@@ -1,0 +1,505 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package org.jellyfin.playback.jellyfin.syncplay
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.jellyfin.playback.core.PlaybackManager
+import org.jellyfin.playback.core.PlayerCommand
+import org.jellyfin.playback.core.PlayerState
+import org.jellyfin.playback.core.backend.PlayerBackend
+import org.jellyfin.playback.core.backend.PlayerBackendEventListener
+import org.jellyfin.playback.core.model.PlayState
+import org.jellyfin.playback.core.model.PositionInfo
+import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.QueueService
+import org.jellyfin.playback.core.queue.initialPlayback
+import org.jellyfin.playback.core.queue.supplier.QueueSupplier
+import org.jellyfin.playback.jellyfin.queue.baseItem
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.operations.SyncPlayApi
+import org.jellyfin.sdk.api.operations.TimeSyncApi
+import org.jellyfin.sdk.api.operations.UserLibraryApi
+import org.jellyfin.sdk.api.sockets.SocketApiState
+import org.jellyfin.sdk.api.sockets.SocketApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.GroupInfoDto
+import org.jellyfin.sdk.model.api.GroupRepeatMode
+import org.jellyfin.sdk.model.api.GroupShuffleMode
+import org.jellyfin.sdk.model.api.GroupStateType
+import org.jellyfin.sdk.model.api.GroupUpdate
+import org.jellyfin.sdk.model.api.MediaType
+import org.jellyfin.sdk.model.api.OutboundWebSocketMessage
+import org.jellyfin.sdk.model.api.PlayQueueUpdate
+import org.jellyfin.sdk.model.api.PlayQueueUpdateReason
+import org.jellyfin.sdk.model.api.ReadyRequestDto
+import org.jellyfin.sdk.model.api.SendCommand
+import org.jellyfin.sdk.model.api.SendCommandType
+import org.jellyfin.sdk.model.api.SyncPlayCommandMessage
+import org.jellyfin.sdk.model.api.SyncPlayGroupJoinedUpdate
+import org.jellyfin.sdk.model.api.SyncPlayGroupUpdateMessage
+import org.jellyfin.sdk.model.api.SyncPlayNotInGroupUpdate
+import org.jellyfin.sdk.model.api.SyncPlayPlayQueueUpdate
+import org.jellyfin.sdk.model.api.SyncPlayQueueItem
+import org.jellyfin.sdk.model.api.SyncPlayUserJoinedUpdate
+import org.jellyfin.sdk.model.api.UtcTimeResponse
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class SyncPlayServiceTests : FunSpec({
+	test("a group queue prepares paused and reports the queue entry identifier when ready") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue(position = 42.seconds)
+			val entry = currentEntry.value.shouldNotBeNull()
+			entry.initialPlayback.playWhenReady shouldBe false
+			entry.initialPlayback.position shouldBe 42.seconds
+			position = 42.seconds
+			listener.captured.onMediaStreamReady(entry)
+			testScope.runCurrent()
+
+			val ready = slot<ReadyRequestDto>()
+			coVerify(exactly = 1) { syncApi.syncPlayReady(capture(ready)) }
+			ready.captured.playlistItemId shouldBe playlistItemId
+			ready.captured.positionTicks shouldBe 420_000_000L
+			ready.captured.isPlaying shouldBe false
+			coVerify(exactly = 0) { syncApi.syncPlayUnpause() }
+			verify(exactly = 0) { backend.play() }
+		}
+	}
+
+	test("scheduled server commands change local playback without echoing group requests") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			sendCommand(SendCommandType.UNPAUSE, scheduledIn = 500)
+			testScope.advanceTimeBy(499)
+			testScope.runCurrent()
+			verify(exactly = 0) { backend.play() }
+			testScope.advanceTimeBy(1)
+			testScope.runCurrent()
+			verify(exactly = 1) { backend.play() }
+			sendCommand(SendCommandType.PAUSE, position = 8.seconds)
+			verify(exactly = 1) { backend.seekTo(8.seconds) }
+			playState.value shouldBe PlayState.PAUSED
+			coVerify(exactly = 0) { syncApi.syncPlayUnpause() }
+			coVerify(exactly = 0) { syncApi.syncPlayPause() }
+			coVerify(exactly = 0) { syncApi.syncPlaySeek(any()) }
+		}
+	}
+
+	test("user playback controls send requests and ordinary playback is restored after leaving") {
+		withService {
+			service.createGroup("Movie night")
+			service.handleCommand(PlayerCommand.Pause) shouldBe true
+			testScope.runCurrent()
+			coVerify(exactly = 1) { syncApi.syncPlayPause() }
+			service.leaveGroup()
+			service.handleCommand(PlayerCommand.Pause) shouldBe false
+			coVerify(exactly = 1) { syncApi.syncPlayLeaveGroup() }
+			verify { backend.setSpeed(1.5f) }
+		}
+	}
+
+	test("leaving cancels a future unpause so a stale group cannot resume the local player") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			sendCommand(SendCommandType.UNPAUSE, scheduledIn = 1000)
+			service.leaveGroup()
+			testScope.advanceTimeBy(2000)
+			testScope.runCurrent()
+			verify(exactly = 0) { backend.play() }
+			service.group.value shouldBe null
+		}
+	}
+
+	test("the server's zero-group NotInGroup error clears local membership") {
+		withService {
+			service.createGroup("Movie night")
+			sendUpdate(SyncPlayNotInGroupUpdate(UUID(0, 0), ""))
+			service.group.value shouldBe null
+			service.handleCommand(PlayerCommand.Play) shouldBe false
+		}
+	}
+
+	test("a join timeout clears pending membership and ignores a late GroupJoined message") {
+		withService {
+			val join = testScope.async { service.joinGroup(groupInfo.groupId) }
+			testScope.runCurrent()
+			testScope.advanceTimeBy(10_001)
+			testScope.runCurrent()
+			join.await()
+			service.busy.value shouldBe false
+			service.error.value.shouldNotBeNull()
+			sendUpdate(SyncPlayGroupJoinedUpdate(groupInfo.groupId, groupInfo))
+			service.group.value shouldBe null
+		}
+	}
+
+	test("refreshing group information does not invalidate a command issued after joining") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			coEvery { syncApi.syncPlayGetGroups() } returns response(listOf(groupInfo.copy(lastUpdatedAt = date(5000))))
+			service.refreshGroups()
+			sendCommand(SendCommandType.UNPAUSE, emittedAt = date(1000))
+			verify(exactly = 1) { backend.play() }
+		}
+	}
+
+	test("buffering pauses the group only after three seconds and recovery sends Ready") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val entry = currentEntry.value.shouldNotBeNull()
+			listener.captured.onMediaStreamReady(entry)
+			testScope.runCurrent()
+			sendCommand(SendCommandType.UNPAUSE)
+			listener.captured.onBuffering(entry, true)
+			testScope.runCurrent()
+			testScope.advanceTimeBy(2999)
+			testScope.runCurrent()
+			coVerify(exactly = 0) { syncApi.syncPlayBuffering(any()) }
+			testScope.advanceTimeBy(1)
+			testScope.runCurrent()
+			coVerify(exactly = 1) { syncApi.syncPlayBuffering(match { it.playlistItemId == playlistItemId && it.isPlaying }) }
+			listener.captured.onMediaStreamReady(entry)
+			testScope.runCurrent()
+			coVerify(exactly = 2) { syncApi.syncPlayReady(match { it.playlistItemId == playlistItemId }) }
+		}
+	}
+
+	test("brief buffering recovers without holding the group") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val entry = currentEntry.value.shouldNotBeNull()
+			listener.captured.onMediaStreamReady(entry)
+			testScope.runCurrent()
+			sendCommand(SendCommandType.UNPAUSE)
+			listener.captured.onBuffering(entry, true)
+			testScope.runCurrent()
+			testScope.advanceTimeBy(1000)
+			listener.captured.onMediaStreamReady(entry)
+			testScope.advanceTimeBy(3000)
+			testScope.runCurrent()
+			coVerify(exactly = 0) { syncApi.syncPlayBuffering(any()) }
+		}
+	}
+
+	test("a queue insertion preserves the active entry and updates its index and surrounding items") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val entry = currentEntry.value.shouldNotBeNull()
+			val addedItem = SyncPlayQueueItem(UUID.randomUUID(), UUID.randomUUID())
+			val previousQueue = latestQueue.shouldNotBeNull()
+			sendUpdate(
+				SyncPlayPlayQueueUpdate(
+					groupInfo.groupId,
+					previousQueue.copy(
+						reason = PlayQueueUpdateReason.QUEUE,
+						lastUpdate = date(1),
+						playlist = listOf(addedItem) + previousQueue.playlist,
+						playingItemIndex = 1,
+					),
+				)
+			)
+			(currentEntry.value === entry) shouldBe true
+			selectedIndex shouldBe 1
+			suppliedQueue.shouldNotBeNull().size shouldBe 2
+			suppliedQueue.shouldNotBeNull().getItem(0).shouldNotBeNull().baseItem.shouldNotBeNull().id shouldBe addedItem.itemId
+			verify(exactly = 1) { backend.pause() }
+		}
+	}
+
+	test("repeat-one restarts the same queue entry and waits for readiness") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue(position = 100.seconds)
+			val originalEntry = currentEntry.value.shouldNotBeNull()
+			sendUpdate(SyncPlayPlayQueueUpdate(groupInfo.groupId, latestQueue.shouldNotBeNull().copy(
+				reason = PlayQueueUpdateReason.NEXT_ITEM,
+				lastUpdate = date(1),
+				startPositionTicks = 0,
+			)))
+			val restartedEntry = currentEntry.value.shouldNotBeNull()
+			(restartedEntry === originalEntry) shouldBe false
+			restartedEntry.initialPlayback.position shouldBe Duration.ZERO
+			restartedEntry.initialPlayback.playWhenReady shouldBe false
+		}
+	}
+
+	test("a seek waiting behind another request cannot change a replacement playlist") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val gate = CompletableDeferred<Unit>()
+			coEvery { syncApi.syncPlayPause() } coAnswers { gate.await(); response(Unit) }
+			service.handleCommand(PlayerCommand.Pause)
+			testScope.runCurrent()
+			service.handleCommand(PlayerCommand.Seek(80.seconds))
+			testScope.runCurrent()
+			loadQueue()
+			gate.complete(Unit)
+			testScope.runCurrent()
+			coVerify(exactly = 0) { syncApi.syncPlaySeek(any()) }
+		}
+	}
+
+	test("a queued item selection keeps its original identity across a queue insertion") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val gate = CompletableDeferred<Unit>()
+			coEvery { syncApi.syncPlayPause() } coAnswers { gate.await(); response(Unit) }
+			service.handleCommand(PlayerCommand.Pause)
+			testScope.runCurrent()
+			service.handleCommand(PlayerCommand.Select(0))
+			testScope.runCurrent()
+			val oldQueue = latestQueue.shouldNotBeNull()
+			sendUpdate(SyncPlayPlayQueueUpdate(groupInfo.groupId, oldQueue.copy(
+				reason = PlayQueueUpdateReason.QUEUE,
+				lastUpdate = date(1),
+				playlist = listOf(SyncPlayQueueItem(UUID.randomUUID(), UUID.randomUUID())) + oldQueue.playlist,
+				playingItemIndex = 1,
+			)))
+			gate.complete(Unit)
+			testScope.runCurrent()
+			coVerify(exactly = 1) { syncApi.syncPlaySetPlaylistItem(match { it.playlistItemId == playlistItemId }) }
+		}
+	}
+
+	test("leaving cancels a request still in flight and removes command interception") {
+		withService {
+			service.createGroup("Movie night")
+			val gate = CompletableDeferred<Unit>()
+			var finished = false
+			coEvery { syncApi.syncPlayPause() } coAnswers {
+				try { gate.await(); response(Unit) } finally { finished = true }
+			}
+			service.handleCommand(PlayerCommand.Pause)
+			testScope.runCurrent()
+			finished shouldBe false
+			service.leaveGroup()
+			testScope.runCurrent()
+			finished shouldBe true
+			service.handleCommand(PlayerCommand.Play) shouldBe false
+		}
+	}
+
+	test("service cancellation removes its listener and stale ready events cannot reach the server") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val entry = currentEntry.value.shouldNotBeNull()
+			scope.cancel()
+			testScope.runCurrent()
+			service.group.value shouldBe null
+			verify(exactly = 1) { manager.removeBackendListener(listener.captured) }
+			listener.captured.onMediaStreamReady(entry)
+			testScope.runCurrent()
+			coVerify(exactly = 0) { syncApi.syncPlayReady(any()) }
+		}
+	}
+
+	test("a group list requested before logout cannot repopulate the next session") {
+		withService {
+			service.createGroup("Movie night")
+			val gate = CompletableDeferred<Unit>()
+			coEvery { syncApi.syncPlayGetGroups() } coAnswers { gate.await(); response(listOf(groupInfo)) }
+			val refresh = testScope.async { service.refreshGroups() }
+			testScope.runCurrent()
+			service.endSession()
+			gate.complete(Unit)
+			refresh.await()
+			service.groups.value shouldBe emptyList()
+			service.group.value shouldBe null
+		}
+	}
+
+	test("a slow participant refresh neither delays playback commands nor restores a departed group") {
+		withService {
+			service.createGroup("Movie night")
+			loadQueue()
+			val gate = CompletableDeferred<Unit>()
+			coEvery { syncApi.syncPlayGetGroups() } coAnswers { gate.await(); response(listOf(groupInfo)) }
+			sendUpdate(SyncPlayUserJoinedUpdate(groupInfo.groupId, "Second viewer"))
+			sendCommand(SendCommandType.UNPAUSE)
+			verify(exactly = 1) { backend.play() }
+			service.endSession()
+			gate.complete(Unit)
+			testScope.runCurrent()
+			service.group.value shouldBe null
+		}
+	}
+})
+
+private suspend fun withService(block: suspend ServiceFixture.() -> Unit) = runTest {
+	val fixture = ServiceFixture(this)
+	try {
+		fixture.service.onInitialize()
+		runCurrent()
+		fixture.block()
+	} finally {
+		fixture.scope.cancel()
+		runCurrent()
+		unmockkObject(fixture.service)
+		Dispatchers.resetMain()
+	}
+}
+
+private class ServiceFixture(val testScope: TestScope) {
+	private val epoch = 1_700_000_000_000L
+	private val dispatcher = StandardTestDispatcher(testScope.testScheduler)
+	val scope = CoroutineScope(SupervisorJob() + dispatcher)
+	val syncApi = mockk<SyncPlayApi>()
+	private val timeApi = mockk<TimeSyncApi>()
+	private val libraryApi = mockk<UserLibraryApi>()
+	private val api = mockk<ApiClient>()
+	private val socket = mockk<SocketApi>(relaxed = true)
+	private val messages = MutableSharedFlow<OutboundWebSocketMessage>(extraBufferCapacity = 16)
+	private val socketState = MutableStateFlow<SocketApiState>(SocketApiState.Connected)
+	val backend = mockk<PlayerBackend>(relaxed = true)
+	val manager = mockk<PlaybackManager>(relaxed = true)
+	private val state = mockk<PlayerState>(relaxed = true)
+	private val queue = mockk<QueueService>(relaxed = true)
+	val listener = slot<PlayerBackendEventListener>()
+	val currentEntry = MutableStateFlow<QueueEntry?>(null)
+	var suppliedQueue: QueueSupplier? = null
+	var selectedIndex = -1
+	var latestQueue: PlayQueueUpdate? = null
+	val playState = MutableStateFlow(PlayState.PAUSED)
+	var position = Duration.ZERO
+	val playlistItemId = UUID.randomUUID()
+	private val mediaId = UUID.randomUUID()
+	val groupInfo = GroupInfoDto(UUID.randomUUID(), "Movie night", GroupStateType.IDLE, listOf("Viewer"), date(0))
+	private val clock = SyncPlayClock({ epoch + testScope.testScheduler.currentTime }, { testScope.testScheduler.currentTime * 1_000_000 })
+	val speed = MutableStateFlow(1.5f)
+	val service = SyncPlayService(api, clock)
+
+	init {
+		Dispatchers.setMain(dispatcher)
+		// Keep the real instance: copying a spy leaves backend listeners bound to the original.
+		mockkObject(service)
+		every { api.baseUrl } returns "https://jellyfin.example.test"
+		every { api.accessToken } returns "test-token"
+		every { api.webSocket } returns socket
+		every { api.getOrCreateApi(SyncPlayApi::class, any()) } returns syncApi
+		every { api.getOrCreateApi(TimeSyncApi::class, any()) } returns timeApi
+		every { api.getOrCreateApi(UserLibraryApi::class, any()) } returns libraryApi
+		every { socket.subscribeAll() } returns messages
+		every { socket.state } returns socketState
+		every { service.manager } returns manager
+		every { service.state } returns state
+		every { service.coroutineScope } returns scope
+		every { manager.backend } returns backend
+		every { manager.getService(QueueService::class) } returns queue
+		every { manager.addBackendListener(capture(listener)) } returns Unit
+		every { queue.entry } returns currentEntry
+		every { state.playState } returns playState
+		every { state.speed } returns speed
+		every { state.positionInfo } answers { PositionInfo(position, position + 30.seconds, 3600.seconds) }
+		every { backend.pause() } answers { playState.value = PlayState.PAUSED }
+		every { backend.play() } answers { playState.value = PlayState.PLAYING }
+		coEvery { timeApi.getUtcTime() } answers { response(UtcTimeResponse(date(), date())) }
+		coEvery { syncApi.syncPlayCreateGroup(any()) } returns response(groupInfo)
+		coEvery { syncApi.syncPlayGetGroups() } returns response(listOf(groupInfo))
+		coEvery { syncApi.syncPlayJoinGroup(any()) } returns response(Unit)
+		coEvery { syncApi.syncPlayLeaveGroup() } returns response(Unit)
+		coEvery { syncApi.syncPlayReady(any()) } returns response(Unit)
+		coEvery { syncApi.syncPlayPing(any()) } returns response(Unit)
+		coEvery { syncApi.syncPlayPause() } returns response(Unit)
+		coEvery { syncApi.syncPlayUnpause() } returns response(Unit)
+		coEvery { syncApi.syncPlaySeek(any()) } returns response(Unit)
+		coEvery { syncApi.syncPlaySetPlaylistItem(any()) } returns response(Unit)
+		coEvery { syncApi.syncPlayStop() } returns response(Unit)
+		coEvery { syncApi.syncPlayBuffering(any()) } returns response(Unit)
+		coEvery { libraryApi.getItem(any(), any()) } answers {
+			response(BaseItemDto(id = firstArg(), name = "Feature", mediaType = MediaType.VIDEO, type = BaseItemKind.MOVIE))
+		}
+		coEvery { queue.synchronize(any(), any()) } coAnswers {
+			suppliedQueue = firstArg()
+			selectedIndex = secondArg()
+			firstArg<QueueSupplier>().getItem(secondArg()).also { currentEntry.value = it }
+		}
+	}
+
+	fun date(offset: Long = testScope.testScheduler.currentTime): LocalDateTime =
+		LocalDateTime.ofInstant(Instant.ofEpochMilli(epoch + offset), ZoneOffset.UTC)
+
+	suspend fun loadQueue(position: Duration = Duration.ZERO) {
+		val update = PlayQueueUpdate(
+			reason = PlayQueueUpdateReason.NEW_PLAYLIST,
+			lastUpdate = date(),
+			playlist = listOf(SyncPlayQueueItem(mediaId, playlistItemId)),
+			playingItemIndex = 0,
+			startPositionTicks = position.inWholeNanoseconds / 100,
+			isPlaying = false,
+			shuffleMode = GroupShuffleMode.SORTED,
+			repeatMode = GroupRepeatMode.REPEAT_NONE,
+		)
+		latestQueue = update
+		sendUpdate(SyncPlayPlayQueueUpdate(groupInfo.groupId, update))
+	}
+
+	suspend fun sendUpdate(update: GroupUpdate) {
+		messages.emit(SyncPlayGroupUpdateMessage(update, UUID.randomUUID()))
+		testScope.runCurrent()
+	}
+
+	suspend fun sendCommand(
+		type: SendCommandType,
+		scheduledIn: Long = 0,
+		position: Duration = Duration.ZERO,
+		emittedAt: LocalDateTime = date(),
+	) {
+		messages.emit(
+			SyncPlayCommandMessage(
+				data = SendCommand(
+					groupId = groupInfo.groupId,
+					playlistItemId = playlistItemId,
+					`when` = date(testScope.testScheduler.currentTime + scheduledIn),
+					positionTicks = position.inWholeNanoseconds / 100,
+					command = type,
+					emittedAt = emittedAt,
+				),
+				messageId = UUID.randomUUID(),
+			)
+		)
+		testScope.runCurrent()
+	}
+}
+
+private fun <T> response(content: T) = Response(content, 200, emptyMap())

--- a/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
+++ b/playback/media3/exoplayer/src/main/kotlin/ExoPlayerBackend.kt
@@ -40,6 +40,7 @@ import org.jellyfin.playback.core.mediastream.normalizationGain
 import org.jellyfin.playback.core.model.PlayState
 import org.jellyfin.playback.core.model.PositionInfo
 import org.jellyfin.playback.core.queue.QueueEntry
+import org.jellyfin.playback.core.queue.initialPlayback
 import org.jellyfin.playback.core.support.PlaySupportReport
 import org.jellyfin.playback.core.timedevent.TimedEvent
 import org.jellyfin.playback.core.ui.PlayerSubtitleView
@@ -115,7 +116,8 @@ class ExoPlayerBackend(
 				exoPlayerOptions.minBufferDuration?.inWholeMilliseconds?.toInt() ?: DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
 				exoPlayerOptions.maxBufferDuration?.inWholeMilliseconds?.toInt() ?: DefaultLoadControl.DEFAULT_MAX_BUFFER_MS,
 				exoPlayerOptions.bufferForPlaybackDuration?.inWholeMilliseconds?.toInt() ?: DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-				exoPlayerOptions.bufferForPlaybackAfterRebufferDuration?.inWholeMilliseconds?.toInt() ?: DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+				exoPlayerOptions.bufferForPlaybackAfterRebufferDuration?.inWholeMilliseconds?.toInt()
+					?: DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
 			)
 			.build()
 
@@ -160,6 +162,7 @@ class ExoPlayerBackend(
 
 		override fun onPlayerError(error: PlaybackException) {
 			listener?.onPlayStateChange(PlayState.ERROR)
+			selectedStream()?.let { listener?.onMediaStreamError(it.queueEntry) }
 		}
 
 		override fun onVideoSizeChanged(size: VideoSize) {
@@ -174,11 +177,15 @@ class ExoPlayerBackend(
 
 		override fun onPlaybackStateChanged(playbackState: Int) {
 			onIsPlayingChanged(exoPlayer.isPlaying)
+			selectedStream()?.queueEntry?.let { entry ->
+				listener?.onBuffering(entry, playbackState == Player.STATE_BUFFERING)
+				if (playbackState == Player.STATE_READY) listener?.onMediaStreamReady(entry)
+			}
 		}
 
 		override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
 			if (reason == Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM) {
-				listener?.onMediaStreamEnd(requireNotNull(currentStream))
+				selectedStream()?.let { listener?.onMediaStreamEnd(it) }
 			}
 		}
 
@@ -189,18 +196,28 @@ class ExoPlayerBackend(
 		override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
 			val queueEntry = mediaItem?.localConfiguration?.tag as? QueueEntry
 			audioPipeline.normalizationGain = queueEntry?.normalizationGain
+			updateDuration()
 		}
 
 		override fun onTimelineChanged(timeline: Timeline, reason: Int) {
-			val duration = exoPlayer.duration.takeUnless { it == C.TIME_UNSET }?.milliseconds
-			if (duration == lastKnownDuration) return
-			timedEventState.onDurationChange(exoPlayer, duration)
-			lastKnownDuration = duration
+			updateDuration()
 		}
 
 		override fun onPositionDiscontinuity(oldPosition: Player.PositionInfo, newPosition: Player.PositionInfo, reason: Int) {
 			timedEventState.onSeek(oldPosition.positionMs.milliseconds, newPosition.positionMs.milliseconds, lastKnownDuration ?: Duration.ZERO)
 		}
+	}
+
+	private fun selectedStream(): PlayableMediaStream? {
+		val selectedEntry = exoPlayer.currentMediaItem?.localConfiguration?.tag as? QueueEntry
+		return currentStream?.takeIf { it.queueEntry === selectedEntry }
+	}
+
+	private fun updateDuration() {
+		val duration = exoPlayer.duration.takeUnless { it == C.TIME_UNSET }?.milliseconds
+		if (duration == lastKnownDuration) return
+		timedEventState.onDurationChange(exoPlayer, duration)
+		lastKnownDuration = duration
 	}
 
 	override fun supportsStream(
@@ -251,6 +268,7 @@ class ExoPlayerBackend(
 		if (currentStream == stream) return
 
 		currentStream = stream
+		exoPlayer.playWhenReady = item.initialPlayback.playWhenReady
 
 		var preparedItemIndex = (0 until exoPlayer.mediaItemCount).firstOrNull { index ->
 			exoPlayer.getMediaItemAt(index).mediaId == stream.hashCode().toString()
@@ -263,12 +281,7 @@ class ExoPlayerBackend(
 		}
 
 		// Seek to prepared media item
-		when (preparedItemIndex) {
-			exoPlayer.currentMediaItemIndex - 1 -> exoPlayer.seekToPreviousMediaItem()
-			exoPlayer.currentMediaItemIndex + 1 -> exoPlayer.seekToNextMediaItem()
-			exoPlayer.currentMediaItemIndex -> Unit
-			else -> exoPlayer.seekTo(preparedItemIndex, 0)
-		}
+		exoPlayer.seekTo(preparedItemIndex, item.initialPlayback.position.inWholeMilliseconds)
 
 		// Update audio attributes
 		val contentType = when (item.mediaType) {
@@ -289,7 +302,12 @@ class ExoPlayerBackend(
 
 		// Enjoy!
 		Timber.i("Playing ${item.mediaStream?.url}")
-		exoPlayer.play()
+		if (item.initialPlayback.playWhenReady) exoPlayer.play()
+		else exoPlayer.pause()
+		// Already prepared entries need a ready notification even without a state transition.
+		if (exoPlayer.playbackState == Player.STATE_READY && selectedStream()?.queueEntry === item) {
+			listener?.onMediaStreamReady(item)
+		}
 	}
 
 	override fun play() {


### PR DESCRIPTION
**Changes**

Add SyncPlay to the TV home toolbar and integrated player so users can create, join, inspect, and leave groups shared with Jellyfin Web. Play, pause, seek, next/previous, and queue changes follow the server's shared playlist; clock synchronization schedules playback commands, with optional drift correction disabled by default to match Web. Playback hooks prepare the requested item and position before reporting readiness, while leaving, backgrounding, disconnecting, or changing accounts cancels pending group work. A shared ordered WebSocket transport prevents the pinned SDK's conflating raw-message flow from dropping consecutive group events.

The change is split into four commits: socket transport, playback hooks, SyncPlay coordination, and TV UI/session integration. Implementation details and device-testing steps are in [docs/syncplay.md](https://github.com/tomerh2001/jellyfin-androidtv/blob/contribution/syncplay/docs/syncplay.md).

Validation:

- Full Gradle test run: 140 tests passed, with no failures, errors, or skips.
- Build, Detekt, and Android lint completed. Existing static-analysis findings remain; none were identified on new or changed lines.
- Official Jellyfin Web and an Android TV API 36 emulator were exercised together against an isolated Jellyfin 12 server with decoded H.264/AAC media: create/join/leave, play/pause/seek in both directions, and D-pad focus/control behavior.
- Physical TV hardware, additional codecs, audio passthrough, and the remaining device-test scenarios are still unverified, so this is a draft.

An [unofficial preview APK](https://github.com/tomerh2001/jellyfin-androidtv/releases/tag/syncplay-preview-20260910) installs alongside the Google Play app as Jellyfin Debug.

**Code assistance**

OpenAI Codex generated the implementation and tests, performed the automated and emulator checks, and drafted this PR description at my request. I reviewed and accepted the changes. This submission text is AI-written; that is disclosed explicitly in light of the project's [LLM policy](https://jellyfin.org/docs/general/contributing/llm-policies/).

**Issues**

Addresses #538.
