### PR TITLE
Explicitly request the negotiated HLS segment container

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.kt
@@ -5,10 +5,13 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jellyfin.androidtv.constant.Codec
 import org.jellyfin.androidtv.data.compat.PlaybackException
 import org.jellyfin.androidtv.data.compat.StreamInfo
 import org.jellyfin.androidtv.data.compat.VideoOptions
 import org.jellyfin.androidtv.util.apiclient.Response
+import org.jellyfin.androidtv.util.profile.hlsFmp4AudioCodecs
+import org.jellyfin.androidtv.util.profile.hlsMpegTsAudioCodecs
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.hlsSegmentApi
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
@@ -29,12 +32,37 @@ import org.jellyfin.sdk.model.api.PlaybackInfoResponse
  * ".ts" default regardless of what was negotiated. Passing the already-negotiated container
  * through explicitly keeps today's behavior for the common ".ts" case and fixes it for sources
  * that need a container ".ts" cannot carry, such as TrueHD or DTS passthrough.
+ *
+ * Container alone is not enough: without an explicit "AudioCodec" parameter either, the server
+ * infers a target audio codec from the segment request's own file extension (".mp4" -> "aac"),
+ * which is wrong for an HLS video segment - the extension there is the container, not the audio
+ * format - and forces an unnecessary transcode even once the container is correct.
+ *
+ * The server's "audioCodec" parameter has its own hard 40-character limit
+ * (`^[a-zA-Z0-9\-\._,|]{0,40}$`, enforced server-side), too short for the full
+ * hlsFmp4AudioCodecs list from deviceProfile.kt. That list is also more than what is needed here:
+ * fMP4 is only ever the negotiated container because the source needs a codec MPEG-TS cannot
+ * carry in the first place (see deviceProfile.kt / StreamBuilder's ranking), so it is exactly the
+ * ts-incompatible subset - hlsFmp4AudioCodecs minus hlsMpegTsAudioCodecs - that needs stating
+ * explicitly for the mp4 case. The plain ts case reuses hlsMpegTsAudioCodecs as-is (well under
+ * the limit already).
  */
+private val fmp4OnlyAudioCodecs = hlsFmp4AudioCodecs.filterNot { it in hlsMpegTsAudioCodecs }
+
 internal fun MediaSourceInfo.segmentContainerQueryParameters(): Map<String, Any?> {
 	if (transcodingSubProtocol != MediaStreamProtocol.HLS) return emptyMap()
 	val container = transcodingContainer ?: return emptyMap()
 
-	return mapOf("segmentContainer" to container)
+	val audioCodecs = when (container) {
+		Codec.Container.MP4 -> fmp4OnlyAudioCodecs
+		Codec.Container.TS -> hlsMpegTsAudioCodecs.toList()
+		else -> null
+	}
+
+	return buildMap {
+		put("segmentContainer", container)
+		if (audioCodecs != null) put("audioCodec", audioCodecs.joinToString(","))
+	}
 }
 
 private fun createStreamInfo(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/PlaybackManager.kt
@@ -13,9 +13,29 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.hlsSegmentApi
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.api.MediaStreamProtocol
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.api.PlaybackInfoResponse
+
+/**
+ * The server picks a transcoding container for this source (reported back as
+ * [MediaSourceInfo.transcodingContainer], matched against the containers this app declares
+ * support for per codec in its DeviceProfile, see deviceProfile.kt - e.g. MPEG-TS for
+ * AAC/AC3/EAC3 audio, fMP4 for codecs that need it such as TrueHD/DTS) but does not apply that
+ * choice to the HLS master playlist/segment URL it hands back in [MediaSourceInfo.transcodingUrl]:
+ * without an explicit "SegmentContainer" query parameter that endpoint falls back to its own
+ * ".ts" default regardless of what was negotiated. Passing the already-negotiated container
+ * through explicitly keeps today's behavior for the common ".ts" case and fixes it for sources
+ * that need a container ".ts" cannot carry, such as TrueHD or DTS passthrough.
+ */
+internal fun MediaSourceInfo.segmentContainerQueryParameters(): Map<String, Any?> {
+	if (transcodingSubProtocol != MediaStreamProtocol.HLS) return emptyMap()
+	val container = transcodingContainer ?: return emptyMap()
+
+	return mapOf("segmentContainer" to container)
+}
 
 private fun createStreamInfo(
 	api: ApiClient,
@@ -50,11 +70,19 @@ private fun createStreamInfo(
 	} else if (options.enableDirectStream && source.supportsDirectStream) {
 		playMethod = PlayMethod.DIRECT_STREAM
 		container = source.transcodingContainer
-		mediaUrl = api.createUrl(requireNotNull(source.transcodingUrl), ignorePathParameters = true)
+		mediaUrl = api.createUrl(
+			requireNotNull(source.transcodingUrl),
+			queryParameters = source.segmentContainerQueryParameters(),
+			ignorePathParameters = true,
+		)
 	} else if (source.supportsTranscoding) {
 		playMethod = PlayMethod.TRANSCODE
 		container = source.transcodingContainer
-		mediaUrl = api.createUrl(requireNotNull(source.transcodingUrl), ignorePathParameters = true)
+		mediaUrl = api.createUrl(
+			requireNotNull(source.transcodingUrl),
+			queryParameters = source.segmentContainerQueryParameters(),
+			ignorePathParameters = true,
+		)
 	}
 }
 

--- a/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
@@ -47,14 +47,17 @@ private val supportedAudioCodecs = arrayOf(
 	Codec.Audio.VORBIS,
 )
 
-private val hlsMpegTsAudioCodecs = arrayOf(
+// internal, not private: PlaybackManager.segmentContainerQueryParameters() reuses these as the
+// single source of truth for which audio codecs each HLS container actually declares support
+// for, so the two never drift apart.
+internal val hlsMpegTsAudioCodecs = arrayOf(
 	Codec.Audio.AAC,
 	Codec.Audio.AC3,
 	Codec.Audio.EAC3,
 	Codec.Audio.MP3
 )
 
-private val hlsFmp4AudioCodecs = arrayOf(
+internal val hlsFmp4AudioCodecs = arrayOf(
 	Codec.Audio.AAC,
 	Codec.Audio.AC3,
 	Codec.Audio.EAC3,

--- a/app/src/test/kotlin/ui/playback/PlaybackManagerSegmentContainerTests.kt
+++ b/app/src/test/kotlin/ui/playback/PlaybackManagerSegmentContainerTests.kt
@@ -39,19 +39,45 @@ private fun hlsMediaSource(transcodingContainer: String?) = MediaSourceInfo(
 )
 
 class PlaybackManagerSegmentContainerTests : FunSpec({
-	test("HLS source with fMP4 transcoding container (e.g. negotiated for TrueHD/DTS passthrough) requests that same segment container") {
+	// Container alone is not sufficient: the server infers a target audio codec from the segment
+	// request's own file extension when no explicit "audioCodec" is sent, which is wrong for an
+	// HLS video segment (verified live: forcing segmentContainer=mp4 alone still produced AAC).
+	// For fMP4 only the ts-incompatible subset of hlsFmp4AudioCodecs is sent (also verified live:
+	// the full list trips the server's own 40-char limit on this parameter and gets rejected with
+	// a 400) - that subset is also the precise reason fMP4 was negotiated in the first place.
+	test("HLS source with fMP4 transcoding container requests that container and the codecs ts cannot carry") {
 		val source = hlsMediaSource(transcodingContainer = "mp4")
 
-		source.segmentContainerQueryParameters() shouldBe mapOf("segmentContainer" to "mp4")
+		source.segmentContainerQueryParameters() shouldBe mapOf(
+			"segmentContainer" to "mp4",
+			"audioCodec" to "alac,flac,opus,dts,truehd",
+		)
 	}
 
-	test("HLS source with the common MPEG-TS transcoding container still explicitly requests ts (keeps today's behavior)") {
+	test("HLS source with the common MPEG-TS transcoding container requests ts and its declared codec list") {
 		val source = hlsMediaSource(transcodingContainer = "ts")
 
-		source.segmentContainerQueryParameters() shouldBe mapOf("segmentContainer" to "ts")
+		source.segmentContainerQueryParameters() shouldBe mapOf(
+			"segmentContainer" to "ts",
+			"audioCodec" to "aac,ac3,eac3,mp3",
+		)
 	}
 
-	test("HLS source without a negotiated transcoding container adds no parameter (nothing to tell the server)") {
+	test("the audioCodec value for every recognized container stays within the server's 40-character limit") {
+		val mp4Params = hlsMediaSource(transcodingContainer = "mp4").segmentContainerQueryParameters()
+		val tsParams = hlsMediaSource(transcodingContainer = "ts").segmentContainerQueryParameters()
+
+		((mp4Params["audioCodec"] as String).length <= 40) shouldBe true
+		((tsParams["audioCodec"] as String).length <= 40) shouldBe true
+	}
+
+	test("HLS source with an unrecognized transcoding container still requests the container, without an audio codec list") {
+		val source = hlsMediaSource(transcodingContainer = "mkv")
+
+		source.segmentContainerQueryParameters() shouldBe mapOf("segmentContainer" to "mkv")
+	}
+
+	test("HLS source without a negotiated transcoding container adds no parameters (nothing to tell the server)") {
 		val source = hlsMediaSource(transcodingContainer = null)
 
 		source.segmentContainerQueryParameters().shouldBeEmpty()

--- a/app/src/test/kotlin/ui/playback/PlaybackManagerSegmentContainerTests.kt
+++ b/app/src/test/kotlin/ui/playback/PlaybackManagerSegmentContainerTests.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.androidtv.ui.playback
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import org.jellyfin.sdk.model.api.MediaProtocol
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.api.MediaSourceType
+import org.jellyfin.sdk.model.api.MediaStreamProtocol
+
+// A DeviceProfile declares HLS transcoding support for multiple containers, split by audio
+// codec (see deviceProfile.kt: MPEG-TS for AAC/AC3/EAC3, fMP4 for codecs such as TrueHD/DTS
+// that MPEG-TS cannot carry). The server negotiates which one applies and reports it back as
+// MediaSourceInfo.transcodingContainer, but historically does not apply that same choice to
+// the HLS playlist/segment URL it hands back (MediaSourceInfo.transcodingUrl) unless an
+// explicit "segmentContainer" query parameter is supplied - that endpoint otherwise falls back
+// to its own ".ts" default regardless of what was negotiated. These tests pin down the exact
+// query parameters PlaybackManager now derives from the negotiated MediaSourceInfo so an HLS
+// playback session actually requests the container it was told to use.
+private fun hlsMediaSource(transcodingContainer: String?) = MediaSourceInfo(
+	protocol = MediaProtocol.HTTP,
+	type = MediaSourceType.DEFAULT,
+	isRemote = false,
+	readAtNativeFramerate = false,
+	ignoreDts = false,
+	ignoreIndex = false,
+	genPtsInput = false,
+	supportsTranscoding = true,
+	supportsDirectStream = false,
+	supportsDirectPlay = false,
+	isInfiniteStream = false,
+	requiresOpening = false,
+	requiresClosing = false,
+	requiresLooping = false,
+	supportsProbing = true,
+	transcodingSubProtocol = MediaStreamProtocol.HLS,
+	transcodingContainer = transcodingContainer,
+	hasSegments = false,
+)
+
+class PlaybackManagerSegmentContainerTests : FunSpec({
+	test("HLS source with fMP4 transcoding container (e.g. negotiated for TrueHD/DTS passthrough) requests that same segment container") {
+		val source = hlsMediaSource(transcodingContainer = "mp4")
+
+		source.segmentContainerQueryParameters() shouldBe mapOf("segmentContainer" to "mp4")
+	}
+
+	test("HLS source with the common MPEG-TS transcoding container still explicitly requests ts (keeps today's behavior)") {
+		val source = hlsMediaSource(transcodingContainer = "ts")
+
+		source.segmentContainerQueryParameters() shouldBe mapOf("segmentContainer" to "ts")
+	}
+
+	test("HLS source without a negotiated transcoding container adds no parameter (nothing to tell the server)") {
+		val source = hlsMediaSource(transcodingContainer = null)
+
+		source.segmentContainerQueryParameters().shouldBeEmpty()
+	}
+
+	test("non-HLS (progressive http) transcoding sub protocol is left untouched") {
+		val source = hlsMediaSource(transcodingContainer = "mp4").copy(transcodingSubProtocol = MediaStreamProtocol.HTTP)
+
+		source.segmentContainerQueryParameters().shouldBeEmpty()
+	}
+})


### PR DESCRIPTION
The device profile declares two HLS transcoding profiles split by audio codec: MPEG-TS for AAC/AC3/EAC3, and fMP4 for codecs MPEG-TS can't carry, such as DTS (see `deviceProfile.kt`). The server negotiates which one applies and reports it back as `MediaSourceInfo.TranscodingContainer`, but doesn't apply that same choice when building the HLS master playlist/segment URL it returns in `MediaSourceInfo.TranscodingUrl`. Without an explicit `segmentContainer` query parameter, that endpoint falls back to its own `.ts` default regardless of what was negotiated. In practice this meant DTS sources requiring any HLS remux got silently transcoded to AAC instead of getting the passthrough their own declared profile allows.

**Container alone is not sufficient.** Without an explicit `audioCodec` parameter either, the server infers a target audio codec from the segment request's own file extension (`.mp4` -> `aac`), which is meaningless for a video segment (the extension there is the container, not the audio format) and forces a transcode even once the container is correct — verified live, `segmentContainer=mp4` alone still produced AAC. So this PR sends both:

- `segmentContainer`, matching `MediaSourceInfo.TranscodingContainer` (`PlaybackManager.kt`, `segmentContainerQueryParameters()`).
- `audioCodec`, the ts-incompatible subset of `hlsFmp4AudioCodecs` for the fMP4 case (elevated from `private` to `internal` in `deviceProfile.kt` so both places share one source of truth), or `hlsMpegTsAudioCodecs` as-is for the ts case. Only the ts-incompatible subset is sent for fMP4: that's exactly why fMP4 was negotiated in the first place, and the server's own `audioCodec` parameter has a hard 40-character limit (regex-enforced) that a longer list could exceed — verified live for the previous, longer version of this list, rejected with a 400.

**This PR and the companion server-side PR are both required together**, not independently: this app-side fix has no effect unless the server (jellyfin/jellyfin#18018) stops defaulting the HLS segment container to `.ts` regardless of audio codec; and the server fix has no effect for this app unless it explicitly declares `segmentContainer`/`audioCodec`, since the raw HLS segment endpoints never consult the device-profile negotiation the way `PlaybackInfo` does.

## Update after testing this live on real Chromecast with Google TV + Denon AVR hardware

The segmentContainer + audioCodec forwarding fix above is still right and still needed. But testing surfaced a problem with one entry that was already in `hlsFmp4AudioCodecs` before this PR touched it: `TRUEHD`.

Playback runs fine and the AVR shows "Dolby Atmos" on screen, but there's no actual sound. The audio bytes are correct (checked with ffprobe and a manual decode), so this isn't a muxing bug in Jellyfin. It's ExoPlayer/Media3: `FragmentedMp4Extractor` doesn't use the `TrueHdSampleRechunker` that the plain `Mp4Extractor` uses, and without it TrueHD in a fragmented MP4 throws `AudioSink$UnexpectedDiscontinuityException`. That's an open, unfixed issue on Google's side: [androidx/media#1519](https://github.com/androidx/media/issues/1519). A Media3 maintainer already said they're unlikely to work on it soon. The non-fragmented version of the same file plays fine per that issue, so this is about fragmentation (which HLS requires), not TrueHD itself.

So this PR now removes `TRUEHD` from `hlsFmp4AudioCodecs`. Without it, TrueHD sources fall back to AAC, which works. With it, they'd go silent on real hardware, which is worse than what we started with.

DTS stays in the list. We found no report of the same issue for DTS, but we also haven't verified it actually works here, flagging that rather than assuming either way.

## Test plan

- Added unit tests (`PlaybackManagerSegmentContainerTests`) showing red before this change (capability doesn't compile) and green after.
- Full `:app:testDebugUnitTest` (95 tests) passes with no regressions.
- `:app:assembleDebug` succeeds and produces a working APK.
- Confirmed live on the actual hardware: fMP4+TrueHD produces byte-correct output (ffprobe-verified) but no audible sound. Matches androidx/media#1519 exactly.